### PR TITLE
Avoid stale lastUpdate cache during prewarm

### DIFF
--- a/internal/update/prewarm.go
+++ b/internal/update/prewarm.go
@@ -1,13 +1,39 @@
 package update
 
 import (
+	"expo-open-ota/internal/types"
 	"log"
 )
 
-// PreWarmManifestCache populates the manifest cache layers for the given
-// branch/runtimeVersion/platform combination. It is intended to be called
-// as a goroutine after MarkUpdateAsChecked so the first client request
-// hits warm caches instead of rebuilding everything from scratch.
+// PreWarmUpdateManifestCache populates the metadata/manifest cache layers for a
+// known update. It intentionally does not resolve the latest update or write the
+// lastUpdate cache: callers that just marked an update as checked already know
+// which update should be warmed, and resolving latest here can race with stale
+// lastUpdate entries.
+func PreWarmUpdateManifestCache(update types.Update, platform string) {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Printf("[PreWarm] panic recovered for update=%s platform=%s: %v", update.UpdateId, platform, r)
+		}
+	}()
+
+	metadata, err := GetMetadata(update)
+	if err != nil {
+		log.Printf("[PreWarm] error getting metadata for update=%s: %v", update.UpdateId, err)
+		return
+	}
+
+	_, err = ComposeUpdateManifest(&metadata, update, platform)
+	if err != nil {
+		log.Printf("[PreWarm] error composing manifest for update=%s platform=%s: %v", update.UpdateId, platform, err)
+		return
+	}
+
+	log.Printf("[PreWarm] successfully pre-warmed manifest cache for update=%s platform=%s", update.UpdateId, platform)
+}
+
+// PreWarmManifestCache resolves the latest checked update for the given
+// branch/runtimeVersion/platform combination and warms its manifest cache.
 func PreWarmManifestCache(branch, runtimeVersion, platform string) {
 	defer func() {
 		if r := recover(); r != nil {

--- a/internal/update/updates.go
+++ b/internal/update/updates.go
@@ -96,8 +96,7 @@ func MarkUpdateAsChecked(update types.Update) error {
 	}
 	reader := strings.NewReader(".check")
 	_ = resolvedBucket.UploadFileIntoUpdate(update, ".check", reader)
-	go PreWarmManifestCache(update.Branch, update.RuntimeVersion, "ios")
-	go PreWarmManifestCache(update.Branch, update.RuntimeVersion, "android")
+	go PreWarmUpdateManifestCache(update, storedMetadata.Platform)
 	return nil
 }
 

--- a/test/manifest_test.go
+++ b/test/manifest_test.go
@@ -636,7 +636,6 @@ func TestEmptyRequestForAndroid(t *testing.T) {
 	assert.Equal(t, "{\"type\":\"noUpdateAvailable\"}", body)
 }
 
-
 func TestPreWarmManifestCache(t *testing.T) {
 	teardown := setup(t)
 	defer teardown()
@@ -665,4 +664,26 @@ func TestPreWarmManifestCache(t *testing.T) {
 	// Verify manifest cache was populated
 	manifestKey := update.ComputeUpdataManifestCacheKey("branch-1", "1", cachedUpdate.UpdateId, "android")
 	assert.NotEqual(t, "", cache.Get(manifestKey), "manifest cache should be populated after prewarm")
+}
+
+func TestPreWarmUpdateManifestCacheDoesNotPopulateLastUpdateCache(t *testing.T) {
+	teardown := setup(t)
+	defer teardown()
+	mockWorkingExpoResponse("staging")
+
+	cache := cache2.GetCache()
+	checkedUpdate := types.Update{
+		Branch:         "branch-1",
+		RuntimeVersion: "1",
+		UpdateId:       "1674170951",
+	}
+
+	lastUpdateKey := update.ComputeLastUpdateCacheKey("branch-1", "1", "android")
+	assert.Equal(t, "", cache.Get(lastUpdateKey), "lastUpdate cache should be empty before prewarm")
+
+	update.PreWarmUpdateManifestCache(checkedUpdate, "android")
+
+	manifestKey := update.ComputeUpdataManifestCacheKey("branch-1", "1", "1674170951", "android")
+	assert.NotEqual(t, "", cache.Get(manifestKey), "manifest cache should be populated after prewarm")
+	assert.Equal(t, "", cache.Get(lastUpdateKey), "prewarming a known update should not populate lastUpdate cache")
 }


### PR DESCRIPTION
## Summary

Fixes #84.

This changes post-publish cache prewarming so `MarkUpdateAsChecked` warms the manifest cache for the update that was just checked, instead of resolving "latest" again through `GetLatestUpdateBundlePathForRuntimeVersion`.

## Why

`GetLatestUpdateBundlePathForRuntimeVersion` reads and writes the `lastUpdate` cache. Calling it from the post-publish prewarm path can race with stale Redis state and re-cache the previous update after a new update has already been marked checked.

That leaves storage/dashboard showing the new update while `/manifest` continues to serve the old one until the Redis TTL expires or the key is deleted manually.

## Changes

- Add `PreWarmUpdateManifestCache(update, platform)` for warming metadata/manifest cache for a known update.
- Use that helper from `MarkUpdateAsChecked` after writing `.check`.
- Keep `PreWarmManifestCache(branch, runtimeVersion, platform)` for callers that genuinely want to resolve latest.
- Add a regression test asserting known-update prewarm does not populate `lastUpdate`.

## Test

```sh
go test ./...
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved update cache prewarming to target the correct platform-specific manifest.
  * Ensured manifest-only prewarming does not incorrectly populate the latest-update cache.
  * Added more reliable error handling and logging during cache prewarming.

* **Tests**
  * Expanded coverage for metadata, manifest, and cache population behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->