### PR TITLE
EAS Identity

### DIFF
--- a/apps/dashboard/src/ee/lib/PermissionsContext.tsx
+++ b/apps/dashboard/src/ee/lib/PermissionsContext.tsx
@@ -23,6 +23,7 @@ export type Permission =
   | 'channel-rollout:manage'
   | 'update-rollout:manage'
   | 'apikeys:manage'
+  | 'identity:manage'
 
 type PermissionsContextValue = {
   // enabled reports whether fine-grained roles are enforced right now

--- a/apps/dashboard/src/ee/lib/permissionCatalog.ts
+++ b/apps/dashboard/src/ee/lib/permissionCatalog.ts
@@ -102,5 +102,15 @@ export const PERMISSION_GROUPS: PermissionGroup[] = [
         description: 'Create and revoke publishing tokens and edit their restrictions.',
       },
     ],
-  }
+  },
+  {
+    label: 'Identity',
+    permissions: [
+      {
+        value: 'identity:manage',
+        label: 'Manage the identity allowlist',
+        description: 'Choose which device metadata keys are accepted and their types. Reading identity and browsing devices stays open to any member.',
+      },
+    ],
+  },
 ];

--- a/ee/audit/exporter_test.go
+++ b/ee/audit/exporter_test.go
@@ -114,7 +114,8 @@ func TestArchiveKeepsDrainingWithoutALicense(t *testing.T) {
 	// would never come for them).
 	repo := seededExportRepo()
 	putter := &fakePutter{}
-	service := NewAuditService(repo, func() bool { return false })
+	service := NewAuditService(repo)
+	service.licenseValid = func() bool { return false }
 
 	_, err := service.archiveNextBatch(context.Background(), putter)
 	require.NoError(t, err)
@@ -172,7 +173,8 @@ func TestArchivePutFailureLeavesTheCursorUntouched(t *testing.T) {
 }
 
 func TestArchiveDeclinesToStartWithoutControlPlane(t *testing.T) {
-	service := NewAuditService(nil, func() bool { return true })
+	service := NewAuditService(nil)
+	service.licenseValid = func() bool { return true }
 	service.startArchive(context.Background(), time.Minute, &fakePutter{})
 	// Declining must not flip the purge into exported-only mode: a stateless
 	// service has no exporter to ever advance the cursor.
@@ -189,7 +191,8 @@ func TestStartArchiveFromEnvStaysOffByDefault(t *testing.T) {
 
 func TestStartArchiveFromEnvRequiresControlPlane(t *testing.T) {
 	t.Setenv("ARCHIVE_AUDIT_LOGS", "true")
-	service := NewAuditService(nil, func() bool { return true })
+	service := NewAuditService(nil)
+	service.licenseValid = func() bool { return true }
 
 	err := service.StartArchiveFromEnv(context.Background())
 	require.ErrorContains(t, err, "control plane")

--- a/ee/audit/handler.go
+++ b/ee/audit/handler.go
@@ -5,7 +5,6 @@
 package audit
 
 import (
-	"encoding/json"
 	"errors"
 	"expo-open-ota/internal/handlers"
 	"net/http"
@@ -76,13 +75,6 @@ func checkAndParseRange(from *string, to *string) (*time.Time, *time.Time, error
 		}
 	}
 	return finalFrom, finalTo, nil
-}
-
-func renderJSON(w http.ResponseWriter, status int, payload interface{}) {
-	marshaledResponse, _ := json.Marshal(payload)
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(status)
-	w.Write(marshaledResponse)
 }
 
 type AuditEventResponse struct {
@@ -190,7 +182,7 @@ func (h *AuditHandler) ListAuditLogsHandler(w http.ResponseWriter, r *http.Reque
 	for i, event := range events {
 		responseEvents[i] = auditEventResponseFrom(event)
 	}
-	renderJSON(w, http.StatusOK, map[string]interface{}{
+	handlers.RenderJSON(w, http.StatusOK, map[string]interface{}{
 		"events":     responseEvents,
 		"nextCursor": nextCursor,
 		"count":      count,

--- a/ee/audit/handler_test.go
+++ b/ee/audit/handler_test.go
@@ -170,7 +170,8 @@ func TestListHandlerRejectsInvalidInput(t *testing.T) {
 }
 
 func TestListHandlerStatelessMode(t *testing.T) {
-	service := NewAuditService(nil, func() bool { return true })
+	service := NewAuditService(nil)
+	service.licenseValid = func() bool { return true }
 
 	recorder := performList(t, service, "")
 	assert.Equal(t, http.StatusBadRequest, recorder.Code)
@@ -200,7 +201,8 @@ func TestListHandlerReadsStayOpenWithoutLicense(t *testing.T) {
 	// A lapsed license stops collection, never read access: the viewer must
 	// keep answering (the UI overlay is the gate, not the server).
 	repo := &fakeAuditRepo{listResult: []Event{{ID: 1, Action: auditlog.ActionUserLogin}}}
-	service := NewAuditService(repo, func() bool { return false })
+	service := NewAuditService(repo)
+	service.licenseValid = func() bool { return false }
 
 	recorder := performList(t, service, "")
 	require.Equal(t, http.StatusOK, recorder.Code)

--- a/ee/audit/service.go
+++ b/ee/audit/service.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 	"expo-open-ota/config"
+	"expo-open-ota/ee/licensing"
 	"expo-open-ota/internal/auditlog"
 	"log"
 	"strconv"
@@ -92,12 +93,14 @@ type AuditService struct {
 }
 
 // NewAuditService accepts a nil repository (stateless mode); reads then answer
-// ErrRequiresControlPlane and Record no-ops. licenseValid is the live
-// licensing gate (licensing.IsEnterprise in production) — a parameter rather
-// than a direct dependency, so this package stays importable from anywhere
-// without dragging the licensing stack along.
-func NewAuditService(repo AuditRepository, licenseValid func() bool) *AuditService {
-	return &AuditService{repo: repo, licenseValid: licenseValid}
+// ErrRequiresControlPlane and Record no-ops. The license gate defaults to
+// licensing.IsEnterprise and is imported directly ON PURPOSE: it must live in
+// EE code so bypassing it means editing an EE-licensed file (a license
+// violation), not swapping a func passed in from the MIT composition root
+// (which anyone may legally replace with `func() bool { return true }`).
+// Tests flip the licenseValid field instead of a signed key.
+func NewAuditService(repo AuditRepository) *AuditService {
+	return &AuditService{repo: repo, licenseValid: licensing.IsEnterprise}
 }
 
 // Enabled reports whether events are being collected right now.

--- a/ee/audit/service_test.go
+++ b/ee/audit/service_test.go
@@ -117,12 +117,15 @@ func (f *fakeAuditRepo) AdvanceExportCursor(ctx context.Context, from int64, to 
 }
 
 func enabledService(repo AuditRepository) *AuditService {
-	return NewAuditService(repo, func() bool { return true })
+	svc := NewAuditService(repo)
+	svc.licenseValid = func() bool { return true }
+	return svc
 }
 
 func TestRecordCollectsNothingWithoutLicense(t *testing.T) {
 	repo := &fakeAuditRepo{}
-	service := NewAuditService(repo, func() bool { return false })
+	service := NewAuditService(repo)
+	service.licenseValid = func() bool { return false }
 
 	service.Record(context.Background(), Event{Action: auditlog.ActionUserLogin})
 
@@ -131,7 +134,8 @@ func TestRecordCollectsNothingWithoutLicense(t *testing.T) {
 }
 
 func TestRecordCollectsNothingInStatelessMode(t *testing.T) {
-	service := NewAuditService(nil, func() bool { return true })
+	service := NewAuditService(nil)
+	service.licenseValid = func() bool { return true }
 
 	// Must be a silent no-op, not a nil dereference.
 	service.Record(context.Background(), Event{Action: auditlog.ActionUserLogin})
@@ -178,7 +182,8 @@ func TestRecordSwallowsInsertErrors(t *testing.T) {
 }
 
 func TestListRequiresControlPlane(t *testing.T) {
-	service := NewAuditService(nil, func() bool { return true })
+	service := NewAuditService(nil)
+	service.licenseValid = func() bool { return true }
 
 	_, _, err := service.List(context.Background(), ListParams{})
 	require.ErrorIs(t, err, ErrRequiresControlPlane)
@@ -228,7 +233,8 @@ func TestPurgeOlderThanUsesTheRetentionCutoff(t *testing.T) {
 	repo := &fakeAuditRepo{purgedCount: 12}
 	// Deliberately unlicensed: retention applies to collected data whatever
 	// the licence state.
-	service := NewAuditService(repo, func() bool { return false })
+	service := NewAuditService(repo)
+	service.licenseValid = func() bool { return false }
 
 	purged, err := service.PurgeOlderThan(context.Background(), 550*24*time.Hour)
 	require.NoError(t, err)
@@ -240,7 +246,8 @@ func TestPurgeOlderThanUsesTheRetentionCutoff(t *testing.T) {
 
 func TestPurgeSparesUnarchivedRowsWhileArchiving(t *testing.T) {
 	repo := &fakeAuditRepo{}
-	service := NewAuditService(repo, func() bool { return true })
+	service := NewAuditService(repo)
+	service.licenseValid = func() bool { return true }
 	service.startArchive(context.Background(), time.Hour, &fakePutter{})
 
 	_, err := service.PurgeOlderThan(context.Background(), 550*24*time.Hour)
@@ -251,7 +258,8 @@ func TestPurgeSparesUnarchivedRowsWhileArchiving(t *testing.T) {
 }
 
 func TestPurgeRequiresControlPlane(t *testing.T) {
-	service := NewAuditService(nil, func() bool { return true })
+	service := NewAuditService(nil)
+	service.licenseValid = func() bool { return true }
 	_, err := service.PurgeOlderThan(context.Background(), time.Hour)
 	require.ErrorIs(t, err, ErrRequiresControlPlane)
 	// And the scheduler declines to start rather than panic.
@@ -260,7 +268,8 @@ func TestPurgeRequiresControlPlane(t *testing.T) {
 
 func TestListReadsStayOpenWithoutLicense(t *testing.T) {
 	repo := &fakeAuditRepo{listResult: []Event{{ID: 1, Action: auditlog.ActionUserLogin, OccurredAt: time.Now()}}}
-	service := NewAuditService(repo, func() bool { return false })
+	service := NewAuditService(repo)
+	service.licenseValid = func() bool { return false }
 
 	// A lapsed license stops collection, never read access to what was
 	// collected while licensed.

--- a/ee/audit/smoke_e2e_test.go
+++ b/ee/audit/smoke_e2e_test.go
@@ -33,7 +33,8 @@ func TestEndToEndArchiveSmoke(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	service := NewAuditService(auditStore, func() bool { return true })
+	service := NewAuditService(auditStore)
+	service.licenseValid = func() bool { return true }
 	// Unique like every other DB test here: the table and the export cursor
 	// are shared across runs, a fixed actor would collide with itself.
 	actorID := "smoke-" + uuid.NewString()

--- a/ee/identity/geoip.go
+++ b/ee/identity/geoip.go
@@ -1,0 +1,89 @@
+// Copyright (c) 2026 Axel Marciano (Mercure Technologies). All rights reserved.
+// This file is governed by the Mercure Technologies Enterprise Edition License
+// (see ee/LICENSE); it is NOT covered by the MIT license of this repository.
+
+package identity
+
+import (
+	"fmt"
+	"log"
+	"net"
+	"strings"
+
+	"github.com/oschwald/geoip2-golang"
+)
+
+// GeoResolver turns a request IP into an optional Geo enrichment. Resolvers
+// must be nil-tolerant on the value they return: no resolution is a normal
+// outcome (private IP, unknown range, no database configured), never an error
+// worth failing an identify over.
+type GeoResolver interface {
+	Resolve(ip string) *Geo
+}
+
+// GeoLite2Resolver resolves against a local MaxMind GeoLite2/GeoIP2 City
+// database (mmdb file). The operator downloads the database with their own
+// MaxMind license key; without a configured file the feature is simply off.
+// City-level accuracy: lat/lng is a city centroid, not a device position.
+type GeoLite2Resolver struct {
+	db *geoip2.Reader
+}
+
+func NewGeoLite2Resolver(path string) (*GeoLite2Resolver, error) {
+	db, err := geoip2.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("opening GeoLite2 database %q: %w", path, err)
+	}
+	// Open succeeds on ANY valid mmdb (ASN, ISP...), after which every City()
+	// lookup fails silently and the operator would see geo mysteriously never
+	// resolve. Fail loud at boot instead.
+	if dbType := db.Metadata().DatabaseType; !strings.Contains(dbType, "City") && !strings.Contains(dbType, "Country") {
+		_ = db.Close()
+		return nil, fmt.Errorf("GeoLite2 database %q has type %q; a City or Country database is required", path, dbType)
+	}
+	log.Printf("🌍 [IDENTITY] GeoLite2 database loaded from %s", path)
+	return &GeoLite2Resolver{db: db}, nil
+}
+
+func (r *GeoLite2Resolver) Close() {
+	if r != nil && r.db != nil {
+		_ = r.db.Close()
+	}
+}
+
+func (r *GeoLite2Resolver) Resolve(ipStr string) *Geo {
+	ip := net.ParseIP(ipStr)
+	if ip == nil || ip.IsPrivate() || ip.IsLoopback() || ip.IsUnspecified() {
+		return nil
+	}
+	if r == nil || r.db == nil {
+		return nil
+	}
+	record, err := r.db.City(ip)
+	if err != nil {
+		return nil
+	}
+
+	geo := &Geo{}
+	resolved := false
+	if code := record.Country.IsoCode; code != "" {
+		geo.CountryCode = &code
+		resolved = true
+	}
+	if city := record.City.Names["en"]; city != "" {
+		geo.City = &city
+		resolved = true
+	}
+	// 0,0 (Null Island) is what the database reports when it has no location;
+	// treat it as absent rather than pinning devices in the Gulf of Guinea.
+	if record.Location.Latitude != 0 || record.Location.Longitude != 0 {
+		lat, lng := record.Location.Latitude, record.Location.Longitude
+		geo.Lat = &lat
+		geo.Lng = &lng
+		resolved = true
+	}
+	if !resolved {
+		return nil
+	}
+	return geo
+}

--- a/ee/identity/handler.go
+++ b/ee/identity/handler.go
@@ -1,0 +1,303 @@
+// Copyright (c) 2026 Axel Marciano (Mercure Technologies). All rights reserved.
+// This file is governed by the Mercure Technologies Enterprise Edition License
+// (see ee/LICENSE); it is NOT covered by the MIT license of this repository.
+
+package identity
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"expo-open-ota/internal/handlers"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/gorilla/mux"
+)
+
+// IdentityHandler serves the dashboard "Identity" section: the metadata
+// allowlist (schema), value autocomplete, and the device inventory. It wraps
+// the same *Service the ingest route uses (handler-over-service, as in
+// ee/audit / ee/rbac). A nil service (stateless, no control plane) answers 400.
+type IdentityHandler struct {
+	service *Service
+}
+
+func NewIdentityHandler(service *Service) *IdentityHandler {
+	return &IdentityHandler{service: service}
+}
+
+// requireService short-circuits with a 400 when identity has no storage
+// (stateless mode). Returns the service and true when it is available.
+func (h *IdentityHandler) requireService(w http.ResponseWriter) (*Service, bool) {
+	if h.service == nil {
+		handlers.RenderError(w, http.StatusBadRequest, "Device identity requires a control plane (database).")
+		return nil, false
+	}
+	return h.service, true
+}
+
+func renderIdentityServiceError(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, ErrTooManySchemaKeys):
+		handlers.RenderError(w, http.StatusConflict, err.Error())
+	default:
+		handlers.RenderError(w, http.StatusInternalServerError, "An internal error occurred.")
+	}
+}
+
+// --- Response shapes (camelCase; timestamps RFC3339 UTC) ---
+
+type schemaKeyResponse struct {
+	Key       string `json:"key"`
+	Type      string `json:"type"`
+	MaxLength int    `json:"maxLength"`
+}
+
+func schemaKeyResponseFrom(spec KeySpec) schemaKeyResponse {
+	return schemaKeyResponse{Key: spec.Key, Type: string(spec.Type), MaxLength: spec.MaxLength}
+}
+
+type deviceResponse struct {
+	EasClientId string         `json:"easClientId"`
+	Metadata    map[string]any `json:"metadata"`
+	CountryCode *string        `json:"countryCode,omitempty"`
+	City        *string        `json:"city,omitempty"`
+	Lat         *float64       `json:"lat,omitempty"`
+	Lng         *float64       `json:"lng,omitempty"`
+	FirstSeenAt string         `json:"firstSeenAt"`
+	LastSeenAt  string         `json:"lastSeenAt"`
+}
+
+func deviceResponseFrom(d Device) deviceResponse {
+	return deviceResponse{
+		EasClientId: d.EASClientID,
+		Metadata:    d.Metadata,
+		CountryCode: d.CountryCode,
+		City:        d.City,
+		Lat:         d.Lat,
+		Lng:         d.Lng,
+		FirstSeenAt: d.FirstSeenAt.UTC().Format(time.RFC3339),
+		LastSeenAt:  d.LastSeenAt.UTC().Format(time.RFC3339),
+	}
+}
+
+// --- Schema (allowlist) ---
+
+func (h *IdentityHandler) GetSchemaHandler(w http.ResponseWriter, r *http.Request) {
+	service, ok := h.requireService(w)
+	if !ok {
+		return
+	}
+	appID := mux.Vars(r)["APP_ID"]
+	schema, err := service.GetSchema(r.Context(), appID)
+	if err != nil {
+		renderIdentityServiceError(w, err)
+		return
+	}
+	// Stable order so the dashboard list does not jitter between reads.
+	keys := make([]schemaKeyResponse, 0, len(schema))
+	for _, spec := range schema {
+		keys = append(keys, schemaKeyResponseFrom(spec))
+	}
+	sortSchemaKeys(keys)
+	handlers.RenderJSON(w, http.StatusOK, map[string]any{"keys": keys})
+}
+
+func (h *IdentityHandler) UpsertSchemaKeyHandler(w http.ResponseWriter, r *http.Request) {
+	service, ok := h.requireService(w)
+	if !ok {
+		return
+	}
+	appID := mux.Vars(r)["APP_ID"]
+	key := mux.Vars(r)["KEY"]
+
+	var body struct {
+		Type      string `json:"type"`
+		MaxLength int    `json:"maxLength"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		handlers.RenderError(w, http.StatusBadRequest, "Invalid request body: "+err.Error())
+		return
+	}
+	spec := KeySpec{Key: key, Type: ValueType(body.Type), MaxLength: body.MaxLength}
+	if spec.MaxLength == 0 {
+		spec.MaxLength = DefaultMaxLength
+	}
+	// Validate before the store so a bad spec is a clear 400, not a 500.
+	if err := ValidateKeySpec(spec); err != nil {
+		handlers.RenderError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	saved, err := service.UpsertSchemaKey(r.Context(), appID, spec)
+	if err != nil {
+		renderIdentityServiceError(w, err)
+		return
+	}
+	handlers.RenderJSON(w, http.StatusOK, schemaKeyResponseFrom(saved))
+}
+
+func (h *IdentityHandler) DeleteSchemaKeyHandler(w http.ResponseWriter, r *http.Request) {
+	service, ok := h.requireService(w)
+	if !ok {
+		return
+	}
+	appID := mux.Vars(r)["APP_ID"]
+	key := mux.Vars(r)["KEY"]
+	deleted, err := service.DeleteSchemaKey(r.Context(), appID, key)
+	if err != nil {
+		renderIdentityServiceError(w, err)
+		return
+	}
+	if !deleted {
+		handlers.RenderError(w, http.StatusNotFound, "No such identity key.")
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// --- Value autocomplete (searchMetadata) ---
+
+func (h *IdentityHandler) SearchValuesHandler(w http.ResponseWriter, r *http.Request) {
+	service, ok := h.requireService(w)
+	if !ok {
+		return
+	}
+	appID := mux.Vars(r)["APP_ID"]
+	query := r.URL.Query()
+	key := query.Get("key")
+	if key == "" {
+		handlers.RenderError(w, http.StatusBadRequest, "Query parameter 'key' is required.")
+		return
+	}
+	limit := parseLimit(query.Get("limit"), 20)
+	values, err := service.SearchMetadataValues(r.Context(), appID, key, query.Get("search"), limit)
+	if err != nil {
+		renderIdentityServiceError(w, err)
+		return
+	}
+	out := make([]ValueCount, 0, len(values))
+	out = append(out, values...) // To init with [] instead of nil for the renderJSON
+	handlers.RenderJSON(w, http.StatusOK, map[string]any{"values": out})
+}
+
+// --- Device inventory ---
+
+func (h *IdentityHandler) ListDevicesHandler(w http.ResponseWriter, r *http.Request) {
+	service, ok := h.requireService(w)
+	if !ok {
+		return
+	}
+	appID := mux.Vars(r)["APP_ID"]
+	query := r.URL.Query()
+
+	var filter *MetadataFilter
+	if fk, fv := query.Get("filterKey"), query.Get("filterValue"); fk != "" && fv != "" {
+		filter = &MetadataFilter{Key: fk, Value: fv}
+	}
+
+	cursor, err := decodeDeviceCursor(query.Get("cursor"))
+	if err != nil {
+		handlers.RenderError(w, http.StatusBadRequest, "Invalid cursor.")
+		return
+	}
+	limit := parseLimit(query.Get("limit"), DefaultDevicesPageSize)
+
+	devices, next, err := service.ListDevices(r.Context(), appID, filter, limit, cursor)
+	if err != nil {
+		renderIdentityServiceError(w, err)
+		return
+	}
+	items := make([]deviceResponse, 0, len(devices))
+	for _, d := range devices {
+		items = append(items, deviceResponseFrom(d))
+	}
+	handlers.RenderJSON(w, http.StatusOK, map[string]any{
+		"devices":    items,
+		"nextCursor": encodeDeviceCursor(next),
+	})
+}
+
+func (h *IdentityHandler) GetDeviceHandler(w http.ResponseWriter, r *http.Request) {
+	service, ok := h.requireService(w)
+	if !ok {
+		return
+	}
+	appID := mux.Vars(r)["APP_ID"]
+	easClientID := mux.Vars(r)["EAS_CLIENT_ID"]
+	// A non-UUID path segment is definitionally not a device: 404, not a 500
+	// from the store's uuid parse.
+	if _, err := uuid.Parse(easClientID); err != nil {
+		handlers.RenderError(w, http.StatusNotFound, "No such device.")
+		return
+	}
+	device, err := service.GetDevice(r.Context(), appID, easClientID)
+	if err != nil {
+		renderIdentityServiceError(w, err)
+		return
+	}
+	if device == nil {
+		handlers.RenderError(w, http.StatusNotFound, "No such device.")
+		return
+	}
+	handlers.RenderJSON(w, http.StatusOK, deviceResponseFrom(*device))
+}
+
+// --- helpers ---
+
+func parseLimit(raw string, fallback int) int {
+	if raw == "" {
+		return fallback
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil {
+		return fallback
+	}
+	return n // the store clamps to its own bounds
+}
+
+func sortSchemaKeys(keys []schemaKeyResponse) {
+	for i := 1; i < len(keys); i++ {
+		for j := i; j > 0 && keys[j-1].Key > keys[j].Key; j-- {
+			keys[j-1], keys[j] = keys[j], keys[j-1]
+		}
+	}
+}
+
+// The device cursor is opaque on the wire: base64 of "RFC3339Nano|uuid". The
+// client only echoes nextCursor back, it never parses it.
+func encodeDeviceCursor(c *DeviceCursor) *string {
+	if c == nil {
+		return nil
+	}
+	raw := c.LastSeenAt.UTC().Format(time.RFC3339Nano) + "|" + c.EASClientID
+	encoded := base64.RawURLEncoding.EncodeToString([]byte(raw))
+	return &encoded
+}
+
+func decodeDeviceCursor(encoded string) (*DeviceCursor, error) {
+	if encoded == "" {
+		return nil, nil
+	}
+	decoded, err := base64.RawURLEncoding.DecodeString(encoded)
+	if err != nil {
+		return nil, err
+	}
+	parts := strings.SplitN(string(decoded), "|", 2)
+	if len(parts) != 2 {
+		return nil, errors.New("malformed cursor")
+	}
+	ts, err := time.Parse(time.RFC3339Nano, parts[0])
+	if err != nil {
+		return nil, err
+	}
+	// Validate the uuid here so a tampered cursor is a 400, not a 500 from the
+	// store's parse.
+	if _, err := uuid.Parse(parts[1]); err != nil {
+		return nil, err
+	}
+	return &DeviceCursor{LastSeenAt: ts, EASClientID: parts[1]}, nil
+}

--- a/ee/identity/handler_test.go
+++ b/ee/identity/handler_test.go
@@ -1,0 +1,258 @@
+// Copyright (c) 2026 Axel Marciano (Mercure Technologies). All rights reserved.
+// This file is governed by the Mercure Technologies Enterprise Edition License
+// (see ee/LICENSE); it is NOT covered by the MIT license of this repository.
+
+package identity
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeStore is an in-memory identity.Store for handler tests. It defines the
+// query/CRUD methods the dashboard exercises; the embedded Store supplies the
+// unused ingest mutator methods so it satisfies the interface.
+type fakeStore struct {
+	Store
+	schema  Schema
+	devices map[string]*Device
+	values  []ValueCount
+	// listDevices lets a test control pagination output.
+	listDevices func(filter *MetadataFilter, limit int, cursor *DeviceCursor) ([]Device, *DeviceCursor, error)
+	upsertErr   error
+}
+
+func newFakeStore() *fakeStore {
+	return &fakeStore{schema: Schema{}, devices: map[string]*Device{}}
+}
+
+func (f *fakeStore) GetSchema(_ context.Context, _ string) (Schema, error) { return f.schema, nil }
+
+func (f *fakeStore) UpsertSchemaKey(_ context.Context, _ string, spec KeySpec) (KeySpec, error) {
+	if f.upsertErr != nil {
+		return KeySpec{}, f.upsertErr
+	}
+	f.schema[spec.Key] = spec
+	return spec, nil
+}
+
+func (f *fakeStore) DeleteSchemaKey(_ context.Context, _ string, key string) (bool, error) {
+	if _, ok := f.schema[key]; !ok {
+		return false, nil
+	}
+	delete(f.schema, key)
+	return true, nil
+}
+
+func (f *fakeStore) SearchMetadataValues(_ context.Context, _ string, _ string, _ string, _ int) ([]ValueCount, error) {
+	return f.values, nil
+}
+
+func (f *fakeStore) ListDevices(_ context.Context, _ string, filter *MetadataFilter, limit int, cursor *DeviceCursor) ([]Device, *DeviceCursor, error) {
+	if f.listDevices != nil {
+		return f.listDevices(filter, limit, cursor)
+	}
+	return nil, nil, nil
+}
+
+func (f *fakeStore) GetDevice(_ context.Context, _ string, easClientID string) (*Device, error) {
+	return f.devices[easClientID], nil
+}
+
+// serve routes a request through a real mux router so path vars resolve.
+func serve(handler *IdentityHandler, method, path, body string) *httptest.ResponseRecorder {
+	router := mux.NewRouter()
+	router.HandleFunc("/api/apps/{APP_ID}/identity/schema", handler.GetSchemaHandler).Methods(http.MethodGet)
+	router.HandleFunc("/api/apps/{APP_ID}/identity/schema/{KEY}", handler.UpsertSchemaKeyHandler).Methods(http.MethodPut)
+	router.HandleFunc("/api/apps/{APP_ID}/identity/schema/{KEY}", handler.DeleteSchemaKeyHandler).Methods(http.MethodDelete)
+	router.HandleFunc("/api/apps/{APP_ID}/identity/values", handler.SearchValuesHandler).Methods(http.MethodGet)
+	router.HandleFunc("/api/apps/{APP_ID}/identity/devices", handler.ListDevicesHandler).Methods(http.MethodGet)
+	router.HandleFunc("/api/apps/{APP_ID}/identity/devices/{EAS_CLIENT_ID}", handler.GetDeviceHandler).Methods(http.MethodGet)
+	req := httptest.NewRequest(method, path, strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+	return rec
+}
+
+const appPath = "/api/apps/app-1/identity"
+
+func TestNilStoreAnswers400(t *testing.T) {
+	h := NewIdentityHandler(nil)
+	for _, path := range []string{
+		appPath + "/schema",
+		appPath + "/values?key=userId",
+		appPath + "/devices",
+		appPath + "/devices/abc",
+	} {
+		rec := serve(h, http.MethodGet, path, "")
+		require.Equal(t, http.StatusBadRequest, rec.Code, path)
+	}
+}
+
+func TestSchemaCRUDHandlers(t *testing.T) {
+	store := newFakeStore()
+	h := NewIdentityHandler(NewService(store, nil))
+
+	// Empty schema.
+	rec := serve(h, http.MethodGet, appPath+"/schema", "")
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, "application/json", rec.Header().Get("Content-Type"))
+	var listed struct {
+		Keys []schemaKeyResponse `json:"keys"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &listed))
+	require.Empty(t, listed.Keys)
+
+	// Upsert a valid key; omitted maxLength defaults.
+	rec = serve(h, http.MethodPut, appPath+"/schema/userId", `{"type":"string"}`)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var saved schemaKeyResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &saved))
+	require.Equal(t, schemaKeyResponse{Key: "userId", Type: "string", MaxLength: DefaultMaxLength}, saved)
+
+	// Invalid type is a 400 before the store.
+	rec = serve(h, http.MethodPut, appPath+"/schema/bad", `{"type":"uuid"}`)
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.Equal(t, "application/problem+json; charset=utf-8", rec.Header().Get("Content-Type"))
+
+	// Malformed body is a 400.
+	rec = serve(h, http.MethodPut, appPath+"/schema/userId", `not json`)
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+
+	// Delete existing then missing.
+	rec = serve(h, http.MethodDelete, appPath+"/schema/userId", "")
+	require.Equal(t, http.StatusNoContent, rec.Code)
+	rec = serve(h, http.MethodDelete, appPath+"/schema/userId", "")
+	require.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+func TestUpsertSchemaKeyLimitIs409(t *testing.T) {
+	store := newFakeStore()
+	store.upsertErr = ErrTooManySchemaKeys
+	h := NewIdentityHandler(NewService(store, nil))
+	rec := serve(h, http.MethodPut, appPath+"/schema/userId", `{"type":"string"}`)
+	require.Equal(t, http.StatusConflict, rec.Code)
+}
+
+func TestSearchValuesHandler(t *testing.T) {
+	store := newFakeStore()
+	store.values = []ValueCount{{Value: "acme", DeviceCount: 3}, {Value: "globex", DeviceCount: 1}}
+	h := NewIdentityHandler(NewService(store, nil))
+
+	// Missing key is a 400.
+	rec := serve(h, http.MethodGet, appPath+"/values", "")
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+
+	rec = serve(h, http.MethodGet, appPath+"/values?key=tenant&search=ac", "")
+	require.Equal(t, http.StatusOK, rec.Code)
+	var out struct {
+		Values []ValueCount `json:"values"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	require.Equal(t, store.values, out.Values)
+}
+
+func TestGetDeviceHandler(t *testing.T) {
+	store := newFakeStore()
+	now := time.Date(2026, 7, 23, 10, 0, 0, 0, time.UTC)
+	deviceID := uuid.NewString()
+	store.devices[deviceID] = &Device{
+		EASClientID: deviceID,
+		Metadata:    map[string]any{"userId": "u1"},
+		CountryCode: strPtr("FR"),
+		FirstSeenAt: now,
+		LastSeenAt:  now,
+	}
+	h := NewIdentityHandler(NewService(store, nil))
+
+	rec := serve(h, http.MethodGet, appPath+"/devices/"+deviceID, "")
+	require.Equal(t, http.StatusOK, rec.Code)
+	var d deviceResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &d))
+	require.Equal(t, deviceID, d.EasClientId)
+	require.Equal(t, "u1", d.Metadata["userId"])
+	require.Equal(t, "FR", *d.CountryCode)
+	require.Equal(t, "2026-07-23T10:00:00Z", d.LastSeenAt)
+
+	// A missing but well-formed uuid → 404.
+	rec = serve(h, http.MethodGet, appPath+"/devices/"+uuid.NewString(), "")
+	require.Equal(t, http.StatusNotFound, rec.Code)
+
+	// A non-uuid path segment is 404, not a 500 from the store's uuid parse.
+	rec = serve(h, http.MethodGet, appPath+"/devices/not-a-uuid", "")
+	require.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+func TestListDevicesTamperedCursorIs400(t *testing.T) {
+	store := newFakeStore()
+	h := NewIdentityHandler(NewService(store, nil))
+	// Valid base64 + valid timestamp but a non-uuid second segment: must 400
+	// at the handler, never reach the store to 500 on the uuid parse.
+	tampered := base64.RawURLEncoding.EncodeToString([]byte("2026-01-01T00:00:00Z|not-a-uuid"))
+	rec := serve(h, http.MethodGet, appPath+"/devices?cursor="+tampered, "")
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestListDevicesHandlerPaginationAndFilter(t *testing.T) {
+	store := newFakeStore()
+	now := time.Date(2026, 7, 23, 10, 0, 0, 0, time.UTC)
+	deviceID := uuid.NewString()
+	var gotFilter *MetadataFilter
+	var gotCursor *DeviceCursor
+	store.listDevices = func(filter *MetadataFilter, limit int, cursor *DeviceCursor) ([]Device, *DeviceCursor, error) {
+		gotFilter, gotCursor = filter, cursor
+		return []Device{{EASClientID: deviceID, FirstSeenAt: now, LastSeenAt: now}},
+			&DeviceCursor{LastSeenAt: now, EASClientID: deviceID}, nil
+	}
+	h := NewIdentityHandler(NewService(store, nil))
+
+	rec := serve(h, http.MethodGet, appPath+"/devices?filterKey=userId&filterValue=u1", "")
+	require.Equal(t, http.StatusOK, rec.Code)
+	var page struct {
+		Devices    []deviceResponse `json:"devices"`
+		NextCursor *string          `json:"nextCursor"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &page))
+	require.Len(t, page.Devices, 1)
+	require.NotNil(t, page.NextCursor)
+	require.Equal(t, &MetadataFilter{Key: "userId", Value: "u1"}, gotFilter)
+	require.Nil(t, gotCursor, "first page has no cursor")
+
+	// The opaque nextCursor round-trips: sending it back decodes to the same position.
+	rec2 := serve(h, http.MethodGet, appPath+"/devices?cursor="+*page.NextCursor, "")
+	require.Equal(t, http.StatusOK, rec2.Code)
+	require.NotNil(t, gotCursor)
+	require.Equal(t, deviceID, gotCursor.EASClientID)
+	require.True(t, gotCursor.LastSeenAt.Equal(now))
+
+	// A malformed cursor is a 400.
+	rec3 := serve(h, http.MethodGet, appPath+"/devices?cursor=!!!notbase64", "")
+	require.Equal(t, http.StatusBadRequest, rec3.Code)
+}
+
+func TestDeviceCursorRoundTrip(t *testing.T) {
+	now := time.Date(2026, 7, 23, 10, 30, 15, 123456789, time.UTC)
+	deviceID := uuid.NewString()
+	c := &DeviceCursor{LastSeenAt: now, EASClientID: deviceID}
+	encoded := encodeDeviceCursor(c)
+	require.NotNil(t, encoded)
+	decoded, err := decodeDeviceCursor(*encoded)
+	require.NoError(t, err)
+	require.Equal(t, deviceID, decoded.EASClientID)
+	require.True(t, decoded.LastSeenAt.Equal(now))
+
+	require.Nil(t, encodeDeviceCursor(nil))
+	got, err := decodeDeviceCursor("")
+	require.NoError(t, err)
+	require.Nil(t, got)
+}

--- a/ee/identity/handler_test.go
+++ b/ee/identity/handler_test.go
@@ -78,7 +78,7 @@ func serve(handler *IdentityHandler, method, path, body string) *httptest.Respon
 	router.HandleFunc("/api/apps/{APP_ID}/identity/values", handler.SearchValuesHandler).Methods(http.MethodGet)
 	router.HandleFunc("/api/apps/{APP_ID}/identity/devices", handler.ListDevicesHandler).Methods(http.MethodGet)
 	router.HandleFunc("/api/apps/{APP_ID}/identity/devices/{EAS_CLIENT_ID}", handler.GetDeviceHandler).Methods(http.MethodGet)
-	req := httptest.NewRequest(method, path, strings.NewReader(body))
+	req := httptest.NewRequestWithContext(context.Background(), method, path, strings.NewReader(body))
 	rec := httptest.NewRecorder()
 	router.ServeHTTP(rec, req)
 	return rec

--- a/ee/identity/identity.go
+++ b/ee/identity/identity.go
@@ -1,0 +1,208 @@
+// Copyright (c) 2026 Axel Marciano (Mercure Technologies). All rights reserved.
+// This file is governed by the Mercure Technologies Enterprise Edition License
+// (see ee/LICENSE); it is NOT covered by the MIT license of this repository.
+
+// Package identity maps expo-eas-client install UUIDs to operator-defined
+// metadata (userId, tenant, ...), fed by `identify` log events on the observe
+// ingestion route. The dashboard "Identity" section declares which metadata
+// keys are accepted and with which type; everything else coming from the wire
+// is dropped, so hostile payloads are bounded by construction.
+//
+// The package is EE-licensed but NOT license-gated: the feature works on
+// community deployments too.
+package identity
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"regexp"
+	"strconv"
+	"time"
+	"unicode/utf8"
+)
+
+type ValueType string
+
+const (
+	ValueTypeString  ValueType = "string"
+	ValueTypeNumber  ValueType = "number"
+	ValueTypeBoolean ValueType = "boolean"
+)
+
+const (
+	// DefaultMaxLength bounds string values when the operator does not pick a
+	// limit; MaxLengthCeiling bounds what the operator may pick. Identity
+	// metadata is lookup keys, not payloads.
+	DefaultMaxLength = 256
+	MaxLengthCeiling = 1024
+	// MaxSchemaKeys caps the allowlist size. Every declared key multiplies the
+	// worst-case device row that the unauthenticated wire can fill, so the
+	// operator-side bound keeps hostile identifies at ~tens of KB per row
+	// instead of megabytes.
+	MaxSchemaKeys = 100
+)
+
+// Key names stay path-friendly and unambiguous: they end up in API routes,
+// autocomplete queries and JSONB lookups.
+var keyPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9_.-]{0,63}$`)
+
+// KeySpec is one allowlisted metadata key as declared in the dashboard.
+type KeySpec struct {
+	Key       string    `json:"key"`
+	Type      ValueType `json:"type"`
+	MaxLength int       `json:"maxLength"`
+}
+
+// Schema is an app's full allowlist, keyed by metadata key.
+type Schema map[string]KeySpec
+
+func ValidateKeySpec(spec KeySpec) error {
+	if !keyPattern.MatchString(spec.Key) {
+		return fmt.Errorf("invalid metadata key %q: must match %s", spec.Key, keyPattern.String())
+	}
+	switch spec.Type {
+	case ValueTypeString, ValueTypeNumber, ValueTypeBoolean:
+	default:
+		return fmt.Errorf("invalid value type %q for key %q: must be string, number or boolean", spec.Type, spec.Key)
+	}
+	if spec.MaxLength < 1 || spec.MaxLength > MaxLengthCeiling {
+		return fmt.Errorf("invalid max length %d for key %q: must be in [1, %d]", spec.MaxLength, spec.Key, MaxLengthCeiling)
+	}
+	return nil
+}
+
+// Sanitize filters raw wire metadata down to the allowlist. A value survives
+// only when its key is declared and its JSON type matches the declared type;
+// violations drop the single entry, never the whole identify. Oversized
+// strings are dropped rather than truncated (a truncated userId would corrupt
+// the mapping silently). The dropped keys come back for counters and logs.
+//
+// Client-side validation (expo-app-metrics caps) is irrelevant here: anything
+// can be forged with a plain HTTP request, this is the enforcement point.
+func (s Schema) Sanitize(raw map[string]any) (map[string]any, []string) {
+	sanitized := make(map[string]any, len(raw))
+	var dropped []string
+	for key, value := range raw {
+		spec, declared := s[key]
+		if !declared {
+			dropped = append(dropped, key)
+			continue
+		}
+		coerced, ok := coerceValue(spec, value)
+		if !ok {
+			dropped = append(dropped, key)
+			continue
+		}
+		sanitized[key] = coerced
+	}
+	return sanitized, dropped
+}
+
+// coerceValue validates one raw value against its spec. Numbers normalize to
+// float64 (what JSON decoding produces anyway); NaN and infinities are
+// dropped because they do not survive json.Marshal into JSONB.
+func coerceValue(spec KeySpec, value any) (any, bool) {
+	switch spec.Type {
+	case ValueTypeString:
+		str, ok := value.(string)
+		if !ok || utf8.RuneCountInString(str) > spec.MaxLength {
+			return nil, false
+		}
+		return str, true
+	case ValueTypeNumber:
+		num, ok := toFloat(value)
+		if !ok || math.IsNaN(num) || math.IsInf(num, 0) {
+			return nil, false
+		}
+		return num, true
+	case ValueTypeBoolean:
+		b, ok := value.(bool)
+		if !ok {
+			return nil, false
+		}
+		return b, true
+	}
+	return nil, false
+}
+
+func toFloat(value any) (float64, bool) {
+	switch v := value.(type) {
+	case float64:
+		return v, true
+	case float32:
+		return float64(v), true
+	case int:
+		return float64(v), true
+	case int32:
+		return float64(v), true
+	case int64:
+		return float64(v), true
+	case uint32:
+		return float64(v), true
+	case uint64:
+		return float64(v), true
+	case json.Number:
+		// The future ingest path may decode with UseNumber(); support it now
+		// so numbers do not silently start dropping when it does.
+		f, err := v.Float64()
+		return f, err == nil
+	}
+	return 0, false
+}
+
+// RenderValue is the canonical text form of a metadata value, used as the
+// identity_value_stats key. Integral floats render without a decimal part so
+// 42 and 42.0 count as the same value.
+func RenderValue(value any) string {
+	switch v := value.(type) {
+	case string:
+		return v
+	case bool:
+		return strconv.FormatBool(v)
+	case float64:
+		return strconv.FormatFloat(v, 'f', -1, 64)
+	default:
+		// Unreachable after Sanitize; fmt keeps a debuggable fallback.
+		return fmt.Sprintf("%v", v)
+	}
+}
+
+// Device is one install of an app and what we know about it. Timestamps stay
+// time.Time here; formatting belongs to the handlers (same split as ee/audit).
+type Device struct {
+	AppID       string
+	EASClientID string
+	Metadata    map[string]any
+	CountryCode *string
+	City        *string
+	Lat         *float64
+	Lng         *float64
+	FirstSeenAt time.Time
+	LastSeenAt  time.Time
+}
+
+// Geo is an optional enrichment resolved from the request IP (GeoLite2,
+// city-level accuracy: lat/lng is a city centroid, not a device position).
+// Fields are per-field optional because partial resolutions are the norm
+// (country without city is very common); a nil field never overwrites a
+// previously known value, only a present one does.
+type Geo struct {
+	CountryCode *string
+	City        *string
+	Lat         *float64
+	Lng         *float64
+}
+
+// ValueCount is one autocomplete suggestion for a metadata key.
+type ValueCount struct {
+	Value       string `json:"value"`
+	DeviceCount int64  `json:"deviceCount"`
+}
+
+// ApplyResult reports what an identify did: the device after merge, and which
+// incoming keys were rejected by the allowlist.
+type ApplyResult struct {
+	Device      Device
+	DroppedKeys []string
+}

--- a/ee/identity/identity.go
+++ b/ee/identity/identity.go
@@ -14,6 +14,7 @@ package identity
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math"
 	"regexp"
@@ -21,6 +22,10 @@ import (
 	"time"
 	"unicode/utf8"
 )
+
+// ErrTooManySchemaKeys is returned when declaring a new allowlist key would
+// exceed MaxSchemaKeys. The dashboard surfaces it as a 409.
+var ErrTooManySchemaKeys = errors.New("identity schema key limit reached")
 
 type ValueType string
 
@@ -181,6 +186,28 @@ type Device struct {
 	FirstSeenAt time.Time
 	LastSeenAt  time.Time
 }
+
+// DeviceCursor is the keyset position for paginating the device inventory:
+// the (last_seen_at, eas_client_id) of the last row returned. Newest-first.
+type DeviceCursor struct {
+	LastSeenAt  time.Time
+	EASClientID string
+}
+
+// MetadataFilter narrows the device inventory to installs whose metadata
+// contains an exact key/value. String values only for now (userId, tenant,
+// plan — the dominant filter targets); typed number/bool filtering is not
+// wired into the dashboard yet.
+type MetadataFilter struct {
+	Key   string
+	Value string
+}
+
+const (
+	// DefaultDevicesPageSize and MaxDevicesPageSize bound the inventory page.
+	DefaultDevicesPageSize = 50
+	MaxDevicesPageSize     = 200
+)
 
 // Geo is an optional enrichment resolved from the request IP (GeoLite2,
 // city-level accuracy: lat/lng is a city centroid, not a device position).

--- a/ee/identity/identity_test.go
+++ b/ee/identity/identity_test.go
@@ -5,6 +5,7 @@
 package identity
 
 import (
+	"encoding/json"
 	"math"
 	"strings"
 	"testing"
@@ -81,6 +82,16 @@ func TestSanitize(t *testing.T) {
 		sanitized, dropped := schema.Sanitize(map[string]any{"userId": "éèêëàâüö"})
 		require.Empty(t, dropped)
 		require.Equal(t, "éèêëàâüö", sanitized["userId"])
+	})
+
+	t.Run("json.Number and unsigned ints coerce like numbers", func(t *testing.T) {
+		sanitized, dropped := schema.Sanitize(map[string]any{"seats": json.Number("42")})
+		require.Empty(t, dropped)
+		require.Equal(t, float64(42), sanitized["seats"])
+		sanitized, _ = schema.Sanitize(map[string]any{"seats": uint64(7)})
+		require.Equal(t, float64(7), sanitized["seats"])
+		_, dropped = schema.Sanitize(map[string]any{"seats": json.Number("not-a-number")})
+		require.Equal(t, []string{"seats"}, dropped)
 	})
 
 	t.Run("non-finite numbers are dropped", func(t *testing.T) {

--- a/ee/identity/identity_test.go
+++ b/ee/identity/identity_test.go
@@ -1,0 +1,115 @@
+// Copyright (c) 2026 Axel Marciano (Mercure Technologies). All rights reserved.
+// This file is governed by the Mercure Technologies Enterprise Edition License
+// (see ee/LICENSE); it is NOT covered by the MIT license of this repository.
+
+package identity
+
+import (
+	"math"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateKeySpec(t *testing.T) {
+	valid := []KeySpec{
+		{Key: "userId", Type: ValueTypeString, MaxLength: 256},
+		{Key: "is_internal", Type: ValueTypeBoolean, MaxLength: 1},
+		{Key: "org.tier-2", Type: ValueTypeNumber, MaxLength: 64},
+	}
+	for _, spec := range valid {
+		require.NoError(t, ValidateKeySpec(spec), spec.Key)
+	}
+
+	invalid := []KeySpec{
+		{Key: "", Type: ValueTypeString, MaxLength: 10},
+		{Key: "_leading", Type: ValueTypeString, MaxLength: 10},
+		{Key: "has space", Type: ValueTypeString, MaxLength: 10},
+		{Key: strings.Repeat("k", 65), Type: ValueTypeString, MaxLength: 10},
+		{Key: "ok", Type: ValueType("uuid"), MaxLength: 10},
+		{Key: "ok", Type: ValueTypeString, MaxLength: 0},
+		{Key: "ok", Type: ValueTypeString, MaxLength: MaxLengthCeiling + 1},
+	}
+	for _, spec := range invalid {
+		require.Error(t, ValidateKeySpec(spec), "%+v", spec)
+	}
+}
+
+func TestSanitize(t *testing.T) {
+	schema := Schema{
+		"userId":     {Key: "userId", Type: ValueTypeString, MaxLength: 8},
+		"seats":      {Key: "seats", Type: ValueTypeNumber, MaxLength: DefaultMaxLength},
+		"isInternal": {Key: "isInternal", Type: ValueTypeBoolean, MaxLength: DefaultMaxLength},
+	}
+
+	sanitized, dropped := schema.Sanitize(map[string]any{
+		"userId":     "user_42",
+		"seats":      int64(12),
+		"isInternal": true,
+		// Undeclared key: the 50k-keys attack lands here and dies here.
+		"junk": "x",
+		// Declared key, wrong JSON type.
+		"seats2":     "12",
+		"userIdLong": "way too long for the limit",
+	})
+	require.Equal(t, map[string]any{
+		"userId":     "user_42",
+		"seats":      float64(12),
+		"isInternal": true,
+	}, sanitized)
+	require.ElementsMatch(t, []string{"junk", "seats2", "userIdLong"}, dropped)
+
+	t.Run("type mismatches drop the entry only", func(t *testing.T) {
+		sanitized, dropped := schema.Sanitize(map[string]any{
+			"userId":     42,                       // number into string
+			"seats":      "12",                     // string into number
+			"isInternal": "true",                   // string into boolean
+			"junk":       map[string]any{"a": "b"}, // containers never pass
+		})
+		require.Empty(t, sanitized)
+		require.Len(t, dropped, 4)
+	})
+
+	t.Run("oversized strings are dropped, not truncated", func(t *testing.T) {
+		sanitized, dropped := schema.Sanitize(map[string]any{"userId": "123456789"})
+		require.Empty(t, sanitized)
+		require.Equal(t, []string{"userId"}, dropped)
+	})
+
+	t.Run("max length counts runes, not bytes", func(t *testing.T) {
+		sanitized, dropped := schema.Sanitize(map[string]any{"userId": "éèêëàâüö"})
+		require.Empty(t, dropped)
+		require.Equal(t, "éèêëàâüö", sanitized["userId"])
+	})
+
+	t.Run("non-finite numbers are dropped", func(t *testing.T) {
+		for _, v := range []float64{math.NaN(), math.Inf(1), math.Inf(-1)} {
+			sanitized, dropped := schema.Sanitize(map[string]any{"seats": v})
+			require.Empty(t, sanitized)
+			require.Equal(t, []string{"seats"}, dropped)
+		}
+	})
+
+	t.Run("null and nil never pass", func(t *testing.T) {
+		sanitized, dropped := schema.Sanitize(map[string]any{"userId": nil})
+		require.Empty(t, sanitized)
+		require.Equal(t, []string{"userId"}, dropped)
+	})
+
+	t.Run("empty schema drops everything", func(t *testing.T) {
+		sanitized, dropped := Schema{}.Sanitize(map[string]any{"userId": "x"})
+		require.Empty(t, sanitized)
+		require.Equal(t, []string{"userId"}, dropped)
+	})
+}
+
+func TestRenderValue(t *testing.T) {
+	require.Equal(t, "acme", RenderValue("acme"))
+	require.Equal(t, "true", RenderValue(true))
+	require.Equal(t, "false", RenderValue(false))
+	// Integral floats render without a decimal part: 42 identified from JS and
+	// 42.0 re-decoded from JSONB must count as the same value.
+	require.Equal(t, "42", RenderValue(float64(42)))
+	require.Equal(t, "42.5", RenderValue(42.5))
+}

--- a/ee/identity/metrics.go
+++ b/ee/identity/metrics.go
@@ -1,0 +1,67 @@
+// Copyright (c) 2026 Axel Marciano (Mercure Technologies). All rights reserved.
+// This file is governed by the Mercure Technologies Enterprise Edition License
+// (see ee/LICENSE); it is NOT covered by the MIT license of this repository.
+
+package identity
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// Identity is expected to be quiet in steady state (per-session, mostly
+// no-op re-identifies); these metrics exist to see the two failure modes
+// coming: latency creep on the hot stat rows during install storms (the
+// signal to move stats to a batched aggregator), and a chronic dropped-keys
+// count (a client sending keys the operator never declared).
+var (
+	identityApplyDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "identity_apply_duration_seconds",
+			Help:    "Duration of identity operations against the store, by operation and outcome",
+			Buckets: []float64{0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5},
+		},
+		// outcome keeps fast-failing hostile requests from skewing the
+		// latency percentiles of legitimate operations down.
+		[]string{"op", "outcome"},
+	)
+
+	identityApplyVec = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "identity_apply_total",
+			Help: "Identity operations applied, by appId, operation and outcome",
+		},
+		[]string{"appId", "op", "outcome"},
+	)
+
+	identityDroppedKeysVec = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "identity_dropped_keys_total",
+			Help: "Metadata keys rejected by the allowlist, by appId",
+		},
+		[]string{"appId"},
+	)
+)
+
+func init() {
+	prometheus.MustRegister(identityApplyDuration, identityApplyVec, identityDroppedKeysVec)
+}
+
+func observeApply(appID string, op Op, err error, droppedKeys int, elapsed time.Duration) {
+	outcome := "ok"
+	if err != nil {
+		outcome = "error"
+		// The appId only becomes trustworthy once the store accepted it (the
+		// device FK guarantees a real app). On errors it may be any string a
+		// hostile client sprayed on the unauthenticated wire, and every unique
+		// label value allocates a permanent child series in the registry, so
+		// error counts are aggregated under a sentinel instead.
+		appID = "unknown"
+	}
+	identityApplyDuration.WithLabelValues(string(op), outcome).Observe(elapsed.Seconds())
+	identityApplyVec.WithLabelValues(appID, string(op), outcome).Inc()
+	if droppedKeys > 0 && err == nil {
+		identityDroppedKeysVec.WithLabelValues(appID).Add(float64(droppedKeys))
+	}
+}

--- a/ee/identity/record.go
+++ b/ee/identity/record.go
@@ -1,0 +1,97 @@
+// Copyright (c) 2026 Axel Marciano (Mercure Technologies). All rights reserved.
+// This file is governed by the Mercure Technologies Enterprise Edition License
+// (see ee/LICENSE); it is NOT covered by the MIT license of this repository.
+
+package identity
+
+// Identity consumes log records already decoded by the transport (ee/observe
+// owns the OTLP wire format); this file owns the identity-side conventions:
+// which record attributes form the operation payload.
+
+// The two record attributes the client SDK reserves on every log record; they
+// are envelope, not payload, and are stripped before sanitization. Stripping
+// is identity policy and lives here on purpose: keyPattern allows dots, so an
+// operator could declare a metadata key literally named "event.name", and the
+// future ClickHouse flattener will keep these as real columns rather than
+// strip them. recordEventNameKey mirrors observe.EventNameKey by necessity
+// (the observe → identity dependency forbids importing it back).
+const (
+	recordEventNameKey = "event.name"
+	recordSessionIDKey = "session.id"
+)
+
+// unsetKeysAttributeKey is the record attribute carrying the key names of a
+// $unset: `logEvent('$unset', { attributes: { keys: ['userId'] } })`. An
+// explicit array attribute because null values never leave the stock SDK
+// (dropped client-side), so "set to null" cannot express removal.
+const unsetKeysAttributeKey = "keys"
+
+// RequestFromRecord builds an identity Request from one decoded log record.
+// The second return is false when the record carries nothing applicable
+// (a $unset without keys, a $set with an empty payload): skipping those saves
+// a store transaction that would be a no-op. attributes ownership transfers
+// to the request (the map is mutated to strip the envelope keys).
+func RequestFromRecord(appID string, easClientID string, op Op, attributes map[string]any, remoteIP string) (Request, bool) {
+	req := Request{AppID: appID, EASClientID: easClientID, Op: op, RemoteIP: remoteIP}
+	switch op {
+	case OpUnset:
+		rawKeys, _ := attributes[unsetKeysAttributeKey].([]any)
+		for _, rawKey := range rawKeys {
+			if key, ok := rawKey.(string); ok && key != "" {
+				req.UnsetKeys = append(req.UnsetKeys, key)
+			}
+		}
+		if len(req.UnsetKeys) == 0 {
+			return Request{}, false
+		}
+	case OpSet, OpSetOnce:
+		delete(attributes, recordEventNameKey)
+		delete(attributes, recordSessionIDKey)
+		if len(attributes) == 0 {
+			return Request{}, false
+		}
+		req.Attributes = attributes
+	default:
+		return Request{}, false
+	}
+	return req, true
+}
+
+// CoalesceRequests folds ADJACENT same-op requests of the same device into
+// one store transaction: the SDK ships its whole backlog in a single batch,
+// so several $set of one device commonly arrive together. Only adjacent ops
+// merge; folding across a different op in between would reorder the timeline
+// ($set(a) $unset(a) $set(a) must not collapse).
+func CoalesceRequests(requests []Request) []Request {
+	if len(requests) < 2 {
+		return requests
+	}
+	coalesced := make([]Request, 0, len(requests))
+	lastByDevice := make(map[string]int)
+	for _, req := range requests {
+		if idx, seen := lastByDevice[req.EASClientID]; seen && coalesced[idx].Op == req.Op {
+			previous := &coalesced[idx]
+			switch req.Op {
+			case OpUnset:
+				previous.UnsetKeys = append(previous.UnsetKeys, req.UnsetKeys...)
+				continue
+			case OpSet:
+				for key, value := range req.Attributes {
+					previous.Attributes[key] = value
+				}
+				continue
+			case OpSetOnce:
+				// First value wins within the fold, matching the store.
+				for key, value := range req.Attributes {
+					if _, held := previous.Attributes[key]; !held {
+						previous.Attributes[key] = value
+					}
+				}
+				continue
+			}
+		}
+		coalesced = append(coalesced, req)
+		lastByDevice[req.EASClientID] = len(coalesced) - 1
+	}
+	return coalesced
+}

--- a/ee/identity/record.go
+++ b/ee/identity/record.go
@@ -57,20 +57,23 @@ func RequestFromRecord(appID string, easClientID string, op Op, attributes map[s
 	return req, true
 }
 
-// CoalesceRequests folds ADJACENT same-op requests of the same device into
-// one store transaction: the SDK ships its whole backlog in a single batch,
-// so several $set of one device commonly arrive together. Only adjacent ops
-// merge; folding across a different op in between would reorder the timeline
-// ($set(a) $unset(a) $set(a) must not collapse).
+// CoalesceRequests folds ADJACENT same-op requests of the same installation
+// into one store transaction: the SDK ships its whole backlog in a single
+// batch, so several $set operations commonly arrive together. Only adjacent
+// operations from the same app and device merge; folding across another
+// request would reorder the event timeline.
 func CoalesceRequests(requests []Request) []Request {
 	if len(requests) < 2 {
 		return requests
 	}
 	coalesced := make([]Request, 0, len(requests))
-	lastByDevice := make(map[string]int)
 	for _, req := range requests {
-		if idx, seen := lastByDevice[req.EASClientID]; seen && coalesced[idx].Op == req.Op {
-			previous := &coalesced[idx]
+		if len(coalesced) > 0 {
+			previous := &coalesced[len(coalesced)-1]
+			if previous.AppID != req.AppID || previous.EASClientID != req.EASClientID || previous.Op != req.Op {
+				coalesced = append(coalesced, req)
+				continue
+			}
 			switch req.Op {
 			case OpUnset:
 				previous.UnsetKeys = append(previous.UnsetKeys, req.UnsetKeys...)
@@ -91,7 +94,6 @@ func CoalesceRequests(requests []Request) []Request {
 			}
 		}
 		coalesced = append(coalesced, req)
-		lastByDevice[req.EASClientID] = len(coalesced) - 1
 	}
 	return coalesced
 }

--- a/ee/identity/record_test.go
+++ b/ee/identity/record_test.go
@@ -1,0 +1,110 @@
+// Copyright (c) 2026 Axel Marciano (Mercure Technologies). All rights reserved.
+// This file is governed by the Mercure Technologies Enterprise Edition License
+// (see ee/LICENSE); it is NOT covered by the MIT license of this repository.
+
+package identity
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRequestFromRecord(t *testing.T) {
+	t.Run("set strips the envelope and keeps the payload", func(t *testing.T) {
+		req, ok := RequestFromRecord("app", "client", OpSet, map[string]any{
+			"event.name": "$set",
+			"session.id": "aaaa",
+			"userId":     "u1",
+		}, "203.0.113.7")
+		require.True(t, ok)
+		require.Equal(t, OpSet, req.Op)
+		require.Equal(t, map[string]any{"userId": "u1"}, req.Attributes)
+		require.Equal(t, "203.0.113.7", req.RemoteIP)
+	})
+
+	t.Run("set with only envelope is skipped", func(t *testing.T) {
+		_, ok := RequestFromRecord("app", "client", OpSet, map[string]any{
+			"event.name": "$set",
+			"session.id": "aaaa",
+		}, "")
+		require.False(t, ok)
+	})
+
+	t.Run("unset reads its keys array and tolerates junk entries", func(t *testing.T) {
+		req, ok := RequestFromRecord("app", "client", OpUnset, map[string]any{
+			"event.name": "$unset",
+			"keys":       []any{"userId", "", 42, "tenant"},
+		}, "")
+		require.True(t, ok)
+		require.Equal(t, []string{"userId", "tenant"}, req.UnsetKeys)
+	})
+
+	t.Run("unset without usable keys is skipped", func(t *testing.T) {
+		_, ok := RequestFromRecord("app", "client", OpUnset, map[string]any{"event.name": "$unset"}, "")
+		require.False(t, ok)
+		_, ok = RequestFromRecord("app", "client", OpUnset, map[string]any{"keys": "userId"}, "")
+		require.False(t, ok)
+	})
+
+	t.Run("unknown op is skipped", func(t *testing.T) {
+		_, ok := RequestFromRecord("app", "client", Op("identify"), map[string]any{"userId": "u1"}, "")
+		require.False(t, ok)
+	})
+}
+
+func TestCoalesceRequests(t *testing.T) {
+	set := func(device string, kv map[string]any) Request {
+		return Request{AppID: "app", EASClientID: device, Op: OpSet, Attributes: kv}
+	}
+
+	t.Run("adjacent sets of one device fold, later keys win", func(t *testing.T) {
+		out := CoalesceRequests([]Request{
+			set("d1", map[string]any{"a": "1", "b": "1"}),
+			set("d1", map[string]any{"b": "2"}),
+			set("d2", map[string]any{"a": "x"}),
+		})
+		require.Len(t, out, 2)
+		require.Equal(t, map[string]any{"a": "1", "b": "2"}, out[0].Attributes)
+		require.Equal(t, "d2", out[1].EASClientID)
+	})
+
+	t.Run("a different op in between blocks the fold", func(t *testing.T) {
+		out := CoalesceRequests([]Request{
+			set("d1", map[string]any{"a": "1"}),
+			{AppID: "app", EASClientID: "d1", Op: OpUnset, UnsetKeys: []string{"a"}},
+			set("d1", map[string]any{"a": "2"}),
+		})
+		require.Len(t, out, 3, "$set $unset $set must not collapse")
+	})
+
+	t.Run("set_once folds with first value winning", func(t *testing.T) {
+		out := CoalesceRequests([]Request{
+			{AppID: "app", EASClientID: "d1", Op: OpSetOnce, Attributes: map[string]any{"ref": "organic"}},
+			{AppID: "app", EASClientID: "d1", Op: OpSetOnce, Attributes: map[string]any{"ref": "paid", "v": "1"}},
+		})
+		require.Len(t, out, 1)
+		require.Equal(t, map[string]any{"ref": "organic", "v": "1"}, out[0].Attributes)
+	})
+
+	t.Run("adjacent unsets append keys", func(t *testing.T) {
+		out := CoalesceRequests([]Request{
+			{AppID: "app", EASClientID: "d1", Op: OpUnset, UnsetKeys: []string{"a"}},
+			{AppID: "app", EASClientID: "d1", Op: OpUnset, UnsetKeys: []string{"b"}},
+		})
+		require.Len(t, out, 1)
+		require.Equal(t, []string{"a", "b"}, out[0].UnsetKeys)
+	})
+
+	t.Run("interleaved devices still fold per device", func(t *testing.T) {
+		out := CoalesceRequests([]Request{
+			set("d1", map[string]any{"a": "1"}),
+			set("d2", map[string]any{"a": "x"}),
+			set("d1", map[string]any{"b": "2"}),
+		})
+		// d1's two sets fold even though d2 sits between them: "adjacent" is
+		// per device, order across devices carries no meaning.
+		require.Len(t, out, 2)
+		require.Equal(t, map[string]any{"a": "1", "b": "2"}, out[0].Attributes)
+	})
+}

--- a/ee/identity/record_test.go
+++ b/ee/identity/record_test.go
@@ -96,15 +96,23 @@ func TestCoalesceRequests(t *testing.T) {
 		require.Equal(t, []string{"a", "b"}, out[0].UnsetKeys)
 	})
 
-	t.Run("interleaved devices still fold per device", func(t *testing.T) {
+	t.Run("interleaved devices preserve cross-device order", func(t *testing.T) {
 		out := CoalesceRequests([]Request{
 			set("d1", map[string]any{"a": "1"}),
 			set("d2", map[string]any{"a": "x"}),
 			set("d1", map[string]any{"b": "2"}),
 		})
-		// d1's two sets fold even though d2 sits between them: "adjacent" is
-		// per device, order across devices carries no meaning.
+		require.Len(t, out, 3)
+		require.Equal(t, map[string]any{"a": "1"}, out[0].Attributes)
+		require.Equal(t, "d2", out[1].EASClientID)
+		require.Equal(t, map[string]any{"b": "2"}, out[2].Attributes)
+	})
+
+	t.Run("same client id in different apps does not fold", func(t *testing.T) {
+		out := CoalesceRequests([]Request{
+			set("d1", map[string]any{"a": "1"}),
+			{AppID: "other-app", EASClientID: "d1", Op: OpSet, Attributes: map[string]any{"b": "2"}},
+		})
 		require.Len(t, out, 2)
-		require.Equal(t, map[string]any{"a": "1", "b": "2"}, out[0].Attributes)
 	})
 }

--- a/ee/identity/service.go
+++ b/ee/identity/service.go
@@ -33,27 +33,68 @@ func IsIdentityOp(eventName string) bool {
 	return false
 }
 
-// IdentityMutator is what the service needs from the store; narrow on purpose
-// so tests can fake it and future stores stay honest about the contract.
+// IdentityMutator is the ingest write path: $set / $set_once / $unset with
+// geo enrichment. Kept as its own interface so the vocabulary stays explicit.
 type IdentityMutator interface {
 	ApplySet(ctx context.Context, appID string, easClientID string, raw map[string]any, geo *Geo) (ApplyResult, error)
 	ApplySetOnce(ctx context.Context, appID string, easClientID string, raw map[string]any, geo *Geo) (ApplyResult, error)
 	ApplyUnset(ctx context.Context, appID string, easClientID string, keys []string, geo *Geo) (ApplyResult, error)
 }
 
-// Service applies identity operations coming off the wire: resolve the
-// request IP into a geo enrichment, dispatch to the store, and account for
-// what happened in Prometheus. The ingest route owns transport concerns
-// (decoding, response codes); the service owns semantics.
+// Store is the full data surface the service needs: the ingest write path plus
+// the dashboard read/CRUD queries. *PostgresIdentityStore implements it. The
+// service is the single owner of the store, so both the ingest route and the
+// dashboard handler go through it — which is also where license gating will
+// sit (one gate for the whole feature).
+type Store interface {
+	IdentityMutator
+	GetSchema(ctx context.Context, appID string) (Schema, error)
+	UpsertSchemaKey(ctx context.Context, appID string, spec KeySpec) (KeySpec, error)
+	DeleteSchemaKey(ctx context.Context, appID string, key string) (bool, error)
+	SearchMetadataValues(ctx context.Context, appID string, key string, search string, limit int) ([]ValueCount, error)
+	ListDevices(ctx context.Context, appID string, filter *MetadataFilter, limit int, cursor *DeviceCursor) ([]Device, *DeviceCursor, error)
+	GetDevice(ctx context.Context, appID string, easClientID string) (*Device, error)
+}
+
+// Service owns the store and the geo resolver. The ingest route calls Apply;
+// the dashboard handler calls the read/CRUD methods below. The route/handler
+// own transport (decoding, response codes); the service owns semantics.
 type Service struct {
-	store IdentityMutator
+	store Store
 	geo   GeoResolver
 }
 
 // NewService builds the identity service. geo may be nil: identity works
 // without a GeoLite2 database, devices simply stay unlocated.
-func NewService(store IdentityMutator, geo GeoResolver) *Service {
+func NewService(store Store, geo GeoResolver) *Service {
 	return &Service{store: store, geo: geo}
+}
+
+// Dashboard read/CRUD surface. Thin delegations today; the license gate will
+// live here in the enterprise batch so it covers ingest and dashboard alike.
+
+func (s *Service) GetSchema(ctx context.Context, appID string) (Schema, error) {
+	return s.store.GetSchema(ctx, appID)
+}
+
+func (s *Service) UpsertSchemaKey(ctx context.Context, appID string, spec KeySpec) (KeySpec, error) {
+	return s.store.UpsertSchemaKey(ctx, appID, spec)
+}
+
+func (s *Service) DeleteSchemaKey(ctx context.Context, appID string, key string) (bool, error) {
+	return s.store.DeleteSchemaKey(ctx, appID, key)
+}
+
+func (s *Service) SearchMetadataValues(ctx context.Context, appID string, key string, search string, limit int) ([]ValueCount, error) {
+	return s.store.SearchMetadataValues(ctx, appID, key, search, limit)
+}
+
+func (s *Service) ListDevices(ctx context.Context, appID string, filter *MetadataFilter, limit int, cursor *DeviceCursor) ([]Device, *DeviceCursor, error) {
+	return s.store.ListDevices(ctx, appID, filter, limit, cursor)
+}
+
+func (s *Service) GetDevice(ctx context.Context, appID string, easClientID string) (*Device, error) {
+	return s.store.GetDevice(ctx, appID, easClientID)
 }
 
 // Request is one identity operation extracted from a log event.

--- a/ee/identity/service.go
+++ b/ee/identity/service.go
@@ -1,0 +1,103 @@
+// Copyright (c) 2026 Axel Marciano (Mercure Technologies). All rights reserved.
+// This file is governed by the Mercure Technologies Enterprise Edition License
+// (see ee/LICENSE); it is NOT covered by the MIT license of this repository.
+
+package identity
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+// Op is one identity operation as carried on the wire (the log event name).
+// The vocabulary mirrors PostHog/Mixpanel/Amplitude on purpose: $set merges,
+// $set_once only fills absent keys, $unset removes. There is deliberately no
+// reset(): the eas_client_id cannot rotate, so logout is expressed as $unset.
+type Op string
+
+const (
+	OpSet     Op = "$set"
+	OpSetOnce Op = "$set_once"
+	OpUnset   Op = "$unset"
+)
+
+// IsIdentityOp reports whether a log event name is one of the identity
+// operations; the ingest route uses it to route identity events away from the
+// telemetry path.
+func IsIdentityOp(eventName string) bool {
+	switch Op(eventName) {
+	case OpSet, OpSetOnce, OpUnset:
+		return true
+	}
+	return false
+}
+
+// IdentityMutator is what the service needs from the store; narrow on purpose
+// so tests can fake it and future stores stay honest about the contract.
+type IdentityMutator interface {
+	ApplySet(ctx context.Context, appID string, easClientID string, raw map[string]any, geo *Geo) (ApplyResult, error)
+	ApplySetOnce(ctx context.Context, appID string, easClientID string, raw map[string]any, geo *Geo) (ApplyResult, error)
+	ApplyUnset(ctx context.Context, appID string, easClientID string, keys []string, geo *Geo) (ApplyResult, error)
+}
+
+// Service applies identity operations coming off the wire: resolve the
+// request IP into a geo enrichment, dispatch to the store, and account for
+// what happened in Prometheus. The ingest route owns transport concerns
+// (decoding, response codes); the service owns semantics.
+type Service struct {
+	store IdentityMutator
+	geo   GeoResolver
+}
+
+// NewService builds the identity service. geo may be nil: identity works
+// without a GeoLite2 database, devices simply stay unlocated.
+func NewService(store IdentityMutator, geo GeoResolver) *Service {
+	return &Service{store: store, geo: geo}
+}
+
+// Request is one identity operation extracted from a log event.
+type Request struct {
+	AppID       string
+	EASClientID string
+	Op          Op
+	// Attributes carries the key/value payload of $set and $set_once.
+	Attributes map[string]any
+	// UnsetKeys carries the key names of $unset.
+	UnsetKeys []string
+	// RemoteIP is the already-resolved client IP of the HTTP request that
+	// delivered the batch (proxy handling happens upstream).
+	RemoteIP string
+}
+
+func (s *Service) Apply(ctx context.Context, req Request) (ApplyResult, error) {
+	start := time.Now()
+
+	var geo *Geo
+	if s.geo != nil && req.RemoteIP != "" {
+		geo = s.geo.Resolve(req.RemoteIP)
+	}
+
+	var result ApplyResult
+	var err error
+	switch req.Op {
+	case OpSet:
+		result, err = s.store.ApplySet(ctx, req.AppID, req.EASClientID, req.Attributes, geo)
+	case OpSetOnce:
+		result, err = s.store.ApplySetOnce(ctx, req.AppID, req.EASClientID, req.Attributes, geo)
+	case OpUnset:
+		result, err = s.store.ApplyUnset(ctx, req.AppID, req.EASClientID, req.UnsetKeys, geo)
+	default:
+		// The op sentinel keeps the label set bounded: req.Op is wire input
+		// here, not one of our constants.
+		err = fmt.Errorf("unknown identity op %q", req.Op)
+		observeApply(req.AppID, Op("unknown"), err, 0, time.Since(start))
+		return ApplyResult{}, err
+	}
+
+	observeApply(req.AppID, req.Op, err, len(result.DroppedKeys), time.Since(start))
+	if err != nil {
+		return ApplyResult{}, err
+	}
+	return result, nil
+}

--- a/ee/identity/service_test.go
+++ b/ee/identity/service_test.go
@@ -13,7 +13,10 @@ import (
 )
 
 // fakeMutator records the exact call the service dispatched, geo included.
+// The embedded Store supplies the dashboard query methods (unused here) so the
+// fake satisfies identity.Store.
 type fakeMutator struct {
+	Store
 	calledOp Op
 	raw      map[string]any
 	keys     []string

--- a/ee/identity/service_test.go
+++ b/ee/identity/service_test.go
@@ -1,0 +1,124 @@
+// Copyright (c) 2026 Axel Marciano (Mercure Technologies). All rights reserved.
+// This file is governed by the Mercure Technologies Enterprise Edition License
+// (see ee/LICENSE); it is NOT covered by the MIT license of this repository.
+
+package identity
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeMutator records the exact call the service dispatched, geo included.
+type fakeMutator struct {
+	calledOp Op
+	raw      map[string]any
+	keys     []string
+	geo      *Geo
+}
+
+func (f *fakeMutator) ApplySet(_ context.Context, _ string, _ string, raw map[string]any, geo *Geo) (ApplyResult, error) {
+	f.calledOp, f.raw, f.geo = OpSet, raw, geo
+	return ApplyResult{}, nil
+}
+
+func (f *fakeMutator) ApplySetOnce(_ context.Context, _ string, _ string, raw map[string]any, geo *Geo) (ApplyResult, error) {
+	f.calledOp, f.raw, f.geo = OpSetOnce, raw, geo
+	return ApplyResult{}, nil
+}
+
+func (f *fakeMutator) ApplyUnset(_ context.Context, _ string, _ string, keys []string, geo *Geo) (ApplyResult, error) {
+	f.calledOp, f.keys, f.geo = OpUnset, keys, geo
+	return ApplyResult{}, nil
+}
+
+type fakeResolver struct {
+	geo    *Geo
+	lastIP string
+}
+
+func (f *fakeResolver) Resolve(ip string) *Geo {
+	f.lastIP = ip
+	return f.geo
+}
+
+func TestIsIdentityOp(t *testing.T) {
+	require.True(t, IsIdentityOp("$set"))
+	require.True(t, IsIdentityOp("$set_once"))
+	require.True(t, IsIdentityOp("$unset"))
+	require.False(t, IsIdentityOp("identify"))
+	require.False(t, IsIdentityOp("exception"))
+	require.False(t, IsIdentityOp(""))
+}
+
+func TestServiceDispatchAndGeo(t *testing.T) {
+	appID, clientID := uuid.NewString(), uuid.NewString()
+	geo := &Geo{CountryCode: strPtr("FR")}
+
+	t.Run("set carries attributes and resolved geo", func(t *testing.T) {
+		mutator := &fakeMutator{}
+		resolver := &fakeResolver{geo: geo}
+		service := NewService(mutator, resolver)
+		_, err := service.Apply(context.Background(), Request{
+			AppID: appID, EASClientID: clientID, Op: OpSet,
+			Attributes: map[string]any{"userId": "u1"},
+			RemoteIP:   "203.0.113.7",
+		})
+		require.NoError(t, err)
+		require.Equal(t, OpSet, mutator.calledOp)
+		require.Equal(t, map[string]any{"userId": "u1"}, mutator.raw)
+		require.Equal(t, geo, mutator.geo)
+		require.Equal(t, "203.0.113.7", resolver.lastIP)
+	})
+
+	t.Run("set_once and unset dispatch to their store paths", func(t *testing.T) {
+		mutator := &fakeMutator{}
+		service := NewService(mutator, nil)
+		_, err := service.Apply(context.Background(), Request{AppID: appID, EASClientID: clientID, Op: OpSetOnce, Attributes: map[string]any{"a": "b"}})
+		require.NoError(t, err)
+		require.Equal(t, OpSetOnce, mutator.calledOp)
+
+		_, err = service.Apply(context.Background(), Request{AppID: appID, EASClientID: clientID, Op: OpUnset, UnsetKeys: []string{"userId"}})
+		require.NoError(t, err)
+		require.Equal(t, OpUnset, mutator.calledOp)
+		require.Equal(t, []string{"userId"}, mutator.keys)
+	})
+
+	t.Run("nil resolver and empty ip mean nil geo", func(t *testing.T) {
+		mutator := &fakeMutator{}
+		service := NewService(mutator, nil)
+		_, err := service.Apply(context.Background(), Request{AppID: appID, EASClientID: clientID, Op: OpSet})
+		require.NoError(t, err)
+		require.Nil(t, mutator.geo)
+
+		resolver := &fakeResolver{geo: geo}
+		service = NewService(mutator, resolver)
+		_, err = service.Apply(context.Background(), Request{AppID: appID, EASClientID: clientID, Op: OpSet})
+		require.NoError(t, err)
+		require.Empty(t, resolver.lastIP, "resolver must not be called without an IP")
+	})
+
+	t.Run("unknown op is an error", func(t *testing.T) {
+		service := NewService(&fakeMutator{}, nil)
+		_, err := service.Apply(context.Background(), Request{AppID: appID, EASClientID: clientID, Op: Op("identify")})
+		require.ErrorContains(t, err, "unknown identity op")
+	})
+}
+
+func TestGeoLite2ResolverGuards(t *testing.T) {
+	// Constructor surfaces a clear error on a missing database.
+	_, err := NewGeoLite2Resolver("/nonexistent/GeoLite2-City.mmdb")
+	require.Error(t, err)
+
+	// The IP guards run before any database access, so an empty resolver is
+	// safe: garbage, private, loopback and unspecified IPs resolve to nil.
+	resolver := &GeoLite2Resolver{}
+	for _, ip := range []string{"", "not-an-ip", "10.1.2.3", "192.168.1.1", "127.0.0.1", "0.0.0.0", "::1", "fd00::1"} {
+		require.Nil(t, resolver.Resolve(ip), "ip %q", ip)
+	}
+	// Public IP with no database still resolves to nil instead of panicking.
+	require.Nil(t, resolver.Resolve("203.0.113.7"))
+}

--- a/ee/identity/store_postgres.go
+++ b/ee/identity/store_postgres.go
@@ -104,7 +104,7 @@ func (s *PostgresIdentityStore) UpsertSchemaKey(ctx context.Context, appID strin
 			return fmt.Errorf("listing identity schema: %w", err)
 		}
 		if _, declared := schemaFromRows(existing)[spec.Key]; !declared && len(existing) >= MaxSchemaKeys {
-			return fmt.Errorf("identity schema is limited to %d keys per app", MaxSchemaKeys)
+			return ErrTooManySchemaKeys
 		}
 		row, err := q.UpsertIdentitySchemaKey(ctx, pgdb.UpsertIdentitySchemaKeyParams{
 			AppID:     appUUID,
@@ -358,6 +358,68 @@ func (s *PostgresIdentityStore) GetDevice(ctx context.Context, appID string, eas
 		return nil, err
 	}
 	return &device, nil
+}
+
+// ListDevices returns one page of the device inventory, newest-seen first,
+// keyset-paginated. A nil cursor starts at the first page; the returned cursor
+// is nil on the last page. An optional filter narrows to installs whose
+// metadata contains the key/value (served by the GIN index).
+func (s *PostgresIdentityStore) ListDevices(ctx context.Context, appID string, filter *MetadataFilter, limit int, cursor *DeviceCursor) ([]Device, *DeviceCursor, error) {
+	appUUID, err := toPgUUID(appID)
+	if err != nil {
+		return nil, nil, err
+	}
+	switch {
+	case limit < 1:
+		limit = DefaultDevicesPageSize
+	case limit > MaxDevicesPageSize:
+		limit = MaxDevicesPageSize
+	}
+
+	params := pgdb.ListDevicesParams{
+		AppID: appUUID,
+		// One extra row detects whether a next page exists.
+		Lim: int32(limit + 1),
+	}
+	if filter != nil {
+		filterJSON, err := json.Marshal(map[string]string{filter.Key: filter.Value})
+		if err != nil {
+			return nil, nil, fmt.Errorf("marshalling device filter: %w", err)
+		}
+		params.Filter = filterJSON
+	}
+	if cursor != nil {
+		params.BeforeLastSeen = pgtype.Timestamptz{Time: cursor.LastSeenAt, Valid: true}
+		cursorUUID, err := toPgUUID(cursor.EASClientID)
+		if err != nil {
+			return nil, nil, err
+		}
+		params.BeforeClientID = cursorUUID
+	}
+
+	rows, err := s.engine.Queries.ListDevices(ctx, params)
+	if err != nil {
+		return nil, nil, fmt.Errorf("listing devices: %w", err)
+	}
+
+	var next *DeviceCursor
+	if len(rows) > limit {
+		rows = rows[:limit]
+		last := rows[len(rows)-1]
+		next = &DeviceCursor{
+			LastSeenAt:  last.LastSeenAt.Time,
+			EASClientID: uuid.UUID(last.EasClientID.Bytes).String(),
+		}
+	}
+	devices := make([]Device, 0, len(rows))
+	for _, row := range rows {
+		device, err := deviceFromRow(row)
+		if err != nil {
+			return nil, nil, err
+		}
+		devices = append(devices, device)
+	}
+	return devices, next, nil
 }
 
 // SearchMetadataValues is the autocomplete behind searchMetadata: top values

--- a/ee/identity/store_postgres.go
+++ b/ee/identity/store_postgres.go
@@ -10,6 +10,7 @@ import (
 	"expo-open-ota/internal/database"
 	"expo-open-ota/internal/database/postgres/pgdb"
 	"fmt"
+	"sort"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgtype"
@@ -23,6 +24,9 @@ func NewPostgresIdentityStore(engine *database.Engine) *PostgresIdentityStore {
 	return &PostgresIdentityStore{engine: engine}
 }
 
+// toPgUUID differs from store.ToPgUUID on purpose: identity ids come from the
+// unauthenticated wire, so a parse failure must surface as an error the caller
+// can act on, not as a zero UUID silently written to the database.
 func toPgUUID(id string) (pgtype.UUID, error) {
 	parsed, err := uuid.Parse(id)
 	if err != nil {
@@ -33,6 +37,14 @@ func toPgUUID(id string) (pgtype.UUID, error) {
 
 func specFromRow(row pgdb.IdentitySchema) KeySpec {
 	return KeySpec{Key: row.Key, Type: ValueType(row.ValueType), MaxLength: int(row.MaxLength)}
+}
+
+func schemaFromRows(rows []pgdb.IdentitySchema) Schema {
+	schema := make(Schema, len(rows))
+	for _, row := range rows {
+		schema[row.Key] = specFromRow(row)
+	}
+	return schema
 }
 
 func deviceFromRow(row pgdb.DeviceIdentity) (Device, error) {
@@ -50,8 +62,8 @@ func deviceFromRow(row pgdb.DeviceIdentity) (Device, error) {
 		City:        row.City,
 		Lat:         row.Lat,
 		Lng:         row.Lng,
-		FirstSeenAt: row.FirstSeenAt.Time.UTC().Format("2006-01-02T15:04:05.000Z"),
-		LastSeenAt:  row.LastSeenAt.Time.UTC().Format("2006-01-02T15:04:05.000Z"),
+		FirstSeenAt: row.FirstSeenAt.Time,
+		LastSeenAt:  row.LastSeenAt.Time,
 	}, nil
 }
 
@@ -67,11 +79,7 @@ func (s *PostgresIdentityStore) GetSchema(ctx context.Context, appID string) (Sc
 	if err != nil {
 		return nil, fmt.Errorf("listing identity schema: %w", err)
 	}
-	schema := make(Schema, len(rows))
-	for _, row := range rows {
-		schema[row.Key] = specFromRow(row)
-	}
-	return schema, nil
+	return schemaFromRows(rows), nil
 }
 
 func (s *PostgresIdentityStore) UpsertSchemaKey(ctx context.Context, appID string, spec KeySpec) (KeySpec, error) {
@@ -85,16 +93,35 @@ func (s *PostgresIdentityStore) UpsertSchemaKey(ctx context.Context, appID strin
 	if err != nil {
 		return KeySpec{}, err
 	}
-	row, err := s.engine.Queries.UpsertIdentitySchemaKey(ctx, pgdb.UpsertIdentitySchemaKeyParams{
-		AppID:     appUUID,
-		Key:       spec.Key,
-		ValueType: string(spec.Type),
-		MaxLength: int32(spec.MaxLength),
+
+	var saved KeySpec
+	err = s.engine.WithTx(ctx, func(q *pgdb.Queries) error {
+		// The key-count cap runs in the same transaction as the insert so two
+		// concurrent declarations cannot both slip under the limit. Updating
+		// an already-declared key is always allowed, even at the cap.
+		existing, err := q.ListIdentitySchemaKeys(ctx, appUUID)
+		if err != nil {
+			return fmt.Errorf("listing identity schema: %w", err)
+		}
+		if _, declared := schemaFromRows(existing)[spec.Key]; !declared && len(existing) >= MaxSchemaKeys {
+			return fmt.Errorf("identity schema is limited to %d keys per app", MaxSchemaKeys)
+		}
+		row, err := q.UpsertIdentitySchemaKey(ctx, pgdb.UpsertIdentitySchemaKeyParams{
+			AppID:     appUUID,
+			Key:       spec.Key,
+			ValueType: string(spec.Type),
+			MaxLength: int32(spec.MaxLength),
+		})
+		if err != nil {
+			return fmt.Errorf("upserting identity schema key: %w", err)
+		}
+		saved = specFromRow(row)
+		return nil
 	})
 	if err != nil {
-		return KeySpec{}, fmt.Errorf("upserting identity schema key: %w", err)
+		return KeySpec{}, err
 	}
-	return specFromRow(row), nil
+	return saved, nil
 }
 
 // DeleteSchemaKey removes a key from the allowlist and wipes its autocomplete
@@ -106,24 +133,35 @@ func (s *PostgresIdentityStore) DeleteSchemaKey(ctx context.Context, appID strin
 	if err != nil {
 		return false, err
 	}
-	tx, err := s.engine.DB.Begin(ctx)
+	var deleted bool
+	err = s.engine.WithTx(ctx, func(q *pgdb.Queries) error {
+		tag, err := q.DeleteIdentitySchemaKey(ctx, pgdb.DeleteIdentitySchemaKeyParams{AppID: appUUID, Key: key})
+		if err != nil {
+			return fmt.Errorf("deleting identity schema key: %w", err)
+		}
+		if err := q.DeleteIdentityValueStatsForKey(ctx, pgdb.DeleteIdentityValueStatsForKeyParams{AppID: appUUID, Key: key}); err != nil {
+			return fmt.Errorf("deleting identity value stats: %w", err)
+		}
+		deleted = tag.RowsAffected() > 0
+		return nil
+	})
 	if err != nil {
-		return false, fmt.Errorf("beginning delete schema key tx: %w", err)
+		return false, err
 	}
-	defer func() { _ = tx.Rollback(ctx) }()
-	qtx := s.engine.Queries.WithTx(tx)
+	return deleted, nil
+}
 
-	tag, err := qtx.DeleteIdentitySchemaKey(ctx, pgdb.DeleteIdentitySchemaKeyParams{AppID: appUUID, Key: key})
-	if err != nil {
-		return false, fmt.Errorf("deleting identity schema key: %w", err)
-	}
-	if err := qtx.DeleteIdentityValueStatsForKey(ctx, pgdb.DeleteIdentityValueStatsForKeyParams{AppID: appUUID, Key: key}); err != nil {
-		return false, fmt.Errorf("deleting identity value stats: %w", err)
-	}
-	if err := tx.Commit(ctx); err != nil {
-		return false, fmt.Errorf("committing delete schema key tx: %w", err)
-	}
-	return tag.RowsAffected() > 0, nil
+// statOp is one pending change to identity_value_stats. Ops are executed in
+// deterministic (key, value) order across the whole transaction: increments
+// and decrements both take row locks held until commit, and Go map iteration
+// order is random, so unordered execution lets two identifies of DIFFERENT
+// devices that share stat rows (same tenant, same plan...) acquire those locks
+// in opposite orders and deadlock. Sorting by key alone is not enough: A
+// moving tenant acme->globex and B moving globex->acme would still cross.
+type statOp struct {
+	key       string
+	value     string
+	decrement bool
 }
 
 // ApplyIdentify runs one identify against the store: sanitize the raw wire
@@ -142,101 +180,108 @@ func (s *PostgresIdentityStore) ApplyIdentify(ctx context.Context, appID string,
 		return ApplyResult{}, err
 	}
 
-	tx, err := s.engine.DB.Begin(ctx)
-	if err != nil {
-		return ApplyResult{}, fmt.Errorf("beginning identify tx: %w", err)
-	}
-	defer func() { _ = tx.Rollback(ctx) }()
-	qtx := s.engine.Queries.WithTx(tx)
-
-	// The schema read shares the transaction so a concurrent allowlist change
-	// cannot produce a merge that mixes two versions of the schema.
-	schemaRows, err := qtx.ListIdentitySchemaKeys(ctx, appUUID)
-	if err != nil {
-		return ApplyResult{}, fmt.Errorf("listing identity schema: %w", err)
-	}
-	schema := make(Schema, len(schemaRows))
-	for _, row := range schemaRows {
-		schema[row.Key] = specFromRow(row)
-	}
-	sanitized, dropped := schema.Sanitize(raw)
-
-	if err := qtx.EnsureDeviceIdentity(ctx, pgdb.EnsureDeviceIdentityParams{AppID: appUUID, EasClientID: clientUUID}); err != nil {
-		return ApplyResult{}, fmt.Errorf("ensuring device row: %w", err)
-	}
-	current, err := qtx.GetDeviceIdentityForUpdate(ctx, pgdb.GetDeviceIdentityForUpdateParams{AppID: appUUID, EasClientID: clientUUID})
-	if err != nil {
-		return ApplyResult{}, fmt.Errorf("locking device row: %w", err)
-	}
-	previous := map[string]any{}
-	if len(current.Metadata) > 0 {
-		if err := json.Unmarshal(current.Metadata, &previous); err != nil {
-			return ApplyResult{}, fmt.Errorf("corrupt device metadata: %w", err)
+	var result ApplyResult
+	err = s.engine.WithTx(ctx, func(q *pgdb.Queries) error {
+		// The schema read shares the transaction so a concurrent allowlist
+		// change cannot produce a merge mixing two versions of the schema.
+		schemaRows, err := q.ListIdentitySchemaKeys(ctx, appUUID)
+		if err != nil {
+			return fmt.Errorf("listing identity schema: %w", err)
 		}
-	}
+		sanitized, dropped := schemaFromRows(schemaRows).Sanitize(raw)
 
-	merged := make(map[string]any, len(previous)+len(sanitized))
-	for key, value := range previous {
-		merged[key] = value
-	}
-	for key, value := range sanitized {
-		merged[key] = value
-	}
-	mergedJSON, err := json.Marshal(merged)
-	if err != nil {
-		return ApplyResult{}, fmt.Errorf("marshalling merged metadata: %w", err)
-	}
+		if err := q.EnsureDeviceIdentity(ctx, pgdb.EnsureDeviceIdentityParams{AppID: appUUID, EasClientID: clientUUID}); err != nil {
+			return fmt.Errorf("ensuring device row: %w", err)
+		}
+		current, err := q.GetDeviceIdentityForUpdate(ctx, pgdb.GetDeviceIdentityForUpdateParams{AppID: appUUID, EasClientID: clientUUID})
+		if err != nil {
+			return fmt.Errorf("locking device row: %w", err)
+		}
+		previous := map[string]any{}
+		if len(current.Metadata) > 0 {
+			if err := json.Unmarshal(current.Metadata, &previous); err != nil {
+				return fmt.Errorf("corrupt device metadata: %w", err)
+			}
+		}
 
-	params := pgdb.UpdateDeviceIdentityParams{
-		AppID:       appUUID,
-		EasClientID: clientUUID,
-		Metadata:    mergedJSON,
-	}
-	if geo != nil {
-		params.CountryCode = &geo.CountryCode
-		params.City = &geo.City
-		params.Lat = &geo.Lat
-		params.Lng = &geo.Lng
-	}
-	updated, err := qtx.UpdateDeviceIdentity(ctx, params)
-	if err != nil {
-		return ApplyResult{}, fmt.Errorf("updating device row: %w", err)
-	}
+		merged := make(map[string]any, len(previous)+len(sanitized))
+		for key, value := range previous {
+			merged[key] = value
+		}
+		var ops []statOp
+		for key, value := range sanitized {
+			merged[key] = value
+			newRendered := RenderValue(value)
+			if oldValue, existed := previous[key]; existed {
+				oldRendered := RenderValue(oldValue)
+				if oldRendered == newRendered {
+					continue
+				}
+				ops = append(ops, statOp{key: key, value: oldRendered, decrement: true})
+			}
+			ops = append(ops, statOp{key: key, value: newRendered})
+		}
+		mergedJSON, err := json.Marshal(merged)
+		if err != nil {
+			return fmt.Errorf("marshalling merged metadata: %w", err)
+		}
 
-	// Value stats: a key newly set counts its value in; a changed value moves
-	// the device from the old value's count to the new one. Comparison happens
-	// on the rendered form, the same normalization the stats table stores.
-	for key, value := range sanitized {
-		newRendered := RenderValue(value)
-		oldValue, existed := previous[key]
-		if existed {
-			oldRendered := RenderValue(oldValue)
-			if oldRendered == newRendered {
+		params := pgdb.UpdateDeviceIdentityParams{
+			AppID:       appUUID,
+			EasClientID: clientUUID,
+			Metadata:    mergedJSON,
+		}
+		if geo != nil {
+			params.CountryCode = geo.CountryCode
+			params.City = geo.City
+			params.Lat = geo.Lat
+			params.Lng = geo.Lng
+		}
+		updated, err := q.UpdateDeviceIdentity(ctx, params)
+		if err != nil {
+			return fmt.Errorf("updating device row: %w", err)
+		}
+
+		sort.Slice(ops, func(i, j int) bool {
+			if ops[i].key != ops[j].key {
+				return ops[i].key < ops[j].key
+			}
+			if ops[i].value != ops[j].value {
+				return ops[i].value < ops[j].value
+			}
+			return ops[i].decrement
+		})
+		for _, op := range ops {
+			if op.decrement {
+				decParams := pgdb.DecrementIdentityValueStatParams{AppID: appUUID, Key: op.key, Value: op.value}
+				if err := q.DecrementIdentityValueStat(ctx, decParams); err != nil {
+					return fmt.Errorf("decrementing value stat: %w", err)
+				}
+				// Prune immediately: same row, already locked by the
+				// decrement, so this cannot introduce a new lock ordering.
+				delParams := pgdb.DeleteZeroIdentityValueStatsParams{AppID: appUUID, Key: op.key, Value: op.value}
+				if err := q.DeleteZeroIdentityValueStats(ctx, delParams); err != nil {
+					return fmt.Errorf("pruning zero value stat: %w", err)
+				}
 				continue
 			}
-			decParams := pgdb.DecrementIdentityValueStatParams{AppID: appUUID, Key: key, Value: oldRendered}
-			if err := qtx.DecrementIdentityValueStat(ctx, decParams); err != nil {
-				return ApplyResult{}, fmt.Errorf("decrementing value stat: %w", err)
-			}
-			delParams := pgdb.DeleteZeroIdentityValueStatsParams{AppID: appUUID, Key: key, Value: oldRendered}
-			if err := qtx.DeleteZeroIdentityValueStats(ctx, delParams); err != nil {
-				return ApplyResult{}, fmt.Errorf("pruning zero value stat: %w", err)
+			incParams := pgdb.IncrementIdentityValueStatParams{AppID: appUUID, Key: op.key, Value: op.value}
+			if err := q.IncrementIdentityValueStat(ctx, incParams); err != nil {
+				return fmt.Errorf("incrementing value stat: %w", err)
 			}
 		}
-		incParams := pgdb.IncrementIdentityValueStatParams{AppID: appUUID, Key: key, Value: newRendered}
-		if err := qtx.IncrementIdentityValueStat(ctx, incParams); err != nil {
-			return ApplyResult{}, fmt.Errorf("incrementing value stat: %w", err)
-		}
-	}
 
-	if err := tx.Commit(ctx); err != nil {
-		return ApplyResult{}, fmt.Errorf("committing identify tx: %w", err)
-	}
-	device, err := deviceFromRow(updated)
+		device, err := deviceFromRow(updated)
+		if err != nil {
+			return err
+		}
+		result = ApplyResult{Device: device, DroppedKeys: dropped}
+		return nil
+	})
 	if err != nil {
 		return ApplyResult{}, err
 	}
-	return ApplyResult{Device: device, DroppedKeys: dropped}, nil
+	return result, nil
 }
 
 // GetDevice returns nil when the install was never seen.
@@ -264,15 +309,36 @@ func (s *PostgresIdentityStore) GetDevice(ctx context.Context, appID string, eas
 }
 
 // SearchMetadataValues is the autocomplete behind searchMetadata: top values
-// of one key ranked by device count, optionally narrowed by a substring.
+// of one key ranked by device count, optionally narrowed by a substring. The
+// two arms are separate prepared statements on purpose (see queries.sql).
 func (s *PostgresIdentityStore) SearchMetadataValues(ctx context.Context, appID string, key string, search string, limit int) ([]ValueCount, error) {
 	appUUID, err := toPgUUID(appID)
 	if err != nil {
 		return nil, err
 	}
-	if limit < 1 || limit > 100 {
+	switch {
+	case limit < 1:
 		limit = 20
+	case limit > 100:
+		limit = 100
 	}
+
+	if search == "" {
+		rows, err := s.engine.Queries.TopIdentityValues(ctx, pgdb.TopIdentityValuesParams{
+			AppID:      appUUID,
+			Key:        key,
+			MaxResults: int32(limit),
+		})
+		if err != nil {
+			return nil, fmt.Errorf("listing top identity values: %w", err)
+		}
+		values := make([]ValueCount, 0, len(rows))
+		for _, row := range rows {
+			values = append(values, ValueCount{Value: row.Value, DeviceCount: row.DeviceCount})
+		}
+		return values, nil
+	}
+
 	rows, err := s.engine.Queries.SearchIdentityValues(ctx, pgdb.SearchIdentityValuesParams{
 		AppID:      appUUID,
 		Key:        key,

--- a/ee/identity/store_postgres.go
+++ b/ee/identity/store_postgres.go
@@ -7,6 +7,7 @@ package identity
 import (
 	"context"
 	"encoding/json"
+	"expo-open-ota/ee/licensing"
 	"expo-open-ota/internal/database"
 	"expo-open-ota/internal/database/postgres/pgdb"
 	"fmt"
@@ -16,12 +17,40 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
+const (
+	// FreeDeviceLimit is how many devices an app may keep WITHOUT a valid
+	// enterprise license. Beyond it, the oldest-by-last_seen device is evicted
+	// when a new one is registered, so an unlicensed app tracks its 1000 most
+	// recently active installs. A valid license lifts the cap entirely.
+	FreeDeviceLimit = 1000
+	// maxEvictPerWrite bounds how many devices a single write evicts, so a
+	// large app that just lost its license shrinks toward the cap over many
+	// registrations instead of in one giant transaction.
+	maxEvictPerWrite = 50
+)
+
 type PostgresIdentityStore struct {
 	engine *database.Engine
+	// licenseValid reports whether a valid enterprise license is active. Nil
+	// or true means no cap; false activates the device-limit eviction. It
+	// defaults to licensing.IsEnterprise, imported directly ON PURPOSE: the gate
+	// must live in EE code so bypassing the cap means editing an EE-licensed
+	// file, not swapping a func handed in from the MIT composition root. A field
+	// so same-package tests flip it without a signed key.
+	licenseValid func() bool
+	// deviceLimit is the free-tier cap, defaulting to FreeDeviceLimit; a field
+	// so tests can shrink it instead of seeding a thousand rows.
+	deviceLimit int
 }
 
 func NewPostgresIdentityStore(engine *database.Engine) *PostgresIdentityStore {
-	return &PostgresIdentityStore{engine: engine}
+	return &PostgresIdentityStore{engine: engine, licenseValid: licensing.IsEnterprise, deviceLimit: FreeDeviceLimit}
+}
+
+// capActive reports whether the free-tier device cap should be enforced: only
+// when a license check is configured and it says unlicensed.
+func (s *PostgresIdentityStore) capActive() bool {
+	return s.licenseValid != nil && !s.licenseValid()
 }
 
 // toPgUUID differs from store.ToPgUUID on purpose: identity ids come from the
@@ -223,7 +252,8 @@ func (s *PostgresIdentityStore) mutate(ctx context.Context, appID string, easCli
 			sanitized, dropped = schemaFromRows(schemaRows).Sanitize(raw)
 		}
 
-		if err := q.EnsureDeviceIdentity(ctx, pgdb.EnsureDeviceIdentityParams{AppID: appUUID, EasClientID: clientUUID}); err != nil {
+		inserted, err := q.EnsureDeviceIdentity(ctx, pgdb.EnsureDeviceIdentityParams{AppID: appUUID, EasClientID: clientUUID})
+		if err != nil {
 			return fmt.Errorf("ensuring device row: %w", err)
 		}
 		current, err := q.GetDeviceIdentityForUpdate(ctx, pgdb.GetDeviceIdentityForUpdateParams{AppID: appUUID, EasClientID: clientUUID})
@@ -294,6 +324,43 @@ func (s *PostgresIdentityStore) mutate(ctx context.Context, appID string, easCli
 			return fmt.Errorf("updating device row: %w", err)
 		}
 
+		// Free-tier cap: only a genuine new-device insert can push an app over
+		// the limit, so the count + eviction run solely on that path. Evicted
+		// devices' stat decrements fold into the same sorted op sequence below,
+		// keeping the deadlock-free (key,value) ordering; their rows are
+		// deleted after the stats settle.
+		var evictIDs []pgtype.UUID
+		if inserted == 1 && s.capActive() {
+			count, err := q.CountDevices(ctx, appUUID)
+			if err != nil {
+				return fmt.Errorf("counting devices: %w", err)
+			}
+			if overflow := count - int64(s.deviceLimit); overflow > 0 {
+				limit := overflow
+				if limit > maxEvictPerWrite {
+					limit = maxEvictPerWrite
+				}
+				oldest, err := q.OldestDevicesExcluding(ctx, pgdb.OldestDevicesExcludingParams{
+					AppID: appUUID, EasClientID: clientUUID, Lim: int32(limit),
+				})
+				if err != nil {
+					return fmt.Errorf("selecting devices to evict: %w", err)
+				}
+				for _, row := range oldest {
+					evictIDs = append(evictIDs, row.EasClientID)
+					evictedMeta := map[string]any{}
+					if len(row.Metadata) > 0 {
+						if err := json.Unmarshal(row.Metadata, &evictedMeta); err != nil {
+							return fmt.Errorf("corrupt evicted device metadata: %w", err)
+						}
+					}
+					for key, value := range evictedMeta {
+						ops = append(ops, statOp{key: key, value: RenderValue(value), decrement: true})
+					}
+				}
+			}
+		}
+
 		sort.Slice(ops, func(i, j int) bool {
 			if ops[i].key != ops[j].key {
 				return ops[i].key < ops[j].key
@@ -320,6 +387,13 @@ func (s *PostgresIdentityStore) mutate(ctx context.Context, appID string, easCli
 			incParams := pgdb.IncrementIdentityValueStatParams{AppID: appUUID, Key: op.key, Value: op.value}
 			if err := q.IncrementIdentityValueStat(ctx, incParams); err != nil {
 				return fmt.Errorf("incrementing value stat: %w", err)
+			}
+		}
+
+		// Delete the evicted device rows now that their stats are decremented.
+		if len(evictIDs) > 0 {
+			if err := q.DeleteDevices(ctx, pgdb.DeleteDevicesParams{AppID: appUUID, ClientIds: evictIDs}); err != nil {
+				return fmt.Errorf("deleting evicted devices: %w", err)
 			}
 		}
 

--- a/ee/identity/store_postgres.go
+++ b/ee/identity/store_postgres.go
@@ -164,13 +164,41 @@ type statOp struct {
 	decrement bool
 }
 
-// ApplyIdentify runs one identify against the store: sanitize the raw wire
-// metadata against the allowlist, merge it into the device row (per-key merge,
-// incoming keys win), refresh geo when provided, and keep the per-value
-// device counts in sync. Everything happens in one transaction with the
-// device row locked, so concurrent identifies of the same install serialize
-// and the counts never drift from the merges that produced them.
-func (s *PostgresIdentityStore) ApplyIdentify(ctx context.Context, appID string, easClientID string, raw map[string]any, geo *Geo) (ApplyResult, error) {
+type mutationKind int
+
+const (
+	mutationSet mutationKind = iota
+	mutationSetOnce
+	mutationUnset
+)
+
+// ApplySet runs one $set against the store: sanitize the raw wire metadata
+// against the allowlist, merge it into the device row (per-key merge, incoming
+// keys win), refresh geo when provided, and keep the per-value device counts
+// in sync. Everything happens in one transaction with the device row locked,
+// so concurrent identifies of the same install serialize and the counts never
+// drift from the merges that produced them.
+func (s *PostgresIdentityStore) ApplySet(ctx context.Context, appID string, easClientID string, raw map[string]any, geo *Geo) (ApplyResult, error) {
+	return s.mutate(ctx, appID, easClientID, mutationSet, raw, nil, geo)
+}
+
+// ApplySetOnce is $set_once: a sanitized key is written only when the device
+// does not hold it yet; keys already present are silently left untouched
+// (same contract as PostHog/Mixpanel/Amplitude).
+func (s *PostgresIdentityStore) ApplySetOnce(ctx context.Context, appID string, easClientID string, raw map[string]any, geo *Geo) (ApplyResult, error) {
+	return s.mutate(ctx, appID, easClientID, mutationSetOnce, raw, nil, geo)
+}
+
+// ApplyUnset removes keys from the device and moves the stat counts down.
+// Keys the device does not hold are ignored, which also bounds the work to
+// the (schema-capped) size of the device's metadata no matter how many keys
+// a hostile payload lists. Unset works even for keys since removed from the
+// allowlist: it is the cleanup path.
+func (s *PostgresIdentityStore) ApplyUnset(ctx context.Context, appID string, easClientID string, keys []string, geo *Geo) (ApplyResult, error) {
+	return s.mutate(ctx, appID, easClientID, mutationUnset, nil, keys, geo)
+}
+
+func (s *PostgresIdentityStore) mutate(ctx context.Context, appID string, easClientID string, kind mutationKind, raw map[string]any, unsetKeys []string, geo *Geo) (ApplyResult, error) {
 	appUUID, err := toPgUUID(appID)
 	if err != nil {
 		return ApplyResult{}, err
@@ -182,13 +210,18 @@ func (s *PostgresIdentityStore) ApplyIdentify(ctx context.Context, appID string,
 
 	var result ApplyResult
 	err = s.engine.WithTx(ctx, func(q *pgdb.Queries) error {
-		// The schema read shares the transaction so a concurrent allowlist
-		// change cannot produce a merge mixing two versions of the schema.
-		schemaRows, err := q.ListIdentitySchemaKeys(ctx, appUUID)
-		if err != nil {
-			return fmt.Errorf("listing identity schema: %w", err)
+		var sanitized map[string]any
+		var dropped []string
+		if kind != mutationUnset {
+			// The schema read shares the transaction so a concurrent allowlist
+			// change cannot produce a merge mixing two versions of the schema.
+			// Unset skips it entirely: it bypasses the allowlist by design.
+			schemaRows, err := q.ListIdentitySchemaKeys(ctx, appUUID)
+			if err != nil {
+				return fmt.Errorf("listing identity schema: %w", err)
+			}
+			sanitized, dropped = schemaFromRows(schemaRows).Sanitize(raw)
 		}
-		sanitized, dropped := schemaFromRows(schemaRows).Sanitize(raw)
 
 		if err := q.EnsureDeviceIdentity(ctx, pgdb.EnsureDeviceIdentityParams{AppID: appUUID, EasClientID: clientUUID}); err != nil {
 			return fmt.Errorf("ensuring device row: %w", err)
@@ -209,17 +242,36 @@ func (s *PostgresIdentityStore) ApplyIdentify(ctx context.Context, appID string,
 			merged[key] = value
 		}
 		var ops []statOp
-		for key, value := range sanitized {
-			merged[key] = value
-			newRendered := RenderValue(value)
-			if oldValue, existed := previous[key]; existed {
-				oldRendered := RenderValue(oldValue)
-				if oldRendered == newRendered {
+		switch kind {
+		case mutationSet, mutationSetOnce:
+			for key, value := range sanitized {
+				oldValue, existed := previous[key]
+				if kind == mutationSetOnce && existed {
 					continue
 				}
-				ops = append(ops, statOp{key: key, value: oldRendered, decrement: true})
+				merged[key] = value
+				newRendered := RenderValue(value)
+				if existed {
+					oldRendered := RenderValue(oldValue)
+					if oldRendered == newRendered {
+						continue
+					}
+					ops = append(ops, statOp{key: key, value: oldRendered, decrement: true})
+				}
+				ops = append(ops, statOp{key: key, value: newRendered})
 			}
-			ops = append(ops, statOp{key: key, value: newRendered})
+		case mutationUnset:
+			for _, key := range unsetKeys {
+				oldValue, existed := previous[key]
+				if !existed {
+					continue
+				}
+				// Also remove from previous so a duplicated key in the payload
+				// cannot decrement the same stat row twice.
+				delete(previous, key)
+				delete(merged, key)
+				ops = append(ops, statOp{key: key, value: RenderValue(oldValue), decrement: true})
+			}
 		}
 		mergedJSON, err := json.Marshal(merged)
 		if err != nil {

--- a/ee/identity/store_postgres.go
+++ b/ee/identity/store_postgres.go
@@ -1,0 +1,290 @@
+// Copyright (c) 2026 Axel Marciano (Mercure Technologies). All rights reserved.
+// This file is governed by the Mercure Technologies Enterprise Edition License
+// (see ee/LICENSE); it is NOT covered by the MIT license of this repository.
+
+package identity
+
+import (
+	"context"
+	"encoding/json"
+	"expo-open-ota/internal/database"
+	"expo-open-ota/internal/database/postgres/pgdb"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+type PostgresIdentityStore struct {
+	engine *database.Engine
+}
+
+func NewPostgresIdentityStore(engine *database.Engine) *PostgresIdentityStore {
+	return &PostgresIdentityStore{engine: engine}
+}
+
+func toPgUUID(id string) (pgtype.UUID, error) {
+	parsed, err := uuid.Parse(id)
+	if err != nil {
+		return pgtype.UUID{}, fmt.Errorf("invalid uuid %q: %w", id, err)
+	}
+	return pgtype.UUID{Bytes: parsed, Valid: true}, nil
+}
+
+func specFromRow(row pgdb.IdentitySchema) KeySpec {
+	return KeySpec{Key: row.Key, Type: ValueType(row.ValueType), MaxLength: int(row.MaxLength)}
+}
+
+func deviceFromRow(row pgdb.DeviceIdentity) (Device, error) {
+	metadata := map[string]any{}
+	if len(row.Metadata) > 0 {
+		if err := json.Unmarshal(row.Metadata, &metadata); err != nil {
+			return Device{}, fmt.Errorf("corrupt device metadata: %w", err)
+		}
+	}
+	return Device{
+		AppID:       uuid.UUID(row.AppID.Bytes).String(),
+		EASClientID: uuid.UUID(row.EasClientID.Bytes).String(),
+		Metadata:    metadata,
+		CountryCode: row.CountryCode,
+		City:        row.City,
+		Lat:         row.Lat,
+		Lng:         row.Lng,
+		FirstSeenAt: row.FirstSeenAt.Time.UTC().Format("2006-01-02T15:04:05.000Z"),
+		LastSeenAt:  row.LastSeenAt.Time.UTC().Format("2006-01-02T15:04:05.000Z"),
+	}, nil
+}
+
+// GetSchema returns the app's allowlist. An app with no declared keys gets an
+// empty schema, under which Sanitize drops everything: identity is opt-in per
+// app by declaring keys, there is no implicit passthrough.
+func (s *PostgresIdentityStore) GetSchema(ctx context.Context, appID string) (Schema, error) {
+	appUUID, err := toPgUUID(appID)
+	if err != nil {
+		return nil, err
+	}
+	rows, err := s.engine.Queries.ListIdentitySchemaKeys(ctx, appUUID)
+	if err != nil {
+		return nil, fmt.Errorf("listing identity schema: %w", err)
+	}
+	schema := make(Schema, len(rows))
+	for _, row := range rows {
+		schema[row.Key] = specFromRow(row)
+	}
+	return schema, nil
+}
+
+func (s *PostgresIdentityStore) UpsertSchemaKey(ctx context.Context, appID string, spec KeySpec) (KeySpec, error) {
+	if spec.MaxLength == 0 {
+		spec.MaxLength = DefaultMaxLength
+	}
+	if err := ValidateKeySpec(spec); err != nil {
+		return KeySpec{}, err
+	}
+	appUUID, err := toPgUUID(appID)
+	if err != nil {
+		return KeySpec{}, err
+	}
+	row, err := s.engine.Queries.UpsertIdentitySchemaKey(ctx, pgdb.UpsertIdentitySchemaKeyParams{
+		AppID:     appUUID,
+		Key:       spec.Key,
+		ValueType: string(spec.Type),
+		MaxLength: int32(spec.MaxLength),
+	})
+	if err != nil {
+		return KeySpec{}, fmt.Errorf("upserting identity schema key: %w", err)
+	}
+	return specFromRow(row), nil
+}
+
+// DeleteSchemaKey removes a key from the allowlist and wipes its autocomplete
+// stats in the same transaction, so searchMetadata never suggests values of a
+// removed key. Values already merged into device metadata are left in place;
+// they stop being accepted and stop being suggested.
+func (s *PostgresIdentityStore) DeleteSchemaKey(ctx context.Context, appID string, key string) (bool, error) {
+	appUUID, err := toPgUUID(appID)
+	if err != nil {
+		return false, err
+	}
+	tx, err := s.engine.DB.Begin(ctx)
+	if err != nil {
+		return false, fmt.Errorf("beginning delete schema key tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	qtx := s.engine.Queries.WithTx(tx)
+
+	tag, err := qtx.DeleteIdentitySchemaKey(ctx, pgdb.DeleteIdentitySchemaKeyParams{AppID: appUUID, Key: key})
+	if err != nil {
+		return false, fmt.Errorf("deleting identity schema key: %w", err)
+	}
+	if err := qtx.DeleteIdentityValueStatsForKey(ctx, pgdb.DeleteIdentityValueStatsForKeyParams{AppID: appUUID, Key: key}); err != nil {
+		return false, fmt.Errorf("deleting identity value stats: %w", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return false, fmt.Errorf("committing delete schema key tx: %w", err)
+	}
+	return tag.RowsAffected() > 0, nil
+}
+
+// ApplyIdentify runs one identify against the store: sanitize the raw wire
+// metadata against the allowlist, merge it into the device row (per-key merge,
+// incoming keys win), refresh geo when provided, and keep the per-value
+// device counts in sync. Everything happens in one transaction with the
+// device row locked, so concurrent identifies of the same install serialize
+// and the counts never drift from the merges that produced them.
+func (s *PostgresIdentityStore) ApplyIdentify(ctx context.Context, appID string, easClientID string, raw map[string]any, geo *Geo) (ApplyResult, error) {
+	appUUID, err := toPgUUID(appID)
+	if err != nil {
+		return ApplyResult{}, err
+	}
+	clientUUID, err := toPgUUID(easClientID)
+	if err != nil {
+		return ApplyResult{}, err
+	}
+
+	tx, err := s.engine.DB.Begin(ctx)
+	if err != nil {
+		return ApplyResult{}, fmt.Errorf("beginning identify tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	qtx := s.engine.Queries.WithTx(tx)
+
+	// The schema read shares the transaction so a concurrent allowlist change
+	// cannot produce a merge that mixes two versions of the schema.
+	schemaRows, err := qtx.ListIdentitySchemaKeys(ctx, appUUID)
+	if err != nil {
+		return ApplyResult{}, fmt.Errorf("listing identity schema: %w", err)
+	}
+	schema := make(Schema, len(schemaRows))
+	for _, row := range schemaRows {
+		schema[row.Key] = specFromRow(row)
+	}
+	sanitized, dropped := schema.Sanitize(raw)
+
+	if err := qtx.EnsureDeviceIdentity(ctx, pgdb.EnsureDeviceIdentityParams{AppID: appUUID, EasClientID: clientUUID}); err != nil {
+		return ApplyResult{}, fmt.Errorf("ensuring device row: %w", err)
+	}
+	current, err := qtx.GetDeviceIdentityForUpdate(ctx, pgdb.GetDeviceIdentityForUpdateParams{AppID: appUUID, EasClientID: clientUUID})
+	if err != nil {
+		return ApplyResult{}, fmt.Errorf("locking device row: %w", err)
+	}
+	previous := map[string]any{}
+	if len(current.Metadata) > 0 {
+		if err := json.Unmarshal(current.Metadata, &previous); err != nil {
+			return ApplyResult{}, fmt.Errorf("corrupt device metadata: %w", err)
+		}
+	}
+
+	merged := make(map[string]any, len(previous)+len(sanitized))
+	for key, value := range previous {
+		merged[key] = value
+	}
+	for key, value := range sanitized {
+		merged[key] = value
+	}
+	mergedJSON, err := json.Marshal(merged)
+	if err != nil {
+		return ApplyResult{}, fmt.Errorf("marshalling merged metadata: %w", err)
+	}
+
+	params := pgdb.UpdateDeviceIdentityParams{
+		AppID:       appUUID,
+		EasClientID: clientUUID,
+		Metadata:    mergedJSON,
+	}
+	if geo != nil {
+		params.CountryCode = &geo.CountryCode
+		params.City = &geo.City
+		params.Lat = &geo.Lat
+		params.Lng = &geo.Lng
+	}
+	updated, err := qtx.UpdateDeviceIdentity(ctx, params)
+	if err != nil {
+		return ApplyResult{}, fmt.Errorf("updating device row: %w", err)
+	}
+
+	// Value stats: a key newly set counts its value in; a changed value moves
+	// the device from the old value's count to the new one. Comparison happens
+	// on the rendered form, the same normalization the stats table stores.
+	for key, value := range sanitized {
+		newRendered := RenderValue(value)
+		oldValue, existed := previous[key]
+		if existed {
+			oldRendered := RenderValue(oldValue)
+			if oldRendered == newRendered {
+				continue
+			}
+			decParams := pgdb.DecrementIdentityValueStatParams{AppID: appUUID, Key: key, Value: oldRendered}
+			if err := qtx.DecrementIdentityValueStat(ctx, decParams); err != nil {
+				return ApplyResult{}, fmt.Errorf("decrementing value stat: %w", err)
+			}
+			delParams := pgdb.DeleteZeroIdentityValueStatsParams{AppID: appUUID, Key: key, Value: oldRendered}
+			if err := qtx.DeleteZeroIdentityValueStats(ctx, delParams); err != nil {
+				return ApplyResult{}, fmt.Errorf("pruning zero value stat: %w", err)
+			}
+		}
+		incParams := pgdb.IncrementIdentityValueStatParams{AppID: appUUID, Key: key, Value: newRendered}
+		if err := qtx.IncrementIdentityValueStat(ctx, incParams); err != nil {
+			return ApplyResult{}, fmt.Errorf("incrementing value stat: %w", err)
+		}
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return ApplyResult{}, fmt.Errorf("committing identify tx: %w", err)
+	}
+	device, err := deviceFromRow(updated)
+	if err != nil {
+		return ApplyResult{}, err
+	}
+	return ApplyResult{Device: device, DroppedKeys: dropped}, nil
+}
+
+// GetDevice returns nil when the install was never seen.
+func (s *PostgresIdentityStore) GetDevice(ctx context.Context, appID string, easClientID string) (*Device, error) {
+	appUUID, err := toPgUUID(appID)
+	if err != nil {
+		return nil, err
+	}
+	clientUUID, err := toPgUUID(easClientID)
+	if err != nil {
+		return nil, err
+	}
+	row, err := s.engine.Queries.GetDeviceIdentity(ctx, pgdb.GetDeviceIdentityParams{AppID: appUUID, EasClientID: clientUUID})
+	if err != nil {
+		if database.IsNoRows(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("getting device identity: %w", err)
+	}
+	device, err := deviceFromRow(row)
+	if err != nil {
+		return nil, err
+	}
+	return &device, nil
+}
+
+// SearchMetadataValues is the autocomplete behind searchMetadata: top values
+// of one key ranked by device count, optionally narrowed by a substring.
+func (s *PostgresIdentityStore) SearchMetadataValues(ctx context.Context, appID string, key string, search string, limit int) ([]ValueCount, error) {
+	appUUID, err := toPgUUID(appID)
+	if err != nil {
+		return nil, err
+	}
+	if limit < 1 || limit > 100 {
+		limit = 20
+	}
+	rows, err := s.engine.Queries.SearchIdentityValues(ctx, pgdb.SearchIdentityValuesParams{
+		AppID:      appUUID,
+		Key:        key,
+		Search:     search,
+		MaxResults: int32(limit),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("searching identity values: %w", err)
+	}
+	values := make([]ValueCount, 0, len(rows))
+	for _, row := range rows {
+		values = append(values, ValueCount{Value: row.Value, DeviceCount: row.DeviceCount})
+	}
+	return values, nil
+}

--- a/ee/identity/store_postgres_test.go
+++ b/ee/identity/store_postgres_test.go
@@ -476,10 +476,114 @@ func TestUpsertSchemaKeyCap(t *testing.T) {
 		_, err := store.UpsertSchemaKey(ctx, appID, KeySpec{Key: fmt.Sprintf("key%d", i), Type: ValueTypeString})
 		require.NoError(t, err)
 	}
-	// The 101st key is rejected...
+	// The 101st key is rejected with the typed sentinel...
 	_, err := store.UpsertSchemaKey(ctx, appID, KeySpec{Key: "overflow", Type: ValueTypeString})
-	require.ErrorContains(t, err, "limited to")
+	require.ErrorIs(t, err, ErrTooManySchemaKeys)
 	// ...but re-declaring an existing key at the cap still works.
 	_, err = store.UpsertSchemaKey(ctx, appID, KeySpec{Key: "key0", Type: ValueTypeNumber})
 	require.NoError(t, err)
+}
+
+func TestListDevicesPaginationAndFilter(t *testing.T) {
+	store, pool := setupIdentityStore(t)
+	appID := seedApp(t, pool)
+	ctx := context.Background()
+	declareKey(t, store, appID, "tenant", ValueTypeString)
+
+	// Seed devices with staggered last_seen_at (later ApplySet = more recent).
+	var ids []string
+	for i := 0; i < 5; i++ {
+		id := uuid.NewString()
+		ids = append(ids, id)
+		tenant := "acme"
+		if i%2 == 1 {
+			tenant = "globex"
+		}
+		_, err := store.ApplySet(ctx, appID, id, map[string]any{"tenant": tenant}, nil)
+		require.NoError(t, err)
+	}
+
+	// Full unfiltered listing, newest-first, paginated 2 at a time.
+	var seen []string
+	var cursor *DeviceCursor
+	for {
+		devices, next, err := store.ListDevices(ctx, appID, nil, 2, cursor)
+		require.NoError(t, err)
+		for _, d := range devices {
+			seen = append(seen, d.EASClientID)
+		}
+		if next == nil {
+			break
+		}
+		cursor = next
+		require.LessOrEqual(t, len(seen), 5, "pagination must terminate")
+	}
+	require.Len(t, seen, 5)
+	// Newest-first: the last-seeded device comes first.
+	require.Equal(t, ids[4], seen[0])
+	// No duplicates across pages.
+	require.Len(t, uniqueStrings(seen), 5)
+
+	// Filter to tenant=globex (devices 1 and 3): 2 of them.
+	filtered, next, err := store.ListDevices(ctx, appID, &MetadataFilter{Key: "tenant", Value: "globex"}, 10, nil)
+	require.NoError(t, err)
+	require.Nil(t, next)
+	require.Len(t, filtered, 2)
+	for _, d := range filtered {
+		require.Equal(t, "globex", d.Metadata["tenant"])
+	}
+
+	// A filter matching nothing returns an empty page.
+	none, _, err := store.ListDevices(ctx, appID, &MetadataFilter{Key: "tenant", Value: "nope"}, 10, nil)
+	require.NoError(t, err)
+	require.Empty(t, none)
+}
+
+// When many devices share the exact same last_seen_at (the likely case: a
+// burst of identifies), pagination must fall back on the eas_client_id
+// tiebreaker and still return every row once. Sequential ApplySet calls get
+// distinct timestamps, so force a tie with a direct UPDATE.
+func TestListDevicesKeysetUnderTies(t *testing.T) {
+	store, pool := setupIdentityStore(t)
+	appID := seedApp(t, pool)
+	ctx := context.Background()
+
+	for i := 0; i < 6; i++ {
+		_, err := store.ApplySet(ctx, appID, uuid.NewString(), map[string]any{}, nil)
+		require.NoError(t, err)
+	}
+	// Pin all six rows to the same instant.
+	_, err := pool.Exec(ctx,
+		"UPDATE device_identity SET last_seen_at = '2026-07-23T10:00:00Z' WHERE app_id = $1", appID)
+	require.NoError(t, err)
+
+	var seen []string
+	var cursor *DeviceCursor
+	for {
+		devices, next, err := store.ListDevices(ctx, appID, nil, 2, cursor)
+		require.NoError(t, err)
+		for _, d := range devices {
+			seen = append(seen, d.EASClientID)
+		}
+		if next == nil {
+			break
+		}
+		cursor = next
+		require.LessOrEqual(t, len(seen), 6, "pagination must terminate under ties")
+	}
+	// All six, each exactly once, despite identical last_seen_at.
+	require.Len(t, seen, 6)
+	require.Len(t, uniqueStrings(seen), 6)
+}
+
+func uniqueStrings(in []string) []string {
+	seen := map[string]struct{}{}
+	var out []string
+	for _, s := range in {
+		if _, ok := seen[s]; !ok {
+			seen[s] = struct{}{}
+			out = append(out, s)
+		}
+	}
+	return out
 }

--- a/ee/identity/store_postgres_test.go
+++ b/ee/identity/store_postgres_test.go
@@ -26,6 +26,7 @@ import (
 	"expo-open-ota/internal/database/postgres/pgdb"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stretchr/testify/require"
 )
@@ -48,8 +49,14 @@ func setupIdentityStore(t *testing.T) (*PostgresIdentityStore, *pgxpool.Pool) {
 	pool, err := pgxpool.New(context.Background(), dbURL)
 	require.NoError(t, err)
 	t.Cleanup(pool.Close)
-	return NewPostgresIdentityStore(&database.Engine{Queries: pgdb.New(pool), DB: pool}), pool
+	// Licensed by default so the free-tier cap is inert; the cap test builds
+	// its own unlicensed store.
+	store := NewPostgresIdentityStore(&database.Engine{Queries: pgdb.New(pool), DB: pool})
+	store.licenseValid = alwaysLicensed
+	return store, pool
 }
+
+func alwaysLicensed() bool { return true }
 
 func seedApp(t *testing.T, pool *pgxpool.Pool) string {
 	t.Helper()
@@ -586,4 +593,111 @@ func uniqueStrings(in []string) []string {
 		}
 	}
 	return out
+}
+
+// unlicensedStore builds a store with the free-tier cap active at a small
+// limit so the eviction path is testable without seeding a thousand rows.
+func unlicensedStore(pool *pgxpool.Pool, limit int) *PostgresIdentityStore {
+	s := NewPostgresIdentityStore(&database.Engine{Queries: pgdb.New(pool), DB: pool})
+	s.licenseValid = func() bool { return false }
+	s.deviceLimit = limit
+	return s
+}
+
+func TestFreeTierCapEvictsOldest(t *testing.T) {
+	_, pool := setupIdentityStore(t)
+	appID := seedApp(t, pool)
+	ctx := context.Background()
+	store := unlicensedStore(pool, 3)
+	declareKey(t, store, appID, "tenant", ValueTypeString)
+
+	// Register 3 devices (at the cap). Stagger last_seen via distinct txns.
+	ids := make([]string, 4)
+	for i := 0; i < 3; i++ {
+		ids[i] = uuid.NewString()
+		_, err := store.ApplySet(ctx, appID, ids[i], map[string]any{"tenant": "acme"}, nil)
+		require.NoError(t, err)
+	}
+	count, err := store.engine.Queries.CountDevices(ctx, mustPgUUID(t, appID))
+	require.NoError(t, err)
+	require.Equal(t, int64(3), count)
+
+	// A 4th device evicts the oldest (ids[0]); count stays at the cap.
+	ids[3] = uuid.NewString()
+	_, err = store.ApplySet(ctx, appID, ids[3], map[string]any{"tenant": "globex"}, nil)
+	require.NoError(t, err)
+
+	count, err = store.engine.Queries.CountDevices(ctx, mustPgUUID(t, appID))
+	require.NoError(t, err)
+	require.Equal(t, int64(3), count, "cap holds the app at the limit")
+
+	// The oldest is gone, the newest is present.
+	evicted, err := store.GetDevice(ctx, appID, ids[0])
+	require.NoError(t, err)
+	require.Nil(t, evicted, "the oldest device was evicted")
+	newest, err := store.GetDevice(ctx, appID, ids[3])
+	require.NoError(t, err)
+	require.NotNil(t, newest)
+
+	// Value stats followed the eviction: acme went 3 -> 2 (one evicted),
+	// globex is 1. No ghost counts from the evicted device.
+	values, err := store.SearchMetadataValues(ctx, appID, "tenant", "", 10)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []ValueCount{{Value: "acme", DeviceCount: 2}, {Value: "globex", DeviceCount: 1}}, values)
+}
+
+func TestLicensedStoreHasNoCap(t *testing.T) {
+	baseline, pool := setupIdentityStore(t) // alwaysLicensed
+	appID := seedApp(t, pool)
+	ctx := context.Background()
+	// Same tiny limit, but licensed → cap inert.
+	licensed := NewPostgresIdentityStore(&database.Engine{Queries: pgdb.New(pool), DB: pool})
+	licensed.licenseValid = func() bool { return true }
+	licensed.deviceLimit = 3
+	_ = baseline
+
+	for i := 0; i < 6; i++ {
+		_, err := licensed.ApplySet(ctx, appID, uuid.NewString(), map[string]any{}, nil)
+		require.NoError(t, err)
+	}
+	count, err := licensed.engine.Queries.CountDevices(ctx, mustPgUUID(t, appID))
+	require.NoError(t, err)
+	require.Equal(t, int64(6), count, "a valid license lifts the cap")
+}
+
+// Updates to existing devices must not trigger eviction (only new inserts do).
+func TestFreeTierCapIgnoresUpdates(t *testing.T) {
+	_, pool := setupIdentityStore(t)
+	appID := seedApp(t, pool)
+	ctx := context.Background()
+	store := unlicensedStore(pool, 3)
+	declareKey(t, store, appID, "tenant", ValueTypeString)
+
+	ids := make([]string, 3)
+	for i := 0; i < 3; i++ {
+		ids[i] = uuid.NewString()
+		_, err := store.ApplySet(ctx, appID, ids[i], map[string]any{"tenant": "acme"}, nil)
+		require.NoError(t, err)
+	}
+	// Re-identify the OLDEST many times: it stays (updates don't evict), and
+	// no device is dropped.
+	for i := 0; i < 5; i++ {
+		_, err := store.ApplySet(ctx, appID, ids[0], map[string]any{"tenant": "acme"}, nil)
+		require.NoError(t, err)
+	}
+	count, err := store.engine.Queries.CountDevices(ctx, mustPgUUID(t, appID))
+	require.NoError(t, err)
+	require.Equal(t, int64(3), count)
+	for _, id := range ids {
+		d, err := store.GetDevice(ctx, appID, id)
+		require.NoError(t, err)
+		require.NotNil(t, d, "no device evicted on updates")
+	}
+}
+
+func mustPgUUID(t *testing.T, id string) pgtype.UUID {
+	t.Helper()
+	u, err := toPgUUID(id)
+	require.NoError(t, err)
+	return u
 }

--- a/ee/identity/store_postgres_test.go
+++ b/ee/identity/store_postgres_test.go
@@ -1,0 +1,273 @@
+// Copyright (c) 2026 Axel Marciano (Mercure Technologies). All rights reserved.
+// This file is governed by the Mercure Technologies Enterprise Edition License
+// (see ee/LICENSE); it is NOT covered by the MIT license of this repository.
+
+// Integration tests for the identity store: the merge-under-lock transaction,
+// the value-stat bookkeeping and the trigram search need a real Postgres.
+// They skip unless TEST_DATABASE_URL is set, e.g.:
+//
+//	docker run -d --name eoo-pg -e POSTGRES_PASSWORD=test -p 55432:5432 postgres:16-alpine
+//	TEST_DATABASE_URL="postgres://postgres:test@localhost:55432/postgres?sslmode=disable" go test ./ee/identity/
+//
+// Every test creates its own app row, so tests never observe each other's
+// devices or stats even on a database reused across runs.
+
+package identity
+
+import (
+	"context"
+	"os"
+	"sync"
+	"testing"
+
+	"expo-open-ota/internal/database"
+	"expo-open-ota/internal/database/postgres"
+	"expo-open-ota/internal/database/postgres/pgdb"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+)
+
+func setupIdentityStore(t *testing.T) (*PostgresIdentityStore, *pgxpool.Pool) {
+	t.Helper()
+	dbURL := os.Getenv("TEST_DATABASE_URL")
+	if dbURL == "" {
+		// Same guard as the audit and rbac store tests: a skip in CI is a
+		// green job that ran none of these queries.
+		if os.Getenv("CI") != "" {
+			t.Fatal("TEST_DATABASE_URL must be set in CI: these tests cover SQL that unit tests cannot reach")
+		}
+		t.Skip("TEST_DATABASE_URL not set — start a Postgres and set it to run the identity store tests")
+	}
+	t.Setenv("ADMIN_EMAIL", "seed-admin@example.com")
+	t.Setenv("ADMIN_PASSWORD", "Sup3rSecret!")
+	postgres.RunDBMigrations(dbURL)
+
+	pool, err := pgxpool.New(context.Background(), dbURL)
+	require.NoError(t, err)
+	t.Cleanup(pool.Close)
+	return NewPostgresIdentityStore(&database.Engine{Queries: pgdb.New(pool), DB: pool}), pool
+}
+
+func seedApp(t *testing.T, pool *pgxpool.Pool) string {
+	t.Helper()
+	appID := uuid.NewString()
+	_, err := pool.Exec(context.Background(), "INSERT INTO apps (id, name) VALUES ($1, $2)", appID, "identity-test-"+appID[:8])
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(), "DELETE FROM apps WHERE id = $1", appID)
+	})
+	return appID
+}
+
+func declareKey(t *testing.T, store *PostgresIdentityStore, appID, key string, valueType ValueType) {
+	t.Helper()
+	_, err := store.UpsertSchemaKey(context.Background(), appID, KeySpec{Key: key, Type: valueType, MaxLength: DefaultMaxLength})
+	require.NoError(t, err)
+}
+
+func TestSchemaCRUD(t *testing.T) {
+	store, pool := setupIdentityStore(t)
+	appID := seedApp(t, pool)
+	ctx := context.Background()
+
+	schema, err := store.GetSchema(ctx, appID)
+	require.NoError(t, err)
+	require.Empty(t, schema)
+
+	_, err = store.UpsertSchemaKey(ctx, appID, KeySpec{Key: "userId", Type: ValueTypeString})
+	require.NoError(t, err)
+	_, err = store.UpsertSchemaKey(ctx, appID, KeySpec{Key: "seats", Type: ValueTypeNumber, MaxLength: 32})
+	require.NoError(t, err)
+
+	schema, err = store.GetSchema(ctx, appID)
+	require.NoError(t, err)
+	require.Len(t, schema, 2)
+	// Omitted max length lands on the default, not on zero.
+	require.Equal(t, DefaultMaxLength, schema["userId"].MaxLength)
+	require.Equal(t, 32, schema["seats"].MaxLength)
+
+	// Upsert re-types a key in place.
+	_, err = store.UpsertSchemaKey(ctx, appID, KeySpec{Key: "seats", Type: ValueTypeString, MaxLength: 32})
+	require.NoError(t, err)
+	schema, err = store.GetSchema(ctx, appID)
+	require.NoError(t, err)
+	require.Equal(t, ValueTypeString, schema["seats"].Type)
+
+	// Invalid specs are rejected before touching the database.
+	_, err = store.UpsertSchemaKey(ctx, appID, KeySpec{Key: "bad key", Type: ValueTypeString})
+	require.Error(t, err)
+
+	deleted, err := store.DeleteSchemaKey(ctx, appID, "seats")
+	require.NoError(t, err)
+	require.True(t, deleted)
+	deleted, err = store.DeleteSchemaKey(ctx, appID, "seats")
+	require.NoError(t, err)
+	require.False(t, deleted)
+}
+
+func TestApplyIdentifyMergesAndCounts(t *testing.T) {
+	store, pool := setupIdentityStore(t)
+	appID := seedApp(t, pool)
+	ctx := context.Background()
+	declareKey(t, store, appID, "userId", ValueTypeString)
+	declareKey(t, store, appID, "tenant", ValueTypeString)
+
+	clientID := uuid.NewString()
+	result, err := store.ApplyIdentify(ctx, appID, clientID, map[string]any{
+		"userId": "user_1",
+		"junk":   "dropped by the allowlist",
+	}, nil)
+	require.NoError(t, err)
+	require.Equal(t, map[string]any{"userId": "user_1"}, result.Device.Metadata)
+	require.Equal(t, []string{"junk"}, result.DroppedKeys)
+
+	// Second identify adds a key and keeps the first one (per-key merge).
+	result, err = store.ApplyIdentify(ctx, appID, clientID, map[string]any{"tenant": "acme"}, nil)
+	require.NoError(t, err)
+	require.Equal(t, map[string]any{"userId": "user_1", "tenant": "acme"}, result.Device.Metadata)
+
+	// Changing a value moves the device count from the old value to the new
+	// one and prunes the emptied row.
+	_, err = store.ApplyIdentify(ctx, appID, clientID, map[string]any{"tenant": "globex"}, nil)
+	require.NoError(t, err)
+	values, err := store.SearchMetadataValues(ctx, appID, "tenant", "", 10)
+	require.NoError(t, err)
+	require.Equal(t, []ValueCount{{Value: "globex", DeviceCount: 1}}, values)
+
+	// Re-identifying the same value must not inflate the count.
+	_, err = store.ApplyIdentify(ctx, appID, clientID, map[string]any{"tenant": "globex"}, nil)
+	require.NoError(t, err)
+	values, err = store.SearchMetadataValues(ctx, appID, "tenant", "", 10)
+	require.NoError(t, err)
+	require.Equal(t, []ValueCount{{Value: "globex", DeviceCount: 1}}, values)
+
+	device, err := store.GetDevice(ctx, appID, clientID)
+	require.NoError(t, err)
+	require.NotNil(t, device)
+	require.Equal(t, "globex", device.Metadata["tenant"])
+
+	missing, err := store.GetDevice(ctx, appID, uuid.NewString())
+	require.NoError(t, err)
+	require.Nil(t, missing)
+
+	_, err = store.ApplyIdentify(ctx, appID, "not-a-uuid", map[string]any{}, nil)
+	require.Error(t, err)
+}
+
+func TestApplyIdentifyGeoCoalesce(t *testing.T) {
+	store, pool := setupIdentityStore(t)
+	appID := seedApp(t, pool)
+	ctx := context.Background()
+	clientID := uuid.NewString()
+
+	result, err := store.ApplyIdentify(ctx, appID, clientID, nil, &Geo{CountryCode: "FR", City: "Paris", Lat: 48.85, Lng: 2.35})
+	require.NoError(t, err)
+	require.NotNil(t, result.Device.CountryCode)
+	require.Equal(t, "FR", *result.Device.CountryCode)
+
+	// An identify that resolves no geo keeps the previously known location.
+	result, err = store.ApplyIdentify(ctx, appID, clientID, nil, nil)
+	require.NoError(t, err)
+	require.NotNil(t, result.Device.CountryCode)
+	require.Equal(t, "FR", *result.Device.CountryCode)
+	require.NotNil(t, result.Device.Lat)
+	require.InDelta(t, 48.85, *result.Device.Lat, 0.001)
+}
+
+func TestSearchMetadataValuesRankingAndFilter(t *testing.T) {
+	store, pool := setupIdentityStore(t)
+	appID := seedApp(t, pool)
+	ctx := context.Background()
+	declareKey(t, store, appID, "tenant", ValueTypeString)
+
+	seed := map[string]int{"acme": 3, "acme-eu": 2, "globex": 1}
+	for tenant, devices := range seed {
+		for i := 0; i < devices; i++ {
+			_, err := store.ApplyIdentify(ctx, appID, uuid.NewString(), map[string]any{"tenant": tenant}, nil)
+			require.NoError(t, err)
+		}
+	}
+
+	// Empty search: top values by device count.
+	values, err := store.SearchMetadataValues(ctx, appID, "tenant", "", 10)
+	require.NoError(t, err)
+	require.Equal(t, []ValueCount{{Value: "acme", DeviceCount: 3}, {Value: "acme-eu", DeviceCount: 2}, {Value: "globex", DeviceCount: 1}}, values)
+
+	// Case-insensitive substring narrows, ranking is preserved.
+	values, err = store.SearchMetadataValues(ctx, appID, "tenant", "ACME", 10)
+	require.NoError(t, err)
+	require.Equal(t, []ValueCount{{Value: "acme", DeviceCount: 3}, {Value: "acme-eu", DeviceCount: 2}}, values)
+
+	// Limit applies after ranking.
+	values, err = store.SearchMetadataValues(ctx, appID, "tenant", "", 1)
+	require.NoError(t, err)
+	require.Equal(t, []ValueCount{{Value: "acme", DeviceCount: 3}}, values)
+
+	// Unknown key: no rows, no error.
+	values, err = store.SearchMetadataValues(ctx, appID, "nope", "", 10)
+	require.NoError(t, err)
+	require.Empty(t, values)
+}
+
+func TestDeleteSchemaKeyWipesItsStats(t *testing.T) {
+	store, pool := setupIdentityStore(t)
+	appID := seedApp(t, pool)
+	ctx := context.Background()
+	declareKey(t, store, appID, "tenant", ValueTypeString)
+	declareKey(t, store, appID, "plan", ValueTypeString)
+
+	_, err := store.ApplyIdentify(ctx, appID, uuid.NewString(), map[string]any{"tenant": "acme", "plan": "pro"}, nil)
+	require.NoError(t, err)
+
+	deleted, err := store.DeleteSchemaKey(ctx, appID, "tenant")
+	require.NoError(t, err)
+	require.True(t, deleted)
+
+	// The removed key stops being suggested; the surviving key is untouched.
+	values, err := store.SearchMetadataValues(ctx, appID, "tenant", "", 10)
+	require.NoError(t, err)
+	require.Empty(t, values)
+	values, err = store.SearchMetadataValues(ctx, appID, "plan", "", 10)
+	require.NoError(t, err)
+	require.Equal(t, []ValueCount{{Value: "pro", DeviceCount: 1}}, values)
+
+	// And its values are no longer accepted on the next identify.
+	result, err := store.ApplyIdentify(ctx, appID, uuid.NewString(), map[string]any{"tenant": "acme"}, nil)
+	require.NoError(t, err)
+	require.Empty(t, result.Device.Metadata)
+	require.Equal(t, []string{"tenant"}, result.DroppedKeys)
+}
+
+// Concurrent first identifies of the same install must both land: the
+// insert-then-lock sequence serializes the merges, so neither metadata write
+// nor stat increment is lost.
+func TestApplyIdentifyConcurrentFirstWrite(t *testing.T) {
+	store, pool := setupIdentityStore(t)
+	appID := seedApp(t, pool)
+	ctx := context.Background()
+	declareKey(t, store, appID, "userId", ValueTypeString)
+	declareKey(t, store, appID, "tenant", ValueTypeString)
+
+	clientID := uuid.NewString()
+	var wg sync.WaitGroup
+	errs := make([]error, 2)
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		_, errs[0] = store.ApplyIdentify(ctx, appID, clientID, map[string]any{"userId": "user_1"}, nil)
+	}()
+	go func() {
+		defer wg.Done()
+		_, errs[1] = store.ApplyIdentify(ctx, appID, clientID, map[string]any{"tenant": "acme"}, nil)
+	}()
+	wg.Wait()
+	require.NoError(t, errs[0])
+	require.NoError(t, errs[1])
+
+	device, err := store.GetDevice(ctx, appID, clientID)
+	require.NoError(t, err)
+	require.NotNil(t, device)
+	require.Equal(t, map[string]any{"userId": "user_1", "tenant": "acme"}, device.Metadata)
+}

--- a/ee/identity/store_postgres_test.go
+++ b/ee/identity/store_postgres_test.go
@@ -108,7 +108,7 @@ func TestSchemaCRUD(t *testing.T) {
 	require.False(t, deleted)
 }
 
-func TestApplyIdentifyMergesAndCounts(t *testing.T) {
+func TestApplySetMergesAndCounts(t *testing.T) {
 	store, pool := setupIdentityStore(t)
 	appID := seedApp(t, pool)
 	ctx := context.Background()
@@ -116,7 +116,7 @@ func TestApplyIdentifyMergesAndCounts(t *testing.T) {
 	declareKey(t, store, appID, "tenant", ValueTypeString)
 
 	clientID := uuid.NewString()
-	result, err := store.ApplyIdentify(ctx, appID, clientID, map[string]any{
+	result, err := store.ApplySet(ctx, appID, clientID, map[string]any{
 		"userId": "user_1",
 		"junk":   "dropped by the allowlist",
 	}, nil)
@@ -125,20 +125,20 @@ func TestApplyIdentifyMergesAndCounts(t *testing.T) {
 	require.Equal(t, []string{"junk"}, result.DroppedKeys)
 
 	// Second identify adds a key and keeps the first one (per-key merge).
-	result, err = store.ApplyIdentify(ctx, appID, clientID, map[string]any{"tenant": "acme"}, nil)
+	result, err = store.ApplySet(ctx, appID, clientID, map[string]any{"tenant": "acme"}, nil)
 	require.NoError(t, err)
 	require.Equal(t, map[string]any{"userId": "user_1", "tenant": "acme"}, result.Device.Metadata)
 
 	// Changing a value moves the device count from the old value to the new
 	// one and prunes the emptied row.
-	_, err = store.ApplyIdentify(ctx, appID, clientID, map[string]any{"tenant": "globex"}, nil)
+	_, err = store.ApplySet(ctx, appID, clientID, map[string]any{"tenant": "globex"}, nil)
 	require.NoError(t, err)
 	values, err := store.SearchMetadataValues(ctx, appID, "tenant", "", 10)
 	require.NoError(t, err)
 	require.Equal(t, []ValueCount{{Value: "globex", DeviceCount: 1}}, values)
 
 	// Re-identifying the same value must not inflate the count.
-	_, err = store.ApplyIdentify(ctx, appID, clientID, map[string]any{"tenant": "globex"}, nil)
+	_, err = store.ApplySet(ctx, appID, clientID, map[string]any{"tenant": "globex"}, nil)
 	require.NoError(t, err)
 	values, err = store.SearchMetadataValues(ctx, appID, "tenant", "", 10)
 	require.NoError(t, err)
@@ -153,27 +153,27 @@ func TestApplyIdentifyMergesAndCounts(t *testing.T) {
 	require.NoError(t, err)
 	require.Nil(t, missing)
 
-	_, err = store.ApplyIdentify(ctx, appID, "not-a-uuid", map[string]any{}, nil)
+	_, err = store.ApplySet(ctx, appID, "not-a-uuid", map[string]any{}, nil)
 	require.Error(t, err)
 }
 
 func strPtr(s string) *string     { return &s }
 func floatPtr(f float64) *float64 { return &f }
 
-func TestApplyIdentifyGeoCoalesce(t *testing.T) {
+func TestApplySetGeoCoalesce(t *testing.T) {
 	store, pool := setupIdentityStore(t)
 	appID := seedApp(t, pool)
 	ctx := context.Background()
 	clientID := uuid.NewString()
 
 	fullGeo := &Geo{CountryCode: strPtr("FR"), City: strPtr("Paris"), Lat: floatPtr(48.85), Lng: floatPtr(2.35)}
-	result, err := store.ApplyIdentify(ctx, appID, clientID, nil, fullGeo)
+	result, err := store.ApplySet(ctx, appID, clientID, nil, fullGeo)
 	require.NoError(t, err)
 	require.NotNil(t, result.Device.CountryCode)
 	require.Equal(t, "FR", *result.Device.CountryCode)
 
 	// An identify that resolves no geo keeps the previously known location.
-	result, err = store.ApplyIdentify(ctx, appID, clientID, nil, nil)
+	result, err = store.ApplySet(ctx, appID, clientID, nil, nil)
 	require.NoError(t, err)
 	require.NotNil(t, result.Device.CountryCode)
 	require.Equal(t, "FR", *result.Device.CountryCode)
@@ -182,7 +182,7 @@ func TestApplyIdentifyGeoCoalesce(t *testing.T) {
 
 	// A PARTIAL resolution (country-only is the common GeoLite2 case) updates
 	// what it knows and never blanks the rest with '' or 0/0.
-	result, err = store.ApplyIdentify(ctx, appID, clientID, nil, &Geo{CountryCode: strPtr("BE")})
+	result, err = store.ApplySet(ctx, appID, clientID, nil, &Geo{CountryCode: strPtr("BE")})
 	require.NoError(t, err)
 	require.Equal(t, "BE", *result.Device.CountryCode)
 	require.NotNil(t, result.Device.City)
@@ -200,7 +200,7 @@ func TestSearchMetadataValuesRankingAndFilter(t *testing.T) {
 	seed := map[string]int{"acme": 3, "acme-eu": 2, "globex": 1}
 	for tenant, devices := range seed {
 		for i := 0; i < devices; i++ {
-			_, err := store.ApplyIdentify(ctx, appID, uuid.NewString(), map[string]any{"tenant": tenant}, nil)
+			_, err := store.ApplySet(ctx, appID, uuid.NewString(), map[string]any{"tenant": tenant}, nil)
 			require.NoError(t, err)
 		}
 	}
@@ -233,7 +233,7 @@ func TestDeleteSchemaKeyWipesItsStats(t *testing.T) {
 	declareKey(t, store, appID, "tenant", ValueTypeString)
 	declareKey(t, store, appID, "plan", ValueTypeString)
 
-	_, err := store.ApplyIdentify(ctx, appID, uuid.NewString(), map[string]any{"tenant": "acme", "plan": "pro"}, nil)
+	_, err := store.ApplySet(ctx, appID, uuid.NewString(), map[string]any{"tenant": "acme", "plan": "pro"}, nil)
 	require.NoError(t, err)
 
 	deleted, err := store.DeleteSchemaKey(ctx, appID, "tenant")
@@ -249,7 +249,7 @@ func TestDeleteSchemaKeyWipesItsStats(t *testing.T) {
 	require.Equal(t, []ValueCount{{Value: "pro", DeviceCount: 1}}, values)
 
 	// And its values are no longer accepted on the next identify.
-	result, err := store.ApplyIdentify(ctx, appID, uuid.NewString(), map[string]any{"tenant": "acme"}, nil)
+	result, err := store.ApplySet(ctx, appID, uuid.NewString(), map[string]any{"tenant": "acme"}, nil)
 	require.NoError(t, err)
 	require.Empty(t, result.Device.Metadata)
 	require.Equal(t, []string{"tenant"}, result.DroppedKeys)
@@ -258,7 +258,7 @@ func TestDeleteSchemaKeyWipesItsStats(t *testing.T) {
 // Concurrent first identifies of the same install must both land: the
 // insert-then-lock sequence serializes the merges, so neither metadata write
 // nor stat increment is lost.
-func TestApplyIdentifyConcurrentFirstWrite(t *testing.T) {
+func TestApplySetConcurrentFirstWrite(t *testing.T) {
 	store, pool := setupIdentityStore(t)
 	appID := seedApp(t, pool)
 	ctx := context.Background()
@@ -271,11 +271,11 @@ func TestApplyIdentifyConcurrentFirstWrite(t *testing.T) {
 	wg.Add(2)
 	go func() {
 		defer wg.Done()
-		_, errs[0] = store.ApplyIdentify(ctx, appID, clientID, map[string]any{"userId": "user_1"}, nil)
+		_, errs[0] = store.ApplySet(ctx, appID, clientID, map[string]any{"userId": "user_1"}, nil)
 	}()
 	go func() {
 		defer wg.Done()
-		_, errs[1] = store.ApplyIdentify(ctx, appID, clientID, map[string]any{"tenant": "acme"}, nil)
+		_, errs[1] = store.ApplySet(ctx, appID, clientID, map[string]any{"tenant": "acme"}, nil)
 	}()
 	wg.Wait()
 	require.NoError(t, errs[0])
@@ -300,7 +300,7 @@ func TestApplyIdentifyConcurrentFirstWrite(t *testing.T) {
 // values) must not deadlock: the store orders its stat-row locks by
 // (key, value) precisely for this. Before that ordering, this test deadlocked
 // within a handful of iterations (40P01 after the 1s deadlock_timeout).
-func TestApplyIdentifyConcurrentSharedStatRowsNoDeadlock(t *testing.T) {
+func TestApplySetConcurrentSharedStatRowsNoDeadlock(t *testing.T) {
 	store, pool := setupIdentityStore(t)
 	appID := seedApp(t, pool)
 	ctx := context.Background()
@@ -325,7 +325,7 @@ func TestApplyIdentifyConcurrentSharedStatRowsNoDeadlock(t *testing.T) {
 			if i%2 == 1 {
 				p = alternate
 			}
-			if _, err := store.ApplyIdentify(ctx, appID, deviceA, p, nil); err != nil {
+			if _, err := store.ApplySet(ctx, appID, deviceA, p, nil); err != nil {
 				errsA[i] = err
 				return
 			}
@@ -338,7 +338,7 @@ func TestApplyIdentifyConcurrentSharedStatRowsNoDeadlock(t *testing.T) {
 			if i%2 == 1 {
 				p = payload
 			}
-			if _, err := store.ApplyIdentify(ctx, appID, deviceB, p, nil); err != nil {
+			if _, err := store.ApplySet(ctx, appID, deviceB, p, nil); err != nil {
 				errsB[i] = err
 				return
 			}
@@ -366,26 +366,105 @@ func TestApplyIdentifyConcurrentSharedStatRowsNoDeadlock(t *testing.T) {
 // A number-typed key must round-trip through JSONB without corrupting the
 // stat bookkeeping: 42 stored then re-read as float64 must compare equal to
 // an incoming 42 (no phantom dec/inc), and a real change must move the count.
-func TestApplyIdentifyNumberRoundtrip(t *testing.T) {
+func TestApplySetNumberRoundtrip(t *testing.T) {
 	store, pool := setupIdentityStore(t)
 	appID := seedApp(t, pool)
 	ctx := context.Background()
 	declareKey(t, store, appID, "seats", ValueTypeNumber)
 
 	clientID := uuid.NewString()
-	_, err := store.ApplyIdentify(ctx, appID, clientID, map[string]any{"seats": int64(42)}, nil)
+	_, err := store.ApplySet(ctx, appID, clientID, map[string]any{"seats": int64(42)}, nil)
 	require.NoError(t, err)
-	_, err = store.ApplyIdentify(ctx, appID, clientID, map[string]any{"seats": float64(42)}, nil)
+	_, err = store.ApplySet(ctx, appID, clientID, map[string]any{"seats": float64(42)}, nil)
 	require.NoError(t, err)
 	values, err := store.SearchMetadataValues(ctx, appID, "seats", "", 10)
 	require.NoError(t, err)
 	require.Equal(t, []ValueCount{{Value: "42", DeviceCount: 1}}, values)
 
-	_, err = store.ApplyIdentify(ctx, appID, clientID, map[string]any{"seats": 42.5}, nil)
+	_, err = store.ApplySet(ctx, appID, clientID, map[string]any{"seats": 42.5}, nil)
 	require.NoError(t, err)
 	values, err = store.SearchMetadataValues(ctx, appID, "seats", "", 10)
 	require.NoError(t, err)
 	require.Equal(t, []ValueCount{{Value: "42.5", DeviceCount: 1}}, values)
+}
+
+func TestApplySetOnce(t *testing.T) {
+	store, pool := setupIdentityStore(t)
+	appID := seedApp(t, pool)
+	ctx := context.Background()
+	declareKey(t, store, appID, "initialReferrer", ValueTypeString)
+	declareKey(t, store, appID, "plan", ValueTypeString)
+
+	clientID := uuid.NewString()
+	result, err := store.ApplySetOnce(ctx, appID, clientID, map[string]any{"initialReferrer": "organic"}, nil)
+	require.NoError(t, err)
+	require.Equal(t, map[string]any{"initialReferrer": "organic"}, result.Device.Metadata)
+
+	// A second set_once on a held key is silently ignored; absent keys apply.
+	result, err = store.ApplySetOnce(ctx, appID, clientID, map[string]any{"initialReferrer": "paid", "plan": "pro"}, nil)
+	require.NoError(t, err)
+	require.Equal(t, map[string]any{"initialReferrer": "organic", "plan": "pro"}, result.Device.Metadata)
+
+	// The ignored write must not have touched the stats either.
+	values, err := store.SearchMetadataValues(ctx, appID, "initialReferrer", "", 10)
+	require.NoError(t, err)
+	require.Equal(t, []ValueCount{{Value: "organic", DeviceCount: 1}}, values)
+
+	// $set still overwrites what $set_once pinned.
+	result, err = store.ApplySet(ctx, appID, clientID, map[string]any{"initialReferrer": "paid"}, nil)
+	require.NoError(t, err)
+	require.Equal(t, "paid", result.Device.Metadata["initialReferrer"])
+}
+
+func TestApplyUnset(t *testing.T) {
+	store, pool := setupIdentityStore(t)
+	appID := seedApp(t, pool)
+	ctx := context.Background()
+	declareKey(t, store, appID, "userId", ValueTypeString)
+	declareKey(t, store, appID, "tenant", ValueTypeString)
+
+	clientID := uuid.NewString()
+	_, err := store.ApplySet(ctx, appID, clientID, map[string]any{"userId": "user_1", "tenant": "acme"}, nil)
+	require.NoError(t, err)
+	// A second device holds the same userId value so the count sits at 2:
+	// without the payload dedupe, the duplicated key below would decrement
+	// twice, hit zero, and wrongly prune this survivor's count.
+	survivor := uuid.NewString()
+	_, err = store.ApplySet(ctx, appID, survivor, map[string]any{"userId": "user_1"}, nil)
+	require.NoError(t, err)
+
+	// Unset removes the key, decrements its stat once, and ignores
+	// duplicated and unknown keys in the payload.
+	result, err := store.ApplyUnset(ctx, appID, clientID, []string{"userId", "userId", "neverSeen"}, nil)
+	require.NoError(t, err)
+	require.Equal(t, map[string]any{"tenant": "acme"}, result.Device.Metadata)
+	values, err := store.SearchMetadataValues(ctx, appID, "userId", "", 10)
+	require.NoError(t, err)
+	require.Equal(t, []ValueCount{{Value: "user_1", DeviceCount: 1}}, values)
+
+	// Unsetting the survivor takes the count to zero and prunes the row.
+	_, err = store.ApplyUnset(ctx, appID, survivor, []string{"userId"}, nil)
+	require.NoError(t, err)
+	values, err = store.SearchMetadataValues(ctx, appID, "userId", "", 10)
+	require.NoError(t, err)
+	require.Empty(t, values)
+	values, err = store.SearchMetadataValues(ctx, appID, "tenant", "", 10)
+	require.NoError(t, err)
+	require.Equal(t, []ValueCount{{Value: "acme", DeviceCount: 1}}, values)
+
+	// Unset still works for a key removed from the allowlist: cleanup path.
+	deleted, err := store.DeleteSchemaKey(ctx, appID, "tenant")
+	require.NoError(t, err)
+	require.True(t, deleted)
+	result, err = store.ApplyUnset(ctx, appID, clientID, []string{"tenant"}, nil)
+	require.NoError(t, err)
+	require.Empty(t, result.Device.Metadata)
+
+	// Unsetting on a never-seen device just creates the empty row, no error.
+	fresh := uuid.NewString()
+	result, err = store.ApplyUnset(ctx, appID, fresh, []string{"userId"}, nil)
+	require.NoError(t, err)
+	require.Empty(t, result.Device.Metadata)
 }
 
 func TestUpsertSchemaKeyCap(t *testing.T) {

--- a/ee/identity/store_postgres_test.go
+++ b/ee/identity/store_postgres_test.go
@@ -16,6 +16,7 @@ package identity
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"sync"
 	"testing"
@@ -156,13 +157,17 @@ func TestApplyIdentifyMergesAndCounts(t *testing.T) {
 	require.Error(t, err)
 }
 
+func strPtr(s string) *string     { return &s }
+func floatPtr(f float64) *float64 { return &f }
+
 func TestApplyIdentifyGeoCoalesce(t *testing.T) {
 	store, pool := setupIdentityStore(t)
 	appID := seedApp(t, pool)
 	ctx := context.Background()
 	clientID := uuid.NewString()
 
-	result, err := store.ApplyIdentify(ctx, appID, clientID, nil, &Geo{CountryCode: "FR", City: "Paris", Lat: 48.85, Lng: 2.35})
+	fullGeo := &Geo{CountryCode: strPtr("FR"), City: strPtr("Paris"), Lat: floatPtr(48.85), Lng: floatPtr(2.35)}
+	result, err := store.ApplyIdentify(ctx, appID, clientID, nil, fullGeo)
 	require.NoError(t, err)
 	require.NotNil(t, result.Device.CountryCode)
 	require.Equal(t, "FR", *result.Device.CountryCode)
@@ -172,6 +177,16 @@ func TestApplyIdentifyGeoCoalesce(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, result.Device.CountryCode)
 	require.Equal(t, "FR", *result.Device.CountryCode)
+	require.NotNil(t, result.Device.Lat)
+	require.InDelta(t, 48.85, *result.Device.Lat, 0.001)
+
+	// A PARTIAL resolution (country-only is the common GeoLite2 case) updates
+	// what it knows and never blanks the rest with '' or 0/0.
+	result, err = store.ApplyIdentify(ctx, appID, clientID, nil, &Geo{CountryCode: strPtr("BE")})
+	require.NoError(t, err)
+	require.Equal(t, "BE", *result.Device.CountryCode)
+	require.NotNil(t, result.Device.City)
+	require.Equal(t, "Paris", *result.Device.City)
 	require.NotNil(t, result.Device.Lat)
 	require.InDelta(t, 48.85, *result.Device.Lat, 0.001)
 }
@@ -270,4 +285,122 @@ func TestApplyIdentifyConcurrentFirstWrite(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, device)
 	require.Equal(t, map[string]any{"userId": "user_1", "tenant": "acme"}, device.Metadata)
+
+	// The stat increments must survive the serialization too: a lost or
+	// double-counted increment would pass a metadata-only assertion.
+	values, err := store.SearchMetadataValues(ctx, appID, "userId", "", 10)
+	require.NoError(t, err)
+	require.Equal(t, []ValueCount{{Value: "user_1", DeviceCount: 1}}, values)
+	values, err = store.SearchMetadataValues(ctx, appID, "tenant", "", 10)
+	require.NoError(t, err)
+	require.Equal(t, []ValueCount{{Value: "acme", DeviceCount: 1}}, values)
+}
+
+// Two identifies of DIFFERENT devices sharing stat rows (same tenant/plan
+// values) must not deadlock: the store orders its stat-row locks by
+// (key, value) precisely for this. Before that ordering, this test deadlocked
+// within a handful of iterations (40P01 after the 1s deadlock_timeout).
+func TestApplyIdentifyConcurrentSharedStatRowsNoDeadlock(t *testing.T) {
+	store, pool := setupIdentityStore(t)
+	appID := seedApp(t, pool)
+	ctx := context.Background()
+	declareKey(t, store, appID, "tenant", ValueTypeString)
+	declareKey(t, store, appID, "plan", ValueTypeString)
+	declareKey(t, store, appID, "region", ValueTypeString)
+
+	deviceA, deviceB := uuid.NewString(), uuid.NewString()
+	payload := map[string]any{"tenant": "acme", "plan": "pro", "region": "eu"}
+	// Alternating payload so decrements and increments cross between rounds.
+	alternate := map[string]any{"tenant": "globex", "plan": "free", "region": "us"}
+
+	const rounds = 40
+	var wg sync.WaitGroup
+	errsA := make([]error, rounds)
+	errsB := make([]error, rounds)
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < rounds; i++ {
+			p := payload
+			if i%2 == 1 {
+				p = alternate
+			}
+			if _, err := store.ApplyIdentify(ctx, appID, deviceA, p, nil); err != nil {
+				errsA[i] = err
+				return
+			}
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < rounds; i++ {
+			p := alternate
+			if i%2 == 1 {
+				p = payload
+			}
+			if _, err := store.ApplyIdentify(ctx, appID, deviceB, p, nil); err != nil {
+				errsB[i] = err
+				return
+			}
+		}
+	}()
+	wg.Wait()
+	for i := 0; i < rounds; i++ {
+		require.NoError(t, errsA[i], "device A round %d", i)
+		require.NoError(t, errsB[i], "device B round %d", i)
+	}
+
+	// Both devices ran an even number of rounds, so A ends on `alternate` and
+	// B ends on `payload`: every value should count exactly one device.
+	for key, want := range map[string][]ValueCount{
+		"tenant": {{Value: "acme", DeviceCount: 1}, {Value: "globex", DeviceCount: 1}},
+		"plan":   {{Value: "free", DeviceCount: 1}, {Value: "pro", DeviceCount: 1}},
+		"region": {{Value: "eu", DeviceCount: 1}, {Value: "us", DeviceCount: 1}},
+	} {
+		values, err := store.SearchMetadataValues(ctx, appID, key, "", 10)
+		require.NoError(t, err)
+		require.ElementsMatch(t, want, values, "key %s", key)
+	}
+}
+
+// A number-typed key must round-trip through JSONB without corrupting the
+// stat bookkeeping: 42 stored then re-read as float64 must compare equal to
+// an incoming 42 (no phantom dec/inc), and a real change must move the count.
+func TestApplyIdentifyNumberRoundtrip(t *testing.T) {
+	store, pool := setupIdentityStore(t)
+	appID := seedApp(t, pool)
+	ctx := context.Background()
+	declareKey(t, store, appID, "seats", ValueTypeNumber)
+
+	clientID := uuid.NewString()
+	_, err := store.ApplyIdentify(ctx, appID, clientID, map[string]any{"seats": int64(42)}, nil)
+	require.NoError(t, err)
+	_, err = store.ApplyIdentify(ctx, appID, clientID, map[string]any{"seats": float64(42)}, nil)
+	require.NoError(t, err)
+	values, err := store.SearchMetadataValues(ctx, appID, "seats", "", 10)
+	require.NoError(t, err)
+	require.Equal(t, []ValueCount{{Value: "42", DeviceCount: 1}}, values)
+
+	_, err = store.ApplyIdentify(ctx, appID, clientID, map[string]any{"seats": 42.5}, nil)
+	require.NoError(t, err)
+	values, err = store.SearchMetadataValues(ctx, appID, "seats", "", 10)
+	require.NoError(t, err)
+	require.Equal(t, []ValueCount{{Value: "42.5", DeviceCount: 1}}, values)
+}
+
+func TestUpsertSchemaKeyCap(t *testing.T) {
+	store, pool := setupIdentityStore(t)
+	appID := seedApp(t, pool)
+	ctx := context.Background()
+
+	for i := 0; i < MaxSchemaKeys; i++ {
+		_, err := store.UpsertSchemaKey(ctx, appID, KeySpec{Key: fmt.Sprintf("key%d", i), Type: ValueTypeString})
+		require.NoError(t, err)
+	}
+	// The 101st key is rejected...
+	_, err := store.UpsertSchemaKey(ctx, appID, KeySpec{Key: "overflow", Type: ValueTypeString})
+	require.ErrorContains(t, err, "limited to")
+	// ...but re-declaring an existing key at the cap still works.
+	_, err = store.UpsertSchemaKey(ctx, appID, KeySpec{Key: "key0", Type: ValueTypeNumber})
+	require.NoError(t, err)
 }

--- a/ee/licensing/handler.go
+++ b/ee/licensing/handler.go
@@ -58,13 +58,6 @@ func licenseResponseFrom(status LicenseStatus) LicenseResponse {
 	return response
 }
 
-func renderJSON(w http.ResponseWriter, status int, payload interface{}) {
-	marshaledResponse, _ := json.Marshal(payload)
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(status)
-	w.Write(marshaledResponse)
-}
-
 // renderLicenseServiceError maps key-validation failures onto 400s with the
 // actionable reason; anything unrecognized stays an opaque 500.
 func renderLicenseServiceError(w http.ResponseWriter, err error) {
@@ -86,7 +79,7 @@ func (h *LicenseHandler) GetLicenseHandler(w http.ResponseWriter, r *http.Reques
 		renderLicenseServiceError(w, err)
 		return
 	}
-	renderJSON(w, http.StatusOK, licenseResponseFrom(status))
+	handlers.RenderJSON(w, http.StatusOK, licenseResponseFrom(status))
 }
 
 func (h *LicenseHandler) ActivateLicenseHandler(w http.ResponseWriter, r *http.Request) {
@@ -106,7 +99,7 @@ func (h *LicenseHandler) ActivateLicenseHandler(w http.ResponseWriter, r *http.R
 		renderLicenseServiceError(w, err)
 		return
 	}
-	renderJSON(w, http.StatusOK, licenseResponseFrom(status))
+	handlers.RenderJSON(w, http.StatusOK, licenseResponseFrom(status))
 }
 
 func (h *LicenseHandler) RemoveLicenseHandler(w http.ResponseWriter, r *http.Request) {

--- a/ee/licensing/service_audit_test.go
+++ b/ee/licensing/service_audit_test.go
@@ -6,7 +6,6 @@ package licensing
 
 import (
 	"context"
-	"expo-open-ota/ee/audit"
 	"expo-open-ota/internal/auditlog"
 	"expo-open-ota/internal/services"
 	"testing"
@@ -16,41 +15,26 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// fakeAuditStore lets these tests run the REAL AuditService gated by the real
-// IsEnterprise, so the emit-before-Deactivate ordering in Remove is actually
-// exercised: an event emitted after the gate closed lands nowhere and the
-// assertions fail.
-type fakeAuditStore struct{ inserted []auditlog.Event }
-
-func (f *fakeAuditStore) Insert(_ context.Context, event auditlog.Event) (auditlog.Event, error) {
-	f.inserted = append(f.inserted, event)
-	return event, nil
-}
-func (f *fakeAuditStore) List(_ context.Context, _ audit.ListParams) ([]auditlog.Event, error) {
-	return nil, nil
-}
-func (f *fakeAuditStore) Count(_ context.Context, _ audit.ListFilters) (int64, error) {
-	return 0, nil
-}
-func (f *fakeAuditStore) PurgeBefore(_ context.Context, _ time.Time, _ bool) (int64, error) {
-	return 0, nil
-}
-func (f *fakeAuditStore) ListAfter(_ context.Context, _ int64, _ int) ([]auditlog.Event, error) {
-	return nil, nil
-}
-func (f *fakeAuditStore) ExportCursor(_ context.Context) (int64, error) { return 0, nil }
-func (f *fakeAuditStore) TryExportLock(_ context.Context) (func(), bool, error) {
-	return func() {}, true, nil
-}
-func (f *fakeAuditStore) AdvanceExportCursor(_ context.Context, _ int64, _ int64) (bool, error) {
-	return true, nil
+// The recorder mirrors audit.AuditService.Record's license gate (an event
+// emitted after the gate closed is dropped) with a LOCAL func rather than the
+// real AuditService — this package must not import ee/audit, which imports
+// ee/licensing back (the gate lives in EE code by design), so pulling the real
+// service in here would be an import cycle. The behavior under test is
+// licensing's own ordering (emit BEFORE Deactivate), and the local gate
+// reproduces exactly what would drop a mis-ordered event.
+func gatedRecorder(recorded *[]auditlog.Event) auditlog.RecordFunc {
+	return func(_ context.Context, event auditlog.Event) {
+		if IsEnterprise() {
+			*recorded = append(*recorded, event)
+		}
+	}
 }
 
 func TestActivateAndRemoveEmitAuditEvents(t *testing.T) {
 	priv := setupTestKeypair(t)
 	service := NewLicenseService(&fakeLicenseRepo{})
-	auditStore := &fakeAuditStore{}
-	service.SetOnAuditEvent(audit.NewAuditService(auditStore, IsEnterprise).Record)
+	var recorded []auditlog.Event
+	service.SetOnAuditEvent(gatedRecorder(&recorded))
 	ctx := services.WithPrincipal(context.Background(),
 		&services.DashboardPrincipal{UserId: "admin-1", Email: "admin@example.com"})
 
@@ -59,8 +43,8 @@ func TestActivateAndRemoveEmitAuditEvents(t *testing.T) {
 	require.NoError(t, err)
 
 	// The activation itself is recorded through the gate it just opened.
-	require.Len(t, auditStore.inserted, 1)
-	activated := auditStore.inserted[0]
+	require.Len(t, recorded, 1)
+	activated := recorded[0]
 	assert.Equal(t, auditlog.ActionLicenseActivated, activated.Action)
 	assert.Equal(t, "admin-1", activated.ActorID)
 	assert.Equal(t, "admin@example.com", activated.ActorDisplay)
@@ -71,7 +55,7 @@ func TestActivateAndRemoveEmitAuditEvents(t *testing.T) {
 
 	// Emitted before Deactivate: the removal is the last entry the license
 	// gate lets through. A regression emitting after would drop it here.
-	require.Len(t, auditStore.inserted, 2)
-	assert.Equal(t, auditlog.ActionLicenseRemoved, auditStore.inserted[1].Action)
+	require.Len(t, recorded, 2)
+	assert.Equal(t, auditlog.ActionLicenseRemoved, recorded[1].Action)
 	assert.False(t, IsEnterprise())
 }

--- a/ee/observe/ingest.go
+++ b/ee/observe/ingest.go
@@ -1,0 +1,166 @@
+// Copyright (c) 2026 Axel Marciano (Mercure Technologies). All rights reserved.
+// This file is governed by the Mercure Technologies Enterprise Edition License
+// (see ee/LICENSE); it is NOT covered by the MIT license of this repository.
+
+package observe
+
+import (
+	"errors"
+	"expo-open-ota/ee/identity"
+	"expo-open-ota/internal/helpers"
+	"io"
+	"log"
+	"net/http"
+
+	"github.com/google/uuid"
+	"github.com/gorilla/mux"
+)
+
+// observeResult labels the batches_total counter; see metrics.go.
+const (
+	resultAccepted    = "accepted"
+	resultBadRequest  = "bad_request"
+	resultTooLarge    = "too_large"
+	resultUnavailable = "unavailable"
+)
+
+// maxLogsBodyBytes caps a /v1/logs body. The SDK sends its whole pending
+// backlog uncompressed in one POST with no client-side cap; a realistic batch
+// is hundreds of KB, 16MB covers a device coming back from a long offline
+// stretch. Beyond it we answer 413: the SDK treats it as a permanent failure
+// and drops the batch, which is the point: a 5xx would make the device
+// re-send the same oversized poison pill forever.
+const maxLogsBodyBytes = 16 << 20
+
+// IngestHandler owns the expo-observe ingestion routes. The response contract
+// is dictated by the SDK's classification and every arm of it either destroys
+// or preserves data on the device:
+//
+//	2xx              batch deleted on the device
+//	429/502/503/504  batch kept, retried later
+//	anything else    batch deleted (permanent failure)
+//
+// Two rules follow. Never answer 500 (a panic destroys a batch: the recover
+// arm answers 503), and only answer 503 for genuinely transient conditions
+// (a healthy retry, not a poison-pill loop).
+type IngestHandler struct {
+	// identityService applies $set/$set_once/$unset records. nil in stateless
+	// mode (no control plane): identity ops are then acknowledged and dropped,
+	// like every other record, so devices never accumulate a backlog.
+	identityService *identity.Service
+}
+
+func NewIngestHandler(identityService *identity.Service) *IngestHandler {
+	return &IngestHandler{identityService: identityService}
+}
+
+// HandleLogs ingests POST /observe/{APP_ID}/{projectId}/v1/logs. Rate
+// limiting and app-existence run in middleware ahead of this handler. Today
+// the only consumer is identity; telemetry records are acknowledged and
+// dropped. When the ClickHouse path lands, its dispatch slots in right after
+// the identity split, behind the enterprise license gate (identity stays
+// free).
+func (h *IngestHandler) HandleLogs(w http.ResponseWriter, r *http.Request) {
+	// A panic must not turn into gorilla's 500: 500 destroys the batch on the
+	// device, 503 preserves it for a retry.
+	defer func() {
+		if rec := recover(); rec != nil {
+			log.Printf("observe: recovered panic in logs ingestion: %v", rec)
+			observeBatch(resultUnavailable)
+			w.WriteHeader(http.StatusServiceUnavailable)
+		}
+	}()
+
+	body, err := io.ReadAll(http.MaxBytesReader(w, r.Body, maxLogsBodyBytes))
+	if err != nil {
+		var maxBytesErr *http.MaxBytesError
+		if errors.As(err, &maxBytesErr) {
+			observeBatch(resultTooLarge)
+			w.WriteHeader(http.StatusRequestEntityTooLarge)
+			return
+		}
+		// The body could not be read off the wire: transient, preserve.
+		observeBatch(resultUnavailable)
+		w.WriteHeader(http.StatusServiceUnavailable)
+		return
+	}
+
+	batch, err := DecodeLogs(body)
+	if err != nil {
+		// Structurally unreadable JSON: a broken client will not repair
+		// itself, 400 (permanent) rather than an eternal retry loop.
+		observeBatch(resultBadRequest)
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	if h.identityService == nil {
+		observeBatch(resultAccepted)
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+
+	appID := mux.Vars(r)["APP_ID"]
+	remoteIP := ""
+	if clientIP := helpers.ClientIP(r); clientIP.IsValid() {
+		remoteIP = clientIP.String()
+	}
+
+	requests := identityRequestsFromBatch(batch, appID, remoteIP)
+	for _, req := range identity.CoalesceRequests(requests) {
+		if _, err := h.identityService.Apply(r.Context(), req); err != nil {
+			// Store errors are transient (pool exhausted, database down):
+			// 503 keeps the batch on the device for a retry. Re-applying the
+			// already-committed prefix on that retry is idempotent ($set
+			// merges, $unset ignores absent keys), so no double effects.
+			log.Printf("observe: identity apply failed: %v", err)
+			observeBatch(resultUnavailable)
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+	}
+
+	observeBatch(resultAccepted)
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// identityRequestsFromBatch turns a decoded logs batch into the identity
+// operations it carries, dropping (and counting) records that cannot be
+// attributed or are telemetry, not identity. Pure apart from the drop
+// counters, so it is unit-tested directly without an HTTP round-trip.
+func identityRequestsFromBatch(batch LogBatch, appID, remoteIP string) []identity.Request {
+	var requests []identity.Request
+	for _, resource := range batch.Resources {
+		clientID, _ := resource.Attributes[EASClientIDKey].(string)
+		// A missing or forged client id cannot be attributed to an install:
+		// skip those records instead of failing the batch (a non-2xx would
+		// also destroy or block every legitimate record around them).
+		if _, err := uuid.Parse(clientID); err != nil {
+			observeRecordsDropped(reasonForgedClientID, len(resource.Records))
+			continue
+		}
+		for _, record := range resource.Records {
+			eventName, _ := record.Attributes[EventNameKey].(string)
+			if !identity.IsIdentityOp(eventName) {
+				observeRecordsDropped(reasonTelemetry, 1) // ClickHouse path, later.
+				continue
+			}
+			if req, ok := identity.RequestFromRecord(appID, clientID, identity.Op(eventName), record.Attributes, remoteIP); ok {
+				requests = append(requests, req)
+			}
+		}
+	}
+	return requests
+}
+
+// HandleMetrics reserves POST /observe/{APP_ID}/{projectId}/v1/metrics.
+// Metrics are acknowledged and dropped until the ClickHouse path lands: for
+// the SDK, 204 and 404 destroy the batch identically, but the registered
+// route keeps operator logs quiet and the URL shape final. Rate limiting runs
+// in middleware ahead of this handler.
+func (h *IngestHandler) HandleMetrics(w http.ResponseWriter, r *http.Request) {
+	// Drain within the same cap so keep-alive connections stay reusable.
+	_, _ = io.Copy(io.Discard, http.MaxBytesReader(w, r.Body, maxLogsBodyBytes))
+	observeBatch(resultAccepted)
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/ee/observe/ingest.go
+++ b/ee/observe/ingest.go
@@ -5,12 +5,14 @@
 package observe
 
 import (
+	"context"
 	"errors"
 	"expo-open-ota/ee/identity"
 	"expo-open-ota/internal/helpers"
 	"io"
 	"log"
 	"net/http"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/gorilla/mux"
@@ -31,6 +33,10 @@ const (
 // and drops the batch, which is the point: a 5xx would make the device
 // re-send the same oversized poison pill forever.
 const maxLogsBodyBytes = 16 << 20
+
+// identityApplyTimeout keeps a stalled store operation from tying up an
+// ingestion request indefinitely. Each coalesced operation gets its own bound.
+const identityApplyTimeout = 5 * time.Second
 
 // IngestHandler owns the expo-observe ingestion routes. The response contract
 // is dictated by the SDK's classification and every arm of it either destroys
@@ -108,7 +114,10 @@ func (h *IngestHandler) HandleLogs(w http.ResponseWriter, r *http.Request) {
 
 	requests := identityRequestsFromBatch(batch, appID, remoteIP)
 	for _, req := range identity.CoalesceRequests(requests) {
-		if _, err := h.identityService.Apply(r.Context(), req); err != nil {
+		applyContext, cancelApply := context.WithTimeout(r.Context(), identityApplyTimeout)
+		_, err := h.identityService.Apply(applyContext, req)
+		cancelApply()
+		if err != nil {
 			// Store errors are transient (pool exhausted, database down):
 			// 503 keeps the batch on the device for a retry. Re-applying the
 			// already-committed prefix on that retry is idempotent ($set

--- a/ee/observe/ingest_test.go
+++ b/ee/observe/ingest_test.go
@@ -32,7 +32,7 @@ func serveIngest(handler *IngestHandler, method, path string, body []byte) *http
 	router := mux.NewRouter()
 	router.HandleFunc("/observe/{APP_ID}/{PROJECT_ID}/v1/logs", handler.HandleLogs).Methods(http.MethodPost)
 	router.HandleFunc("/observe/{APP_ID}/{PROJECT_ID}/v1/metrics", handler.HandleMetrics).Methods(http.MethodPost)
-	req := httptest.NewRequest(method, path, bytes.NewReader(body))
+	req := httptest.NewRequestWithContext(context.Background(), method, path, bytes.NewReader(body))
 	req.RemoteAddr = "203.0.113.9:40000"
 	recorder := httptest.NewRecorder()
 	router.ServeHTTP(recorder, req)
@@ -47,9 +47,12 @@ type recordingMutator struct {
 	sets   []map[string]any
 	unsets [][]string
 	fail   bool
+	// hadDeadline proves the HTTP handler bounds each store operation.
+	hadDeadline bool
 }
 
-func (m *recordingMutator) ApplySet(_ context.Context, _ string, _ string, raw map[string]any, _ *identity.Geo) (identity.ApplyResult, error) {
+func (m *recordingMutator) ApplySet(ctx context.Context, _ string, _ string, raw map[string]any, _ *identity.Geo) (identity.ApplyResult, error) {
+	_, m.hadDeadline = ctx.Deadline()
 	if m.fail {
 		return identity.ApplyResult{}, fmt.Errorf("database is down")
 	}
@@ -119,6 +122,7 @@ func TestHandleLogsResponseContract(t *testing.T) {
 		handler := NewIngestHandler(identity.NewService(mutator, nil))
 		recorder := serveIngest(handler, http.MethodPost, logsPath, []byte(androidLogsFixture))
 		require.Equal(t, http.StatusNoContent, recorder.Code)
+		require.True(t, mutator.hadDeadline, "each identity apply must have a request-scoped deadline")
 		require.Len(t, mutator.sets, 1)
 		require.Equal(t, "user_42", mutator.sets[0]["userId"])
 		// The envelope attributes were stripped before the store.

--- a/ee/observe/ingest_test.go
+++ b/ee/observe/ingest_test.go
@@ -1,0 +1,203 @@
+// Copyright (c) 2026 Axel Marciano (Mercure Technologies). All rights reserved.
+// This file is governed by the Mercure Technologies Enterprise Edition License
+// (see ee/LICENSE); it is NOT covered by the MIT license of this repository.
+
+package observe
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"expo-open-ota/ee/identity"
+	"expo-open-ota/internal/database"
+	"expo-open-ota/internal/database/postgres"
+	"expo-open-ota/internal/database/postgres/pgdb"
+
+	"github.com/google/uuid"
+	"github.com/gorilla/mux"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+)
+
+// serveIngest routes a request through the handler ONLY (no middleware), so
+// handler-contract tests are not perturbed by the rate limiter or the app
+// resolver. The middleware chain has its own tests.
+func serveIngest(handler *IngestHandler, method, path string, body []byte) *httptest.ResponseRecorder {
+	router := mux.NewRouter()
+	router.HandleFunc("/observe/{APP_ID}/{PROJECT_ID}/v1/logs", handler.HandleLogs).Methods(http.MethodPost)
+	router.HandleFunc("/observe/{APP_ID}/{PROJECT_ID}/v1/metrics", handler.HandleMetrics).Methods(http.MethodPost)
+	req := httptest.NewRequest(method, path, bytes.NewReader(body))
+	req.RemoteAddr = "203.0.113.9:40000"
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(recorder, req)
+	return recorder
+}
+
+type recordingMutator struct {
+	sets   []map[string]any
+	unsets [][]string
+	fail   bool
+}
+
+func (m *recordingMutator) ApplySet(_ context.Context, _ string, _ string, raw map[string]any, _ *identity.Geo) (identity.ApplyResult, error) {
+	if m.fail {
+		return identity.ApplyResult{}, fmt.Errorf("database is down")
+	}
+	m.sets = append(m.sets, raw)
+	return identity.ApplyResult{}, nil
+}
+
+func (m *recordingMutator) ApplySetOnce(_ context.Context, _ string, _ string, raw map[string]any, _ *identity.Geo) (identity.ApplyResult, error) {
+	return identity.ApplyResult{}, nil
+}
+
+func (m *recordingMutator) ApplyUnset(_ context.Context, _ string, _ string, keys []string, _ *identity.Geo) (identity.ApplyResult, error) {
+	if m.fail {
+		return identity.ApplyResult{}, fmt.Errorf("database is down")
+	}
+	m.unsets = append(m.unsets, keys)
+	return identity.ApplyResult{}, nil
+}
+
+const logsPath = "/observe/app-1/ignored-project/v1/logs"
+
+func TestHandleLogsResponseContract(t *testing.T) {
+	t.Run("nil service acknowledges and drops", func(t *testing.T) {
+		recorder := serveIngest(NewIngestHandler(nil), http.MethodPost, logsPath, []byte(androidLogsFixture))
+		require.Equal(t, http.StatusNoContent, recorder.Code)
+	})
+
+	t.Run("unreadable body is a permanent 400", func(t *testing.T) {
+		handler := NewIngestHandler(identity.NewService(&recordingMutator{}, nil))
+		recorder := serveIngest(handler, http.MethodPost, logsPath, []byte("not json"))
+		require.Equal(t, http.StatusBadRequest, recorder.Code)
+	})
+
+	t.Run("oversized body is a permanent 413", func(t *testing.T) {
+		handler := NewIngestHandler(identity.NewService(&recordingMutator{}, nil))
+		big := bytes.Repeat([]byte("x"), maxLogsBodyBytes+1)
+		recorder := serveIngest(handler, http.MethodPost, logsPath, big)
+		require.Equal(t, http.StatusRequestEntityTooLarge, recorder.Code)
+	})
+
+	t.Run("store failure is a retryable 503, never 500", func(t *testing.T) {
+		handler := NewIngestHandler(identity.NewService(&recordingMutator{fail: true}, nil))
+		recorder := serveIngest(handler, http.MethodPost, logsPath, []byte(androidLogsFixture))
+		require.Equal(t, http.StatusServiceUnavailable, recorder.Code)
+	})
+
+	t.Run("telemetry-only batch is acknowledged untouched", func(t *testing.T) {
+		mutator := &recordingMutator{}
+		handler := NewIngestHandler(identity.NewService(mutator, nil))
+		body := strings.ReplaceAll(androidLogsFixture, "$set", "exception")
+		recorder := serveIngest(handler, http.MethodPost, logsPath, []byte(body))
+		require.Equal(t, http.StatusNoContent, recorder.Code)
+		require.Empty(t, mutator.sets)
+	})
+
+	t.Run("forged client id skips records without failing the batch", func(t *testing.T) {
+		mutator := &recordingMutator{}
+		handler := NewIngestHandler(identity.NewService(mutator, nil))
+		body := strings.ReplaceAll(androidLogsFixture, "8b9c1fe0-93b3-4b3a-8c1d-2f4a5e6b7c8d", "not-a-uuid")
+		recorder := serveIngest(handler, http.MethodPost, logsPath, []byte(body))
+		require.Equal(t, http.StatusNoContent, recorder.Code)
+		require.Empty(t, mutator.sets)
+	})
+
+	t.Run("identity ops reach the service", func(t *testing.T) {
+		mutator := &recordingMutator{}
+		handler := NewIngestHandler(identity.NewService(mutator, nil))
+		recorder := serveIngest(handler, http.MethodPost, logsPath, []byte(androidLogsFixture))
+		require.Equal(t, http.StatusNoContent, recorder.Code)
+		require.Len(t, mutator.sets, 1)
+		require.Equal(t, "user_42", mutator.sets[0]["userId"])
+		// The envelope attributes were stripped before the store.
+		require.NotContains(t, mutator.sets[0], "event.name")
+		require.NotContains(t, mutator.sets[0], "session.id")
+
+		recorder = serveIngest(handler, http.MethodPost, logsPath, []byte(iosLogsFixture))
+		require.Equal(t, http.StatusNoContent, recorder.Code)
+		require.Equal(t, [][]string{{"userId", "tenant"}}, mutator.unsets)
+	})
+
+	t.Run("metrics stub acknowledges and drops", func(t *testing.T) {
+		recorder := serveIngest(NewIngestHandler(nil), http.MethodPost, "/observe/app-1/p/v1/metrics", []byte(`{"resourceMetrics":[]}`))
+		require.Equal(t, http.StatusNoContent, recorder.Code)
+	})
+}
+
+// End-to-end against a real Postgres: an SDK-shaped batch lands as a device
+// row. Gated like the identity store tests.
+func TestIngestEndToEnd(t *testing.T) {
+	dbURL := os.Getenv("TEST_DATABASE_URL")
+	if dbURL == "" {
+		if os.Getenv("CI") != "" {
+			t.Fatal("TEST_DATABASE_URL must be set in CI")
+		}
+		t.Skip("TEST_DATABASE_URL not set")
+	}
+	t.Setenv("ADMIN_EMAIL", "seed-admin@example.com")
+	t.Setenv("ADMIN_PASSWORD", "Sup3rSecret!")
+	postgres.RunDBMigrations(dbURL)
+	pool, err := pgxpool.New(context.Background(), dbURL)
+	require.NoError(t, err)
+	t.Cleanup(pool.Close)
+
+	appID := uuid.NewString()
+	_, err = pool.Exec(context.Background(), "INSERT INTO apps (id, name) VALUES ($1, $2)", appID, "observe-e2e")
+	require.NoError(t, err)
+	t.Cleanup(func() { _, _ = pool.Exec(context.Background(), "DELETE FROM apps WHERE id = $1", appID) })
+
+	identityStore := identity.NewPostgresIdentityStore(&database.Engine{Queries: pgdb.New(pool), DB: pool})
+	for _, spec := range []identity.KeySpec{
+		{Key: "userId", Type: identity.ValueTypeString},
+		{Key: "seats", Type: identity.ValueTypeNumber},
+		{Key: "isInternal", Type: identity.ValueTypeBoolean},
+	} {
+		_, err := identityStore.UpsertSchemaKey(context.Background(), appID, spec)
+		require.NoError(t, err)
+	}
+
+	handler := NewIngestHandler(identity.NewService(identityStore, nil))
+	path := "/observe/" + appID + "/whatever-project/v1/logs"
+	recorder := serveIngest(handler, http.MethodPost, path, []byte(androidLogsFixture))
+	require.Equal(t, http.StatusNoContent, recorder.Code)
+
+	device, err := identityStore.GetDevice(context.Background(), appID, "8b9c1fe0-93b3-4b3a-8c1d-2f4a5e6b7c8d")
+	require.NoError(t, err)
+	require.NotNil(t, device)
+	require.Equal(t, "user_42", device.Metadata["userId"])
+	require.Equal(t, float64(12), device.Metadata["seats"])
+	require.Equal(t, true, device.Metadata["isInternal"])
+}
+
+func TestIdentityRequestsFromBatch(t *testing.T) {
+	batch, err := DecodeLogs([]byte(androidLogsFixture))
+	require.NoError(t, err)
+	requests := identityRequestsFromBatch(batch, "app-1", "203.0.113.7")
+	require.Len(t, requests, 1)
+	require.Equal(t, identity.OpSet, requests[0].Op)
+	require.Equal(t, "app-1", requests[0].AppID)
+	require.Equal(t, "203.0.113.7", requests[0].RemoteIP)
+	require.Equal(t, "user_42", requests[0].Attributes["userId"])
+
+	t.Run("forged client id yields no requests", func(t *testing.T) {
+		body := strings.ReplaceAll(androidLogsFixture, "8b9c1fe0-93b3-4b3a-8c1d-2f4a5e6b7c8d", "not-a-uuid")
+		b, err := DecodeLogs([]byte(body))
+		require.NoError(t, err)
+		require.Empty(t, identityRequestsFromBatch(b, "app-1", ""))
+	})
+
+	t.Run("telemetry records yield no requests", func(t *testing.T) {
+		body := strings.ReplaceAll(androidLogsFixture, "$set", "exception")
+		b, err := DecodeLogs([]byte(body))
+		require.NoError(t, err)
+		require.Empty(t, identityRequestsFromBatch(b, "app-1", ""))
+	})
+}

--- a/ee/observe/ingest_test.go
+++ b/ee/observe/ingest_test.go
@@ -40,6 +40,10 @@ func serveIngest(handler *IngestHandler, method, path string, body []byte) *http
 }
 
 type recordingMutator struct {
+	// The embedded Store supplies the dashboard query methods (never called on
+	// the ingest path) so the fake satisfies identity.Store; only the three
+	// write methods below are exercised.
+	identity.Store
 	sets   []map[string]any
 	unsets [][]string
 	fail   bool

--- a/ee/observe/metrics.go
+++ b/ee/observe/metrics.go
@@ -1,0 +1,50 @@
+// Copyright (c) 2026 Axel Marciano (Mercure Technologies). All rights reserved.
+// This file is governed by the Mercure Technologies Enterprise Edition License
+// (see ee/LICENSE); it is NOT covered by the MIT license of this repository.
+
+package observe
+
+import "github.com/prometheus/client_golang/prometheus"
+
+// The ingestion route is a public, unauthenticated endpoint; these counters
+// are how an operator sees rejection and abuse rates. A 429 spike is a source
+// being throttled; a bad_request/too_large spike is a broken or hostile
+// client; a telemetry drop count is the size of the analytics backlog waiting
+// for the ClickHouse path. No appId label: the id is wire input on this route,
+// so labeling by it would be an unbounded-cardinality hole.
+var (
+	observeBatchesVec = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "observe_batches_total",
+			Help: "expo-observe ingestion batches, by result",
+		},
+		[]string{"result"},
+	)
+
+	observeRecordsDroppedVec = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "observe_records_dropped_total",
+			Help: "Log records received but not stored, by reason",
+		},
+		[]string{"reason"},
+	)
+)
+
+const (
+	reasonForgedClientID = "forged_client_id"
+	reasonTelemetry      = "telemetry_no_sink"
+)
+
+func init() {
+	prometheus.MustRegister(observeBatchesVec, observeRecordsDroppedVec)
+}
+
+func observeBatch(result string) {
+	observeBatchesVec.WithLabelValues(result).Inc()
+}
+
+func observeRecordsDropped(reason string, n int) {
+	if n > 0 {
+		observeRecordsDroppedVec.WithLabelValues(reason).Add(float64(n))
+	}
+}

--- a/ee/observe/middleware.go
+++ b/ee/observe/middleware.go
@@ -1,0 +1,80 @@
+// Copyright (c) 2026 Axel Marciano (Mercure Technologies). All rights reserved.
+// This file is governed by the Mercure Technologies Enterprise Edition License
+// (see ee/LICENSE); it is NOT covered by the MIT license of this repository.
+
+package observe
+
+import (
+	"expo-open-ota/config"
+	"expo-open-ota/internal/cache"
+	"expo-open-ota/internal/services"
+	"net/http"
+
+	"github.com/gorilla/mux"
+)
+
+// The observe subrouter runs CachedAppResolverMiddleware before the handler.
+// (Request rate limiting is intentionally not implemented yet: per-IP would
+// punish the shared-NAT / carrier-CGNAT case that dominates mobile, and the
+// right shape is operator-configurable, so it is deferred. Hard limits belong
+// at the edge in the meantime; the store's own per-device bounds still apply.)
+
+// appExistenceTTLSeconds bounds how long a known/unknown app id is trusted
+// from cache. Short enough that a freshly created or deleted app converges
+// quickly, long enough that a device fleet backgrounding in unison collapses
+// to one database read per app per window instead of one per request.
+const appExistenceTTLSeconds = 60
+
+const (
+	appKnownCacheValue   = "1"
+	appUnknownCacheValue = "0"
+)
+
+// CachedAppResolverMiddleware validates {APP_ID} against the registry like the
+// generic AppResolverMiddleware, but memoizes the lookup so telemetry (which
+// fires on every app-background of every device) does not issue an uncached
+// primary-key query per request. Both outcomes are cached: a valid id skips
+// the query for the window, an invalid id is short-circuited to 404 without
+// re-hitting the database under a flood of the same bad id.
+func CachedAppResolverMiddleware(appRepo services.AppRepository) func(http.Handler) http.Handler {
+	c := cache.GetCache()
+	ttl := appExistenceTTLSeconds
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			appID := mux.Vars(r)["APP_ID"]
+			if !isValidAppID(appID) {
+				// 404, not 400: for the SDK both are permanent (batch dropped),
+				// and 404 matches the manifest/asset edge for unknown ids.
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+
+			cacheKey := "observe:app_exists:" + appID
+			switch c.Get(cacheKey) {
+			case appKnownCacheValue:
+				next.ServeHTTP(w, r)
+				return
+			case appUnknownCacheValue:
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+
+			if _, err := appRepo.GetAppByID(r.Context(), appID); err != nil {
+				_ = c.Set(cacheKey, appUnknownCacheValue, &ttl)
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+			_ = c.Set(cacheKey, appKnownCacheValue, &ttl)
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// isValidAppID uses the same syntactic guard as the generic
+// AppResolverMiddleware (internal/middleware delegates to this too): the
+// observe {APP_ID} is the same internal app id and must obey the same rules.
+// We call config directly rather than import internal/middleware, which would
+// pull the whole handler graph into ee/observe.
+func isValidAppID(id string) bool {
+	return config.ValidateAppId(id, "appId") == nil
+}

--- a/ee/observe/middleware_test.go
+++ b/ee/observe/middleware_test.go
@@ -1,0 +1,104 @@
+// Copyright (c) 2026 Axel Marciano (Mercure Technologies). All rights reserved.
+// This file is governed by the Mercure Technologies Enterprise Edition License
+// (see ee/LICENSE); it is NOT covered by the MIT license of this repository.
+
+package observe
+
+import (
+	"bytes"
+	"context"
+	"expo-open-ota/config"
+	"expo-open-ota/internal/cache"
+	"expo-open-ota/internal/services"
+	"expo-open-ota/internal/store"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/require"
+)
+
+func resetObserveCache(t *testing.T) {
+	t.Helper()
+	require.NoError(t, cache.GetCache().Clear())
+}
+
+// countingAppRepo counts GetAppByID calls so the cache's effect is observable.
+type countingAppRepo struct {
+	calls   int64
+	unknown bool
+}
+
+func (r *countingAppRepo) GetAppByID(_ context.Context, _ string) (config.AppConfig, error) {
+	atomic.AddInt64(&r.calls, 1)
+	if r.unknown {
+		return config.AppConfig{}, fmt.Errorf("app not found")
+	}
+	return config.AppConfig{}, nil
+}
+func (r *countingAppRepo) InsertApp(context.Context, store.InsertAppParameters) (string, error) {
+	return "", nil
+}
+func (r *countingAppRepo) DeleteAppByID(context.Context, string) error             { return nil }
+func (r *countingAppRepo) GetApps(context.Context) ([]config.AppDescriptor, error) { return nil, nil }
+func (r *countingAppRepo) UpdateAppNameByID(context.Context, string, string) error { return nil }
+
+// Just here to verify correct compilation of the mocked appRepo
+var _ services.AppRepository = (*countingAppRepo)(nil)
+
+func chain(handler *IngestHandler, repo services.AppRepository) http.Handler {
+	router := mux.NewRouter()
+	sub := router.PathPrefix("/observe/{APP_ID}").Subrouter()
+	sub.Use(CachedAppResolverMiddleware(repo))
+	sub.HandleFunc("/{PROJECT_ID}/v1/logs", handler.HandleLogs).Methods(http.MethodPost)
+	return router
+}
+
+func post(h http.Handler, path, remote string) *httptest.ResponseRecorder {
+	// A valid empty batch: these tests exercise the middleware chain, not the
+	// decoder, so the handler must reach its 204 rather than 400 on the body.
+	req := httptest.NewRequest(http.MethodPost, path, bytes.NewReader([]byte(`{}`)))
+	req.RemoteAddr = remote
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	return rec
+}
+
+func TestCachedAppResolverMemoizesLookup(t *testing.T) {
+	resetObserveCache(t)
+	repo := &countingAppRepo{}
+	h := chain(NewIngestHandler(nil), repo)
+
+	for i := 0; i < 5; i++ {
+		rec := post(h, "/observe/known-app/proj/v1/logs", "203.0.113.20:1")
+		require.Equal(t, http.StatusNoContent, rec.Code)
+	}
+	// The five requests share one database read.
+	require.Equal(t, int64(1), atomic.LoadInt64(&repo.calls))
+}
+
+func TestCachedAppResolverCachesUnknown(t *testing.T) {
+	resetObserveCache(t)
+	repo := &countingAppRepo{unknown: true}
+	h := chain(NewIngestHandler(nil), repo)
+
+	for i := 0; i < 5; i++ {
+		rec := post(h, "/observe/ghost-app/proj/v1/logs", "203.0.113.21:1")
+		require.Equal(t, http.StatusNotFound, rec.Code)
+	}
+	// A flood of the same unknown id does not re-hit the database each time.
+	require.Equal(t, int64(1), atomic.LoadInt64(&repo.calls))
+}
+
+func TestCachedAppResolverRejectsMalformedID(t *testing.T) {
+	resetObserveCache(t)
+	repo := &countingAppRepo{}
+	h := chain(NewIngestHandler(nil), repo)
+	// A control character in the id fails the syntactic guard before any read.
+	rec := post(h, "/observe/%00bad/proj/v1/logs", "203.0.113.22:1")
+	require.Equal(t, http.StatusNotFound, rec.Code)
+	require.Equal(t, int64(0), atomic.LoadInt64(&repo.calls))
+}

--- a/ee/observe/otlp.go
+++ b/ee/observe/otlp.go
@@ -1,0 +1,171 @@
+// Copyright (c) 2026 Axel Marciano (Mercure Technologies). All rights reserved.
+// This file is governed by the Mercure Technologies Enterprise Edition License
+// (see ee/LICENSE); it is NOT covered by the MIT license of this repository.
+
+// Package observe receives expo-observe telemetry: the OTLP/JSON ingestion
+// routes, decoding, and dispatch. It sees EVERY log record a device ships;
+// identity operations ($set, $set_once, $unset) are routed to ee/identity,
+// and the remaining telemetry records will feed the ClickHouse path when it
+// lands. Identity dispatch is NOT license-gated (the identity feature is free);
+// the future telemetry path is where the enterprise gate will sit.
+package observe
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+)
+
+// Minimal, tolerant decoder for the OTLP/JSON bodies the expo-observe SDK
+// POSTs. Deliberately hand-rolled over the otlp protobuf bindings: we only
+// need resource attributes and per-record attributes, and the two platforms
+// diverge from strict OTLP anyway (iOS sends intValue as a raw JSON number
+// where the spec says string). Unknown fields are ignored by encoding/json,
+// which is exactly the tolerance we want: rejecting a batch destroys it on
+// the device. The decoded types are neutral on purpose: the ClickHouse
+// flattener will extend them (timestamps, severity, body) without another
+// decoder.
+
+// LogBatch is one decoded /v1/logs body.
+type LogBatch struct {
+	Resources []ResourceLogs
+}
+
+// ResourceLogs is one device session's worth of records: the resource
+// attributes (device, app, update...) and the log records they scope.
+type ResourceLogs struct {
+	Attributes map[string]any
+	Records    []LogRecord
+}
+
+// LogRecord is one log record's attributes. Telemetry fields (timestamp,
+// severity, body) are not decoded yet: nothing consumes them before the
+// ClickHouse path exists.
+type LogRecord struct {
+	Attributes map[string]any
+}
+
+// EASClientIDKey is the resource attribute carrying the persistent
+// per-install UUID from expo-eas-client.
+const EASClientIDKey = "expo.eas_client.id"
+
+// EventNameKey is the record attribute carrying the log event name; it is
+// what identity operations are recognized by. Deliberately also defined in
+// ee/identity (recordEventNameKey): observe reads it here to classify
+// identity-vs-telemetry, identity strips it there as envelope. The dependency
+// direction (observe → identity) and the future flattener wanting it as a real
+// column both forbid collapsing the two into one owner today.
+const EventNameKey = "event.name"
+
+// DecodeLogs parses an OTLP/JSON logs body. An error means the body is not
+// JSON we can read at all; a readable body with zero records is normal.
+func DecodeLogs(body []byte) (LogBatch, error) {
+	var decoded otlpLogsBody
+	if err := json.Unmarshal(body, &decoded); err != nil {
+		return LogBatch{}, fmt.Errorf("unreadable OTLP logs body: %w", err)
+	}
+	batch := LogBatch{Resources: make([]ResourceLogs, 0, len(decoded.ResourceLogs))}
+	for _, resource := range decoded.ResourceLogs {
+		entry := ResourceLogs{Attributes: kvToMap(resource.Resource.Attributes)}
+		for _, scope := range resource.ScopeLogs {
+			for _, record := range scope.LogRecords {
+				entry.Records = append(entry.Records, LogRecord{Attributes: kvToMap(record.Attributes)})
+			}
+		}
+		batch.Resources = append(batch.Resources, entry)
+	}
+	return batch, nil
+}
+
+type otlpLogsBody struct {
+	ResourceLogs []otlpResourceLogs `json:"resourceLogs"`
+}
+
+type otlpResourceLogs struct {
+	Resource  otlpResource    `json:"resource"`
+	ScopeLogs []otlpScopeLogs `json:"scopeLogs"`
+}
+
+type otlpResource struct {
+	Attributes []otlpKV `json:"attributes"`
+}
+
+type otlpScopeLogs struct {
+	LogRecords []otlpLogRecord `json:"logRecords"`
+}
+
+type otlpLogRecord struct {
+	Attributes []otlpKV `json:"attributes"`
+}
+
+type otlpKV struct {
+	Key   string       `json:"key"`
+	Value otlpAnyValue `json:"value"`
+}
+
+type otlpAnyValue struct {
+	StringValue *string          `json:"stringValue"`
+	IntValue    json.RawMessage  `json:"intValue"`
+	DoubleValue *float64         `json:"doubleValue"`
+	BoolValue   *bool            `json:"boolValue"`
+	ArrayValue  *otlpArrayValue  `json:"arrayValue"`
+	KvlistValue *otlpKvlistValue `json:"kvlistValue"`
+}
+
+type otlpArrayValue struct {
+	Values []otlpAnyValue `json:"values"`
+}
+
+type otlpKvlistValue struct {
+	Values []otlpKV `json:"values"`
+}
+
+// toGo unwraps the single-key AnyValue union into plain Go values. intValue
+// accepts both wire forms: Android emits the OTLP-conformant string ("42"),
+// iOS deliberately emits a raw JSON number (42). Unrepresentable values decode
+// to nil; downstream consumers (identity's Sanitize, the future flattener)
+// drop them.
+func (v otlpAnyValue) toGo() any {
+	switch {
+	case v.StringValue != nil:
+		return *v.StringValue
+	case len(v.IntValue) > 0:
+		var num json.Number
+		if err := json.Unmarshal(v.IntValue, &num); err == nil {
+			if i, err := num.Int64(); err == nil {
+				return i
+			}
+		}
+		var str string
+		if err := json.Unmarshal(v.IntValue, &str); err == nil {
+			if i, err := strconv.ParseInt(str, 10, 64); err == nil {
+				return i
+			}
+		}
+		return nil
+	case v.DoubleValue != nil:
+		return *v.DoubleValue
+	case v.BoolValue != nil:
+		return *v.BoolValue
+	case v.ArrayValue != nil:
+		values := make([]any, 0, len(v.ArrayValue.Values))
+		for _, item := range v.ArrayValue.Values {
+			values = append(values, item.toGo())
+		}
+		return values
+	case v.KvlistValue != nil:
+		return kvToMap(v.KvlistValue.Values)
+	}
+	return nil
+}
+
+func kvToMap(kvs []otlpKV) map[string]any {
+	m := make(map[string]any, len(kvs))
+	for _, kv := range kvs {
+		if kv.Key == "" {
+			continue
+		}
+		m[kv.Key] = kv.Value.toGo()
+	}
+	return m
+}

--- a/ee/observe/otlp_test.go
+++ b/ee/observe/otlp_test.go
@@ -1,0 +1,107 @@
+// Copyright (c) 2026 Axel Marciano (Mercure Technologies). All rights reserved.
+// This file is governed by the Mercure Technologies Enterprise Edition License
+// (see ee/LICENSE); it is NOT covered by the MIT license of this repository.
+
+package observe
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Android wire shape: pretty-printed, intValue as OTLP-conformant string.
+const androidLogsFixture = `{
+  "resourceLogs": [
+    {
+      "resource": {
+        "attributes": [
+          { "key": "expo.eas_client.id", "value": { "stringValue": "8b9c1fe0-93b3-4b3a-8c1d-2f4a5e6b7c8d" } },
+          { "key": "os.type", "value": { "stringValue": "linux" } },
+          { "key": "service.name", "value": { "stringValue": "fr.skeat.myapp" } }
+        ]
+      },
+      "scopeLogs": [
+        {
+          "scope": { "name": "expo-observe", "version": "56.0.16" },
+          "logRecords": [
+            {
+              "timeUnixNano": 1767960489000000000,
+              "severityNumber": 9,
+              "severityText": "INFO",
+              "body": { "stringValue": "" },
+              "attributes": [
+                { "key": "session.id", "value": { "stringValue": "aaaa-1111" } },
+                { "key": "event.name", "value": { "stringValue": "$set" } },
+                { "key": "userId", "value": { "stringValue": "user_42" } },
+                { "key": "seats", "value": { "intValue": "12" } },
+                { "key": "isInternal", "value": { "boolValue": true } }
+              ]
+            }
+          ]
+        }
+      ],
+      "schemaUrl": "https://opentelemetry.io/schemas/1.27.0"
+    }
+  ]
+}`
+
+// iOS wire shape: compact, intValue as a raw JSON number (deliberate OTLP
+// deviation of the Swift client).
+const iosLogsFixture = `{"resourceLogs":[{"resource":{"attributes":[{"key":"expo.eas_client.id","value":{"stringValue":"7A6B5C4D-3E2F-1A0B-9C8D-7E6F5A4B3C2D"}}]},"scopeLogs":[{"scope":{"name":"expo-observe","version":"56.0.16"},"logRecords":[{"timeUnixNano":1767960489000000000,"severityNumber":9,"severityText":"INFO","body":{"stringValue":"user logged in"},"attributes":[{"key":"event.name","value":{"stringValue":"$unset"}},{"key":"keys","value":{"arrayValue":{"values":[{"stringValue":"userId"},{"stringValue":"tenant"}]}}},{"key":"seats","value":{"intValue":42}}]}]}],"schemaUrl":"https://opentelemetry.io/schemas/1.27.0"}]}`
+
+func TestDecodeLogsAndroidShape(t *testing.T) {
+	batch, err := DecodeLogs([]byte(androidLogsFixture))
+	require.NoError(t, err)
+	require.Len(t, batch.Resources, 1)
+
+	resource := batch.Resources[0]
+	require.Equal(t, "8b9c1fe0-93b3-4b3a-8c1d-2f4a5e6b7c8d", resource.Attributes[EASClientIDKey])
+	require.Len(t, resource.Records, 1)
+
+	attrs := resource.Records[0].Attributes
+	require.Equal(t, "$set", attrs[EventNameKey])
+	require.Equal(t, "user_42", attrs["userId"])
+	// Android string-form intValue decodes to a number.
+	require.Equal(t, int64(12), attrs["seats"])
+	require.Equal(t, true, attrs["isInternal"])
+}
+
+func TestDecodeLogsIOSShape(t *testing.T) {
+	batch, err := DecodeLogs([]byte(iosLogsFixture))
+	require.NoError(t, err)
+	require.Len(t, batch.Resources, 1)
+
+	attrs := batch.Resources[0].Records[0].Attributes
+	require.Equal(t, "$unset", attrs[EventNameKey])
+	// iOS raw-number intValue decodes to the same Go value as Android's.
+	require.Equal(t, int64(42), attrs["seats"])
+	// Nested arrayValue unwraps to []any of plain values.
+	require.Equal(t, []any{"userId", "tenant"}, attrs["keys"])
+}
+
+func TestDecodeLogsTolerance(t *testing.T) {
+	// Unknown fields and empty bodies are tolerated: rejecting destroys the
+	// batch on the device.
+	batch, err := DecodeLogs([]byte(`{"resourceLogs":[],"partialSuccess":{"whatever":1}}`))
+	require.NoError(t, err)
+	require.Empty(t, batch.Resources)
+
+	batch, err = DecodeLogs([]byte(`{}`))
+	require.NoError(t, err)
+	require.Empty(t, batch.Resources)
+
+	// Structural garbage is a hard error (the 400 arm).
+	_, err = DecodeLogs([]byte(`not json at all`))
+	require.Error(t, err)
+
+	// Unrepresentable values decode to nil instead of failing the batch.
+	batch, err = DecodeLogs([]byte(`{"resourceLogs":[{"resource":{"attributes":[{"key":"x","value":{"intValue":"not-a-number"}}]},"scopeLogs":[]}]}`))
+	require.NoError(t, err)
+	require.Nil(t, batch.Resources[0].Attributes["x"])
+
+	// kvlistValue unwraps to a nested map.
+	batch, err = DecodeLogs([]byte(`{"resourceLogs":[{"resource":{"attributes":[{"key":"nested","value":{"kvlistValue":{"values":[{"key":"a","value":{"doubleValue":1.5}}]}}}]},"scopeLogs":[]}]}`))
+	require.NoError(t, err)
+	require.Equal(t, map[string]any{"a": 1.5}, batch.Resources[0].Attributes["nested"])
+}

--- a/ee/rbac/handler.go
+++ b/ee/rbac/handler.go
@@ -70,13 +70,6 @@ func grantResponseFrom(grant AppGrant) GrantResponse {
 	}
 }
 
-func renderJSON(w http.ResponseWriter, status int, payload interface{}) {
-	marshaledResponse, _ := json.Marshal(payload)
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(status)
-	w.Write(marshaledResponse)
-}
-
 func renderRBACServiceError(w http.ResponseWriter, err error) {
 	validationErr := (*ValidationError)(nil)
 	alreadyExistsErr := (*store.ErrResourceAlreadyExists)(nil)
@@ -108,7 +101,7 @@ func (h *RBACHandler) ListRolesHandler(w http.ResponseWriter, r *http.Request) {
 	for i, role := range roles {
 		response[i] = roleResponseFrom(role)
 	}
-	renderJSON(w, http.StatusOK, response)
+	handlers.RenderJSON(w, http.StatusOK, response)
 }
 
 type rolePayload struct {
@@ -127,7 +120,7 @@ func (h *RBACHandler) CreateRoleHandler(w http.ResponseWriter, r *http.Request) 
 		renderRBACServiceError(w, err)
 		return
 	}
-	renderJSON(w, http.StatusCreated, roleResponseFrom(role))
+	handlers.RenderJSON(w, http.StatusCreated, roleResponseFrom(role))
 }
 
 func (h *RBACHandler) UpdateRoleHandler(w http.ResponseWriter, r *http.Request) {
@@ -185,7 +178,7 @@ func (h *RBACHandler) GetUserGrantsHandler(w http.ResponseWriter, r *http.Reques
 	for i, grant := range grants {
 		response[i] = grantResponseFrom(grant)
 	}
-	renderJSON(w, http.StatusOK, response)
+	handlers.RenderJSON(w, http.StatusOK, response)
 }
 
 func (h *RBACHandler) SetUserGrantsHandler(w http.ResponseWriter, r *http.Request) {
@@ -225,7 +218,7 @@ func (h *RBACHandler) GetGrantSummaryHandler(w http.ResponseWriter, r *http.Requ
 		renderRBACServiceError(w, err)
 		return
 	}
-	renderJSON(w, http.StatusOK, counts)
+	handlers.RenderJSON(w, http.StatusOK, counts)
 }
 
 // MyPermissionsResponse tells the dashboard what to show the current account.
@@ -256,5 +249,5 @@ func (h *RBACHandler) GetMyPermissionsHandler(w http.ResponseWriter, r *http.Req
 			response.Apps[appId] = fromPermissions(perms)
 		}
 	}
-	renderJSON(w, http.StatusOK, response)
+	handlers.RenderJSON(w, http.StatusOK, response)
 }

--- a/ee/rbac/permissions.go
+++ b/ee/rbac/permissions.go
@@ -35,6 +35,11 @@ const (
 	// edits their enterprise restrictions (IP allowlists, protected-branch
 	// access).
 	PermApiKeysManage Permission = "apikeys:manage"
+	// PermIdentityManage edits the device-identity metadata allowlist (the
+	// dashboard "Identity" section): which metadata keys are accepted and
+	// their types. Reading identity and browsing devices stays open to any app
+	// viewer; only shaping the allowlist needs this.
+	PermIdentityManage Permission = "identity:manage"
 )
 
 // AllPermissions is the catalog, in the order the dashboard displays it.
@@ -51,6 +56,7 @@ var AllPermissions = []Permission{
 	PermChannelRolloutManage,
 	PermUpdateRolloutManage,
 	PermApiKeysManage,
+	PermIdentityManage,
 }
 
 var permissionSet = func() map[Permission]struct{} {

--- a/ee/sso/handler.go
+++ b/ee/sso/handler.go
@@ -40,13 +40,6 @@ func NewSSOHandler(service *SSOService) *SSOHandler {
 	return &SSOHandler{service: service}
 }
 
-func renderJSON(w http.ResponseWriter, status int, payload interface{}) {
-	marshaledResponse, _ := json.Marshal(payload)
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(status)
-	w.Write(marshaledResponse)
-}
-
 // renderSSOServiceError maps the service's business errors onto explicit
 // status codes for the admin endpoints; anything unrecognized stays an
 // opaque 500.
@@ -134,7 +127,7 @@ func (h *SSOHandler) GetPublicConfigHandler(w http.ResponseWriter, r *http.Reque
 		handlers.RenderError(w, http.StatusNotFound, "Dashboard is disabled")
 		return
 	}
-	renderJSON(w, http.StatusOK, h.service.PublicConfig(r.Context()))
+	handlers.RenderJSON(w, http.StatusOK, h.service.PublicConfig(r.Context()))
 }
 
 // LoginRedirectHandler starts the flow: it drops the flow cookie and sends
@@ -245,7 +238,7 @@ func (h *SSOHandler) GetConfigHandler(w http.ResponseWriter, r *http.Request) {
 		renderSSOServiceError(w, err)
 		return
 	}
-	renderJSON(w, http.StatusOK, adminConfigResponseFrom(view))
+	handlers.RenderJSON(w, http.StatusOK, adminConfigResponseFrom(view))
 }
 
 func (h *SSOHandler) SaveConfigHandler(w http.ResponseWriter, r *http.Request) {
@@ -283,7 +276,7 @@ func (h *SSOHandler) SaveConfigHandler(w http.ResponseWriter, r *http.Request) {
 		renderSSOServiceError(w, err)
 		return
 	}
-	renderJSON(w, http.StatusOK, adminConfigResponseFrom(view))
+	handlers.RenderJSON(w, http.StatusOK, adminConfigResponseFrom(view))
 }
 
 func (h *SSOHandler) DeleteConfigHandler(w http.ResponseWriter, r *http.Request) {

--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	golang.org/x/crypto v0.54.0
 	golang.org/x/oauth2 v0.35.0
 	golang.org/x/sync v0.22.0
+	golang.org/x/time v0.5.0
 	google.golang.org/api v0.178.0
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -91,7 +92,6 @@ require (
 	golang.org/x/net v0.57.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/text v0.40.0 // indirect
-	golang.org/x/time v0.5.0 // indirect
 	google.golang.org/genproto v0.0.0-20240401170217-c3f982113cda // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20251202230838-ff82c1b0f217 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20251202230838-ff82c1b0f217 // indirect

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/jackc/pgx/v5 v5.9.2
 	github.com/jarcoal/httpmock v1.3.1
 	github.com/joho/godotenv v1.5.1
+	github.com/oschwald/geoip2-golang v1.13.0
 	github.com/pressly/goose/v3 v3.26.0
 	github.com/prometheus/client_golang v1.20.5
 	github.com/redis/go-redis/v9 v9.18.0
@@ -72,6 +73,7 @@ require (
 	github.com/klauspost/compress v1.18.0 // indirect
 	github.com/mfridman/interpolate v0.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/oschwald/maxminddb-golang v1.13.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.55.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -179,6 +179,10 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/ncruces/go-strftime v0.1.9 h1:bY0MQC28UADQmHmaF5dgpLmImcShSi2kHU9XLdhx/f4=
 github.com/ncruces/go-strftime v0.1.9/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
+github.com/oschwald/geoip2-golang v1.13.0 h1:Q44/Ldc703pasJeP5V9+aFSZFmBN7DKHbNsSFzQATJI=
+github.com/oschwald/geoip2-golang v1.13.0/go.mod h1:P9zG+54KPEFOliZ29i7SeYZ/GM6tfEL+rgSn03hYuUo=
+github.com/oschwald/maxminddb-golang v1.13.0 h1:R8xBorY71s84yO06NgTmQvqvTvlS/bnYZrrWX1MElnU=
+github.com/oschwald/maxminddb-golang v1.13.0/go.mod h1:BU0z8BfFVhi1LQaonTwwGQlsHUEu9pWNdMfmq4ztm0o=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmdv1U2eRNDiU2ErMBj1gwrq8eQ=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c/go.mod h1:7rwL4CYBLnjLxUqIJNnCWiEdr3bn6IUYi15bNlnbCCU=
 github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 h1:GFCKgmp0tecUJ0sJuv4pzYCqS9+RGSn52M3FUwPs+uo=

--- a/internal/database/postgres/migrations/20260722150000_identity.sql
+++ b/internal/database/postgres/migrations/20260722150000_identity.sql
@@ -1,0 +1,84 @@
+-- +goose Up
+-- +goose StatementBegin
+
+-- Device identity (ee/identity). Maps an expo-eas-client install UUID to
+-- operator-defined metadata (userId, tenant, ...) fed by `identify` log
+-- events on the observe ingestion route, plus GeoIP columns resolved from
+-- the request IP. EE-licensed code, but NOT license-gated: the feature works
+-- on community deployments too.
+
+-- Trigram index support for the metadata value autocomplete. Ships with the
+-- postgres contrib package (present in the official Docker images and on the
+-- managed offerings: RDS, Cloud SQL, Neon, Supabase). Operators on a build
+-- without contrib get a clear migration failure here, not a silent one later.
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+-- The allowlist managed in the dashboard "Identity" section. Ingestion drops
+-- every metadata key that is not declared here with a matching value type,
+-- which is what makes hostile payloads (thousands of keys, megabyte values)
+-- a non-issue by construction rather than by heuristics.
+CREATE TABLE identity_schema (
+    app_id UUID NOT NULL REFERENCES apps (id) ON DELETE CASCADE,
+    key TEXT NOT NULL,
+    value_type TEXT NOT NULL CHECK (value_type IN ('string', 'number', 'boolean')),
+    -- Applies to string values only. A string over the limit is dropped, not
+    -- truncated: a truncated userId would silently corrupt the mapping.
+    max_length INT NOT NULL DEFAULT 256,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (app_id, key)
+);
+
+-- One row per install. eas_client_id is the persistent per-install UUID from
+-- expo-eas-client (sent as the expo.eas_client.id resource attribute).
+-- metadata only ever contains allowlisted keys, so its size is bounded by the
+-- schema, and the GIN index serves equality/containment lookups on any key
+-- (metadata @> '{"userId": "X"}') without per-key indexes.
+CREATE TABLE device_identity (
+    app_id UUID NOT NULL REFERENCES apps (id) ON DELETE CASCADE,
+    eas_client_id UUID NOT NULL,
+    metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+    -- GeoIP enrichment, city-level accuracy (MaxMind GeoLite2). Nullable:
+    -- resolution is best-effort and optional. COALESCE semantics on update:
+    -- a request that resolves no geo never erases a previously known one.
+    country_code TEXT,
+    city TEXT,
+    lat DOUBLE PRECISION,
+    lng DOUBLE PRECISION,
+    first_seen_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    last_seen_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (app_id, eas_client_id)
+);
+
+CREATE INDEX idx_device_identity_metadata ON device_identity USING GIN (metadata jsonb_path_ops);
+CREATE INDEX idx_device_identity_country ON device_identity (app_id, country_code);
+CREATE INDEX idx_device_identity_last_seen ON device_identity (app_id, last_seen_at);
+
+-- Distinct-value stats powering searchMetadata (dashboard autocomplete and
+-- segmentation dropdowns). Cardinality is the number of distinct values, not
+-- the number of devices, so lookups stay cheap at any fleet size. Counts are
+-- maintained transactionally with device updates but treated as approximate
+-- ranking signals, not billing-grade numbers.
+CREATE TABLE identity_value_stats (
+    app_id UUID NOT NULL REFERENCES apps (id) ON DELETE CASCADE,
+    key TEXT NOT NULL,
+    value TEXT NOT NULL,
+    device_count BIGINT NOT NULL DEFAULT 0,
+    last_seen_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (app_id, key, value)
+);
+
+CREATE INDEX idx_identity_value_stats_trgm ON identity_value_stats USING GIN (value gin_trgm_ops);
+
+-- Serves the empty-search autocomplete (dropdown open, the most common call)
+-- as an index-only top-N scan. Without it, every call top-N sorts all distinct
+-- values of the key, which is O(user count) for a userId-style key.
+CREATE INDEX idx_identity_value_stats_top ON identity_value_stats (app_id, key, device_count DESC, value ASC);
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP TABLE IF EXISTS identity_value_stats;
+DROP TABLE IF EXISTS device_identity;
+DROP TABLE IF EXISTS identity_schema;
+-- +goose StatementEnd

--- a/internal/database/postgres/pgdb/models.go
+++ b/internal/database/postgres/pgdb/models.go
@@ -84,11 +84,39 @@ type ChannelRollout struct {
 	UpdatedAt       pgtype.Timestamptz `json:"updated_at"`
 }
 
+type DeviceIdentity struct {
+	AppID       pgtype.UUID        `json:"app_id"`
+	EasClientID pgtype.UUID        `json:"eas_client_id"`
+	Metadata    []byte             `json:"metadata"`
+	CountryCode *string            `json:"country_code"`
+	City        *string            `json:"city"`
+	Lat         *float64           `json:"lat"`
+	Lng         *float64           `json:"lng"`
+	FirstSeenAt pgtype.Timestamptz `json:"first_seen_at"`
+	LastSeenAt  pgtype.Timestamptz `json:"last_seen_at"`
+}
+
 type EnterpriseLicense struct {
 	Singleton  bool               `json:"singleton"`
 	LicenseKey string             `json:"license_key"`
 	CreatedAt  pgtype.Timestamptz `json:"created_at"`
 	UpdatedAt  pgtype.Timestamptz `json:"updated_at"`
+}
+
+type IdentitySchema struct {
+	AppID     pgtype.UUID        `json:"app_id"`
+	Key       string             `json:"key"`
+	ValueType string             `json:"value_type"`
+	MaxLength int32              `json:"max_length"`
+	CreatedAt pgtype.Timestamptz `json:"created_at"`
+}
+
+type IdentityValueStat struct {
+	AppID       pgtype.UUID        `json:"app_id"`
+	Key         string             `json:"key"`
+	Value       string             `json:"value"`
+	DeviceCount int64              `json:"device_count"`
+	LastSeenAt  pgtype.Timestamptz `json:"last_seen_at"`
 }
 
 type Role struct {

--- a/internal/database/postgres/pgdb/queries.sql.go
+++ b/internal/database/postgres/pgdb/queries.sql.go
@@ -138,6 +138,23 @@ func (q *Queries) CountGrantsPerUser(ctx context.Context) ([]CountGrantsPerUserR
 	return items, nil
 }
 
+const decrementIdentityValueStat = `-- name: DecrementIdentityValueStat :exec
+UPDATE identity_value_stats
+SET device_count = GREATEST(device_count - 1, 0)
+WHERE app_id = $1 AND key = $2 AND value = $3
+`
+
+type DecrementIdentityValueStatParams struct {
+	AppID pgtype.UUID `json:"app_id"`
+	Key   string      `json:"key"`
+	Value string      `json:"value"`
+}
+
+func (q *Queries) DecrementIdentityValueStat(ctx context.Context, arg DecrementIdentityValueStatParams) error {
+	_, err := q.db.Exec(ctx, decrementIdentityValueStat, arg.AppID, arg.Key, arg.Value)
+	return err
+}
+
 const deleteAppByID = `-- name: DeleteAppByID :execresult
 DELETE FROM apps
 WHERE id = $1
@@ -206,6 +223,38 @@ func (q *Queries) DeleteEnterpriseLicense(ctx context.Context) error {
 	return err
 }
 
+const deleteIdentitySchemaKey = `-- name: DeleteIdentitySchemaKey :execresult
+DELETE FROM identity_schema
+WHERE app_id = $1 AND key = $2
+`
+
+type DeleteIdentitySchemaKeyParams struct {
+	AppID pgtype.UUID `json:"app_id"`
+	Key   string      `json:"key"`
+}
+
+func (q *Queries) DeleteIdentitySchemaKey(ctx context.Context, arg DeleteIdentitySchemaKeyParams) (pgconn.CommandTag, error) {
+	return q.db.Exec(ctx, deleteIdentitySchemaKey, arg.AppID, arg.Key)
+}
+
+const deleteIdentityValueStatsForKey = `-- name: DeleteIdentityValueStatsForKey :exec
+DELETE FROM identity_value_stats
+WHERE app_id = $1 AND key = $2
+`
+
+type DeleteIdentityValueStatsForKeyParams struct {
+	AppID pgtype.UUID `json:"app_id"`
+	Key   string      `json:"key"`
+}
+
+// Wipes the autocomplete entries of a key when it leaves the allowlist, so
+// searchMetadata never suggests values of a key the operator removed. The
+// values already merged into device_identity.metadata are left in place.
+func (q *Queries) DeleteIdentityValueStatsForKey(ctx context.Context, arg DeleteIdentityValueStatsForKeyParams) error {
+	_, err := q.db.Exec(ctx, deleteIdentityValueStatsForKey, arg.AppID, arg.Key)
+	return err
+}
+
 const deleteRole = `-- name: DeleteRole :execresult
 DELETE FROM roles
 WHERE id = $1
@@ -253,6 +302,42 @@ WHERE users.id = $1
 // an account that cannot sign in is no safety net.
 func (q *Queries) DeleteUserByID(ctx context.Context, id pgtype.UUID) (pgconn.CommandTag, error) {
 	return q.db.Exec(ctx, deleteUserByID, id)
+}
+
+const deleteZeroIdentityValueStats = `-- name: DeleteZeroIdentityValueStats :exec
+DELETE FROM identity_value_stats
+WHERE app_id = $1 AND key = $2 AND value = $3 AND device_count <= 0
+`
+
+type DeleteZeroIdentityValueStatsParams struct {
+	AppID pgtype.UUID `json:"app_id"`
+	Key   string      `json:"key"`
+	Value string      `json:"value"`
+}
+
+func (q *Queries) DeleteZeroIdentityValueStats(ctx context.Context, arg DeleteZeroIdentityValueStatsParams) error {
+	_, err := q.db.Exec(ctx, deleteZeroIdentityValueStats, arg.AppID, arg.Key, arg.Value)
+	return err
+}
+
+const ensureDeviceIdentity = `-- name: EnsureDeviceIdentity :exec
+INSERT INTO device_identity (app_id, eas_client_id)
+VALUES ($1, $2)
+ON CONFLICT (app_id, eas_client_id) DO NOTHING
+`
+
+type EnsureDeviceIdentityParams struct {
+	AppID       pgtype.UUID `json:"app_id"`
+	EasClientID pgtype.UUID `json:"eas_client_id"`
+}
+
+// Creates the row if this install was never seen. Split from the update on
+// purpose: FOR UPDATE cannot lock a row that does not exist yet, so two
+// concurrent first identifies of the same install would both merge against
+// an empty map and one would silently win. Insert-then-lock serializes them.
+func (q *Queries) EnsureDeviceIdentity(ctx context.Context, arg EnsureDeviceIdentityParams) error {
+	_, err := q.db.Exec(ctx, ensureDeviceIdentity, arg.AppID, arg.EasClientID)
+	return err
 }
 
 const getActiveRolloutUpdates = `-- name: GetActiveRolloutUpdates :many
@@ -763,6 +848,61 @@ func (q *Queries) GetChannelsByAppID(ctx context.Context, appID pgtype.UUID) ([]
 		return nil, err
 	}
 	return items, nil
+}
+
+const getDeviceIdentity = `-- name: GetDeviceIdentity :one
+SELECT app_id, eas_client_id, metadata, country_code, city, lat, lng, first_seen_at, last_seen_at FROM device_identity
+WHERE app_id = $1 AND eas_client_id = $2
+`
+
+type GetDeviceIdentityParams struct {
+	AppID       pgtype.UUID `json:"app_id"`
+	EasClientID pgtype.UUID `json:"eas_client_id"`
+}
+
+func (q *Queries) GetDeviceIdentity(ctx context.Context, arg GetDeviceIdentityParams) (DeviceIdentity, error) {
+	row := q.db.QueryRow(ctx, getDeviceIdentity, arg.AppID, arg.EasClientID)
+	var i DeviceIdentity
+	err := row.Scan(
+		&i.AppID,
+		&i.EasClientID,
+		&i.Metadata,
+		&i.CountryCode,
+		&i.City,
+		&i.Lat,
+		&i.Lng,
+		&i.FirstSeenAt,
+		&i.LastSeenAt,
+	)
+	return i, err
+}
+
+const getDeviceIdentityForUpdate = `-- name: GetDeviceIdentityForUpdate :one
+SELECT app_id, eas_client_id, metadata, country_code, city, lat, lng, first_seen_at, last_seen_at FROM device_identity
+WHERE app_id = $1 AND eas_client_id = $2
+FOR UPDATE
+`
+
+type GetDeviceIdentityForUpdateParams struct {
+	AppID       pgtype.UUID `json:"app_id"`
+	EasClientID pgtype.UUID `json:"eas_client_id"`
+}
+
+func (q *Queries) GetDeviceIdentityForUpdate(ctx context.Context, arg GetDeviceIdentityForUpdateParams) (DeviceIdentity, error) {
+	row := q.db.QueryRow(ctx, getDeviceIdentityForUpdate, arg.AppID, arg.EasClientID)
+	var i DeviceIdentity
+	err := row.Scan(
+		&i.AppID,
+		&i.EasClientID,
+		&i.Metadata,
+		&i.CountryCode,
+		&i.City,
+		&i.Lat,
+		&i.Lng,
+		&i.FirstSeenAt,
+		&i.LastSeenAt,
+	)
+	return i, err
 }
 
 const getEnterpriseLicense = `-- name: GetEnterpriseLicense :one
@@ -1516,6 +1656,25 @@ func (q *Queries) HasActiveRolloutUpdate(ctx context.Context, arg HasActiveRollo
 	return exists, err
 }
 
+const incrementIdentityValueStat = `-- name: IncrementIdentityValueStat :exec
+INSERT INTO identity_value_stats (app_id, key, value, device_count)
+VALUES ($1, $2, $3, 1)
+ON CONFLICT (app_id, key, value) DO UPDATE SET
+    device_count = identity_value_stats.device_count + 1,
+    last_seen_at = CURRENT_TIMESTAMP
+`
+
+type IncrementIdentityValueStatParams struct {
+	AppID pgtype.UUID `json:"app_id"`
+	Key   string      `json:"key"`
+	Value string      `json:"value"`
+}
+
+func (q *Queries) IncrementIdentityValueStat(ctx context.Context, arg IncrementIdentityValueStatParams) error {
+	_, err := q.db.Exec(ctx, incrementIdentityValueStat, arg.AppID, arg.Key, arg.Value)
+	return err
+}
+
 const insertApiKey = `-- name: InsertApiKey :one
 INSERT INTO api_keys (app_id, name, hint, hashed_key)
 VALUES ($1, $2, $3, $4)
@@ -2215,6 +2374,42 @@ func (q *Queries) ListAuditLogEventsAfter(ctx context.Context, arg ListAuditLogE
 	return items, nil
 }
 
+const listIdentitySchemaKeys = `-- name: ListIdentitySchemaKeys :many
+
+SELECT app_id, key, value_type, max_length, created_at FROM identity_schema
+WHERE app_id = $1
+ORDER BY key ASC
+`
+
+// ============================================================
+// Identity (ee/identity)
+// ============================================================
+func (q *Queries) ListIdentitySchemaKeys(ctx context.Context, appID pgtype.UUID) ([]IdentitySchema, error) {
+	rows, err := q.db.Query(ctx, listIdentitySchemaKeys, appID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []IdentitySchema
+	for rows.Next() {
+		var i IdentitySchema
+		if err := rows.Scan(
+			&i.AppID,
+			&i.Key,
+			&i.ValueType,
+			&i.MaxLength,
+			&i.CreatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listRoles = `-- name: ListRoles :many
 SELECT id, name, permissions, created_at, updated_at FROM roles
 ORDER BY name ASC
@@ -2640,6 +2835,54 @@ func (q *Queries) RevokeApiKeyByID(ctx context.Context, arg RevokeApiKeyByIDPara
 	return name, err
 }
 
+const searchIdentityValues = `-- name: SearchIdentityValues :many
+SELECT value, device_count FROM identity_value_stats
+WHERE app_id = $1 AND key = $2
+  AND value ILIKE '%' || $3::TEXT || '%'
+ORDER BY device_count DESC, value ASC
+LIMIT $4::INT
+`
+
+type SearchIdentityValuesParams struct {
+	AppID      pgtype.UUID `json:"app_id"`
+	Key        string      `json:"key"`
+	Search     string      `json:"search"`
+	MaxResults int32       `json:"max_results"`
+}
+
+type SearchIdentityValuesRow struct {
+	Value       string `json:"value"`
+	DeviceCount int64  `json:"device_count"`
+}
+
+// Autocomplete, substring arm: case-insensitive containment served by the
+// trigram index. % and _ in the search act as SQL wildcards; harmless for
+// autocomplete, so they are not escaped.
+func (q *Queries) SearchIdentityValues(ctx context.Context, arg SearchIdentityValuesParams) ([]SearchIdentityValuesRow, error) {
+	rows, err := q.db.Query(ctx, searchIdentityValues,
+		arg.AppID,
+		arg.Key,
+		arg.Search,
+		arg.MaxResults,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []SearchIdentityValuesRow
+	for rows.Next() {
+		var i SearchIdentityValuesRow
+		if err := rows.Scan(&i.Value, &i.DeviceCount); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const setBranchProtected = `-- name: SetBranchProtected :execrows
 UPDATE branches
 SET protected = $1
@@ -2720,6 +2963,50 @@ func (q *Queries) StoreUpdateUUID(ctx context.Context, arg StoreUpdateUUIDParams
 		arg.AppID,
 		arg.Name,
 	)
+}
+
+const topIdentityValues = `-- name: TopIdentityValues :many
+SELECT value, device_count FROM identity_value_stats
+WHERE app_id = $1 AND key = $2
+ORDER BY device_count DESC, value ASC
+LIMIT $3::INT
+`
+
+type TopIdentityValuesParams struct {
+	AppID      pgtype.UUID `json:"app_id"`
+	Key        string      `json:"key"`
+	MaxResults int32       `json:"max_results"`
+}
+
+type TopIdentityValuesRow struct {
+	Value       string `json:"value"`
+	DeviceCount int64  `json:"device_count"`
+}
+
+// Autocomplete, empty-search arm: top values of a key by device count.
+// Deliberately a separate query from SearchIdentityValues: an OR'd
+// "search = ” OR value ILIKE ..." arm makes the statement un-indexable under
+// a generic plan (pgx prepares statements), forcing a seq scan of every
+// distinct value. Split, each arm gets its own stable plan: this one is an
+// index-only scan on (app_id, key, device_count DESC, value ASC).
+func (q *Queries) TopIdentityValues(ctx context.Context, arg TopIdentityValuesParams) ([]TopIdentityValuesRow, error) {
+	rows, err := q.db.Query(ctx, topIdentityValues, arg.AppID, arg.Key, arg.MaxResults)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []TopIdentityValuesRow
+	for rows.Next() {
+		var i TopIdentityValuesRow
+		if err := rows.Scan(&i.Value, &i.DeviceCount); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
 }
 
 const touchSSOIdentityLastLogin = `-- name: TouchSSOIdentityLastLogin :exec
@@ -2840,6 +3127,53 @@ func (q *Queries) UpdateChannelRolloutPercentage(ctx context.Context, arg Update
 	return result.RowsAffected(), nil
 }
 
+const updateDeviceIdentity = `-- name: UpdateDeviceIdentity :one
+UPDATE device_identity SET
+    metadata = $3,
+    country_code = COALESCE($4, country_code),
+    city = COALESCE($5, city),
+    lat = COALESCE($6, lat),
+    lng = COALESCE($7, lng),
+    last_seen_at = CURRENT_TIMESTAMP
+WHERE app_id = $1 AND eas_client_id = $2
+RETURNING app_id, eas_client_id, metadata, country_code, city, lat, lng, first_seen_at, last_seen_at
+`
+
+type UpdateDeviceIdentityParams struct {
+	AppID       pgtype.UUID `json:"app_id"`
+	EasClientID pgtype.UUID `json:"eas_client_id"`
+	Metadata    []byte      `json:"metadata"`
+	CountryCode *string     `json:"country_code"`
+	City        *string     `json:"city"`
+	Lat         *float64    `json:"lat"`
+	Lng         *float64    `json:"lng"`
+}
+
+func (q *Queries) UpdateDeviceIdentity(ctx context.Context, arg UpdateDeviceIdentityParams) (DeviceIdentity, error) {
+	row := q.db.QueryRow(ctx, updateDeviceIdentity,
+		arg.AppID,
+		arg.EasClientID,
+		arg.Metadata,
+		arg.CountryCode,
+		arg.City,
+		arg.Lat,
+		arg.Lng,
+	)
+	var i DeviceIdentity
+	err := row.Scan(
+		&i.AppID,
+		&i.EasClientID,
+		&i.Metadata,
+		&i.CountryCode,
+		&i.City,
+		&i.Lat,
+		&i.Lng,
+		&i.FirstSeenAt,
+		&i.LastSeenAt,
+	)
+	return i, err
+}
+
 const updateRole = `-- name: UpdateRole :execresult
 UPDATE roles
 SET name = $2, permissions = $3, updated_at = CURRENT_TIMESTAMP
@@ -2936,6 +3270,40 @@ func (q *Queries) UpsertEnterpriseLicense(ctx context.Context, licenseKey string
 		&i.LicenseKey,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+	)
+	return i, err
+}
+
+const upsertIdentitySchemaKey = `-- name: UpsertIdentitySchemaKey :one
+INSERT INTO identity_schema (app_id, key, value_type, max_length)
+VALUES ($1, $2, $3, $4)
+ON CONFLICT (app_id, key) DO UPDATE SET
+    value_type = EXCLUDED.value_type,
+    max_length = EXCLUDED.max_length
+RETURNING app_id, key, value_type, max_length, created_at
+`
+
+type UpsertIdentitySchemaKeyParams struct {
+	AppID     pgtype.UUID `json:"app_id"`
+	Key       string      `json:"key"`
+	ValueType string      `json:"value_type"`
+	MaxLength int32       `json:"max_length"`
+}
+
+func (q *Queries) UpsertIdentitySchemaKey(ctx context.Context, arg UpsertIdentitySchemaKeyParams) (IdentitySchema, error) {
+	row := q.db.QueryRow(ctx, upsertIdentitySchemaKey,
+		arg.AppID,
+		arg.Key,
+		arg.ValueType,
+		arg.MaxLength,
+	)
+	var i IdentitySchema
+	err := row.Scan(
+		&i.AppID,
+		&i.Key,
+		&i.ValueType,
+		&i.MaxLength,
+		&i.CreatedAt,
 	)
 	return i, err
 }

--- a/internal/database/postgres/pgdb/queries.sql.go
+++ b/internal/database/postgres/pgdb/queries.sql.go
@@ -93,6 +93,17 @@ func (q *Queries) CountAuditLogEvents(ctx context.Context, arg CountAuditLogEven
 	return count, err
 }
 
+const countDevices = `-- name: CountDevices :one
+SELECT COUNT(*) FROM device_identity WHERE app_id = $1
+`
+
+func (q *Queries) CountDevices(ctx context.Context, appID pgtype.UUID) (int64, error) {
+	row := q.db.QueryRow(ctx, countDevices, appID)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
 const countGrantsByRole = `-- name: CountGrantsByRole :one
 SELECT COUNT(*) FROM user_app_grants
 WHERE role_id = $1
@@ -214,6 +225,21 @@ func (q *Queries) DeleteChannelRollout(ctx context.Context, arg DeleteChannelRol
 	return result.RowsAffected(), nil
 }
 
+const deleteDevices = `-- name: DeleteDevices :exec
+DELETE FROM device_identity
+WHERE app_id = $1 AND eas_client_id = ANY($2::uuid[])
+`
+
+type DeleteDevicesParams struct {
+	AppID     pgtype.UUID   `json:"app_id"`
+	ClientIds []pgtype.UUID `json:"client_ids"`
+}
+
+func (q *Queries) DeleteDevices(ctx context.Context, arg DeleteDevicesParams) error {
+	_, err := q.db.Exec(ctx, deleteDevices, arg.AppID, arg.ClientIds)
+	return err
+}
+
 const deleteEnterpriseLicense = `-- name: DeleteEnterpriseLicense :exec
 DELETE FROM enterprise_license
 `
@@ -320,7 +346,7 @@ func (q *Queries) DeleteZeroIdentityValueStats(ctx context.Context, arg DeleteZe
 	return err
 }
 
-const ensureDeviceIdentity = `-- name: EnsureDeviceIdentity :exec
+const ensureDeviceIdentity = `-- name: EnsureDeviceIdentity :execrows
 INSERT INTO device_identity (app_id, eas_client_id)
 VALUES ($1, $2)
 ON CONFLICT (app_id, eas_client_id) DO NOTHING
@@ -335,9 +361,15 @@ type EnsureDeviceIdentityParams struct {
 // purpose: FOR UPDATE cannot lock a row that does not exist yet, so two
 // concurrent first identifies of the same install would both merge against
 // an empty map and one would silently win. Insert-then-lock serializes them.
-func (q *Queries) EnsureDeviceIdentity(ctx context.Context, arg EnsureDeviceIdentityParams) error {
-	_, err := q.db.Exec(ctx, ensureDeviceIdentity, arg.AppID, arg.EasClientID)
-	return err
+// Returns the number of rows inserted: 1 when this install is brand new, 0
+// when it already existed. The free-tier device cap only needs to run on a
+// genuine new-device insert, so the caller keys the count/eviction off this.
+func (q *Queries) EnsureDeviceIdentity(ctx context.Context, arg EnsureDeviceIdentityParams) (int64, error) {
+	result, err := q.db.Exec(ctx, ensureDeviceIdentity, arg.AppID, arg.EasClientID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
 }
 
 const getActiveRolloutUpdates = `-- name: GetActiveRolloutUpdates :many
@@ -2824,6 +2856,48 @@ func (q *Queries) MigrateLegacyUpdate(ctx context.Context, arg MigrateLegacyUpda
 		arg.CreatedAt,
 	)
 	return err
+}
+
+const oldestDevicesExcluding = `-- name: OldestDevicesExcluding :many
+SELECT eas_client_id, metadata FROM device_identity
+WHERE app_id = $1 AND eas_client_id <> $2
+ORDER BY last_seen_at ASC, eas_client_id ASC
+LIMIT $3::int
+`
+
+type OldestDevicesExcludingParams struct {
+	AppID       pgtype.UUID `json:"app_id"`
+	EasClientID pgtype.UUID `json:"eas_client_id"`
+	Lim         int32       `json:"lim"`
+}
+
+type OldestDevicesExcludingRow struct {
+	EasClientID pgtype.UUID `json:"eas_client_id"`
+	Metadata    []byte      `json:"metadata"`
+}
+
+// The oldest devices of an app by last activity, excluding one (the install
+// being written, which is the most recent and must never be evicted). Feeds
+// the free-tier eviction: their metadata is read so the per-value stats can be
+// decremented before the rows are deleted.
+func (q *Queries) OldestDevicesExcluding(ctx context.Context, arg OldestDevicesExcludingParams) ([]OldestDevicesExcludingRow, error) {
+	rows, err := q.db.Query(ctx, oldestDevicesExcluding, arg.AppID, arg.EasClientID, arg.Lim)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []OldestDevicesExcludingRow
+	for rows.Next() {
+		var i OldestDevicesExcludingRow
+		if err := rows.Scan(&i.EasClientID, &i.Metadata); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
 }
 
 const purgeAuditLogEventsBefore = `-- name: PurgeAuditLogEventsBefore :execresult

--- a/internal/database/postgres/pgdb/queries.sql.go
+++ b/internal/database/postgres/pgdb/queries.sql.go
@@ -2374,6 +2374,68 @@ func (q *Queries) ListAuditLogEventsAfter(ctx context.Context, arg ListAuditLogE
 	return items, nil
 }
 
+const listDevices = `-- name: ListDevices :many
+SELECT app_id, eas_client_id, metadata, country_code, city, lat, lng, first_seen_at, last_seen_at FROM device_identity
+WHERE app_id = $1
+  AND ($2::jsonb IS NULL OR metadata @> $2::jsonb)
+  AND (
+    $3::timestamptz IS NULL
+    OR last_seen_at < $3::timestamptz
+    OR (last_seen_at = $3::timestamptz
+        AND eas_client_id < $4::uuid)
+  )
+ORDER BY last_seen_at DESC, eas_client_id DESC
+LIMIT $5::int
+`
+
+type ListDevicesParams struct {
+	AppID          pgtype.UUID        `json:"app_id"`
+	Filter         []byte             `json:"filter"`
+	BeforeLastSeen pgtype.Timestamptz `json:"before_last_seen"`
+	BeforeClientID pgtype.UUID        `json:"before_client_id"`
+	Lim            int32              `json:"lim"`
+}
+
+// Device inventory for the dashboard: newest-seen first, keyset-paginated on
+// (last_seen_at DESC, eas_client_id DESC) so deep pages stay cheap. The
+// optional jsonb filter (metadata @> $filter, served by the GIN index) powers
+// "devices for a userId / tenant". Fetch one extra row to detect the next page.
+func (q *Queries) ListDevices(ctx context.Context, arg ListDevicesParams) ([]DeviceIdentity, error) {
+	rows, err := q.db.Query(ctx, listDevices,
+		arg.AppID,
+		arg.Filter,
+		arg.BeforeLastSeen,
+		arg.BeforeClientID,
+		arg.Lim,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []DeviceIdentity
+	for rows.Next() {
+		var i DeviceIdentity
+		if err := rows.Scan(
+			&i.AppID,
+			&i.EasClientID,
+			&i.Metadata,
+			&i.CountryCode,
+			&i.City,
+			&i.Lat,
+			&i.Lng,
+			&i.FirstSeenAt,
+			&i.LastSeenAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listIdentitySchemaKeys = `-- name: ListIdentitySchemaKeys :many
 
 SELECT app_id, key, value_type, max_length, created_at FROM identity_schema

--- a/internal/database/postgres/queries/queries.sql
+++ b/internal/database/postgres/queries/queries.sql
@@ -1070,3 +1070,20 @@ WHERE app_id = $1 AND key = $2
   AND value ILIKE '%' || sqlc.arg(search)::TEXT || '%'
 ORDER BY device_count DESC, value ASC
 LIMIT sqlc.arg(max_results)::INT;
+
+-- Device inventory for the dashboard: newest-seen first, keyset-paginated on
+-- (last_seen_at DESC, eas_client_id DESC) so deep pages stay cheap. The
+-- optional jsonb filter (metadata @> $filter, served by the GIN index) powers
+-- "devices for a userId / tenant". Fetch one extra row to detect the next page.
+-- name: ListDevices :many
+SELECT * FROM device_identity
+WHERE app_id = $1
+  AND (sqlc.narg('filter')::jsonb IS NULL OR metadata @> sqlc.narg('filter')::jsonb)
+  AND (
+    sqlc.narg('before_last_seen')::timestamptz IS NULL
+    OR last_seen_at < sqlc.narg('before_last_seen')::timestamptz
+    OR (last_seen_at = sqlc.narg('before_last_seen')::timestamptz
+        AND eas_client_id < sqlc.narg('before_client_id')::uuid)
+  )
+ORDER BY last_seen_at DESC, eas_client_id DESC
+LIMIT sqlc.arg('lim')::int;

--- a/internal/database/postgres/queries/queries.sql
+++ b/internal/database/postgres/queries/queries.sql
@@ -975,3 +975,98 @@ WHERE (sqlc.narg('actor_id')::TEXT IS NULL OR actor_id = sqlc.narg('actor_id'))
   AND (sqlc.narg('outcome')::TEXT IS NULL OR outcome = sqlc.narg('outcome'))
   AND (sqlc.narg('occurred_from')::TIMESTAMPTZ IS NULL OR occurred_at >= sqlc.narg('occurred_from'))
   AND (sqlc.narg('occurred_to')::TIMESTAMPTZ IS NULL OR occurred_at <= sqlc.narg('occurred_to'));
+
+-- ============================================================
+-- Identity (ee/identity)
+-- ============================================================
+
+-- name: ListIdentitySchemaKeys :many
+SELECT * FROM identity_schema
+WHERE app_id = $1
+ORDER BY key ASC;
+
+-- name: UpsertIdentitySchemaKey :one
+INSERT INTO identity_schema (app_id, key, value_type, max_length)
+VALUES ($1, $2, $3, $4)
+ON CONFLICT (app_id, key) DO UPDATE SET
+    value_type = EXCLUDED.value_type,
+    max_length = EXCLUDED.max_length
+RETURNING *;
+
+-- name: DeleteIdentitySchemaKey :execresult
+DELETE FROM identity_schema
+WHERE app_id = $1 AND key = $2;
+
+-- Wipes the autocomplete entries of a key when it leaves the allowlist, so
+-- searchMetadata never suggests values of a key the operator removed. The
+-- values already merged into device_identity.metadata are left in place.
+-- name: DeleteIdentityValueStatsForKey :exec
+DELETE FROM identity_value_stats
+WHERE app_id = $1 AND key = $2;
+
+-- Creates the row if this install was never seen. Split from the update on
+-- purpose: FOR UPDATE cannot lock a row that does not exist yet, so two
+-- concurrent first identifies of the same install would both merge against
+-- an empty map and one would silently win. Insert-then-lock serializes them.
+-- name: EnsureDeviceIdentity :exec
+INSERT INTO device_identity (app_id, eas_client_id)
+VALUES ($1, $2)
+ON CONFLICT (app_id, eas_client_id) DO NOTHING;
+
+-- name: GetDeviceIdentityForUpdate :one
+SELECT * FROM device_identity
+WHERE app_id = $1 AND eas_client_id = $2
+FOR UPDATE;
+
+-- name: GetDeviceIdentity :one
+SELECT * FROM device_identity
+WHERE app_id = $1 AND eas_client_id = $2;
+
+-- name: UpdateDeviceIdentity :one
+UPDATE device_identity SET
+    metadata = $3,
+    country_code = COALESCE(sqlc.narg('country_code'), country_code),
+    city = COALESCE(sqlc.narg('city'), city),
+    lat = COALESCE(sqlc.narg('lat'), lat),
+    lng = COALESCE(sqlc.narg('lng'), lng),
+    last_seen_at = CURRENT_TIMESTAMP
+WHERE app_id = $1 AND eas_client_id = $2
+RETURNING *;
+
+-- name: IncrementIdentityValueStat :exec
+INSERT INTO identity_value_stats (app_id, key, value, device_count)
+VALUES ($1, $2, $3, 1)
+ON CONFLICT (app_id, key, value) DO UPDATE SET
+    device_count = identity_value_stats.device_count + 1,
+    last_seen_at = CURRENT_TIMESTAMP;
+
+-- name: DecrementIdentityValueStat :exec
+UPDATE identity_value_stats
+SET device_count = GREATEST(device_count - 1, 0)
+WHERE app_id = $1 AND key = $2 AND value = $3;
+
+-- name: DeleteZeroIdentityValueStats :exec
+DELETE FROM identity_value_stats
+WHERE app_id = $1 AND key = $2 AND value = $3 AND device_count <= 0;
+
+-- Autocomplete, empty-search arm: top values of a key by device count.
+-- Deliberately a separate query from SearchIdentityValues: an OR'd
+-- "search = '' OR value ILIKE ..." arm makes the statement un-indexable under
+-- a generic plan (pgx prepares statements), forcing a seq scan of every
+-- distinct value. Split, each arm gets its own stable plan: this one is an
+-- index-only scan on (app_id, key, device_count DESC, value ASC).
+-- name: TopIdentityValues :many
+SELECT value, device_count FROM identity_value_stats
+WHERE app_id = $1 AND key = $2
+ORDER BY device_count DESC, value ASC
+LIMIT sqlc.arg(max_results)::INT;
+
+-- Autocomplete, substring arm: case-insensitive containment served by the
+-- trigram index. % and _ in the search act as SQL wildcards; harmless for
+-- autocomplete, so they are not escaped.
+-- name: SearchIdentityValues :many
+SELECT value, device_count FROM identity_value_stats
+WHERE app_id = $1 AND key = $2
+  AND value ILIKE '%' || sqlc.arg(search)::TEXT || '%'
+ORDER BY device_count DESC, value ASC
+LIMIT sqlc.arg(max_results)::INT;

--- a/internal/database/postgres/queries/queries.sql
+++ b/internal/database/postgres/queries/queries.sql
@@ -1008,10 +1008,30 @@ WHERE app_id = $1 AND key = $2;
 -- purpose: FOR UPDATE cannot lock a row that does not exist yet, so two
 -- concurrent first identifies of the same install would both merge against
 -- an empty map and one would silently win. Insert-then-lock serializes them.
--- name: EnsureDeviceIdentity :exec
+-- Returns the number of rows inserted: 1 when this install is brand new, 0
+-- when it already existed. The free-tier device cap only needs to run on a
+-- genuine new-device insert, so the caller keys the count/eviction off this.
+-- name: EnsureDeviceIdentity :execrows
 INSERT INTO device_identity (app_id, eas_client_id)
 VALUES ($1, $2)
 ON CONFLICT (app_id, eas_client_id) DO NOTHING;
+
+-- name: CountDevices :one
+SELECT COUNT(*) FROM device_identity WHERE app_id = $1;
+
+-- The oldest devices of an app by last activity, excluding one (the install
+-- being written, which is the most recent and must never be evicted). Feeds
+-- the free-tier eviction: their metadata is read so the per-value stats can be
+-- decremented before the rows are deleted.
+-- name: OldestDevicesExcluding :many
+SELECT eas_client_id, metadata FROM device_identity
+WHERE app_id = $1 AND eas_client_id <> $2
+ORDER BY last_seen_at ASC, eas_client_id ASC
+LIMIT sqlc.arg('lim')::int;
+
+-- name: DeleteDevices :exec
+DELETE FROM device_identity
+WHERE app_id = $1 AND eas_client_id = ANY(sqlc.arg('client_ids')::uuid[]);
 
 -- name: GetDeviceIdentityForUpdate :one
 SELECT * FROM device_identity

--- a/internal/handlers/dashboard/users_handler.go
+++ b/internal/handlers/dashboard/users_handler.go
@@ -55,13 +55,6 @@ func userResponseFrom(user store.User) UserResponse {
 	}
 }
 
-func renderJSON(w http.ResponseWriter, status int, payload interface{}) {
-	marshaledResponse, _ := json.Marshal(payload)
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(status)
-	w.Write(marshaledResponse)
-}
-
 // renderUserServiceError maps the user service's business-rule errors onto
 // explicit status codes; anything unrecognized stays an opaque 500.
 func renderUserServiceError(w http.ResponseWriter, err error) {
@@ -112,7 +105,7 @@ func (h *UsersHandler) GetMeHandler(w http.ResponseWriter, r *http.Request) {
 		handlers.RenderError(w, http.StatusInternalServerError, "An internal error occurred.")
 		return
 	}
-	renderJSON(w, http.StatusOK, userResponseFrom(user))
+	handlers.RenderJSON(w, http.StatusOK, userResponseFrom(user))
 }
 
 func (h *UsersHandler) ChangeMyPasswordHandler(w http.ResponseWriter, r *http.Request) {
@@ -151,7 +144,7 @@ func (h *UsersHandler) GetUsersHandler(w http.ResponseWriter, r *http.Request) {
 	for i, user := range users {
 		response[i] = userResponseFrom(user)
 	}
-	renderJSON(w, http.StatusOK, response)
+	handlers.RenderJSON(w, http.StatusOK, response)
 }
 
 func (h *UsersHandler) CreateUserHandler(w http.ResponseWriter, r *http.Request) {
@@ -173,7 +166,7 @@ func (h *UsersHandler) CreateUserHandler(w http.ResponseWriter, r *http.Request)
 		renderUserServiceError(w, err)
 		return
 	}
-	renderJSON(w, http.StatusCreated, userResponseFrom(user))
+	handlers.RenderJSON(w, http.StatusCreated, userResponseFrom(user))
 }
 
 // UpdateUserHandler patches the two admin-controlled flags of an account. Both

--- a/internal/handlers/errors.go
+++ b/internal/handlers/errors.go
@@ -24,6 +24,17 @@ func RenderError(w http.ResponseWriter, status int, detail string) {
 	})
 }
 
+// RenderJSON writes payload as a JSON body with the given status. The success
+// counterpart to RenderError, shared so every handler renders the same way.
+// A marshal failure writes the status with an empty body (the historical
+// behavior of the per-package copies this replaced).
+func RenderJSON(w http.ResponseWriter, status int, payload interface{}) {
+	marshaledResponse, _ := json.Marshal(payload)
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	w.Write(marshaledResponse)
+}
+
 // activeRolloutConflictMessage is the CLI-facing 409 body for publish, republish and
 // rollback attempts against a branch and runtime version with an active per-update
 // rollout. The republish and rollback commands print it verbatim.

--- a/internal/handlers/errors.go
+++ b/internal/handlers/errors.go
@@ -26,13 +26,15 @@ func RenderError(w http.ResponseWriter, status int, detail string) {
 
 // RenderJSON writes payload as a JSON body with the given status. The success
 // counterpart to RenderError, shared so every handler renders the same way.
-// A marshal failure writes the status with an empty body (the historical
-// behavior of the per-package copies this replaced).
 func RenderJSON(w http.ResponseWriter, status int, payload interface{}) {
-	marshaledResponse, _ := json.Marshal(payload)
+	marshaledResponse, err := json.Marshal(payload)
+	if err != nil {
+		RenderError(w, http.StatusInternalServerError, "An internal error occurred.")
+		return
+	}
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
-	w.Write(marshaledResponse)
+	_, _ = w.Write(marshaledResponse)
 }
 
 // activeRolloutConflictMessage is the CLI-facing 409 body for publish, republish and

--- a/internal/handlers/errors_test.go
+++ b/internal/handlers/errors_test.go
@@ -1,0 +1,22 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRenderJSONMarshalFailureReturnsProblem(t *testing.T) {
+	recorder := httptest.NewRecorder()
+
+	RenderJSON(recorder, http.StatusCreated, make(chan int))
+
+	require.Equal(t, http.StatusInternalServerError, recorder.Code)
+	require.Equal(t, "application/problem+json; charset=utf-8", recorder.Header().Get("Content-Type"))
+	var problem APIError
+	require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &problem))
+	require.Equal(t, http.StatusInternalServerError, problem.Status)
+}

--- a/internal/middleware/logging_middleware.go
+++ b/internal/middleware/logging_middleware.go
@@ -26,6 +26,12 @@ func LoggingMiddleware(next http.Handler) http.Handler {
 			next.ServeHTTP(w, r)
 			return
 		}
+		// Telemetry ingestion fires on every app-background of every device;
+		// logging each batch would drown the request log.
+		if strings.HasSuffix(r.URL.Path, "/v1/logs") || strings.HasSuffix(r.URL.Path, "/v1/metrics") {
+			next.ServeHTTP(w, r)
+			return
+		}
 		start := time.Now()
 
 		safeHeaders := redactHeaders(r.Header)

--- a/internal/middleware/logging_middleware.go
+++ b/internal/middleware/logging_middleware.go
@@ -26,6 +26,16 @@ func LoggingMiddleware(next http.Handler) http.Handler {
 			next.ServeHTTP(w, r)
 			return
 		}
+
+		safeHeaders := redactHeaders(r.Header)
+		defer func() {
+			if err := recover(); err != nil {
+				log.Printf("Panic recovered during %s %s\nQuery: %s\nHeaders: %v\nError: %v\nStack Trace:\n%s",
+					r.Method, r.RequestURI, r.URL.RawQuery, safeHeaders, err, debug.Stack())
+				http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			}
+		}()
+
 		// Telemetry ingestion fires on every app-background of every device;
 		// logging each batch would drown the request log.
 		if strings.HasSuffix(r.URL.Path, "/v1/logs") || strings.HasSuffix(r.URL.Path, "/v1/metrics") {
@@ -34,19 +44,9 @@ func LoggingMiddleware(next http.Handler) http.Handler {
 		}
 		start := time.Now()
 
-		safeHeaders := redactHeaders(r.Header)
-
 		log.Printf("Started %s %s with query: %s and headers: %v", r.Method, r.RequestURI, r.URL.RawQuery, safeHeaders)
 
 		recorder := &statusRecorder{ResponseWriter: w, statusCode: http.StatusOK}
-
-		defer func() {
-			if err := recover(); err != nil {
-				log.Printf("Panic recovered during %s %s\nQuery: %s\nHeaders: %v\nError: %v\nStack Trace:\n%s",
-					r.Method, r.RequestURI, r.URL.RawQuery, safeHeaders, err, debug.Stack())
-				http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
-			}
-		}()
 
 		next.ServeHTTP(recorder, r)
 

--- a/internal/middleware/logging_middleware_test.go
+++ b/internal/middleware/logging_middleware_test.go
@@ -1,0 +1,30 @@
+package middleware
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoggingMiddlewareRecoversTelemetryPanics(t *testing.T) {
+	for _, path := range []string{
+		"/observe/app-1/project-1/v1/logs",
+		"/observe/app-1/project-1/v1/metrics",
+	} {
+		t.Run(path, func(t *testing.T) {
+			handler := LoggingMiddleware(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+				panic("boom")
+			}))
+			request := httptest.NewRequestWithContext(context.Background(), http.MethodPost, path, nil)
+			recorder := httptest.NewRecorder()
+
+			require.NotPanics(t, func() {
+				handler.ServeHTTP(recorder, request)
+			})
+			require.Equal(t, http.StatusInternalServerError, recorder.Code)
+		})
+	}
+}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -2,6 +2,7 @@ package infrastructure
 
 import (
 	"expo-open-ota/config"
+	"expo-open-ota/ee/observe"
 	"expo-open-ota/ee/rbac"
 	dashutils "expo-open-ota/internal/dashboard"
 	"expo-open-ota/internal/metrics"
@@ -64,6 +65,21 @@ func NewRouter(container *AppContainer) *mux.Router {
 	appSubrouter.HandleFunc("/markUpdateAsUploaded/{BRANCH}", container.UploadHandler.MarkUpdateAsUploadedHandler).Methods(http.MethodPost)
 	appSubrouter.HandleFunc("/rollback/{BRANCH}", container.RollbackHandler.HandleRollback).Methods(http.MethodPost)
 	appSubrouter.HandleFunc("/republish/{BRANCH}", container.RepublishHandler.HandleRepublish).Methods(http.MethodPost)
+
+	// expo-observe ingestion (ee/observe), all under one /observe prefix. The
+	// operator sets extra.eas.observe.endpointUrl to
+	// https://<host>/observe/{APP_ID}; the SDK appends /{projectId}/v1/logs
+	// with the app's REAL EAS project id (used by EAS builds, never equal to
+	// our APP_ID), so the PROJECT_ID segment is deliberately ignored, exactly
+	// as the SDK itself never validates it. Exact paths, no trailing-slash
+	// variant: a gorilla 301 would turn the POST into a bodyless GET.
+	observeSubrouter := r.PathPrefix("/observe/{APP_ID}").Subrouter()
+	// The app check is memoized so telemetry (which fires on every
+	// app-background of every device) does not issue an uncached primary-key
+	// query per request.
+	observeSubrouter.Use(observe.CachedAppResolverMiddleware(container.AppRepo))
+	observeSubrouter.HandleFunc("/{PROJECT_ID}/v1/logs", container.ObserveIngestHandler.HandleLogs).Methods(http.MethodPost)
+	observeSubrouter.HandleFunc("/{PROJECT_ID}/v1/metrics", container.ObserveIngestHandler.HandleMetrics).Methods(http.MethodPost)
 
 	r.HandleFunc("/manifest", container.ExpoProtocolHandler.HandleManifest).Methods(http.MethodGet)
 	r.HandleFunc("/assets", container.ExpoProtocolHandler.HandleAssets).Methods(http.MethodGet)

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -253,5 +253,15 @@ func NewRouter(container *AppContainer) *mux.Router {
 	appAuthSubrouter.HandleFunc("/apiKeys/restrictions", container.ApiKeyRestrictionHandler.GetApiKeyRestrictionsHandler).Methods(http.MethodGet)
 	appAuthSubrouter.Handle("/apiKeys/{API_KEY_ID}/restrictions", requirePermission(rbac.PermApiKeysManage)(http.HandlerFunc(container.ApiKeyRestrictionHandler.SetApiKeyRestrictionsHandler))).Methods(http.MethodPut)
 	appAuthSubrouter.Handle("/branches/{BRANCH}/protection", requirePermission(rbac.PermBranchProtect)(http.HandlerFunc(container.ApiKeyRestrictionHandler.SetBranchProtectionHandler))).Methods(http.MethodPut)
+	// Device identity (ee/identity). Reads stay open to any app viewer; the
+	// allowlist is operator config, so schema mutations are admin-only. Free up
+	// to 1000 devices/MAU without a license, enterprise beyond (the freemium
+	// gate + eviction cap land in a later batch, enforced in identity.Service).
+	appAuthSubrouter.HandleFunc("/identity/schema", container.IdentityHandler.GetSchemaHandler).Methods(http.MethodGet)
+	appAuthSubrouter.Handle("/identity/schema/{KEY}", adminOnly(http.HandlerFunc(container.IdentityHandler.UpsertSchemaKeyHandler))).Methods(http.MethodPut)
+	appAuthSubrouter.Handle("/identity/schema/{KEY}", adminOnly(http.HandlerFunc(container.IdentityHandler.DeleteSchemaKeyHandler))).Methods(http.MethodDelete)
+	appAuthSubrouter.HandleFunc("/identity/values", container.IdentityHandler.SearchValuesHandler).Methods(http.MethodGet)
+	appAuthSubrouter.HandleFunc("/identity/devices", container.IdentityHandler.ListDevicesHandler).Methods(http.MethodGet)
+	appAuthSubrouter.HandleFunc("/identity/devices/{EAS_CLIENT_ID}", container.IdentityHandler.GetDeviceHandler).Methods(http.MethodGet)
 	return r
 }

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -253,13 +253,13 @@ func NewRouter(container *AppContainer) *mux.Router {
 	appAuthSubrouter.HandleFunc("/apiKeys/restrictions", container.ApiKeyRestrictionHandler.GetApiKeyRestrictionsHandler).Methods(http.MethodGet)
 	appAuthSubrouter.Handle("/apiKeys/{API_KEY_ID}/restrictions", requirePermission(rbac.PermApiKeysManage)(http.HandlerFunc(container.ApiKeyRestrictionHandler.SetApiKeyRestrictionsHandler))).Methods(http.MethodPut)
 	appAuthSubrouter.Handle("/branches/{BRANCH}/protection", requirePermission(rbac.PermBranchProtect)(http.HandlerFunc(container.ApiKeyRestrictionHandler.SetBranchProtectionHandler))).Methods(http.MethodPut)
-	// Device identity (ee/identity). Reads stay open to any app viewer; the
-	// allowlist is operator config, so schema mutations are admin-only. Free up
-	// to 1000 devices/MAU without a license, enterprise beyond (the freemium
-	// gate + eviction cap land in a later batch, enforced in identity.Service).
+	// Device identity (ee/identity). Reads stay open to any app viewer; shaping
+	// the allowlist needs the identity:manage permission (admins bypass it).
+	// Free up to 1000 devices/MAU without a license, enterprise beyond (the
+	// freemium gate + eviction cap land in a later batch, in identity.Service).
 	appAuthSubrouter.HandleFunc("/identity/schema", container.IdentityHandler.GetSchemaHandler).Methods(http.MethodGet)
-	appAuthSubrouter.Handle("/identity/schema/{KEY}", adminOnly(http.HandlerFunc(container.IdentityHandler.UpsertSchemaKeyHandler))).Methods(http.MethodPut)
-	appAuthSubrouter.Handle("/identity/schema/{KEY}", adminOnly(http.HandlerFunc(container.IdentityHandler.DeleteSchemaKeyHandler))).Methods(http.MethodDelete)
+	appAuthSubrouter.Handle("/identity/schema/{KEY}", requirePermission(rbac.PermIdentityManage)(http.HandlerFunc(container.IdentityHandler.UpsertSchemaKeyHandler))).Methods(http.MethodPut)
+	appAuthSubrouter.Handle("/identity/schema/{KEY}", requirePermission(rbac.PermIdentityManage)(http.HandlerFunc(container.IdentityHandler.DeleteSchemaKeyHandler))).Methods(http.MethodDelete)
 	appAuthSubrouter.HandleFunc("/identity/values", container.IdentityHandler.SearchValuesHandler).Methods(http.MethodGet)
 	appAuthSubrouter.HandleFunc("/identity/devices", container.IdentityHandler.ListDevicesHandler).Methods(http.MethodGet)
 	appAuthSubrouter.HandleFunc("/identity/devices/{EAS_CLIENT_ID}", container.IdentityHandler.GetDeviceHandler).Methods(http.MethodGet)

--- a/internal/router/wire.go
+++ b/internal/router/wire.go
@@ -178,7 +178,7 @@ func InitDependencies(ctx context.Context) (*AppContainer, func()) {
 	// The audit recorder is handed to every emitting surface below; it
 	// no-ops without a control plane and a currently valid license, so the
 	// call sites stay unconditional.
-	auditService := audit.NewAuditService(auditRepo, licensing.IsEnterprise)
+	auditService := audit.NewAuditService(auditRepo)
 	// The archive and the retention purge read their own configuration: that
 	// knowledge is the feature's, not the wiring's. The archive starts first
 	// so the purge spares unarchived rows, and an enabled-but-misconfigured

--- a/internal/router/wire.go
+++ b/internal/router/wire.go
@@ -5,7 +5,9 @@ import (
 	"expo-open-ota/config"
 	"expo-open-ota/ee/apikeyrestrictions"
 	"expo-open-ota/ee/audit"
+	"expo-open-ota/ee/identity"
 	"expo-open-ota/ee/licensing"
+	"expo-open-ota/ee/observe"
 	"expo-open-ota/ee/rbac"
 	"expo-open-ota/ee/sso"
 	"expo-open-ota/internal/bucket"
@@ -44,6 +46,7 @@ type AppContainer struct {
 	UsersHandler             *dashhandlers.UsersHandler
 	AuditHandler             *audit.AuditHandler
 	UserRepo                 services.UserRepository
+	ObserveIngestHandler     *observe.IngestHandler
 }
 
 // logLegacyAppIdFallback states, once at boot, which app receives manifest and
@@ -87,6 +90,10 @@ func InitDependencies(ctx context.Context) (*AppContainer, func()) {
 	// The audit trail (ee/audit) as well: nil keeps its recorder a no-op, so
 	// stateless deployments never collect an event.
 	var auditRepo audit.AuditRepository
+	// Device identity (ee/identity) lives in the database; nil makes the
+	// observe ingestion acknowledge-and-drop, so stateless deployments never
+	// block a device's telemetry queue. EE-licensed code, NOT license-gated.
+	var identityService *identity.Service
 
 	cleanup := func() {}
 	dbUrl := config.GetDBURL()
@@ -123,6 +130,24 @@ func InitDependencies(ctx context.Context) (*AppContainer, func()) {
 		channelRepo = store.NewPostgresChannelStore(dbEngine)
 		updateRepo = store.NewPostgresUpdateStore(dbEngine)
 		rolloutRepo = store.NewPostgresRolloutStore(dbEngine)
+
+		// GeoIP enrichment is optional: without a configured GeoLite2 City
+		// database, devices simply stay unlocated. A configured-but-broken
+		// path fails the boot loudly instead of resolving nothing forever.
+		var geoResolver identity.GeoResolver
+		if mmdbPath := config.GetEnv("GEOIP_MMDB_PATH"); mmdbPath != "" {
+			resolver, err := identity.NewGeoLite2Resolver(mmdbPath)
+			if err != nil {
+				log.Fatalf("🚨 [IDENTITY] %v", err)
+			}
+			geoResolver = resolver
+			dbCleanup := cleanup
+			cleanup = func() {
+				resolver.Close()
+				dbCleanup()
+			}
+		}
+		identityService = identity.NewService(identity.NewPostgresIdentityStore(dbEngine), geoResolver)
 	} else {
 		log.Println("⚙️  [STATELESS] Initializing Stateless Mode (Flat-Env Mode)...")
 		if err := config.LoadAppsFromFlatEnv(); err != nil {
@@ -223,5 +248,6 @@ func InitDependencies(ctx context.Context) (*AppContainer, func()) {
 		UploadHandler:            handlers.NewUploadHandler(cliAuthService, deploymentService),
 		UsersHandler:             dashhandlers.NewUsersHandler(userService),
 		UserRepo:                 userRepo,
+		ObserveIngestHandler:     observe.NewIngestHandler(identityService),
 	}, cleanup
 }

--- a/internal/router/wire.go
+++ b/internal/router/wire.go
@@ -47,6 +47,7 @@ type AppContainer struct {
 	AuditHandler             *audit.AuditHandler
 	UserRepo                 services.UserRepository
 	ObserveIngestHandler     *observe.IngestHandler
+	IdentityHandler          *identity.IdentityHandler
 }
 
 // logLegacyAppIdFallback states, once at boot, which app receives manifest and
@@ -91,8 +92,9 @@ func InitDependencies(ctx context.Context) (*AppContainer, func()) {
 	// stateless deployments never collect an event.
 	var auditRepo audit.AuditRepository
 	// Device identity (ee/identity) lives in the database; nil makes the
-	// observe ingestion acknowledge-and-drop, so stateless deployments never
-	// block a device's telemetry queue. EE-licensed code, NOT license-gated.
+	// observe ingestion acknowledge-and-drop and the dashboard handler answer
+	// 400, so stateless deployments never block on it. The service owns the
+	// store; the ingest route and the dashboard handler both go through it.
 	var identityService *identity.Service
 
 	cleanup := func() {}
@@ -249,5 +251,6 @@ func InitDependencies(ctx context.Context) (*AppContainer, func()) {
 		UsersHandler:             dashhandlers.NewUsersHandler(userService),
 		UserRepo:                 userRepo,
 		ObserveIngestHandler:     observe.NewIngestHandler(identityService),
+		IdentityHandler:          identity.NewIdentityHandler(identityService),
 	}, cleanup
 }


### PR DESCRIPTION
This pull request introduces a new GeoIP resolver for device identity enrichment, adds a new permission for managing identity allowlists, and refines how license checks are handled in the audit service. It also improves testability and maintainability by adjusting how the license gate is injected, and cleans up JSON rendering in the audit handler.

**Identity and Permissions**

* Added a new `GeoLite2Resolver` in `ee/identity/geoip.go` for optional GeoIP enrichment of device identities, supporting MaxMind GeoLite2/GeoIP2 City and Country databases.
* Introduced a new `'identity:manage'` permission to the permissions catalog and type definitions, enabling management of device identity allowlists. [[1]](diffhunk://#diff-efe3360106bba6a0ce935596af3286f5c4f61906649755684570ae1719c3ae98R26) [[2]](diffhunk://#diff-e84e6eee3d569f707943303b9ed9ceb6cbca4d5437e3cec4bc068d7901ffdd4eL105-R115)

**Audit Service License Handling**

* Refactored `NewAuditService` in `ee/audit/service.go` to directly import and use `licensing.IsEnterprise` as the default license check, rather than accepting a function parameter. Tests now override the `licenseValid` field directly for test scenarios. [[1]](diffhunk://#diff-aaf186cb7571b2b6a71c84d5dbf0755ddd84639fc5e4c172b3af11431cd78e86L95-R103) [[2]](diffhunk://#diff-aaf186cb7571b2b6a71c84d5dbf0755ddd84639fc5e4c172b3af11431cd78e86R11)
* Updated all audit service tests to set `licenseValid` on the service instance after creation, reflecting the new initialization pattern. [[1]](diffhunk://#diff-488bb030d9c8121c8a89b6da548ca657435f8cc507a9ccfc11bd2000f0ffddadL120-R128) [[2]](diffhunk://#diff-488bb030d9c8121c8a89b6da548ca657435f8cc507a9ccfc11bd2000f0ffddadL134-R138) [[3]](diffhunk://#diff-488bb030d9c8121c8a89b6da548ca657435f8cc507a9ccfc11bd2000f0ffddadL181-R186) [[4]](diffhunk://#diff-488bb030d9c8121c8a89b6da548ca657435f8cc507a9ccfc11bd2000f0ffddadL231-R237) [[5]](diffhunk://#diff-488bb030d9c8121c8a89b6da548ca657435f8cc507a9ccfc11bd2000f0ffddadL243-R250) [[6]](diffhunk://#diff-488bb030d9c8121c8a89b6da548ca657435f8cc507a9ccfc11bd2000f0ffddadL254-R262) [[7]](diffhunk://#diff-488bb030d9c8121c8a89b6da548ca657435f8cc507a9ccfc11bd2000f0ffddadL263-R272) [[8]](diffhunk://#diff-b9e054dcac2e89f4bfeb40ba244deaa62709d74294254ab3187be179645a8a81L117-R118) [[9]](diffhunk://#diff-b9e054dcac2e89f4bfeb40ba244deaa62709d74294254ab3187be179645a8a81L175-R177) [[10]](diffhunk://#diff-b9e054dcac2e89f4bfeb40ba244deaa62709d74294254ab3187be179645a8a81L192-R195) [[11]](diffhunk://#diff-3a330ce04934ba0d9e9293f39f763a877ff45b3361f7969714a0645c27a54b2bL173-R174) [[12]](diffhunk://#diff-3a330ce04934ba0d9e9293f39f763a877ff45b3361f7969714a0645c27a54b2bL203-R205) [[13]](diffhunk://#diff-f9d29b0a61291731894afbd8a47d94cbb8e3896a6fe93009f898604e648e2aadL36-R37)

**Audit Handler Improvements**

* Removed the local `renderJSON` function from `ee/audit/handler.go` and switched to using the shared `handlers.RenderJSON`, reducing code duplication. [[1]](diffhunk://#diff-73831c50c62307b997f759a8e7f3b1f0aad6f425a3b7703ceb84eccc628698caL8) [[2]](diffhunk://#diff-73831c50c62307b997f759a8e7f3b1f0aad6f425a3b7703ceb84eccc628698caL81-L87) [[3]](diffhunk://#diff-73831c50c62307b997f759a8e7f3b1f0aad6f425a3b7703ceb84eccc628698caL193-R185)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added identity metadata allowlisting with schema CRUD, value autocomplete/search, and per-device inventory/detail.
  * Added identity ingestion for `$set`, `$set_once`, and `$unset` during logs ingestion (with clear retry-friendly error handling).
  * Added optional GeoIP enrichment for device identity data.
  * Added fine-grained identity management permission (`identity:manage`) and expanded the permission catalog.
* **Improvements**
  * Added Prometheus metrics for identity and ingest outcomes/dropped records.
  * Improved telemetry/logging handling for ingest routes and standardized JSON responses across endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->