### PR TITLE
feat: implement publish group functionality for grouped updates

### DIFF
--- a/apps/dashboard/index.html
+++ b/apps/dashboard/index.html
@@ -4,6 +4,20 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/dashboard.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <script>
+      (() => {
+        const stored = localStorage.getItem('expo-open-ota-theme');
+        const preference = ['light', 'system', 'dark'].includes(stored) ? stored : 'system';
+        const theme =
+          preference === 'system'
+            ? matchMedia('(prefers-color-scheme: dark)').matches
+              ? 'dark'
+              : 'light'
+            : preference;
+        document.documentElement.classList.add(theme);
+        document.documentElement.style.colorScheme = theme;
+      })();
+    </script>
     <script type="module" src="/env.js"></script>
     <title>Expo Open OTA</title>
   </head>

--- a/apps/dashboard/src/App.tsx
+++ b/apps/dashboard/src/App.tsx
@@ -1,5 +1,5 @@
 import { Layout } from '@/containers/Layout';
-import { Route, Routes, useNavigate } from 'react-router';
+import { Navigate, Route, Routes, useNavigate } from 'react-router';
 import { isAuthenticated } from '@/lib/auth.ts';
 import { useEffect, ReactNode } from 'react';
 import { Login } from '@/pages/Login';
@@ -21,6 +21,8 @@ import { SettingsProvider } from '@/lib/SettingsContext';
 import { CurrentUserProvider } from '@/lib/CurrentUserContext';
 import { PermissionsProvider } from '@/ee/lib/PermissionsContext';
 import { RequiresApp } from '@/components/RequiresApp';
+import { Branches } from '@/pages/Branches';
+import { useSettings } from '@/lib/SettingsContext';
 
 function withLayout(children: ReactNode) {
   return <Layout>{children}</Layout>;
@@ -31,6 +33,19 @@ function withLayout(children: ReactNode) {
 function withApp(children: ReactNode) {
   return <RequiresApp>{children}</RequiresApp>;
 }
+
+const DashboardHome = () => {
+  const { CONTROL_PLANE_ENABLED } = useSettings();
+  return <Navigate to={CONTROL_PLANE_ENABLED ? '/updates' : '/branches'} replace />;
+};
+
+// The update feed is control-plane only (a stateless server has no update
+// store to feed it): deep links degrade to the branches view instead of a
+// page whose query can only fail.
+const RequiresControlPlane = ({ children }: { children: ReactNode }) => {
+  const { CONTROL_PLANE_ENABLED } = useSettings();
+  return CONTROL_PLANE_ENABLED ? <>{children}</> : <Navigate to="/branches" replace />;
+};
 
 export const App = () => {
   const isLoggedIn = isAuthenticated();
@@ -55,20 +70,43 @@ export const App = () => {
                 <CurrentUserProvider>
                   <PermissionsProvider>
                     <SelectedAppProvider>
-                    <Routes>
-                      <Route path="/" element={withLayout(withApp(<Updates />))} />
-                      <Route path="/settings" element={withLayout(<Settings />)} />
-                      <Route path="/channels" element={withLayout(withApp(<Channels />))} />
-                      <Route path="/app-info" element={withLayout(withApp(<AppInfo />))} />
-                      <Route path="/tokens" element={withLayout(withApp(<ApiTokens />))} />
-                      <Route path="/users" element={withLayout(<Users />)} />
-                      <Route path="/roles" element={withLayout(<Roles />)} />
-                      <Route path="/audit-logs" element={withLayout(<AuditLog />)} />
-                      <Route path="/sso" element={withLayout(<Sso />)} />
-                      <Route path="/license" element={withLayout(<License />)} />
-                      <Route path="/account" element={withLayout(<Account />)} />
-                      <Route path="/logout" element={withLayout(<Logout />)} />
-                    </Routes>
+                      <Routes>
+                        <Route path="/" element={withLayout(withApp(<DashboardHome />))} />
+                        <Route path="/settings" element={withLayout(<Settings />)} />
+                        <Route path="/channels" element={withLayout(withApp(<Channels />))} />
+                        <Route
+                          path="/channels/:channelName"
+                          element={withLayout(withApp(<Channels />))}
+                        />
+                        <Route path="/branches" element={withLayout(withApp(<Branches />))} />
+                        <Route
+                          path="/branches/:branchName"
+                          element={withLayout(withApp(<Branches />))}
+                        />
+                        <Route
+                          path="/branches/:branchName/runtime-versions/:runtimeVersion"
+                          element={withLayout(withApp(<Branches />))}
+                        />
+                        <Route
+                          path="/updates"
+                          element={withLayout(
+                            withApp(
+                              <RequiresControlPlane>
+                                <Updates />
+                              </RequiresControlPlane>
+                            )
+                          )}
+                        />
+                        <Route path="/app-info" element={withLayout(withApp(<AppInfo />))} />
+                        <Route path="/tokens" element={withLayout(withApp(<ApiTokens />))} />
+                        <Route path="/users" element={withLayout(<Users />)} />
+                        <Route path="/roles" element={withLayout(<Roles />)} />
+                        <Route path="/audit-logs" element={withLayout(<AuditLog />)} />
+                        <Route path="/sso" element={withLayout(<Sso />)} />
+                        <Route path="/license" element={withLayout(<License />)} />
+                        <Route path="/account" element={withLayout(<Account />)} />
+                        <Route path="/logout" element={withLayout(<Logout />)} />
+                      </Routes>
                     </SelectedAppProvider>
                   </PermissionsProvider>
                 </CurrentUserProvider>

--- a/apps/dashboard/src/components/ChannelBranchMapping.tsx
+++ b/apps/dashboard/src/components/ChannelBranchMapping.tsx
@@ -1,0 +1,225 @@
+import { Button } from '@/components/ui/button';
+import { GitBranch, Pencil, Radio } from 'lucide-react';
+import { Link } from 'react-router';
+
+type BranchStatus = {
+  label: 'Current update' | 'Current rollout';
+  commitHash: string;
+  percentage?: number;
+};
+
+type Props = {
+  branchName?: string | null;
+  channelNames: string[];
+  focus?: 'channel' | 'branch';
+  branchStatus?: BranchStatus;
+  rolloutStatus?: BranchStatus;
+  rollout?: {
+    branchName: string;
+    percentage: number;
+  };
+  onEdit?: () => void;
+};
+
+const MappingNode = ({
+  type,
+  name,
+  to,
+  active,
+  meta,
+  status,
+  rollout,
+  branchFocused,
+}: {
+  type: 'channel' | 'branch';
+  name: string;
+  to?: string;
+  active?: boolean;
+  meta?: string;
+  status?: Props['branchStatus'];
+  rollout?: boolean;
+  branchFocused?: boolean;
+}) => {
+  const Icon = type === 'channel' ? Radio : GitBranch;
+  const content = (
+    <div
+      className={`flex min-h-[76px] min-w-0 items-center gap-3 rounded-lg border px-5 py-4 shadow-card transition-all duration-200 group-hover:-translate-y-0.5 group-hover:border-input motion-reduce:transition-none motion-reduce:group-hover:translate-y-0 ${
+        active
+          ? 'border-primary/35 bg-primary/10 text-foreground'
+          : rollout
+            ? 'border-emerald-400/30 bg-emerald-400/[0.07] text-foreground'
+            : 'bg-secondary text-foreground'
+      }`}>
+      <Icon
+        className={`h-5 w-5 shrink-0 ${
+          active
+            ? 'text-primary'
+            : rollout
+              ? 'text-emerald-700 dark:text-emerald-300'
+              : 'text-muted-foreground'
+        }`}
+      />
+      <div className="min-w-0">
+        <p className="text-xs font-medium text-muted-foreground">
+          {rollout
+            ? 'Rollout branch'
+            : type === 'channel'
+              ? 'Channel'
+              : branchFocused
+                ? 'Branch'
+                : 'Default branch'}
+        </p>
+        <p className="truncate text-sm font-semibold text-foreground">{name}</p>
+        {meta && <p className="mt-0.5 text-xs text-muted-foreground">{meta}</p>}
+        {status && (
+          <div className="mt-1 flex flex-wrap items-center gap-1.5 text-xs text-muted-foreground">
+            <span>{status.label}</span>
+            {status.percentage != null && (
+              <span className="rounded bg-emerald-400/10 px-1.5 py-0.5 font-medium text-emerald-700 dark:text-emerald-300">
+                {status.percentage}%
+              </span>
+            )}
+            <span className="font-medium text-foreground">{status.commitHash}</span>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+  return to ? (
+    <Link
+      to={to}
+      className="group min-w-0 rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/30">
+      {content}
+    </Link>
+  ) : (
+    content
+  );
+};
+
+const Connector = ({ split = false }: { split?: boolean }) => (
+  <div className="relative hidden h-full min-h-[76px] md:block">
+    <span
+      className={`absolute left-0 top-1/2 border-t border-muted-foreground/40 ${
+        split ? 'w-1/2' : 'w-full'
+      }`}
+    />
+    {split ? (
+      <>
+        <span className="absolute bottom-[23%] left-1/2 top-[23%] border-l border-muted-foreground/40" />
+        <span className="absolute left-1/2 right-0 top-[23%] border-t border-muted-foreground/40" />
+        <span className="absolute bottom-[23%] left-1/2 right-0 border-t border-muted-foreground/40" />
+        <span className="absolute -right-1 top-[calc(23%-3px)] h-2 w-2 rounded-full border border-muted-foreground bg-card" />
+        <span className="absolute -right-1 bottom-[calc(23%-3px)] h-2 w-2 rounded-full border border-muted-foreground bg-card" />
+      </>
+    ) : (
+      <span className="absolute -right-1 top-[calc(50%-3px)] h-2 w-2 rounded-full border border-muted-foreground bg-card" />
+    )}
+    <span className="absolute -left-1 top-[calc(50%-3px)] h-2 w-2 rounded-full border border-muted-foreground bg-card" />
+  </div>
+);
+
+export const ChannelBranchMapping = ({
+  branchName,
+  channelNames,
+  focus = 'channel',
+  branchStatus,
+  rolloutStatus,
+  rollout,
+  onEdit,
+}: Props) => {
+  const mappings = channelNames.length > 0 ? channelNames : [null];
+  const channelDetailMapping = mappings.length === 1 && !!mappings[0] && !!rollout;
+  return (
+    <section className="overflow-hidden rounded-lg border bg-card shadow-card">
+      <header className="flex min-h-14 items-center justify-between gap-4 border-b px-5">
+        <div className="flex items-center gap-2">
+          <GitBranch className="h-4 w-4 text-muted-foreground" />
+          <h2 className="text-sm font-semibold">Channel-branch mapping</h2>
+        </div>
+        {onEdit && (
+          <Button variant="secondary" size="sm" onClick={onEdit}>
+            <Pencil className="h-3.5 w-3.5" />
+            Edit
+          </Button>
+        )}
+      </header>
+      <div
+        className="min-h-[300px] space-y-4 px-8 py-10 lg:px-12 lg:py-12"
+        style={{
+          backgroundImage: 'radial-gradient(hsl(var(--graph-dot) / 0.45) 1px, transparent 1px)',
+          backgroundSize: '14px 14px',
+        }}>
+        {channelDetailMapping ? (
+          <div className="mx-auto grid max-w-[1480px] items-center gap-4 md:grid-cols-[minmax(0,1fr)_112px_minmax(0,1fr)] md:gap-0">
+            <MappingNode
+              type="channel"
+              name={mappings[0] as string}
+              to={`/channels/${encodeURIComponent(mappings[0] as string)}`}
+              active={focus === 'channel'}
+            />
+            <Connector split />
+            <div className="grid gap-5">
+              {branchName ? (
+                <MappingNode
+                  type="branch"
+                  name={branchName}
+                  to={`/branches/${encodeURIComponent(branchName)}`}
+                  meta={`${100 - rollout.percentage}% of devices`}
+                  active={focus === 'branch'}
+                  status={branchStatus}
+                  branchFocused={focus === 'branch'}
+                />
+              ) : (
+                <div className="rounded-lg border border-dashed bg-secondary px-4 py-5 text-sm text-muted-foreground">
+                  No default branch mapped
+                </div>
+              )}
+              <MappingNode
+                type="branch"
+                name={rollout.branchName}
+                to={`/branches/${encodeURIComponent(rollout.branchName)}`}
+                meta={`${rollout.percentage}% of devices`}
+                status={rolloutStatus}
+                rollout
+              />
+            </div>
+          </div>
+        ) : (
+          mappings.map((channelName, index) => (
+            <div
+              key={channelName ?? `unmapped-${index}`}
+              className="mx-auto grid max-w-[1480px] items-center gap-4 md:grid-cols-[minmax(0,1fr)_112px_minmax(0,1fr)] md:gap-0">
+              {channelName ? (
+                <MappingNode
+                  type="channel"
+                  name={channelName}
+                  to={`/channels/${encodeURIComponent(channelName)}`}
+                  active={focus === 'channel'}
+                />
+              ) : (
+                <div className="rounded-lg border border-dashed bg-secondary px-4 py-5 text-sm text-muted-foreground">
+                  No channel mapped
+                </div>
+              )}
+              <Connector />
+              {branchName ? (
+                <MappingNode
+                  type="branch"
+                  name={branchName}
+                  to={`/branches/${encodeURIComponent(branchName)}`}
+                  active={focus === 'branch'}
+                  status={branchStatus}
+                  branchFocused={focus === 'branch'}
+                />
+              ) : (
+                <div className="rounded-lg border border-dashed bg-secondary px-4 py-5 text-sm text-muted-foreground">
+                  No branch mapped
+                </div>
+              )}
+            </div>
+          ))
+        )}
+      </div>
+    </section>
+  );
+};

--- a/apps/dashboard/src/components/Combobox/index.tsx
+++ b/apps/dashboard/src/components/Combobox/index.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import * as React from 'react';
-import { Check, ChevronsUpDown } from 'lucide-react';
+import { Check, ChevronsUpDown, X } from 'lucide-react';
 
 import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
@@ -31,13 +31,15 @@ interface ComboboxProps {
   // Optional action pinned under the options (e.g. "New Application"). Stays
   // visible whatever the search input, since it is not one of the options.
   action?: { label: string; icon?: React.ReactNode; onSelect: () => void };
+  clearable?: boolean;
   // Extra classes for the trigger button; pass "w-full" to make the combobox
   // fill its container (the popover always matches the trigger width).
   className?: string;
 }
 
 export function Combobox(props: ComboboxProps) {
-  const { options, value, onChange, loading, label, disabled, action, className } = props;
+  const { options, value, onChange, loading, label, disabled, action, clearable, className } =
+    props;
   const [open, setOpen] = React.useState(false);
   // Disabling only blocks the trigger: a popover already open when disabled
   // flips to true (e.g. the surrounding form starts saving) would stay
@@ -54,9 +56,28 @@ export function Combobox(props: ComboboxProps) {
           aria-expanded={disabled ? false : open}
           disabled={disabled}
           className={cn('w-max justify-between font-normal', className)}>
-          <span className="truncate">
-            {value ? options.find(opt => opt.value === value)?.label : label || 'Select option'}
+          <span className="min-w-0 flex-1 truncate text-left">
+            {value
+              ? options.find(opt => opt.value === value)?.label || value
+              : label || 'Select option'}
           </span>
+          {clearable && value && (
+            // Pointer-only shortcut: a focusable control nested in the trigger
+            // <button> would be invalid HTML with browser-dependent keyboard
+            // behavior. Keyboard users clear by re-selecting the selected
+            // option (onSelect toggles it to '').
+            <span
+              aria-hidden="true"
+              className="ml-2 rounded-sm p-0.5 text-muted-foreground hover:bg-accent hover:text-foreground"
+              onClick={event => {
+                event.preventDefault();
+                event.stopPropagation();
+                onChange('');
+                setOpen(false);
+              }}>
+              <X className="h-3.5 w-3.5" />
+            </span>
+          )}
           <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
         </Button>
       </PopoverTrigger>
@@ -67,8 +88,7 @@ export function Combobox(props: ComboboxProps) {
             const matchedOption = options.find(opt => opt.value === itemValue);
             const textToSearch = matchedOption ? matchedOption.label : itemValue;
             return textToSearch.toLowerCase().includes(search.toLowerCase()) ? 1 : 0;
-          }}
-        >
+          }}>
           <CommandInput placeholder="Search..." />
           <CommandList>
             <CommandEmpty>No option found.</CommandEmpty>
@@ -102,7 +122,7 @@ export function Combobox(props: ComboboxProps) {
                       action.onSelect();
                       setOpen(false);
                     }}
-                    className="text-gray-600">
+                    className="text-muted-foreground">
                     {action.icon}
                     {action.label}
                   </CommandItem>

--- a/apps/dashboard/src/components/CommandPalette.tsx
+++ b/apps/dashboard/src/components/CommandPalette.tsx
@@ -1,0 +1,192 @@
+import { useQuery } from '@tanstack/react-query';
+import {
+  BadgeCheck,
+  Box,
+  CircleUser,
+  FileText,
+  GitBranch,
+  HardDriveDownload,
+  Info,
+  KeyRound,
+  Radio,
+  ScrollText,
+  Settings,
+  ShieldCheck,
+  Users,
+} from 'lucide-react';
+import { useNavigate } from 'react-router';
+import { api } from '@/lib/api';
+import { useSelectedApp } from '@/lib/SelectedAppContext';
+import { useSettings } from '@/lib/SettingsContext';
+import { useCurrentUser } from '@/lib/CurrentUserContext';
+import {
+  CommandDialog,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandSeparator,
+} from '@/components/ui/command';
+
+type NavigationItem = {
+  label: string;
+  path: string;
+  icon: typeof Box;
+};
+
+export const CommandPalette = ({
+  open,
+  onOpenChange,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) => {
+  const navigate = useNavigate();
+  const { CONTROL_PLANE_ENABLED } = useSettings();
+  const { isAdmin } = useCurrentUser();
+  const { apps, selectedAppId, setSelectedAppId } = useSelectedApp();
+
+  const channelsQuery = useQuery({
+    queryKey: ['channels', selectedAppId],
+    queryFn: () => api.getChannels(),
+    enabled: open && !!selectedAppId,
+  });
+  const branchesQuery = useQuery({
+    queryKey: ['branches', selectedAppId],
+    queryFn: () => api.getBranches(),
+    enabled: open && !!selectedAppId,
+  });
+
+  const appNavigation: NavigationItem[] = selectedAppId
+    ? [
+        ...(CONTROL_PLANE_ENABLED
+          ? [{ label: 'Updates', path: '/updates', icon: HardDriveDownload }]
+          : []),
+        { label: 'Channels', path: '/channels', icon: Box },
+        { label: 'Branches', path: '/branches', icon: GitBranch },
+        { label: 'App info', path: '/app-info', icon: Info },
+        ...(CONTROL_PLANE_ENABLED
+          ? [{ label: 'API tokens', path: '/tokens', icon: KeyRound }]
+          : []),
+      ]
+    : [];
+  const serverNavigation: NavigationItem[] = [
+    { label: 'Settings', path: '/settings', icon: Settings },
+    ...(CONTROL_PLANE_ENABLED ? [{ label: 'License', path: '/license', icon: BadgeCheck }] : []),
+    { label: 'My account', path: '/account', icon: CircleUser },
+    ...(CONTROL_PLANE_ENABLED && isAdmin
+      ? [
+          { label: 'Users', path: '/users', icon: Users },
+          { label: 'Roles', path: '/roles', icon: ShieldCheck },
+          { label: 'SSO', path: '/sso', icon: Radio },
+          { label: 'Audit log', path: '/audit-logs', icon: ScrollText },
+        ]
+      : []),
+  ];
+
+  const goTo = (path: string) => {
+    onOpenChange(false);
+    navigate(path);
+  };
+
+  return (
+    <CommandDialog open={open} onOpenChange={onOpenChange}>
+      <CommandInput placeholder="Search pages, branches, channels..." />
+      <CommandList className="max-h-[min(420px,60vh)]">
+        <CommandEmpty>No result found.</CommandEmpty>
+
+        {appNavigation.length > 0 && (
+          <CommandGroup heading="Application">
+            {appNavigation.map(item => (
+              <CommandItem
+                key={item.path}
+                value={`page ${item.label}`}
+                onSelect={() => goTo(item.path)}>
+                <item.icon />
+                <span>{item.label}</span>
+              </CommandItem>
+            ))}
+          </CommandGroup>
+        )}
+
+        {selectedAppId && (channelsQuery.data?.length ?? 0) > 0 && (
+          <>
+            <CommandSeparator />
+            <CommandGroup heading="Channels">
+              {channelsQuery.data?.map(channel => (
+                <CommandItem
+                  key={channel.releaseChannelId}
+                  value={`channel ${channel.releaseChannelName}`}
+                  onSelect={() =>
+                    goTo(`/channels/${encodeURIComponent(channel.releaseChannelName)}`)
+                  }>
+                  <Box />
+                  <span className="truncate">{channel.releaseChannelName}</span>
+                  {channel.branchName && (
+                    <span className="ml-auto truncate text-xs text-muted-foreground">
+                      {channel.branchName}
+                    </span>
+                  )}
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </>
+        )}
+
+        {selectedAppId && (branchesQuery.data?.length ?? 0) > 0 && (
+          <>
+            <CommandSeparator />
+            <CommandGroup heading="Branches">
+              {branchesQuery.data?.map(branch => (
+                <CommandItem
+                  key={branch.branchId}
+                  value={`branch ${branch.branchName}`}
+                  onSelect={() => goTo(`/branches/${encodeURIComponent(branch.branchName)}`)}>
+                  <GitBranch />
+                  <span className="truncate">{branch.branchName}</span>
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </>
+        )}
+
+        <CommandSeparator />
+        <CommandGroup heading="Server">
+          {serverNavigation.map(item => (
+            <CommandItem
+              key={item.path}
+              value={`page ${item.label}`}
+              onSelect={() => goTo(item.path)}>
+              <item.icon />
+              <span>{item.label}</span>
+            </CommandItem>
+          ))}
+        </CommandGroup>
+
+        {apps.length > 1 && (
+          <>
+            <CommandSeparator />
+            <CommandGroup heading="Applications">
+              {apps.map(app => (
+                <CommandItem
+                  key={app.id}
+                  value={`application ${app.name || app.id}`}
+                  onSelect={() => {
+                    setSelectedAppId(app.id);
+                    goTo(CONTROL_PLANE_ENABLED ? '/updates' : '/branches');
+                  }}>
+                  <FileText />
+                  <span className="truncate">{app.name || app.id}</span>
+                  {app.id === selectedAppId && (
+                    <span className="ml-auto h-1.5 w-1.5 rounded-full bg-primary" />
+                  )}
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </>
+        )}
+      </CommandList>
+    </CommandDialog>
+  );
+};

--- a/apps/dashboard/src/components/DataTable/index.tsx
+++ b/apps/dashboard/src/components/DataTable/index.tsx
@@ -50,7 +50,7 @@ export function DataTable<TData, TValue>({
   });
 
   return (
-    <div className="w-full overflow-hidden rounded-xl border shadow-card">
+    <div className="w-full overflow-hidden rounded-lg border bg-card shadow-card">
       <Table className="w-full">
         <TableHeader className="w-full">
           {table.getHeaderGroups().map(headerGroup => (
@@ -85,8 +85,8 @@ export function DataTable<TData, TValue>({
         </TableHeader>
         <TableBody className="w-full">
           {loading &&
-            Array.from({ length: 5 }).map(() => (
-              <TableRow key={Math.random()}>
+            Array.from({ length: 5 }).map((_, rowIndex) => (
+              <TableRow key={rowIndex}>
                 {columns.map((_, i) => (
                   <TableCell key={i}>
                     <Skeleton className="h-4 w-full" />
@@ -100,8 +100,7 @@ export function DataTable<TData, TValue>({
                   key={row.id}
                   data-state={row.getIsSelected() && 'selected'}
                   className={onRowClick ? 'cursor-pointer' : undefined}
-                  onClick={() => onRowClick?.(row.original)}
-                >
+                  onClick={() => onRowClick?.(row.original)}>
                   {row.getVisibleCells().map(cell => (
                     <TableCell key={cell.id}>
                       {flexRender(cell.column.columnDef.cell, cell.getContext())}

--- a/apps/dashboard/src/components/PageHeader/index.tsx
+++ b/apps/dashboard/src/components/PageHeader/index.tsx
@@ -9,9 +9,11 @@ export const PageHeader = ({
   description?: React.ReactNode;
   actions?: React.ReactNode;
 }) => (
-  <header className="mb-8 space-y-1.5 border-b pb-6">
+  <header className="mb-7 space-y-2 border-b border-border/80 pb-6">
     <div className="flex items-center justify-between gap-4">
-      <h1 className="text-2xl font-semibold tracking-tight">{title}</h1>
+      <h1 className="font-display text-[28px] font-semibold tracking-tight text-foreground">
+        {title}
+      </h1>
       {actions}
     </div>
     {description && (

--- a/apps/dashboard/src/components/UpdateDetailsSheet/index.tsx
+++ b/apps/dashboard/src/components/UpdateDetailsSheet/index.tsx
@@ -24,6 +24,8 @@ interface Update {
   updateId: string;
   platform: string;
   commitHash: string;
+  branch?: string;
+  runtimeVersion?: string;
 }
 
 export type UpdateDetailsRef = {
@@ -49,7 +51,7 @@ const CopyButton = ({ value, label }: { value: string; label: string }) => {
         }
       }}>
       {copied ? (
-        <Check className="h-3.5 w-3.5 text-emerald-600" />
+        <Check className="h-3.5 w-3.5 text-emerald-700 dark:text-emerald-300" />
       ) : (
         <Copy className="h-3.5 w-3.5" />
       )}
@@ -92,8 +94,11 @@ const UpdateDetailsBody = ({
 }) => {
   const { selectedAppId } = useSelectedApp();
   const [showRawConfig, setShowRawConfig] = useState(false);
+  // Keyed on what the fetch actually uses. Never updateUUID: every rollback
+  // row shares the literal "Rollback to embedded", so two rollbacks from
+  // different branches would collide in the cache and show mixed data.
   const { data, isLoading, error } = useQuery({
-    queryKey: ['update-details', selectedAppId, update.updateUUID],
+    queryKey: ['update-details', selectedAppId, branch, runtimeVersion, update.updateId],
     enabled: !!update.updateId && !!selectedAppId,
     queryFn: () => api.getUpdateDetails(branch, runtimeVersion, update.updateId),
   });
@@ -156,14 +161,18 @@ const UpdateDetailsBody = ({
         <div className="flex flex-wrap items-center gap-1.5 pt-1">
           <Badge variant="outline">{platformLabel(data.platform)}</Badge>
           {isRollback ? (
-            <Badge variant="outline" className="border-amber-200 bg-amber-50 text-amber-700">
+            <Badge
+              variant="outline"
+              className="border-amber-400/25 bg-amber-400/10 text-amber-700 dark:text-amber-300">
               Rollback
             </Badge>
           ) : (
             <Badge variant="outline">Normal update</Badge>
           )}
           {rolloutActive && (
-            <Badge variant="outline" className="border-emerald-200 bg-emerald-50 text-emerald-700">
+            <Badge
+              variant="outline"
+              className="border-emerald-400/25 bg-emerald-400/10 text-emerald-700 dark:text-emerald-300">
               <Split className="mr-1 h-3 w-3" />
               Rollout in progress
             </Badge>
@@ -173,9 +182,11 @@ const UpdateDetailsBody = ({
 
       <div className="space-y-5 py-4">
         {rolloutActive && (
-          <div className="space-y-2 rounded-xl border border-emerald-200 bg-emerald-50/40 p-4">
+          <div className="space-y-2 rounded-lg border border-emerald-400/25 bg-emerald-400/[0.07] p-4">
             <div className="flex items-center justify-between gap-4">
-              <span className="text-sm font-medium text-emerald-800">Progressive rollout</span>
+              <span className="text-sm font-medium text-emerald-800 dark:text-emerald-200">
+                Progressive rollout
+              </span>
               <RolloutBar value={data.rolloutPercentage as number} />
             </div>
             {data.controlUpdateId && (
@@ -261,8 +272,8 @@ const UpdateDetailsBody = ({
 };
 
 type Props = {
-  branch: string;
-  runtimeVersion: string;
+  branch?: string;
+  runtimeVersion?: string;
 };
 
 export const UpdateDetailsSheet = forwardRef<UpdateDetailsRef, Props>(
@@ -288,10 +299,10 @@ export const UpdateDetailsSheet = forwardRef<UpdateDetailsRef, Props>(
         <SheetContent className="w-full overflow-y-auto sm:max-w-xl">
           {currentUpdate ? (
             <UpdateDetailsBody
-              key={currentUpdate.updateUUID}
+              key={`${currentUpdate.branch ?? branch ?? ''}:${currentUpdate.runtimeVersion ?? runtimeVersion ?? ''}:${currentUpdate.updateId}`}
               update={currentUpdate}
-              branch={branch}
-              runtimeVersion={runtimeVersion}
+              branch={currentUpdate.branch ?? branch ?? ''}
+              runtimeVersion={currentUpdate.runtimeVersion ?? runtimeVersion ?? ''}
             />
           ) : (
             <SheetHeader>

--- a/apps/dashboard/src/components/app-creation-modal.tsx
+++ b/apps/dashboard/src/components/app-creation-modal.tsx
@@ -19,14 +19,10 @@ type CreateAppModalProps = {
   onAppCreated?: (appId: string) => void;
 };
 
-export const CreateAppModal = ({
-  isOpen,
-  onClose,
-  onAppCreated,
-} : CreateAppModalProps) => {
+export const CreateAppModal = ({ isOpen, onClose, onAppCreated }: CreateAppModalProps) => {
   const { toast } = useToast();
   const [isSubmitting, setIsSubmitting] = useState(false);
-  
+
   const [name, setName] = useState('');
   const [keysMode, setKeysMode] = useState<KeysMode>('database');
   const [publicSecretId, setPublicSecretId] = useState('');
@@ -95,7 +91,7 @@ export const CreateAppModal = ({
   };
 
   return (
-    <Dialog open={isOpen} onOpenChange={(open) => !open && handleClose()}>
+    <Dialog open={isOpen} onOpenChange={open => !open && handleClose()}>
       <DialogContent className="sm:max-w-[480px]">
         <DialogHeader>
           <DialogTitle className="text-lg">New application</DialogTitle>
@@ -110,7 +106,7 @@ export const CreateAppModal = ({
               id="app-name"
               placeholder="e.g. my-mobile-app"
               value={name}
-              onChange={(e) => setName(e.target.value)}
+              onChange={e => setName(e.target.value)}
               disabled={isSubmitting}
               className="h-9"
               required
@@ -120,17 +116,24 @@ export const CreateAppModal = ({
             <Label>Signing keys</Label>
             <div className="grid grid-cols-1 gap-2">
               {[
-                { id: 'database', label: 'Managed for you', desc: 'Keys are generated, sealed with the master key and stored in the database.' },
-                { id: 'aws-secrets-manager', label: 'AWS Secrets Manager', desc: 'Keys are fetched from secrets you manage in AWS.' }
-              ].map((mode) => (
+                {
+                  id: 'database',
+                  label: 'Managed for you',
+                  desc: 'Keys are generated, sealed with the master key and stored in the database.',
+                },
+                {
+                  id: 'aws-secrets-manager',
+                  label: 'AWS Secrets Manager',
+                  desc: 'Keys are fetched from secrets you manage in AWS.',
+                },
+              ].map(mode => (
                 <label
                   key={mode.id}
                   className={`flex items-start gap-3 p-3 rounded-lg border cursor-pointer transition-colors ${
                     keysMode === mode.id
                       ? 'bg-accent/40 border-foreground/30 text-foreground'
                       : 'bg-background/50 border-border text-muted-foreground hover:bg-accent/20'
-                  }`}
-                >
+                  }`}>
                   <input
                     type="radio"
                     name="keysMode"
@@ -159,7 +162,7 @@ export const CreateAppModal = ({
                   id="publicSecretId"
                   placeholder="arn:aws:secretsmanager:..."
                   value={publicSecretId}
-                  onChange={(e) => setPublicSecretId(e.target.value)}
+                  onChange={e => setPublicSecretId(e.target.value)}
                   disabled={isSubmitting}
                   className="h-9 bg-background"
                   required
@@ -173,7 +176,7 @@ export const CreateAppModal = ({
                   id="privateSecretId"
                   placeholder="arn:aws:secretsmanager:..."
                   value={privateSecretId}
-                  onChange={(e) => setPrivateSecretId(e.target.value)}
+                  onChange={e => setPrivateSecretId(e.target.value)}
                   disabled={isSubmitting}
                   className="h-9 bg-background"
                   required
@@ -188,8 +191,7 @@ export const CreateAppModal = ({
               variant="outline"
               onClick={handleClose}
               disabled={isSubmitting}
-              className="h-9 text-xs font-medium"
-            >
+              className="h-9 text-xs font-medium">
               Cancel
             </Button>
             <Button type="submit" disabled={isSubmitting} className="h-9">

--- a/apps/dashboard/src/components/app-sidebar.tsx
+++ b/apps/dashboard/src/components/app-sidebar.tsx
@@ -7,13 +7,18 @@ import {
   Fingerprint,
   ScrollText,
   HardDriveDownload,
+  GitBranch,
   Info,
   KeyRound,
   LogOut,
+  Monitor,
+  Moon,
   Plus,
   Radio,
+  Search,
   Settings,
   ShieldCheck,
+  Sun,
   Users,
 } from 'lucide-react';
 import clsx from 'clsx';
@@ -25,31 +30,35 @@ import { CreateAppModal } from '@/components/app-creation-modal';
 import { useSettings } from '@/lib/SettingsContext';
 import { useCurrentUser } from '@/lib/CurrentUserContext';
 import { EnterpriseBadge } from '@/ee/components/EnterpriseBadge';
+import { ThemePreference, useTheme } from '@/lib/theme';
 
 const NavLink = ({
   to,
   icon: Icon,
   badge,
+  onNavigate,
   children,
 }: {
   to: string;
   icon: typeof Box;
   badge?: React.ReactNode;
+  onNavigate?: () => void;
   children: React.ReactNode;
 }) => {
   const { pathname } = useLocation();
-  const isActive = pathname === to;
+  const isActive = pathname === to || pathname.startsWith(`${to}/`);
   return (
     <Link
       to={to}
       onClick={e => {
         if (isActive) e.preventDefault();
+        onNavigate?.();
       }}
       className={clsx(
-        'flex items-center gap-2.5 rounded-md px-3 py-2 text-sm transition-colors',
+        'flex items-center gap-2.5 rounded-md border border-transparent px-3 py-2 text-sm transition-all duration-150 motion-reduce:transition-none',
         isActive
-          ? 'bg-secondary font-medium text-foreground'
-          : 'text-muted-foreground hover:bg-muted/60 hover:text-foreground'
+          ? 'border-primary/20 bg-primary/10 font-medium text-foreground'
+          : 'text-muted-foreground hover:translate-x-0.5 hover:border-border hover:bg-accent/70 hover:text-foreground motion-reduce:hover:translate-x-0'
       )}>
       <Icon className="h-4 w-4" strokeWidth={1.75} />
       <span>{children}</span>
@@ -61,7 +70,7 @@ const NavLink = ({
 // Marks a nav entry as part of the Enterprise edition, with the emerald
 // accent shared by the enterprise UI.
 const EnterpriseNavBadge = () => (
-  <span className="ml-auto rounded-full border border-emerald-200/80 bg-emerald-50/80 px-1.5 py-px text-[10px] font-medium text-emerald-700">
+  <span className="ml-auto rounded-full border border-emerald-400/25 bg-emerald-400/10 px-1.5 py-px text-[10px] font-medium text-emerald-700 dark:text-emerald-300">
     Enterprise
   </span>
 );
@@ -70,19 +79,67 @@ const EnterpriseNavBadge = () => (
 // notices there is anything to approve, and new members sit blocked in silence.
 const PendingUsersBadge = ({ count }: { count: number }) => (
   <span
-    className="ml-auto rounded-full border border-amber-200/80 bg-amber-50/80 px-1.5 py-px text-[10px] font-medium text-amber-700"
+    className="ml-auto rounded-full border border-amber-400/25 bg-amber-400/10 px-1.5 py-px text-[10px] font-medium text-amber-700 dark:text-amber-300"
     title={`${count} account${count > 1 ? 's' : ''} waiting for approval`}>
     {count}
   </span>
 );
 
 const SectionLabel = ({ children }: { children: React.ReactNode }) => (
-  <p className="px-3 pb-1.5 pt-5 text-[11px] font-medium uppercase tracking-widest text-muted-foreground/70">
-    {children}
-  </p>
+  <p className="px-3 pb-1.5 pt-5 text-xs font-medium text-muted-foreground">{children}</p>
 );
 
-export function AppSidebar() {
+const themeOptions: Array<{
+  value: ThemePreference;
+  label: string;
+  icon: typeof Sun;
+}> = [
+  { value: 'light', label: 'Light', icon: Sun },
+  { value: 'system', label: 'Auto', icon: Monitor },
+  { value: 'dark', label: 'Dark', icon: Moon },
+];
+
+const ThemeSwitcher = () => {
+  const { preference, setPreference } = useTheme();
+  return (
+    <div
+      className="grid shrink-0 grid-cols-3 gap-0.5 rounded-md border bg-secondary/70 p-0.5"
+      aria-label="Color theme">
+      {themeOptions.map(option => {
+        const Icon = option.icon;
+        const active = preference === option.value;
+        return (
+          <button
+            key={option.value}
+            type="button"
+            aria-pressed={active}
+            aria-label={`${option.label} theme`}
+            title={option.value === 'system' ? 'Automatic theme' : `${option.label} theme`}
+            onClick={() => setPreference(option.value)}
+            className={clsx(
+              'flex h-7 w-7 items-center justify-center rounded text-xs font-medium transition-colors',
+              active
+                ? 'bg-card text-foreground shadow-card'
+                : 'text-muted-foreground hover:bg-accent hover:text-foreground'
+            )}>
+            <Icon className="h-3.5 w-3.5" />
+            <span className="sr-only">{option.label}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+};
+
+export function AppSidebar({
+  mobile = false,
+  onNavigate,
+  onOpenCommandPalette,
+}: {
+  mobile?: boolean;
+  onNavigate?: () => void;
+  onOpenCommandPalette?: () => void;
+} = {}) {
   const { CONTROL_PLANE_ENABLED } = useSettings();
   const { isAdmin } = useCurrentUser();
   const { apps, selectedAppId, setSelectedAppId, refreshApps, isLoading } = useSelectedApp();
@@ -96,6 +153,10 @@ export function AppSidebar() {
     enabled: CONTROL_PLANE_ENABLED && isAdmin,
   });
   const pendingUsersCount = (usersQuery.data ?? []).filter(user => !user.enabled).length;
+  const commandPaletteShortcut =
+    typeof navigator !== 'undefined' && /Mac|iPhone|iPad|iPod/i.test(navigator.userAgent)
+      ? '⌘ K'
+      : 'Ctrl K';
 
   const handleAppCreated = async (newAppId: string) => {
     await refreshApps();
@@ -104,12 +165,22 @@ export function AppSidebar() {
 
   return (
     <>
-      <aside className="sticky top-0 flex h-screen w-64 shrink-0 flex-col border-r bg-background">
+      <aside
+        className={clsx(
+          'h-screen w-64 shrink-0 flex-col border-r border-border/80 bg-card dark:bg-[#09090b]',
+          mobile ? 'flex w-full' : 'sticky top-0 hidden lg:flex'
+        )}>
         <div className="flex items-center gap-2.5 px-5 pb-2 pt-5">
-          <div className="flex h-7 w-7 items-center justify-center rounded-lg bg-primary text-primary-foreground">
+          <div className="flex h-8 w-8 items-center justify-center rounded-lg border border-primary/25 bg-primary/10 text-primary">
             <Radio className="h-4 w-4" strokeWidth={2} />
           </div>
-          <span className="text-[15px] font-semibold tracking-tight">Expo Open OTA</span>
+          <span className="font-display text-[15px] font-semibold tracking-tight text-foreground">
+            expo-open-ota
+            <span
+              aria-hidden
+              className="ml-1 inline-block h-1.5 w-1.5 rounded-full bg-primary align-baseline"
+            />
+          </span>
         </div>
 
         <EnterpriseBadge />
@@ -138,6 +209,17 @@ export function AppSidebar() {
                 : undefined
             }
           />
+          <button
+            type="button"
+            onClick={onOpenCommandPalette}
+            aria-keyshortcuts="Meta+K Control+K"
+            className="mt-2 flex h-9 w-full items-center gap-2.5 rounded-md border border-transparent px-3 text-sm text-muted-foreground transition-all duration-150 hover:border-border hover:bg-accent/70 hover:text-foreground">
+            <Search className="h-4 w-4" />
+            <span>Search</span>
+            <kbd className="ml-auto rounded border border-border bg-secondary px-1.5 py-0.5 text-[11px] font-medium text-muted-foreground">
+              {commandPaletteShortcut}
+            </kbd>
+          </button>
         </div>
 
         <nav className="flex-1 overflow-y-auto px-3">
@@ -148,37 +230,42 @@ export function AppSidebar() {
             <>
               <SectionLabel>Application</SectionLabel>
               <div className="space-y-0.5">
-                <NavLink to="/" icon={HardDriveDownload}>
-                  Branches & updates
-                </NavLink>
-                <NavLink to="/channels" icon={Box}>
+                {CONTROL_PLANE_ENABLED && (
+                  <NavLink to="/updates" icon={HardDriveDownload} onNavigate={onNavigate}>
+                    Updates
+                  </NavLink>
+                )}
+                <NavLink to="/channels" icon={Box} onNavigate={onNavigate}>
                   Channels
                 </NavLink>
-                <NavLink to="/app-info" icon={Info}>
+                <NavLink to="/branches" icon={GitBranch} onNavigate={onNavigate}>
+                  Branches
+                </NavLink>
+                <NavLink to="/app-info" icon={Info} onNavigate={onNavigate}>
                   App info
                 </NavLink>
                 {CONTROL_PLANE_ENABLED && (
-                  <NavLink to="/tokens" icon={KeyRound}>
+                  <NavLink to="/tokens" icon={KeyRound} onNavigate={onNavigate}>
                     API tokens
                   </NavLink>
                 )}
               </div>
 
-              <div className="mx-3 mt-5 border-t" />
+              <div className="mx-3 mt-5 border-t border-border/70" />
             </>
           )}
 
           <SectionLabel>Server</SectionLabel>
           <div className="space-y-0.5">
-            <NavLink to="/settings" icon={Settings}>
+            <NavLink to="/settings" icon={Settings} onNavigate={onNavigate}>
               Settings
             </NavLink>
             {CONTROL_PLANE_ENABLED && (
-              <NavLink to="/license" icon={BadgeCheck}>
+              <NavLink to="/license" icon={BadgeCheck} onNavigate={onNavigate}>
                 License
               </NavLink>
             )}
-            <NavLink to="/account" icon={CircleUser}>
+            <NavLink to="/account" icon={CircleUser} onNavigate={onNavigate}>
               My account
             </NavLink>
           </div>
@@ -192,6 +279,7 @@ export function AppSidebar() {
                 <NavLink
                   to="/users"
                   icon={Users}
+                  onNavigate={onNavigate}
                   badge={
                     pendingUsersCount > 0 ? (
                       <PendingUsersBadge count={pendingUsersCount} />
@@ -199,13 +287,25 @@ export function AppSidebar() {
                   }>
                   Users
                 </NavLink>
-                <NavLink to="/roles" icon={ShieldCheck} badge={<EnterpriseNavBadge />}>
+                <NavLink
+                  to="/roles"
+                  icon={ShieldCheck}
+                  badge={<EnterpriseNavBadge />}
+                  onNavigate={onNavigate}>
                   Roles
                 </NavLink>
-                <NavLink to="/sso" icon={Fingerprint} badge={<EnterpriseNavBadge />}>
+                <NavLink
+                  to="/sso"
+                  icon={Fingerprint}
+                  badge={<EnterpriseNavBadge />}
+                  onNavigate={onNavigate}>
                   SSO
                 </NavLink>
-                <NavLink to="/audit-logs" icon={ScrollText} badge={<EnterpriseNavBadge />}>
+                <NavLink
+                  to="/audit-logs"
+                  icon={ScrollText}
+                  badge={<EnterpriseNavBadge />}
+                  onNavigate={onNavigate}>
                   Audit log
                 </NavLink>
               </div>
@@ -213,13 +313,15 @@ export function AppSidebar() {
           )}
         </nav>
 
-        <div className="border-t p-3">
+        <div className="flex items-center gap-2 border-t border-border/80 p-3">
           <Link
             to="/logout"
-            className="flex items-center gap-2.5 rounded-md px-3 py-2 text-sm text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground">
+            onClick={onNavigate}
+            className="flex min-w-0 flex-1 items-center gap-2.5 rounded-md border border-transparent px-2 py-1.5 text-sm text-muted-foreground transition-colors hover:border-border hover:bg-accent/70 hover:text-foreground">
             <LogOut className="h-4 w-4" strokeWidth={1.75} />
             <span>Log out</span>
           </Link>
+          <ThemeSwitcher />
         </div>
       </aside>
 

--- a/apps/dashboard/src/components/rollout/PercentInput.tsx
+++ b/apps/dashboard/src/components/rollout/PercentInput.tsx
@@ -69,7 +69,7 @@ export const PercentInput = ({
             onClick={() => handleChange(String(p))}
             className={cn(
               value === p &&
-                'border-emerald-500 bg-emerald-50 text-emerald-700 hover:bg-emerald-50 hover:text-emerald-700'
+                'border-emerald-400/40 bg-emerald-400/10 text-emerald-700 hover:bg-emerald-400/15 hover:text-emerald-800 dark:text-emerald-300 dark:hover:text-emerald-200'
             )}>
             {p}%
           </Button>

--- a/apps/dashboard/src/components/rollout/RolloutBar.tsx
+++ b/apps/dashboard/src/components/rollout/RolloutBar.tsx
@@ -7,8 +7,8 @@ export const RolloutBar = ({ value, className }: { value: number; className?: st
   <span className={cn('inline-flex items-center gap-2', className)}>
     <Progress
       value={value}
-      className="h-1.5 w-24 bg-emerald-100"
-      indicatorClassName="bg-emerald-500"
+      className="h-1.5 w-24 bg-emerald-400/15"
+      indicatorClassName="bg-emerald-500 dark:bg-emerald-400"
     />
     <span className="text-xs font-medium tabular-nums text-muted-foreground">{value}%</span>
   </span>

--- a/apps/dashboard/src/components/ui/alert.tsx
+++ b/apps/dashboard/src/components/ui/alert.tsx
@@ -1,59 +1,49 @@
-import * as React from "react"
-import { cva, type VariantProps } from "class-variance-authority"
+import * as React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils';
 
 const alertVariants = cva(
-  "relative w-full rounded-lg border px-4 py-3 text-sm [&>svg+div]:translate-y-[-3px] [&>svg]:absolute [&>svg]:left-4 [&>svg]:top-4 [&>svg]:text-foreground [&>svg~*]:pl-7",
+  'relative w-full rounded-lg border px-4 py-3 text-sm [&>svg+div]:translate-y-[-3px] [&>svg]:absolute [&>svg]:left-4 [&>svg]:top-4 [&>svg]:text-foreground [&>svg~*]:pl-7',
   {
     variants: {
       variant: {
-        default: "bg-background text-foreground",
+        default: 'bg-background text-foreground',
         destructive:
-          "border-destructive/50 text-destructive dark:border-destructive [&>svg]:text-destructive",
+          'border-destructive/50 text-destructive dark:border-destructive [&>svg]:text-destructive',
       },
     },
     defaultVariants: {
-      variant: "default",
+      variant: 'default',
     },
   }
-)
+);
 
 const Alert = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement> & VariantProps<typeof alertVariants>
 >(({ className, variant, ...props }, ref) => (
-  <div
-    ref={ref}
-    role="alert"
-    className={cn(alertVariants({ variant }), className)}
-    {...props}
-  />
-))
-Alert.displayName = "Alert"
+  <div ref={ref} role="alert" className={cn(alertVariants({ variant }), className)} {...props} />
+));
+Alert.displayName = 'Alert';
 
-const AlertTitle = React.forwardRef<
-  HTMLParagraphElement,
-  React.HTMLAttributes<HTMLHeadingElement>
->(({ className, ...props }, ref) => (
-  <h5
-    ref={ref}
-    className={cn("mb-1 font-medium leading-none tracking-tight", className)}
-    {...props}
-  />
-))
-AlertTitle.displayName = "AlertTitle"
+const AlertTitle = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLHeadingElement>>(
+  ({ className, ...props }, ref) => (
+    <h5
+      ref={ref}
+      className={cn('mb-1 font-medium leading-none tracking-tight', className)}
+      {...props}
+    />
+  )
+);
+AlertTitle.displayName = 'AlertTitle';
 
 const AlertDescription = React.forwardRef<
   HTMLParagraphElement,
   React.HTMLAttributes<HTMLParagraphElement>
 >(({ className, ...props }, ref) => (
-  <div
-    ref={ref}
-    className={cn("text-sm [&_p]:leading-relaxed", className)}
-    {...props}
-  />
-))
-AlertDescription.displayName = "AlertDescription"
+  <div ref={ref} className={cn('text-sm [&_p]:leading-relaxed', className)} {...props} />
+));
+AlertDescription.displayName = 'AlertDescription';
 
-export { Alert, AlertTitle, AlertDescription }
+export { Alert, AlertTitle, AlertDescription };

--- a/apps/dashboard/src/components/ui/badge.tsx
+++ b/apps/dashboard/src/components/ui/badge.tsx
@@ -1,36 +1,31 @@
-import * as React from "react"
-import { cva, type VariantProps } from "class-variance-authority"
+import * as React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils';
 
 const badgeVariants = cva(
-  "inline-flex items-center gap-1 rounded-full border px-2.5 py-0.5 text-xs font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-ring/30",
+  'inline-flex items-center gap-1 rounded-full border px-2.5 py-0.5 text-xs font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-ring/30',
   {
     variants: {
       variant: {
-        default:
-          "border-transparent bg-primary text-primary-foreground",
-        secondary:
-          "border-transparent bg-secondary text-secondary-foreground",
-        destructive:
-          "border-transparent bg-destructive/10 text-destructive",
-        outline: "border-border bg-background text-foreground shadow-card",
+        default: 'border-transparent bg-primary text-primary-foreground',
+        secondary: 'border-transparent bg-secondary text-secondary-foreground',
+        destructive: 'border-transparent bg-destructive/10 text-destructive',
+        outline: 'border-border bg-background text-foreground shadow-card',
       },
     },
     defaultVariants: {
-      variant: "default",
+      variant: 'default',
     },
   }
-)
+);
 
 export interface BadgeProps
   extends React.HTMLAttributes<HTMLDivElement>,
     VariantProps<typeof badgeVariants> {}
 
 function Badge({ className, variant, ...props }: BadgeProps) {
-  return (
-    <div className={cn(badgeVariants({ variant }), className)} {...props} />
-  )
+  return <div className={cn(badgeVariants({ variant }), className)} {...props} />;
 }
 
-export { Badge, badgeVariants }
+export { Badge, badgeVariants };

--- a/apps/dashboard/src/components/ui/breadcrumb.tsx
+++ b/apps/dashboard/src/components/ui/breadcrumb.tsx
@@ -1,108 +1,92 @@
-import * as React from "react"
-import { Slot } from "@radix-ui/react-slot"
-import { ChevronRight, MoreHorizontal } from "lucide-react"
+import * as React from 'react';
+import { Slot } from '@radix-ui/react-slot';
+import { ChevronRight, MoreHorizontal } from 'lucide-react';
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils';
 
 const Breadcrumb = React.forwardRef<
   HTMLElement,
-  React.ComponentPropsWithoutRef<"nav"> & {
-    separator?: React.ReactNode
+  React.ComponentPropsWithoutRef<'nav'> & {
+    separator?: React.ReactNode;
   }
->(({ ...props }, ref) => <nav ref={ref} aria-label="breadcrumb" {...props} />)
-Breadcrumb.displayName = "Breadcrumb"
+>(({ ...props }, ref) => <nav ref={ref} aria-label="breadcrumb" {...props} />);
+Breadcrumb.displayName = 'Breadcrumb';
 
-const BreadcrumbList = React.forwardRef<
-  HTMLOListElement,
-  React.ComponentPropsWithoutRef<"ol">
->(({ className, ...props }, ref) => (
-  <ol
-    ref={ref}
-    className={cn(
-      "flex flex-wrap items-center gap-1.5 break-words text-sm text-muted-foreground sm:gap-2.5",
-      className
-    )}
-    {...props}
-  />
-))
-BreadcrumbList.displayName = "BreadcrumbList"
+const BreadcrumbList = React.forwardRef<HTMLOListElement, React.ComponentPropsWithoutRef<'ol'>>(
+  ({ className, ...props }, ref) => (
+    <ol
+      ref={ref}
+      className={cn(
+        'flex flex-wrap items-center gap-1.5 break-words text-sm text-muted-foreground sm:gap-2.5',
+        className
+      )}
+      {...props}
+    />
+  )
+);
+BreadcrumbList.displayName = 'BreadcrumbList';
 
-const BreadcrumbItem = React.forwardRef<
-  HTMLLIElement,
-  React.ComponentPropsWithoutRef<"li">
->(({ className, ...props }, ref) => (
-  <li
-    ref={ref}
-    className={cn("inline-flex items-center gap-1.5", className)}
-    {...props}
-  />
-))
-BreadcrumbItem.displayName = "BreadcrumbItem"
+const BreadcrumbItem = React.forwardRef<HTMLLIElement, React.ComponentPropsWithoutRef<'li'>>(
+  ({ className, ...props }, ref) => (
+    <li ref={ref} className={cn('inline-flex items-center gap-1.5', className)} {...props} />
+  )
+);
+BreadcrumbItem.displayName = 'BreadcrumbItem';
 
 const BreadcrumbLink = React.forwardRef<
   HTMLAnchorElement,
-  React.ComponentPropsWithoutRef<"a"> & {
-    asChild?: boolean
+  React.ComponentPropsWithoutRef<'a'> & {
+    asChild?: boolean;
   }
 >(({ asChild, className, ...props }, ref) => {
-  const Comp = asChild ? Slot : "a"
+  const Comp = asChild ? Slot : 'a';
 
   return (
     <Comp
       ref={ref}
-      className={cn("transition-colors hover:text-foreground", className)}
+      className={cn('transition-colors hover:text-foreground', className)}
+      {...props}
+    />
+  );
+});
+BreadcrumbLink.displayName = 'BreadcrumbLink';
+
+const BreadcrumbPage = React.forwardRef<HTMLSpanElement, React.ComponentPropsWithoutRef<'span'>>(
+  ({ className, ...props }, ref) => (
+    <span
+      ref={ref}
+      role="link"
+      aria-disabled="true"
+      aria-current="page"
+      className={cn('font-normal text-foreground', className)}
       {...props}
     />
   )
-})
-BreadcrumbLink.displayName = "BreadcrumbLink"
+);
+BreadcrumbPage.displayName = 'BreadcrumbPage';
 
-const BreadcrumbPage = React.forwardRef<
-  HTMLSpanElement,
-  React.ComponentPropsWithoutRef<"span">
->(({ className, ...props }, ref) => (
-  <span
-    ref={ref}
-    role="link"
-    aria-disabled="true"
-    aria-current="page"
-    className={cn("font-normal text-foreground", className)}
-    {...props}
-  />
-))
-BreadcrumbPage.displayName = "BreadcrumbPage"
-
-const BreadcrumbSeparator = ({
-  children,
-  className,
-  ...props
-}: React.ComponentProps<"li">) => (
+const BreadcrumbSeparator = ({ children, className, ...props }: React.ComponentProps<'li'>) => (
   <li
     role="presentation"
     aria-hidden="true"
-    className={cn("[&>svg]:w-3.5 [&>svg]:h-3.5", className)}
-    {...props}
-  >
+    className={cn('[&>svg]:w-3.5 [&>svg]:h-3.5', className)}
+    {...props}>
     {children ?? <ChevronRight />}
   </li>
-)
-BreadcrumbSeparator.displayName = "BreadcrumbSeparator"
+);
+BreadcrumbSeparator.displayName = 'BreadcrumbSeparator';
 
-const BreadcrumbEllipsis = ({
-  className,
-  ...props
-}: React.ComponentProps<"span">) => (
+const BreadcrumbEllipsis = ({ className, ...props }: React.ComponentProps<'span'>) => (
   <span
     role="presentation"
     aria-hidden="true"
-    className={cn("flex h-9 w-9 items-center justify-center", className)}
-    {...props}
-  >
+    className={cn('flex h-9 w-9 items-center justify-center', className)}
+    {...props}>
     <MoreHorizontal className="h-4 w-4" />
     <span className="sr-only">More</span>
   </span>
-)
-BreadcrumbEllipsis.displayName = "BreadcrumbElipssis"
+);
+BreadcrumbEllipsis.displayName = 'BreadcrumbElipssis';
 
 export {
   Breadcrumb,
@@ -112,4 +96,4 @@ export {
   BreadcrumbPage,
   BreadcrumbSeparator,
   BreadcrumbEllipsis,
-}
+};

--- a/apps/dashboard/src/components/ui/button.tsx
+++ b/apps/dashboard/src/components/ui/button.tsx
@@ -5,15 +5,17 @@ import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '@/lib/utils';
 
 const buttonVariants = cva(
-  'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/30 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
+  'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition duration-150 ease-out active:scale-[0.98] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
   {
     variants: {
       variant: {
-        default: 'bg-primary text-primary-foreground shadow-card hover:bg-primary/90',
-        destructive: 'bg-destructive text-destructive-foreground shadow-card hover:bg-destructive/90',
+        default: 'bg-primary text-primary-foreground shadow-card hover:brightness-110',
+        destructive:
+          'border border-destructive/30 bg-destructive/10 text-destructive hover:bg-destructive/20',
         outline:
-          'border border-border bg-background shadow-card hover:bg-muted/60',
-        secondary: 'bg-secondary text-secondary-foreground hover:bg-secondary/70',
+          'border border-input bg-card text-secondary-foreground shadow-card hover:border-primary/40 hover:bg-primary/[0.04] disabled:border-border disabled:bg-muted dark:bg-secondary dark:hover:bg-accent',
+        secondary:
+          'border border-border bg-muted text-secondary-foreground hover:border-input hover:bg-accent',
         ghost: 'hover:bg-accent hover:text-accent-foreground',
         link: 'text-link underline-offset-4 hover:underline',
       },

--- a/apps/dashboard/src/components/ui/card.tsx
+++ b/apps/dashboard/src/components/ui/card.tsx
@@ -6,7 +6,7 @@ const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElemen
   ({ className, ...props }, ref) => (
     <div
       ref={ref}
-      className={cn('rounded-xl border bg-card text-card-foreground shadow-card', className)}
+      className={cn('rounded-lg border bg-card text-card-foreground shadow-card', className)}
       {...props}
     />
   )

--- a/apps/dashboard/src/components/ui/command.tsx
+++ b/apps/dashboard/src/components/ui/command.tsx
@@ -12,7 +12,7 @@ const Command = React.forwardRef<
   <CommandPrimitive
     ref={ref}
     className={cn(
-      'flex h-full w-full flex-col overflow-hidden rounded-md bg-popover text-popover-foreground',
+      'flex h-full w-full flex-col overflow-hidden rounded-lg bg-popover text-popover-foreground',
       className
     )}
     {...props}
@@ -108,7 +108,7 @@ const CommandItem = React.forwardRef<
   <CommandPrimitive.Item
     ref={ref}
     className={cn(
-      'relative flex cursor-default gap-2 select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none data-[disabled=true]:pointer-events-none data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
+      'relative flex cursor-default select-none items-center gap-2 rounded-md px-2 py-1.5 text-sm outline-none data-[disabled=true]:pointer-events-none data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
       className
     )}
     {...props}

--- a/apps/dashboard/src/components/ui/delete-dialog.tsx
+++ b/apps/dashboard/src/components/ui/delete-dialog.tsx
@@ -31,45 +31,32 @@ export const DeleteDialog = ({
   descriptionText,
   confirmButtonText = 'Delete',
   isDeletingButtonText = 'Deleting...',
-} : DeleteDialogProps) => {
+}: DeleteDialogProps) => {
   return (
-    <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
+    <Dialog open={isOpen} onOpenChange={open => !open && onClose()}>
       <DialogContent className="sm:max-w-[420px]">
         <DialogHeader className="flex flex-col items-start gap-2">
           <div className="w-9 h-9 rounded-full bg-destructive/10 border border-destructive/20 flex items-center justify-center text-destructive">
             <AlertTriangle className="w-5 h-5" />
           </div>
-          <DialogTitle className="text-lg font-semibold tracking-tight mt-2">
-            {title}
-          </DialogTitle>
+          <DialogTitle className="text-lg font-semibold tracking-tight mt-2">{title}</DialogTitle>
           <DialogDescription className="pt-1 text-left text-muted-foreground">
             Are you sure you want to delete{' '}
             {resourceName && (
-              <strong className="font-semibold text-foreground">
-                "{resourceName}"
-              </strong>
+              <strong className="font-semibold text-foreground">"{resourceName}"</strong>
             )}
             ?
-            <br /><br />
+            <br />
+            <br />
             {descriptionText}
           </DialogDescription>
         </DialogHeader>
 
         <DialogFooter className="pt-3 border-t gap-2 sm:gap-0 mt-4">
-          <Button
-            type="button"
-            variant="outline"
-            onClick={onClose}
-            disabled={isDeleting}
-          >
+          <Button type="button" variant="outline" onClick={onClose} disabled={isDeleting}>
             Cancel
           </Button>
-          <Button
-            type="button"
-            variant="destructive"
-            onClick={onConfirm}
-            disabled={isDeleting}
-          >
+          <Button type="button" variant="destructive" onClick={onConfirm} disabled={isDeleting}>
             {isDeleting ? isDeletingButtonText : confirmButtonText}
           </Button>
         </DialogFooter>

--- a/apps/dashboard/src/components/ui/dialog.tsx
+++ b/apps/dashboard/src/components/ui/dialog.tsx
@@ -1,18 +1,18 @@
-"use client"
+'use client';
 
-import * as React from "react"
-import * as DialogPrimitive from "@radix-ui/react-dialog"
-import { X } from "lucide-react"
+import * as React from 'react';
+import * as DialogPrimitive from '@radix-ui/react-dialog';
+import { X } from 'lucide-react';
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils';
 
-const Dialog = DialogPrimitive.Root
+const Dialog = DialogPrimitive.Root;
 
-const DialogTrigger = DialogPrimitive.Trigger
+const DialogTrigger = DialogPrimitive.Trigger;
 
-const DialogPortal = DialogPrimitive.Portal
+const DialogPortal = DialogPrimitive.Portal;
 
-const DialogClose = DialogPrimitive.Close
+const DialogClose = DialogPrimitive.Close;
 
 const DialogOverlay = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Overlay>,
@@ -21,13 +21,13 @@ const DialogOverlay = React.forwardRef<
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      'fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
       className
     )}
     {...props}
   />
-))
-DialogOverlay.displayName = DialogPrimitive.Overlay.displayName
+));
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
 
 const DialogContent = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Content>,
@@ -38,11 +38,10 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        'fixed left-[50%] top-[50%] z-50 grid w-[calc(100%_-_2rem)] max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border bg-card p-6 text-card-foreground shadow-elevated duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%]',
         className
       )}
-      {...props}
-    >
+      {...props}>
       {children}
       <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
         <X className="h-4 w-4" />
@@ -50,36 +49,21 @@ const DialogContent = React.forwardRef<
       </DialogPrimitive.Close>
     </DialogPrimitive.Content>
   </DialogPortal>
-))
-DialogContent.displayName = DialogPrimitive.Content.displayName
+));
+DialogContent.displayName = DialogPrimitive.Content.displayName;
 
-const DialogHeader = ({
-  className,
-  ...props
-}: React.HTMLAttributes<HTMLDivElement>) => (
+const DialogHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn('flex flex-col space-y-1.5 text-center sm:text-left', className)} {...props} />
+);
+DialogHeader.displayName = 'DialogHeader';
+
+const DialogFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
   <div
-    className={cn(
-      "flex flex-col space-y-1.5 text-center sm:text-left",
-      className
-    )}
+    className={cn('flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2', className)}
     {...props}
   />
-)
-DialogHeader.displayName = "DialogHeader"
-
-const DialogFooter = ({
-  className,
-  ...props
-}: React.HTMLAttributes<HTMLDivElement>) => (
-  <div
-    className={cn(
-      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
-      className
-    )}
-    {...props}
-  />
-)
-DialogFooter.displayName = "DialogFooter"
+);
+DialogFooter.displayName = 'DialogFooter';
 
 const DialogTitle = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Title>,
@@ -88,13 +72,13 @@ const DialogTitle = React.forwardRef<
   <DialogPrimitive.Title
     ref={ref}
     className={cn(
-      "text-lg font-semibold leading-none tracking-tight",
+      'font-display text-lg font-semibold leading-none tracking-tight text-foreground',
       className
     )}
     {...props}
   />
-))
-DialogTitle.displayName = DialogPrimitive.Title.displayName
+));
+DialogTitle.displayName = DialogPrimitive.Title.displayName;
 
 const DialogDescription = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Description>,
@@ -102,11 +86,11 @@ const DialogDescription = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <DialogPrimitive.Description
     ref={ref}
-    className={cn("text-sm text-muted-foreground", className)}
+    className={cn('text-sm text-muted-foreground', className)}
     {...props}
   />
-))
-DialogDescription.displayName = DialogPrimitive.Description.displayName
+));
+DialogDescription.displayName = DialogPrimitive.Description.displayName;
 
 export {
   Dialog,
@@ -119,4 +103,4 @@ export {
   DialogFooter,
   DialogTitle,
   DialogDescription,
-}
+};

--- a/apps/dashboard/src/components/ui/input.tsx
+++ b/apps/dashboard/src/components/ui/input.tsx
@@ -8,7 +8,7 @@ const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<'input'>>(
       <input
         type={type}
         className={cn(
-          'flex h-9 w-full rounded-md border border-input bg-background px-3 py-1 text-base shadow-card transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground/70 focus-visible:outline-none focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/20 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
+          'flex h-9 w-full rounded-md border border-input bg-card px-3 py-1 text-base text-foreground shadow-card transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground/60 hover:border-primary/45 focus-visible:border-ring focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/20 disabled:cursor-not-allowed disabled:border-border disabled:bg-muted disabled:text-muted-foreground disabled:opacity-100 read-only:bg-muted/40 dark:bg-secondary dark:disabled:bg-muted md:text-sm',
           className
         )}
         ref={ref}

--- a/apps/dashboard/src/components/ui/popover.tsx
+++ b/apps/dashboard/src/components/ui/popover.tsx
@@ -19,7 +19,7 @@ const PopoverContent = React.forwardRef<
       align={align}
       sideOffset={sideOffset}
       className={cn(
-        'z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+        'z-50 w-72 rounded-lg border bg-popover p-4 text-popover-foreground shadow-elevated outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
         className
       )}
       {...props}

--- a/apps/dashboard/src/components/ui/sheet.tsx
+++ b/apps/dashboard/src/components/ui/sheet.tsx
@@ -31,7 +31,7 @@ const SheetOverlay = React.forwardRef<
 SheetOverlay.displayName = SheetPrimitive.Overlay.displayName;
 
 const sheetVariants = cva(
-  'fixed z-50 gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500 data-[state=open]:animate-in data-[state=closed]:animate-out',
+  'fixed z-50 gap-4 bg-card p-6 text-card-foreground shadow-elevated transition ease-in-out data-[state=closed]:duration-200 data-[state=open]:duration-300 data-[state=open]:animate-in data-[state=closed]:animate-out',
   {
     variants: {
       side: {

--- a/apps/dashboard/src/components/ui/switch.tsx
+++ b/apps/dashboard/src/components/ui/switch.tsx
@@ -22,7 +22,7 @@ export const Switch = ({ checked, onCheckedChange, disabled, ...props }: SwitchP
     }}
     className={cn(
       'relative inline-flex h-5 w-9 shrink-0 items-center rounded-full transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
-      checked ? 'bg-emerald-600' : 'bg-input'
+      checked ? 'bg-emerald-500' : 'bg-input'
     )}
     {...props}>
     <span

--- a/apps/dashboard/src/components/ui/table.tsx
+++ b/apps/dashboard/src/components/ui/table.tsx
@@ -15,7 +15,7 @@ const TableHeader = React.forwardRef<
   HTMLTableSectionElement,
   React.HTMLAttributes<HTMLTableSectionElement>
 >(({ className, ...props }, ref) => (
-  <thead ref={ref} className={cn('bg-muted/50 [&_tr]:border-b', className)} {...props} />
+  <thead ref={ref} className={cn('bg-secondary/70 [&_tr]:border-b', className)} {...props} />
 ));
 TableHeader.displayName = 'TableHeader';
 
@@ -44,7 +44,7 @@ const TableRow = React.forwardRef<HTMLTableRowElement, React.HTMLAttributes<HTML
     <tr
       ref={ref}
       className={cn(
-        'border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted',
+        'border-b border-border/80 transition-colors hover:bg-accent/60 data-[state=selected]:bg-accent',
         className
       )}
       {...props}
@@ -60,7 +60,7 @@ const TableHead = React.forwardRef<
   <th
     ref={ref}
     className={cn(
-      'h-11 px-4 text-left align-middle text-[13px] font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]',
+      'h-11 px-4 text-left align-middle text-xs font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]',
       className
     )}
     {...props}

--- a/apps/dashboard/src/components/ui/timestamp-cell.tsx
+++ b/apps/dashboard/src/components/ui/timestamp-cell.tsx
@@ -7,19 +7,19 @@ type TimestampCellProps = {
   showSeconds?: boolean;
 };
 
-export const TimestampCell: React.FC<TimestampCellProps> = ({ 
-  dateString, 
-  showSeconds = false 
+export const TimestampCell: React.FC<TimestampCellProps> = ({
+  dateString,
+  showSeconds = false,
 }) => {
   const formattedDate = formatTimestamp(dateString, showSeconds);
 
   return (
-    <span className="flex items-center gap-1.5 text-gray-500 whitespace-nowrap">
-      <Calendar className="w-3.5 h-3.5 text-gray-400" />
+    <span className="flex items-center gap-1.5 whitespace-nowrap text-muted-foreground">
+      <Calendar className="h-3.5 w-3.5 text-muted-foreground/70" />
       {formattedDate ? (
         formattedDate
       ) : (
-        <span className="text-gray-400 italic">Legacy Record</span>
+        <span className="italic text-muted-foreground/60">Legacy record</span>
       )}
     </span>
   );

--- a/apps/dashboard/src/components/ui/toast.tsx
+++ b/apps/dashboard/src/components/ui/toast.tsx
@@ -74,7 +74,7 @@ const ToastClose = React.forwardRef<
   <ToastPrimitives.Close
     ref={ref}
     className={cn(
-      'absolute right-1 top-1 rounded-md p-1 text-foreground/50 opacity-0 transition-opacity hover:text-foreground focus:opacity-100 focus:outline-none focus:ring-1 group-hover:opacity-100 group-[.destructive]:text-red-300 group-[.destructive]:hover:text-red-50 group-[.destructive]:focus:ring-red-400 group-[.destructive]:focus:ring-offset-red-600',
+      'absolute right-1 top-1 rounded-md p-1 text-foreground/50 opacity-0 transition-opacity hover:text-foreground focus:opacity-100 focus:outline-none focus:ring-1 group-hover:opacity-100 group-[.destructive]:text-red-700 group-[.destructive]:hover:text-red-900 group-[.destructive]:focus:ring-red-500 dark:group-[.destructive]:text-red-300 dark:group-[.destructive]:hover:text-red-50 dark:group-[.destructive]:focus:ring-red-400',
       className
     )}
     toast-close=""

--- a/apps/dashboard/src/containers/Layout/index.tsx
+++ b/apps/dashboard/src/containers/Layout/index.tsx
@@ -1,12 +1,72 @@
 import { AppSidebar } from '@/components/app-sidebar';
+import { useEffect, useState } from 'react';
+import { Menu, Radio } from 'lucide-react';
+import { useLocation } from 'react-router';
+import { Button } from '@/components/ui/button';
+import { Sheet, SheetContent, SheetTitle } from '@/components/ui/sheet';
+import { CommandPalette } from '@/components/CommandPalette';
 
 export const Layout = ({ children }: { children: React.ReactNode }) => {
+  const [mobileNavOpen, setMobileNavOpen] = useState(false);
+  const [commandPaletteOpen, setCommandPaletteOpen] = useState(false);
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.repeat || event.key.toLowerCase() !== 'k' || (!event.metaKey && !event.ctrlKey))
+        return;
+      event.preventDefault();
+      setCommandPaletteOpen(current => !current);
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, []);
+
+  const openCommandPalette = () => {
+    setMobileNavOpen(false);
+    setCommandPaletteOpen(true);
+  };
+
   return (
-    <div className="flex min-h-screen w-full">
-      <AppSidebar />
-      <main className="min-w-0 flex-1">
-        <div className="mx-auto max-w-7xl px-8 py-10">{children}</div>
-      </main>
-    </div>
+    <>
+      <div className="flex min-h-screen w-full bg-background">
+        <AppSidebar onOpenCommandPalette={openCommandPalette} />
+        <main className="min-w-0 flex-1">
+          <header className="sticky top-0 z-30 flex h-14 items-center justify-between border-b border-border/80 bg-background/95 px-4 backdrop-blur lg:hidden">
+            <div className="flex items-center gap-2.5">
+              <div className="flex h-8 w-8 items-center justify-center rounded-lg border border-primary/25 bg-primary/10 text-primary">
+                <Radio className="h-4 w-4" />
+              </div>
+              <span className="font-display text-sm font-semibold text-foreground">
+                expo-open-ota
+              </span>
+            </div>
+            <Button
+              variant="ghost"
+              size="icon"
+              aria-label="Open navigation"
+              onClick={() => setMobileNavOpen(true)}>
+              <Menu className="h-5 w-5" />
+            </Button>
+          </header>
+          <div
+            key={pathname}
+            className="dashboard-page-enter mx-auto max-w-[1480px] px-4 py-6 sm:px-6 lg:px-10 lg:py-10">
+            {children}
+          </div>
+        </main>
+      </div>
+      <Sheet open={mobileNavOpen} onOpenChange={setMobileNavOpen}>
+        <SheetContent side="left" className="w-72 p-0">
+          <SheetTitle className="sr-only">Navigation</SheetTitle>
+          <AppSidebar
+            mobile
+            onNavigate={() => setMobileNavOpen(false)}
+            onOpenCommandPalette={openCommandPalette}
+          />
+        </SheetContent>
+      </Sheet>
+      <CommandPalette open={commandPaletteOpen} onOpenChange={setCommandPaletteOpen} />
+    </>
   );
 };

--- a/apps/dashboard/src/ee/components/ApiKeyRestrictionsSheet.tsx
+++ b/apps/dashboard/src/ee/components/ApiKeyRestrictionsSheet.tsx
@@ -5,12 +5,7 @@
 
 import { useState } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import {
-  api,
-  ApiKeyRecord,
-  ApiKeyRestrictionsRecord,
-  describeApiError,
-} from '@/lib/api';
+import { api, ApiKeyRecord, ApiKeyRestrictionsRecord, describeApiError } from '@/lib/api';
 import { useSelectedApp } from '@/lib/SelectedAppContext';
 import { useToast } from '@/hooks/use-toast';
 import { Button } from '@/components/ui/button';
@@ -155,8 +150,8 @@ const RestrictionsForm = ({
       <div className="space-y-2">
         <p className="text-sm font-medium">IP allowlist</p>
         <p className="text-xs text-muted-foreground">
-          One address or CIDR range per line, for example 203.0.113.7 or 203.0.113.0/24. Leave
-          empty to allow any source address.
+          One address or CIDR range per line, for example 203.0.113.7 or 203.0.113.0/24. Leave empty
+          to allow any source address.
         </p>
         <textarea
           value={allowedIpsText}

--- a/apps/dashboard/src/ee/components/EnterpriseBadge.tsx
+++ b/apps/dashboard/src/ee/components/EnterpriseBadge.tsx
@@ -27,11 +27,18 @@ export const EnterpriseBadge = () => {
   }
 
   return (
-    <div className="mx-5 mt-2 flex items-center gap-2 rounded-lg border border-emerald-200/80 bg-gradient-to-r from-emerald-50/80 to-teal-50/60 px-2.5 py-1.5 shadow-sm">
-      <BadgeCheck className="h-4 w-4 shrink-0 text-emerald-600" strokeWidth={2} />
+    <div className="mx-5 mt-2 flex items-center gap-2 rounded-lg border border-emerald-400/20 bg-emerald-400/[0.07] px-2.5 py-1.5 shadow-card">
+      <BadgeCheck
+        className="h-4 w-4 shrink-0 text-emerald-700 dark:text-emerald-300"
+        strokeWidth={2}
+      />
       <div className="min-w-0 leading-tight">
-        <div className="text-[11px] font-semibold text-emerald-900">Enterprise</div>
-        <div className="truncate font-mono text-[10px] text-emerald-700/70" title={license.licenseId}>
+        <div className="text-[11px] font-semibold text-emerald-800 dark:text-emerald-200">
+          Enterprise
+        </div>
+        <div
+          className="truncate font-mono text-[10px] text-emerald-700/70 dark:text-emerald-300/60"
+          title={license.licenseId}>
           {license.licenseId?.split('-')[0]}
         </div>
       </div>

--- a/apps/dashboard/src/ee/components/EnterpriseExplainerDialog.tsx
+++ b/apps/dashboard/src/ee/components/EnterpriseExplainerDialog.tsx
@@ -38,19 +38,19 @@ export const EnterpriseExplainerDialog = ({
   <Dialog open={open} onOpenChange={onOpenChange}>
     <DialogContent>
       <DialogHeader>
-        <div className="mb-1 flex h-11 w-11 items-center justify-center rounded-xl bg-gradient-to-br from-emerald-500 to-teal-600 shadow-sm">
-          <Lock className="h-5 w-5 text-white" strokeWidth={2.2} />
+        <div className="mb-1 flex h-11 w-11 items-center justify-center rounded-lg border border-emerald-400/25 bg-emerald-400/10 shadow-card">
+          <Lock className="h-5 w-5 text-emerald-700 dark:text-white" strokeWidth={2.2} />
         </div>
         <DialogTitle>{feature ? feature.name : 'Unlock Enterprise features'}</DialogTitle>
         <DialogDescription>
-          This feature is part of the Enterprise edition of Expo Open OTA. Your deployment
-          currently runs the community edition, so it stays visible here but locked.
+          This feature is part of the Enterprise edition of Expo Open OTA. Your deployment currently
+          runs the community edition, so it stays visible here but locked.
         </DialogDescription>
       </DialogHeader>
       <div className="space-y-3 text-sm text-muted-foreground">
         {feature && (
-          <div className="flex gap-2.5 rounded-lg border border-emerald-100 bg-emerald-50/60 p-3 text-foreground">
-            <Sparkles className="mt-0.5 h-4 w-4 shrink-0 text-emerald-600" />
+          <div className="flex gap-2.5 rounded-lg border border-emerald-400/25 bg-emerald-400/[0.07] p-3 text-foreground">
+            <Sparkles className="mt-0.5 h-4 w-4 shrink-0 text-emerald-700 dark:text-emerald-300" />
             <p className="text-xs leading-relaxed">{feature.description}</p>
           </div>
         )}
@@ -78,9 +78,7 @@ export const EnterpriseExplainerDialog = ({
         <Button variant="outline" onClick={() => onOpenChange(false)}>
           Close
         </Button>
-        <Button
-          asChild
-          className="bg-gradient-to-r from-emerald-600 to-teal-600 text-white hover:from-emerald-700 hover:to-teal-700">
+        <Button asChild>
           <a href={`mailto:${ENTERPRISE_CONTACT_EMAIL}?subject=Expo%20Open%20OTA%20Enterprise`}>
             <Mail className="h-4 w-4" />
             Contact us

--- a/apps/dashboard/src/ee/components/EnterpriseFeatureGate.tsx
+++ b/apps/dashboard/src/ee/components/EnterpriseFeatureGate.tsx
@@ -37,10 +37,10 @@ export const EnterpriseFeatureGate = ({ children }: { children: ReactNode }) => 
         className="pointer-events-none select-none opacity-60">
         {children}
       </div>
-      <div className="absolute inset-0 z-10 flex items-center justify-center rounded-xl bg-white/55 backdrop-blur-[3px]">
-        <div className="flex flex-col items-center gap-3 rounded-2xl border border-emerald-100 bg-white px-8 py-6 text-center shadow-elevated">
-          <div className="flex h-11 w-11 items-center justify-center rounded-xl bg-gradient-to-br from-emerald-500 to-teal-600 shadow-sm">
-            <Lock className="h-5 w-5 text-white" strokeWidth={2.2} />
+      <div className="absolute inset-0 z-10 flex items-center justify-center rounded-lg bg-background/80 backdrop-blur-[3px]">
+        <div className="flex flex-col items-center gap-3 rounded-lg border border-emerald-400/20 bg-card px-8 py-6 text-center shadow-elevated">
+          <div className="flex h-11 w-11 items-center justify-center rounded-lg border border-emerald-400/25 bg-emerald-400/10 shadow-card">
+            <Lock className="h-5 w-5 text-emerald-700 dark:text-white" strokeWidth={2.2} />
           </div>
           <div>
             <p className="text-sm font-semibold">Enterprise feature</p>
@@ -48,10 +48,7 @@ export const EnterpriseFeatureGate = ({ children }: { children: ReactNode }) => 
               Unlock it with an Enterprise license.
             </p>
           </div>
-          <Button
-            size="sm"
-            onClick={() => setIsExplainerOpen(true)}
-            className="bg-gradient-to-r from-emerald-600 to-teal-600 text-white shadow-sm hover:from-emerald-700 hover:to-teal-700">
+          <Button size="sm" onClick={() => setIsExplainerOpen(true)}>
             <Sparkles className="h-3.5 w-3.5" />
             Discover Enterprise
           </Button>

--- a/apps/dashboard/src/ee/components/RoleFormDialog.tsx
+++ b/apps/dashboard/src/ee/components/RoleFormDialog.tsx
@@ -61,7 +61,11 @@ export const RoleFormDialog = ({
 
   const handleSave = async () => {
     if (!name.trim()) {
-      toast({ title: 'Name required', description: 'Give the role a name.', variant: 'destructive' });
+      toast({
+        title: 'Name required',
+        description: 'Give the role a name.',
+        variant: 'destructive',
+      });
       return;
     }
     setIsSaving(true);

--- a/apps/dashboard/src/ee/components/SsoConfigCard.tsx
+++ b/apps/dashboard/src/ee/components/SsoConfigCard.tsx
@@ -438,7 +438,7 @@ export const SsoConfigCard = () => {
                   onClick={handleCopyRedirectUri}
                   title="Copy the redirect URI">
                   {copied ? (
-                    <Check className="h-4 w-4 text-emerald-600" />
+                    <Check className="h-4 w-4 text-emerald-700 dark:text-emerald-300" />
                   ) : (
                     <Copy className="h-4 w-4" />
                   )}

--- a/apps/dashboard/src/ee/components/UserRolesSheet.tsx
+++ b/apps/dashboard/src/ee/components/UserRolesSheet.tsx
@@ -171,7 +171,7 @@ export const UserRolesSheet = ({
           ) : (
             <div className="space-y-4">
               {draft.length === 0 && (
-                <div className="flex items-start gap-2.5 rounded-xl border border-amber-300/60 bg-amber-50 px-4 py-3 text-xs text-amber-800">
+                <div className="flex items-start gap-2.5 rounded-lg border border-amber-400/25 bg-amber-400/10 px-4 py-3 text-xs text-amber-700 dark:text-amber-300">
                   <TriangleAlert className="mt-0.5 h-3.5 w-3.5 shrink-0" />
                   <span>
                     This member has no app access: they will see an empty dashboard. Grant them an

--- a/apps/dashboard/src/ee/lib/PermissionsContext.tsx
+++ b/apps/dashboard/src/ee/lib/PermissionsContext.tsx
@@ -22,7 +22,7 @@ export type Permission =
   | 'channel:edit-branch'
   | 'channel-rollout:manage'
   | 'update-rollout:manage'
-  | 'apikeys:manage'
+  | 'apikeys:manage';
 
 type PermissionsContextValue = {
   // enabled reports whether fine-grained roles are enforced right now

--- a/apps/dashboard/src/ee/lib/permissionCatalog.ts
+++ b/apps/dashboard/src/ee/lib/permissionCatalog.ts
@@ -102,5 +102,5 @@ export const PERMISSION_GROUPS: PermissionGroup[] = [
         description: 'Create and revoke publishing tokens and edit their restrictions.',
       },
     ],
-  }
+  },
 ];

--- a/apps/dashboard/src/ee/pages/AuditLog/index.tsx
+++ b/apps/dashboard/src/ee/pages/AuditLog/index.tsx
@@ -35,13 +35,25 @@ const selectClassName =
 
 const OutcomeBadge = ({ outcome }: { outcome: AuditEventRecord['outcome'] }) => {
   if (outcome === 'success') {
-    return <Badge className="border-transparent bg-emerald-100 text-emerald-700">success</Badge>;
+    return (
+      <Badge className="border-emerald-400/25 bg-emerald-400/10 text-emerald-700 dark:text-emerald-300">
+        success
+      </Badge>
+    );
   }
   if (outcome === 'denied') {
-    return <Badge className="border-transparent bg-red-100 text-red-700">denied</Badge>;
+    return (
+      <Badge className="border-red-400/25 bg-red-400/10 text-red-700 dark:text-red-300">
+        denied
+      </Badge>
+    );
   }
   if (outcome === 'failure') {
-    return <Badge className="border-transparent bg-amber-100 text-amber-700">failure</Badge>;
+    return (
+      <Badge className="border-amber-400/25 bg-amber-400/10 text-amber-700 dark:text-amber-300">
+        failure
+      </Badge>
+    );
   }
   // An empty outcome is an incomplete call site the server refused to paper
   // over; show it honestly.

--- a/apps/dashboard/src/ee/pages/License/index.tsx
+++ b/apps/dashboard/src/ee/pages/License/index.tsx
@@ -94,10 +94,7 @@ export const License = () => {
   if (!CONTROL_PLANE_ENABLED) {
     return (
       <div className="w-full">
-        <PageHeader
-          title="License"
-          description="Enterprise Edition license for this deployment."
-        />
+        <PageHeader title="License" description="Enterprise Edition license for this deployment." />
         <div className="rounded-xl border border-dashed bg-muted/30 p-8 text-center text-sm text-muted-foreground">
           Enterprise licenses are stored in the database and require control-plane (DB) mode.
           Stateless deployments run the community edition.
@@ -112,7 +109,7 @@ export const License = () => {
     <div className="space-y-3">
       <textarea
         value={keyInput}
-        onChange={(event) => setKeyInput(event.target.value)}
+        onChange={event => setKeyInput(event.target.value)}
         placeholder="key/…"
         rows={4}
         spellCheck={false}
@@ -131,7 +128,7 @@ export const License = () => {
           type="file"
           accept=".txt,.key,.lic,text/plain"
           className="hidden"
-          onChange={(event) => handleImportFile(event.target.files?.[0])}
+          onChange={event => handleImportFile(event.target.files?.[0])}
         />
       </div>
     </div>
@@ -163,7 +160,7 @@ export const License = () => {
               <CardTitle className="flex items-center gap-2">
                 {license?.valid ? (
                   <>
-                    <BadgeCheck className="h-5 w-5 text-emerald-600" />
+                    <BadgeCheck className="h-5 w-5 text-emerald-700 dark:text-emerald-300" />
                     Enterprise edition
                     <Badge>Active</Badge>
                   </>
@@ -185,7 +182,9 @@ export const License = () => {
               <CardContent>
                 <div className="divide-y">
                   <StatusRow label="License ID">
-                    <code className="rounded bg-muted px-1.5 py-0.5 text-xs">{license.licenseId}</code>
+                    <code className="rounded bg-muted px-1.5 py-0.5 text-xs">
+                      {license.licenseId}
+                    </code>
                   </StatusRow>
                   <StatusRow label="Issued">
                     <TimestampCell dateString={license.issuedAt ?? null} />
@@ -215,7 +214,9 @@ export const License = () => {
           {isAdmin ? (
             <Card>
               <CardHeader>
-                <CardTitle>{license?.valid ? 'Replace license key' : 'Activate a license key'}</CardTitle>
+                <CardTitle>
+                  {license?.valid ? 'Replace license key' : 'Activate a license key'}
+                </CardTitle>
                 <CardDescription>
                   Paste the license key you received with your Enterprise subscription, or import
                   the file it was delivered in. The key is verified before anything is stored.

--- a/apps/dashboard/src/hooks/use-branch-current-status.ts
+++ b/apps/dashboard/src/hooks/use-branch-current-status.ts
@@ -1,0 +1,41 @@
+import { useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { api } from '@/lib/api';
+import { useSelectedApp } from '@/lib/SelectedAppContext';
+
+export const useBranchCurrentStatus = (branchName?: string | null) => {
+  const { selectedAppId } = useSelectedApp();
+  const branch = branchName ?? '';
+
+  const runtimeVersionsQuery = useQuery({
+    queryKey: ['runtimeVersions', selectedAppId, branch],
+    queryFn: () => api.getRuntimeVersions(branch),
+    enabled: !!selectedAppId && !!branch,
+  });
+  const latestRuntime = useMemo(
+    () =>
+      [...(runtimeVersionsQuery.data ?? [])].sort(
+        (left, right) => Date.parse(right.createdAt) - Date.parse(left.createdAt)
+      )[0],
+    [runtimeVersionsQuery.data]
+  );
+  const updatesQuery = useQuery({
+    queryKey: ['updates', selectedAppId, branch, latestRuntime?.runtimeVersion],
+    queryFn: () => api.getUpdates(branch, latestRuntime!.runtimeVersion),
+    enabled: !!selectedAppId && !!branch && !!latestRuntime,
+  });
+  return useMemo(() => {
+    const updatesByRecency = [...(updatesQuery.data ?? [])].sort(
+      (left, right) => Date.parse(right.createdAt) - Date.parse(left.createdAt)
+    );
+    const currentRollout = updatesByRecency.find(update => update.rolloutPercentage != null);
+    const currentUpdate = currentRollout ?? updatesByRecency[0];
+
+    if (!currentUpdate) return undefined;
+    return {
+      label: currentRollout ? ('Current rollout' as const) : ('Current update' as const),
+      commitHash: currentUpdate.commitHash.slice(0, 8),
+      percentage: currentRollout?.rolloutPercentage ?? undefined,
+    };
+  }, [updatesQuery.data]);
+};

--- a/apps/dashboard/src/hooks/use-mobile.tsx
+++ b/apps/dashboard/src/hooks/use-mobile.tsx
@@ -1,19 +1,19 @@
-import * as React from "react"
+import * as React from 'react';
 
-const MOBILE_BREAKPOINT = 768
+const MOBILE_BREAKPOINT = 768;
 
 export function useIsMobile() {
-  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)
+  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined);
 
   React.useEffect(() => {
-    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)
+    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`);
     const onChange = () => {
-      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
-    }
-    mql.addEventListener("change", onChange)
-    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
-    return () => mql.removeEventListener("change", onChange)
-  }, [])
+      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
+    };
+    mql.addEventListener('change', onChange);
+    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
+    return () => mql.removeEventListener('change', onChange);
+  }, []);
 
-  return !!isMobile
+  return !!isMobile;
 }

--- a/apps/dashboard/src/index.css
+++ b/apps/dashboard/src/index.css
@@ -5,27 +5,77 @@
 @tailwind utilities;
 
 @layer base {
-  :root {
-    --radius: 0.75rem;
-    --background: 0 0% 100%;
-    --foreground: 210 24% 10%;
-    --card: 0 0% 100%;
-    --card-foreground: 210 24% 10%;
-    --popover: 0 0% 100%;
-    --popover-foreground: 210 24% 10%;
-    --primary: 210 24% 10%;
+  :root,
+  .dark {
+    --radius: 0.5rem;
+    --background: 240 6% 6%;
+    --foreground: 240 8% 95%;
+    --card: 240 5% 9%;
+    --card-foreground: 240 8% 95%;
+    --popover: 240 5% 11%;
+    --popover-foreground: 240 8% 95%;
+    --primary: 217 87% 62%;
     --primary-foreground: 0 0% 100%;
-    --secondary: 210 17% 96%;
-    --secondary-foreground: 210 24% 10%;
-    --muted: 210 17% 96%;
-    --muted-foreground: 210 8% 43%;
-    --accent: 210 17% 95%;
-    --accent-foreground: 210 24% 10%;
+    --secondary: 240 5% 13%;
+    --secondary-foreground: 240 8% 95%;
+    --muted: 240 5% 12%;
+    --muted-foreground: 240 6% 70%;
+    --accent: 240 5% 16%;
+    --accent-foreground: 240 8% 95%;
+    --destructive: 0 83% 69%;
+    --destructive-foreground: 0 0% 100%;
+    --border: 240 5% 19%;
+    --input: 240 5% 25%;
+    --ring: 217 87% 62%;
+    --link: 215 87% 69%;
+    --graph-dot: 240 5% 32%;
+  }
+
+  .light {
+    --background: 240 20% 98%;
+    --foreground: 240 10% 10%;
+    --card: 0 0% 100%;
+    --card-foreground: 240 10% 10%;
+    --popover: 0 0% 100%;
+    --popover-foreground: 240 10% 10%;
+    --primary: 221 68% 48%;
+    --primary-foreground: 0 0% 100%;
+    --secondary: 240 12% 95%;
+    --secondary-foreground: 240 10% 15%;
+    --muted: 240 12% 95%;
+    --muted-foreground: 240 5% 42%;
+    --accent: 240 12% 92%;
+    --accent-foreground: 240 10% 12%;
     --destructive: 0 72% 51%;
     --destructive-foreground: 0 0% 100%;
-    --border: 210 16% 91%;
-    --input: 210 14% 86%;
-    --ring: 208 100% 47%;
+    --border: 240 8% 86%;
+    --input: 240 8% 76%;
+    --ring: 221 68% 48%;
+    --link: 221 68% 45%;
+    --graph-dot: 221 20% 78%;
+  }
+}
+
+@layer utilities {
+  @keyframes dashboard-page-enter {
+    from {
+      opacity: 0;
+      transform: translateY(5px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+
+  .dashboard-page-enter {
+    animation: dashboard-page-enter 180ms ease-out both;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .dashboard-page-enter {
+      animation: none;
+    }
   }
 }
 
@@ -39,5 +89,15 @@
   body {
     @apply bg-background text-foreground;
     font-feature-settings: 'cv11';
+    min-height: 100dvh;
+    color: hsl(var(--foreground));
+  }
+  ::selection {
+    background: rgb(76 141 242 / 35%);
+    color: hsl(var(--foreground));
+  }
+  * {
+    scrollbar-color: hsl(var(--input)) hsl(var(--background));
+    scrollbar-width: thin;
   }
 }

--- a/apps/dashboard/src/lib/SelectedAppContext.tsx
+++ b/apps/dashboard/src/lib/SelectedAppContext.tsx
@@ -1,4 +1,12 @@
-import { createContext, useCallback, useContext, useEffect, useMemo, useState, ReactNode } from 'react';
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  ReactNode,
+} from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { api } from '@/lib/api';
 import { isAuthenticated } from '@/lib/auth.ts';

--- a/apps/dashboard/src/lib/SettingsContext.tsx
+++ b/apps/dashboard/src/lib/SettingsContext.tsx
@@ -16,19 +16,18 @@ export function SettingsProvider({ children }: SettingsProviderProps) {
 
   useEffect(() => {
     async function fetchSettings() {
-        try {
-            const data = await api.getSettings();
-            setSettings(data);
-        } 
-        catch (error) {
-            let errorMessage = 'An unexpected server error occurred.';
-            if (error instanceof ApiProblemError) {
-                errorMessage = error.detail;
-            }
-            setError(errorMessage);
-        } finally {
-            setLoading(false);
+      try {
+        const data = await api.getSettings();
+        setSettings(data);
+      } catch (error) {
+        let errorMessage = 'An unexpected server error occurred.';
+        if (error instanceof ApiProblemError) {
+          errorMessage = error.detail;
         }
+        setError(errorMessage);
+      } finally {
+        setLoading(false);
+      }
     }
     fetchSettings();
   }, []);
@@ -52,11 +51,7 @@ export function SettingsProvider({ children }: SettingsProviderProps) {
     );
   }
 
-  return (
-    <SettingsContext.Provider value={settings}>
-      {children}
-    </SettingsContext.Provider>
-  );
+  return <SettingsContext.Provider value={settings}>{children}</SettingsContext.Provider>;
 }
 
 export function useSettings(): Settings {

--- a/apps/dashboard/src/lib/ThemeProvider.tsx
+++ b/apps/dashboard/src/lib/ThemeProvider.tsx
@@ -1,0 +1,42 @@
+import { ReactNode, useEffect, useState } from 'react';
+import {
+  applyTheme,
+  getStoredPreference,
+  resolveTheme,
+  ResolvedTheme,
+  storePreference,
+  SYSTEM_DARK_QUERY,
+  ThemeContext,
+  ThemePreference,
+} from '@/lib/theme';
+
+export const ThemeProvider = ({ children }: { children: ReactNode }) => {
+  const [preference, setPreferenceState] = useState<ThemePreference>(getStoredPreference);
+  const [resolvedTheme, setResolvedTheme] = useState<ResolvedTheme>(() =>
+    resolveTheme(getStoredPreference())
+  );
+
+  useEffect(() => {
+    const media = window.matchMedia(SYSTEM_DARK_QUERY);
+    const syncTheme = () => {
+      const next = resolveTheme(preference);
+      setResolvedTheme(next);
+      applyTheme(next);
+    };
+    syncTheme();
+    if (preference !== 'system') return;
+    media.addEventListener('change', syncTheme);
+    return () => media.removeEventListener('change', syncTheme);
+  }, [preference]);
+
+  const setPreference = (next: ThemePreference) => {
+    storePreference(next);
+    setPreferenceState(next);
+  };
+
+  return (
+    <ThemeContext.Provider value={{ preference, resolvedTheme, setPreference }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+};

--- a/apps/dashboard/src/lib/api.ts
+++ b/apps/dashboard/src/lib/api.ts
@@ -105,6 +105,13 @@ export type CreateAppPayload = {
   keysConfig: KeysConfig;
 };
 
+export type BranchUpdateState = {
+  runtimeVersion: string;
+  commitHash: string;
+  createdAt: string;
+  rolloutPercentage?: number | null;
+};
+
 export type BranchRecord = {
   branchName: string;
   branchId: string;
@@ -112,6 +119,7 @@ export type BranchRecord = {
   createdAt: string | null;
   // Enterprise branch protection; always false in stateless mode.
   protected: boolean;
+  currentUpdate?: BranchUpdateState | null;
 };
 
 // An active channel rollout. Serves `rolloutBranchName` to `percentage`% of
@@ -136,6 +144,8 @@ export type ChannelRecord = {
   // Set while a progressive rollout is active on the channel; null/absent
   // otherwise. The channels list carries it so the table needs no extra call.
   rollout?: ChannelRolloutRecord | null;
+  branchCurrentUpdate?: BranchUpdateState | null;
+  rolloutBranchCurrentUpdate?: BranchUpdateState | null;
 };
 
 export type RuntimeVersionRecord = {
@@ -146,6 +156,7 @@ export type RuntimeVersionRecord = {
   // True when a per-update rollout is active on any update of this runtime
   // version. Optional: only shipped by the control plane.
   activeRollout?: boolean;
+  rolloutPercentage?: number | null;
 };
 
 // A published update. `rolloutPercentage` is set only while this exact update
@@ -161,6 +172,30 @@ export type UpdateRecord = {
   message?: string;
   rolloutPercentage?: number | null;
   controlUpdateId?: string | null;
+  publishGroup?: string | null;
+};
+
+export type UpdateFeedRecord = UpdateRecord & {
+  branch: string;
+  runtimeVersion: string;
+};
+
+export type UpdateFeedQuery = {
+  branch?: string;
+  runtimeVersion?: string;
+  platform?: string;
+  uuid?: string;
+  groupId?: string;
+  commitHash?: string;
+  from?: string;
+  to?: string;
+  cursor?: string;
+  limit?: number;
+};
+
+export type UpdateFeedPage = {
+  items: UpdateFeedRecord[];
+  nextCursor?: string;
 };
 
 // One active per-update rollout row (eoas publishes one per platform, so a
@@ -833,6 +868,20 @@ export class ApiClient {
         method: 'GET',
       }
     );
+  }
+  public async getUpdateFeed(query: UpdateFeedQuery = {}) {
+    const search = new URLSearchParams();
+    for (const [key, value] of Object.entries(query)) {
+      if (value !== undefined && value !== '') search.set(key, String(value));
+    }
+    // Not URLSearchParams.size: it needs Safari 17+/Chrome 113+, above our
+    // build target, and on older browsers `undefined > 0` silently drops
+    // every param (filters AND the pagination cursor).
+    const queryString = search.toString();
+    const suffix = queryString ? `?${queryString}` : '';
+    return this.request<UpdateFeedPage>(`${this.appScope()}/updates${suffix}`, {
+      method: 'GET',
+    });
   }
   public async getUpdateDetails(branch: string, runtimeVersion: string, updateId: string) {
     return this.request<UpdateDetailsRecord>(

--- a/apps/dashboard/src/lib/branch-status.ts
+++ b/apps/dashboard/src/lib/branch-status.ts
@@ -1,0 +1,11 @@
+import type { BranchUpdateState } from '@/lib/api';
+
+export const toBranchStatus = (state?: BranchUpdateState | null) => {
+  if (!state) return undefined;
+  return {
+    label:
+      state.rolloutPercentage != null ? ('Current rollout' as const) : ('Current update' as const),
+    commitHash: state.commitHash.slice(0, 8),
+    percentage: state.rolloutPercentage ?? undefined,
+  };
+};

--- a/apps/dashboard/src/lib/theme.ts
+++ b/apps/dashboard/src/lib/theme.ts
@@ -1,0 +1,45 @@
+import { createContext, useContext } from 'react';
+
+export type ThemePreference = 'light' | 'system' | 'dark';
+export type ResolvedTheme = Exclude<ThemePreference, 'system'>;
+
+const STORAGE_KEY = 'expo-open-ota-theme';
+export const SYSTEM_DARK_QUERY = '(prefers-color-scheme: dark)';
+
+const isThemePreference = (value: string | null): value is ThemePreference =>
+  value === 'light' || value === 'system' || value === 'dark';
+
+export const getStoredPreference = (): ThemePreference => {
+  const stored = window.localStorage.getItem(STORAGE_KEY);
+  return isThemePreference(stored) ? stored : 'system';
+};
+
+export const storePreference = (preference: ThemePreference) => {
+  window.localStorage.setItem(STORAGE_KEY, preference);
+};
+
+export const resolveTheme = (preference: ThemePreference): ResolvedTheme => {
+  if (preference !== 'system') return preference;
+  return window.matchMedia(SYSTEM_DARK_QUERY).matches ? 'dark' : 'light';
+};
+
+export const applyTheme = (theme: ResolvedTheme) => {
+  const root = document.documentElement;
+  root.classList.toggle('light', theme === 'light');
+  root.classList.toggle('dark', theme === 'dark');
+  root.style.colorScheme = theme;
+};
+
+export type ThemeContextValue = {
+  preference: ThemePreference;
+  resolvedTheme: ResolvedTheme;
+  setPreference: (preference: ThemePreference) => void;
+};
+
+export const ThemeContext = createContext<ThemeContextValue | null>(null);
+
+export const useTheme = () => {
+  const context = useContext(ThemeContext);
+  if (!context) throw new Error('useTheme must be used within a ThemeProvider');
+  return context;
+};

--- a/apps/dashboard/src/main.tsx
+++ b/apps/dashboard/src/main.tsx
@@ -2,18 +2,28 @@ import { BrowserRouter } from 'react-router';
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { App } from '@/App.tsx';
+import { ThemeProvider } from '@/lib/ThemeProvider';
 import './index.css';
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
-const queryClient = new QueryClient();
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 30_000,
+      refetchOnWindowFocus: false,
+    },
+  },
+});
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <QueryClientProvider client={queryClient}>
-      <BrowserRouter basename="/dashboard">
-        <App />
-      </BrowserRouter>
-    </QueryClientProvider>
+    <ThemeProvider>
+      <QueryClientProvider client={queryClient}>
+        <BrowserRouter basename="/dashboard">
+          <App />
+        </BrowserRouter>
+      </QueryClientProvider>
+    </ThemeProvider>
   </StrictMode>
 );

--- a/apps/dashboard/src/pages/ApiTokens/index.tsx
+++ b/apps/dashboard/src/pages/ApiTokens/index.tsx
@@ -54,7 +54,9 @@ export const ApiTokens = () => {
       parts.push('Protected access');
     }
     if (restrictions?.allowedIps.length) {
-      parts.push(`${restrictions.allowedIps.length} IP${restrictions.allowedIps.length > 1 ? 's' : ''}`);
+      parts.push(
+        `${restrictions.allowedIps.length} IP${restrictions.allowedIps.length > 1 ? 's' : ''}`
+      );
     }
     return parts.join(' · ');
   };
@@ -88,7 +90,10 @@ export const ApiTokens = () => {
     try {
       await api.revokeApiKey(keyToRevoke.id);
       queryClient.invalidateQueries({ queryKey: ['apiKeys', selectedAppId] });
-      toast({ title: 'Token revoked', description: `"${keyToRevoke.name}" can no longer be used.` });
+      toast({
+        title: 'Token revoked',
+        description: `"${keyToRevoke.name}" can no longer be used.`,
+      });
       setKeyToRevoke(null);
     } catch (error) {
       let errorTitle = 'Revocation failed';
@@ -219,7 +224,7 @@ export const ApiTokens = () => {
               cell: ({ row }: { row: { original: ApiKeyRecord } }) => {
                 const summary = describeRestrictions(row.original.id);
                 const state = summary ? (
-                  <span className="inline-flex items-center gap-1.5 text-sm font-medium text-emerald-700">
+                  <span className="inline-flex items-center gap-1.5 text-sm font-medium text-emerald-700 dark:text-emerald-300">
                     <ShieldCheck className="h-3.5 w-3.5" />
                     {summary}
                   </span>

--- a/apps/dashboard/src/pages/AppInfo/index.tsx
+++ b/apps/dashboard/src/pages/AppInfo/index.tsx
@@ -231,10 +231,7 @@ export const AppInfo = () => {
                   This cannot be undone.
                 </p>
               </div>
-              <Button
-                variant="destructive"
-                size="sm"
-                onClick={() => setShowDeleteAppDialog(true)}>
+              <Button variant="destructive" size="sm" onClick={() => setShowDeleteAppDialog(true)}>
                 <Trash2 className="h-3.5 w-3.5" /> Delete app
               </Button>
             </div>

--- a/apps/dashboard/src/pages/Branches/index.tsx
+++ b/apps/dashboard/src/pages/Branches/index.tsx
@@ -1,0 +1,138 @@
+import { useState } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { ArrowLeft, Plus } from 'lucide-react';
+import { Link, useNavigate, useParams } from 'react-router';
+import { api } from '@/lib/api';
+import { useSelectedApp } from '@/lib/SelectedAppContext';
+import { useSettings } from '@/lib/SettingsContext';
+import { useAppPermission } from '@/ee/lib/PermissionsContext';
+import { useBranchCurrentStatus } from '@/hooks/use-branch-current-status';
+import { toBranchStatus } from '@/lib/branch-status';
+import { PageHeader } from '@/components/PageHeader';
+import { Button } from '@/components/ui/button';
+import { ChannelBranchMapping } from '@/components/ChannelBranchMapping';
+import { CreateBranchModal } from '@/components/branch-creation-modal';
+import { BranchesTable } from '@/pages/Updates/components/BranchesTable';
+import { RuntimeVersionsTable } from '@/pages/Updates/components/RuntimeVersionsTable';
+import { UpdatesTable } from '@/pages/Updates/components/UpdatesTable';
+
+export const Branches = () => {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const { branchName, runtimeVersion } = useParams();
+  const { selectedAppId } = useSelectedApp();
+  const { CONTROL_PLANE_ENABLED } = useSettings();
+  const canCreateBranch = useAppPermission('branch:create');
+  const [createOpen, setCreateOpen] = useState(false);
+  const decodedBranch = branchName ? decodeURIComponent(branchName) : '';
+  const decodedRuntime = runtimeVersion ? decodeURIComponent(runtimeVersion) : undefined;
+  const channelsQuery = useQuery({
+    queryKey: ['channels', selectedAppId],
+    queryFn: () => api.getChannels(),
+    enabled: !!selectedAppId && !!branchName,
+  });
+  const branchesQuery = useQuery({
+    queryKey: ['branches', selectedAppId],
+    queryFn: () => api.getBranches(),
+    enabled: !!selectedAppId && !!branchName && CONTROL_PLANE_ENABLED,
+  });
+  const statelessBranchStatus = useBranchCurrentStatus(
+    CONTROL_PLANE_ENABLED ? undefined : decodedBranch
+  );
+  const selectedBranch = branchesQuery.data?.find(branch => branch.branchName === decodedBranch);
+  const branchStatus = CONTROL_PLANE_ENABLED
+    ? toBranchStatus(selectedBranch?.currentUpdate)
+    : statelessBranchStatus;
+
+  if (!branchName) {
+    return (
+      <div className="w-full">
+        <PageHeader
+          title="Branches"
+          actions={
+            CONTROL_PLANE_ENABLED && canCreateBranch ? (
+              <Button onClick={() => setCreateOpen(true)}>
+                <Plus className="h-4 w-4" />
+                Create branch
+              </Button>
+            ) : undefined
+          }
+        />
+        <BranchesTable />
+        {CONTROL_PLANE_ENABLED && canCreateBranch && (
+          <CreateBranchModal
+            isOpen={createOpen}
+            onClose={() => setCreateOpen(false)}
+            onBranchCreated={async () => {
+              await queryClient.invalidateQueries({ queryKey: ['branches', selectedAppId] });
+            }}
+          />
+        )}
+      </div>
+    );
+  }
+
+  const mappedChannels = (channelsQuery.data ?? [])
+    .filter(channel => channel.branchName === decodedBranch)
+    .map(channel => channel.releaseChannelName);
+
+  const selectRuntime = (selectedRuntime: string) => {
+    if (CONTROL_PLANE_ENABLED) {
+      const filters = new URLSearchParams({
+        branch: decodedBranch,
+        runtimeVersion: selectedRuntime,
+      });
+      navigate(`/updates?${filters.toString()}`);
+      return;
+    }
+    navigate(
+      `/branches/${encodeURIComponent(decodedBranch)}/runtime-versions/${encodeURIComponent(selectedRuntime)}`
+    );
+  };
+
+  return (
+    <div className="w-full">
+      <Link
+        to="/branches"
+        className="mb-4 inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground">
+        <ArrowLeft className="h-4 w-4" />
+        All branches
+      </Link>
+      <PageHeader
+        title={
+          <span className="flex min-w-0 items-center gap-2">
+            <span className="truncate">{decodedBranch}</span>
+            {decodedRuntime && (
+              <code className="rounded-md bg-muted px-2 py-1 font-mono text-sm font-medium">
+                {decodedRuntime}
+              </code>
+            )}
+          </span>
+        }
+      />
+      <div className="space-y-7">
+        <ChannelBranchMapping
+          branchName={decodedBranch}
+          channelNames={mappedChannels}
+          focus="branch"
+          branchStatus={branchStatus}
+        />
+        {decodedRuntime ? (
+          <section className="space-y-3">
+            <h2 className="text-base font-semibold">Updates</h2>
+            <UpdatesTable
+              branch={decodedBranch}
+              runtimeVersion={decodedRuntime}
+              showBreadcrumb={false}
+            />
+          </section>
+        ) : (
+          <section className="space-y-3">
+            <h2 className="text-base font-semibold">Runtime versions</h2>
+            <RuntimeVersionsTable branch={decodedBranch} onSelectRuntime={selectRuntime} />
+          </section>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/apps/dashboard/src/pages/Channels/components/ManageRolloutDialog.tsx
+++ b/apps/dashboard/src/pages/Channels/components/ManageRolloutDialog.tsx
@@ -98,7 +98,7 @@ export const ManageRolloutDialog = ({
       <Dialog open={!!channel} onOpenChange={open => !open && !busy && onClose()}>
         <DialogContent className="sm:max-w-[480px]">
           <DialogHeader className="flex flex-col items-start gap-2">
-            <div className="flex h-9 w-9 items-center justify-center rounded-full border border-emerald-200 bg-emerald-50 text-emerald-600">
+            <div className="flex h-9 w-9 items-center justify-center rounded-full border border-emerald-400/25 bg-emerald-400/10 text-emerald-700 dark:text-emerald-300">
               <Split className="h-5 w-5" />
             </div>
             <DialogTitle className="mt-2 text-lg font-semibold tracking-tight">
@@ -131,8 +131,7 @@ export const ManageRolloutDialog = ({
                   type="button"
                   size="sm"
                   onClick={handleSave}
-                  disabled={busy || percentage === rollout?.percentage}
-                  className="bg-emerald-600 text-white hover:bg-emerald-700">
+                  disabled={busy || percentage === rollout?.percentage}>
                   {isSaving ? 'Saving…' : 'Save percentage'}
                 </Button>
               </div>
@@ -145,7 +144,7 @@ export const ManageRolloutDialog = ({
                 disabled={busy}
                 onClick={() => setConfirm('promote')}
                 className="flex w-full items-start gap-3 rounded-lg border px-3 py-3 text-left transition-colors hover:bg-muted/40 disabled:pointer-events-none disabled:opacity-50">
-                <span className="mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-full border border-emerald-200 bg-emerald-50 text-emerald-600">
+                <span className="mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-full border border-emerald-400/25 bg-emerald-400/10 text-emerald-700 dark:text-emerald-300">
                   <CheckCircle2 className="h-4 w-4" />
                 </span>
                 <span>
@@ -182,7 +181,7 @@ export const ManageRolloutDialog = ({
         onOpenChange={open => !open && !isEnding && setConfirm(null)}>
         <DialogContent className="sm:max-w-[420px]">
           <DialogHeader className="flex flex-col items-start gap-2">
-            <div className="flex h-9 w-9 items-center justify-center rounded-full border border-emerald-200 bg-emerald-50 text-emerald-600">
+            <div className="flex h-9 w-9 items-center justify-center rounded-full border border-emerald-400/25 bg-emerald-400/10 text-emerald-700 dark:text-emerald-300">
               <CheckCircle2 className="h-5 w-5" />
             </div>
             <DialogTitle className="mt-2 text-lg font-semibold tracking-tight">
@@ -208,11 +207,7 @@ export const ManageRolloutDialog = ({
               disabled={isEnding}>
               Cancel
             </Button>
-            <Button
-              type="button"
-              onClick={() => handleEnd('promote')}
-              disabled={isEnding}
-              className="bg-emerald-600 text-white hover:bg-emerald-700">
+            <Button type="button" onClick={() => handleEnd('promote')} disabled={isEnding}>
               {isEnding ? 'Promoting…' : 'Promote'}
             </Button>
           </DialogFooter>

--- a/apps/dashboard/src/pages/Channels/components/SelectBranch/index.tsx
+++ b/apps/dashboard/src/pages/Channels/components/SelectBranch/index.tsx
@@ -12,6 +12,7 @@ export const SelectBranch = ({
   currentBranch,
   onChange,
   loading,
+  disabled,
   className,
   excludeBranchIds,
 }: {
@@ -19,6 +20,7 @@ export const SelectBranch = ({
   // creating a channel, which takes a branch name).
   onChange: (branchId?: string | null, branchName?: string) => void;
   loading?: boolean;
+  disabled?: boolean;
   currentBranch?: string | null;
   className?: string;
   // Branch ids to leave out of the list, e.g. the channel's own default
@@ -55,6 +57,7 @@ export const SelectBranch = ({
       <Combobox
         className={className}
         loading={isLoading || loading}
+        disabled={disabled}
         options={allBranches.map(b => {
           return {
             label: b.branchName,

--- a/apps/dashboard/src/pages/Channels/components/StartRolloutDialog.tsx
+++ b/apps/dashboard/src/pages/Channels/components/StartRolloutDialog.tsx
@@ -63,7 +63,7 @@ export const StartRolloutDialog = ({
     <Dialog open={!!channel} onOpenChange={open => !open && !isStarting && onClose()}>
       <DialogContent className="sm:max-w-[460px]">
         <DialogHeader className="flex flex-col items-start gap-2">
-          <div className="flex h-9 w-9 items-center justify-center rounded-full border border-emerald-200 bg-emerald-50 text-emerald-600">
+          <div className="flex h-9 w-9 items-center justify-center rounded-full border border-emerald-400/25 bg-emerald-400/10 text-emerald-700 dark:text-emerald-300">
             <Split className="h-5 w-5" />
           </div>
           <DialogTitle className="mt-2 text-lg font-semibold tracking-tight">
@@ -75,10 +75,7 @@ export const StartRolloutDialog = ({
               "{channel?.releaseChannelName}"
             </strong>
             . The rest keep receiving{' '}
-            <strong className="font-semibold text-foreground">
-              "{channel?.branchName}"
-            </strong>
-            .
+            <strong className="font-semibold text-foreground">"{channel?.branchName}"</strong>.
           </DialogDescription>
         </DialogHeader>
 
@@ -108,11 +105,7 @@ export const StartRolloutDialog = ({
           <Button type="button" variant="outline" onClick={onClose} disabled={isStarting}>
             Cancel
           </Button>
-          <Button
-            type="button"
-            onClick={handleStart}
-            disabled={isStarting || !rolloutBranch}
-            className="bg-emerald-600 text-white hover:bg-emerald-700">
+          <Button type="button" onClick={handleStart} disabled={isStarting || !rolloutBranch}>
             {isStarting ? 'Starting…' : 'Start rollout'}
           </Button>
         </DialogFooter>

--- a/apps/dashboard/src/pages/Channels/index.tsx
+++ b/apps/dashboard/src/pages/Channels/index.tsx
@@ -1,442 +1,510 @@
-import { useMutation, useQuery } from '@tanstack/react-query';
-import { api, ChannelRecord, ApiProblemError } from '@/lib/api.ts';
-import { ApiError } from '@/components/APIError';
-import { DataTable } from '@/components/DataTable';
-import { SelectBranch } from '@/pages/Channels/components/SelectBranch';
-import { useCallback, useMemo, useState } from 'react';
-import { useToast } from '@/hooks/use-toast.ts';
+import { useMemo, useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { ArrowLeft, Copy, GitBranch, Plus, Search, Split, Trash2 } from 'lucide-react';
+import { Link, useNavigate, useParams } from 'react-router';
+import { api, ChannelRecord, describeApiError } from '@/lib/api';
 import { useSelectedApp } from '@/lib/SelectedAppContext';
-import { Button } from '@/components/ui/button';
-import { Card, CardContent } from '@/components/ui/card';
-import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
-import { PageHeader } from '@/components/PageHeader';
-import { DeleteDialog } from '@/components/ui/delete-dialog';
-import { AdminOnlyNote } from '@/components/ui/admin-only-note';
-import { TimestampCell } from '@/components/ui/timestamp-cell';
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
-import { Trash2, Plus, Split, Lock } from 'lucide-react';
 import { useSettings } from '@/lib/SettingsContext';
 import { useAppPermission } from '@/ee/lib/PermissionsContext';
-import { RolloutBar } from '@/components/rollout/RolloutBar';
+import { useToast } from '@/hooks/use-toast';
+import { useBranchCurrentStatus } from '@/hooks/use-branch-current-status';
+import { toBranchStatus } from '@/lib/branch-status';
+import { PageHeader } from '@/components/PageHeader';
+import { ApiError } from '@/components/APIError';
+import { DataTable } from '@/components/DataTable';
+import { ChannelBranchMapping } from '@/components/ChannelBranchMapping';
+import { SelectBranch } from '@/pages/Channels/components/SelectBranch';
 import { StartRolloutDialog } from '@/pages/Channels/components/StartRolloutDialog';
 import { ManageRolloutDialog } from '@/pages/Channels/components/ManageRolloutDialog';
+import { RolloutBar } from '@/components/rollout/RolloutBar';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { DeleteDialog } from '@/components/ui/delete-dialog';
 
-interface TableColumnConfig {
-  header: string;
-  accessorKey?: keyof ChannelRecord;
-  id?: string;
-  cell: (props: { row: { original: ChannelRecord } }) => React.ReactNode;
-}
+const CreateChannelDialog = ({
+  open,
+  onClose,
+  onCreated,
+}: {
+  open: boolean;
+  onClose: () => void;
+  onCreated: () => Promise<void>;
+}) => {
+  const { toast } = useToast();
+  const [name, setName] = useState('');
+  const [branch, setBranch] = useState<{ id: string; name: string } | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  const close = () => {
+    setName('');
+    setBranch(null);
+    onClose();
+  };
+  const submit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    const channelName = name.trim();
+    if (!channelName) return;
+    setSubmitting(true);
+    try {
+      await api.createChannel({
+        channelName,
+        ...(branch && { branchName: branch.name }),
+      });
+      await onCreated();
+      toast({ title: 'Channel created', description: `"${channelName}" is ready.` });
+      close();
+    } catch (error) {
+      const message = describeApiError(error, 'Could not create channel');
+      toast({ title: message.title, description: message.description, variant: 'destructive' });
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={next => !next && close()}>
+      <DialogContent>
+        <form onSubmit={submit}>
+          <DialogHeader>
+            <DialogTitle>Create channel</DialogTitle>
+            <DialogDescription>
+              Create the channel, then map it to the branch that should serve updates.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4 py-5">
+            <div className="space-y-1.5">
+              <Label htmlFor="channel-name">Channel name</Label>
+              <Input
+                id="channel-name"
+                value={name}
+                onChange={event => setName(event.target.value)}
+                placeholder="production"
+                autoFocus
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label>Branch (optional)</Label>
+              <SelectBranch
+                className="w-full"
+                currentBranch={branch?.id ?? ''}
+                disabled={submitting}
+                onChange={(id, branchName) =>
+                  setBranch(id && branchName ? { id, name: branchName } : null)
+                }
+              />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={close} disabled={submitting}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={submitting || !name.trim()}>
+              {submitting ? 'Creating...' : 'Create channel'}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+};
 
 export const Channels = () => {
+  const { channelName } = useParams();
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+  const { selectedAppId } = useSelectedApp();
   const { CONTROL_PLANE_ENABLED } = useSettings();
-  // Display gating only: the server re-checks each permission on its route.
   const canCreateChannel = useAppPermission('channel:create');
   const canDeleteChannel = useAppPermission('channel:delete');
   const canEditChannelBranch = useAppPermission('channel:edit-branch');
   const canManageRollout = useAppPermission('channel-rollout:manage');
-  const { selectedAppId } = useSelectedApp();
-  const { data, isLoading, error, refetch } = useQuery({
-    queryKey: ['channels', selectedAppId],
-    enabled: !!selectedAppId,
-    queryFn: () => api.getChannels(),
-  });
-  const { toast } = useToast();
-  const [loading, setLoading] = useState(false);
-  const [newChannelName, setNewChannelName] = useState('');
-  const [newChannelBranch, setNewChannelBranch] = useState<{ id: string; name: string } | null>(
-    null
-  );
-  const [isCreating, setIsCreating] = useState(false);
+  const [search, setSearch] = useState('');
+  const [createOpen, setCreateOpen] = useState(false);
+  const [editingMapping, setEditingMapping] = useState(false);
   const [channelToDelete, setChannelToDelete] = useState<ChannelRecord | null>(null);
-  const [isDeleting, setIsDeleting] = useState(false);
-  const [rolloutAction, setRolloutAction] = useState<{
-    type: 'start' | 'manage';
-    channel: ChannelRecord;
-  } | null>(null);
+  const [deleting, setDeleting] = useState(false);
+  const [rolloutAction, setRolloutAction] = useState<'start' | 'manage' | null>(null);
 
-  const handleRolloutDone = useCallback(async () => {
-    await refetch();
-  }, [refetch]);
+  const channelsQuery = useQuery({
+    queryKey: ['channels', selectedAppId],
+    queryFn: () => api.getChannels(),
+    enabled: !!selectedAppId,
+  });
+  const selectedChannel = channelName
+    ? channelsQuery.data?.find(
+        channel => channel.releaseChannelName === decodeURIComponent(channelName)
+      )
+    : undefined;
+  const statelessBranchStatus = useBranchCurrentStatus(
+    CONTROL_PLANE_ENABLED ? undefined : selectedChannel?.branchName
+  );
+  const branchStatus = CONTROL_PLANE_ENABLED
+    ? toBranchStatus(selectedChannel?.branchCurrentUpdate)
+    : statelessBranchStatus;
+  const rolloutBranchStatus = toBranchStatus(selectedChannel?.rolloutBranchCurrentUpdate);
 
-  // The dialogs must render the live record, not the snapshot captured when the
-  // action was opened: after "Save percentage" the refetched channels list is the
-  // source of truth, and a stale snapshot would show the pre-save value.
-  const rolloutActionChannel = useMemo(() => {
-    if (!rolloutAction) return null;
-    return (
-      data?.find(channel => channel.releaseChannelId === rolloutAction.channel.releaseChannelId) ??
-      rolloutAction.channel
-    );
-  }, [rolloutAction, data]);
-
-  const updateBranchMutation = useMutation({
-    mutationKey: ['update-branch'],
-    mutationFn: async ({
-      branchId,
-      releaseChannelId,
-      releaseChannelName,
-    }: {
-      branchId: string;
-      releaseChannelId: string;
-      releaseChannelName: string;
-    }) => {
-      return api.updateChannelBranchMapping(branchId, {
-        releaseChannelId,
-        releaseChannelName,
-      });
-    },
+  const mappingMutation = useMutation({
+    mutationFn: ({ branchId, channel }: { branchId: string; channel: ChannelRecord }) =>
+      api.updateChannelBranchMapping(branchId, {
+        releaseChannelId: channel.releaseChannelId,
+        releaseChannelName: channel.releaseChannelName,
+      }),
   });
 
-  const onBranchChange = useCallback(
-    (channel: ChannelRecord) => async (branchId?: string | null) => {
-      if (!branchId) return;
-      setLoading(true);
-      try {
-        await updateBranchMutation.mutateAsync({
-          branchId,
-          releaseChannelId: channel.releaseChannelId,
-          releaseChannelName: channel.releaseChannelName,
-        });
-        await refetch();
-        toast({
-          title: 'Channel updated',
-          description: `Branch mapping synchronized successfully.`,
-          duration: 2000,
-        });
-      } catch (error) {
-        let errorTitle = 'Error updating channel mapping';
-        let errorMessage = 'An unexpected error occurred.';
-        if (error instanceof ApiProblemError) {
-          errorTitle = error.title;
-          errorMessage = error.detail;
-        } else if (error instanceof Error) {
-          errorMessage = error.message;
-        }
-        toast({
-          title: errorTitle,
-          description: errorMessage,
-          variant: 'destructive',
-        });
-      } finally {
-        setLoading(false);
-      }
-    },
-    [updateBranchMutation, toast, refetch]
-  );
-
-  const handleCreateChannel = async (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!newChannelName.trim()) return;
-    setIsCreating(true);
+  const remap = async (branchId?: string | null) => {
+    if (!selectedChannel || !branchId) return;
     try {
-      await api.createChannel({
-        channelName: newChannelName.trim(),
-        ...(newChannelBranch && { branchName: newChannelBranch.name }),
-      });
-      setNewChannelName('');
-      setNewChannelBranch(null);
-      await refetch();
+      await mappingMutation.mutateAsync({ branchId, channel: selectedChannel });
+      await queryClient.invalidateQueries({ queryKey: ['channels', selectedAppId] });
+      setEditingMapping(false);
       toast({
-        title: 'Channel created',
-        description: newChannelBranch
-          ? `"${newChannelName.trim()}" now serves the "${newChannelBranch.name}" branch.`
-          : `"${newChannelName.trim()}" created. Map it to a branch to start serving updates.`,
+        title: 'Channel updated',
+        description: `"${selectedChannel.releaseChannelName}" now uses the selected branch.`,
       });
     } catch (error) {
-      let errorTitle = 'Error creating channel';
-      let errorMessage = 'An unexpected error occurred.';
-      if (error instanceof ApiProblemError) {
-        errorTitle = error.title;
-        errorMessage = error.detail;
-      } else if (error instanceof Error) {
-        errorMessage = error.message;
-      }
-      toast({
-        title: errorTitle,
-        description: errorMessage,
-        variant: 'destructive',
-      });
-    } finally {
-      setIsCreating(false);
+      const message = describeApiError(error, 'Could not update channel mapping');
+      toast({ title: message.title, description: message.description, variant: 'destructive' });
     }
   };
 
-  const handleExecuteDeletion = async () => {
+  const deleteChannel = async () => {
     if (!channelToDelete) return;
-    setIsDeleting(true);
+    setDeleting(true);
     try {
       await api.deleteChannel(channelToDelete.releaseChannelName);
-      await refetch();
+      await queryClient.invalidateQueries({ queryKey: ['channels', selectedAppId] });
+      if (selectedChannel?.releaseChannelId === channelToDelete.releaseChannelId) {
+        navigate('/channels');
+      }
       toast({
         title: 'Channel deleted',
         description: `"${channelToDelete.releaseChannelName}" was removed.`,
       });
       setChannelToDelete(null);
     } catch (error) {
-      let errorTitle = 'Deletion Failed';
-      let errorMessage = 'Could not clean up the requested release channel.';
-      if (error instanceof ApiProblemError) {
-        errorTitle = error.title;
-        errorMessage = error.detail;
-      } else if (error instanceof Error) {
-        errorMessage = error.message;
-      }
-      toast({
-        title: errorTitle,
-        description: errorMessage,
-        variant: 'destructive',
-      });
+      const message = describeApiError(error, 'Could not delete channel');
+      toast({ title: message.title, description: message.description, variant: 'destructive' });
     } finally {
-      setIsDeleting(false);
+      setDeleting(false);
     }
   };
 
-  const tableColumns = useMemo<TableColumnConfig[]>(() => {
-    return [
+  const filteredChannels = useMemo(() => {
+    const normalized = search.trim().toLowerCase();
+    return (channelsQuery.data ?? []).filter(
+      channel =>
+        !normalized ||
+        channel.releaseChannelName.toLowerCase().includes(normalized) ||
+        channel.branchName?.toLowerCase().includes(normalized)
+    );
+  }, [channelsQuery.data, search]);
+
+  const columns = useMemo(
+    () => [
       {
         header: 'Channel',
         accessorKey: 'releaseChannelName',
-        cell: ({ row }) => <span className="font-medium">{row.original.releaseChannelName}</span>,
+        cell: ({ row }: { row: { original: ChannelRecord } }) => (
+          <span className="font-medium">{row.original.releaseChannelName}</span>
+        ),
       },
       {
-        header: 'Branch',
-        accessorKey: 'branchId',
-        // Remapping a live channel is an admin action (the server enforces
-        // it); everyone else sees the mapping read-only. While a rollout is
-        // active the mapping is locked for everyone: it can only change by
-        // promoting or reverting the rollout.
-        cell: ({ row }) => {
-          if (row.original.rollout) {
-            return (
-              <TooltipProvider delayDuration={200}>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <span className="inline-flex items-center gap-1.5 text-sm text-muted-foreground">
-                      <Lock className="h-3.5 w-3.5" />
-                      {row.original.branchName || 'No branch'}
-                    </span>
-                  </TooltipTrigger>
-                  <TooltipContent className="max-w-xs">
-                    The branch mapping is locked while a rollout is in progress. Promote or revert
-                    the rollout to change it.
-                  </TooltipContent>
-                </Tooltip>
-              </TooltipProvider>
-            );
-          }
-          return canEditChannelBranch ? (
-            <SelectBranch
-              currentBranch={row.original.branchId || ''}
-              loading={isLoading || loading}
-              onChange={onBranchChange(row.original)}
-            />
+        header: 'Status',
+        id: 'status',
+        cell: ({ row }: { row: { original: ChannelRecord } }) => (
+          <Badge
+            variant="outline"
+            className={
+              row.original.branchName
+                ? 'border-emerald-400/25 bg-emerald-400/10 text-emerald-700 dark:text-emerald-300'
+                : 'text-muted-foreground'
+            }>
+            {row.original.branchName ? 'Active' : 'Unmapped'}
+          </Badge>
+        ),
+      },
+      {
+        header: 'Linked branch',
+        accessorKey: 'branchName',
+        cell: ({ row }: { row: { original: ChannelRecord } }) =>
+          row.original.branchName ? (
+            <button
+              type="button"
+              className="inline-flex items-center gap-1.5 font-medium hover:text-link"
+              onClick={event => {
+                event.stopPropagation();
+                navigate(`/branches/${encodeURIComponent(row.original.branchName as string)}`);
+              }}>
+              <GitBranch className="h-4 w-4 text-muted-foreground" />
+              {row.original.branchName}
+            </button>
           ) : (
-            <span className="text-muted-foreground">{row.original.branchName || 'No branch'}</span>
-          );
-        },
+            <span className="text-muted-foreground/60">None</span>
+          ),
       },
       ...(CONTROL_PLANE_ENABLED
         ? [
             {
               header: 'Rollout',
               id: 'rollout',
-              cell: ({ row }) => {
-                const channel = row.original;
-                if (channel.rollout) {
-                  return (
-                    <div className="flex items-center gap-2.5">
-                      <RolloutBar value={channel.rollout.percentage} />
-                      <span className="text-xs text-muted-foreground">
-                        to {channel.rollout.rolloutBranchName}
-                      </span>
-                      {canManageRollout && (
-                        <button
-                          type="button"
-                          onClick={() => setRolloutAction({ type: 'manage', channel })}
-                          className="text-sm font-medium text-link hover:underline">
-                          Manage
-                        </button>
-                      )}
-                    </div>
-                  );
-                }
-                // Nothing to roll out until the channel serves a branch.
-                if (!channel.branchId) {
-                  return <span className="text-muted-foreground/60">None</span>;
-                }
-                if (canManageRollout) {
-                  return (
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      onClick={() => setRolloutAction({ type: 'start', channel })}
-                      className="text-muted-foreground hover:text-foreground">
-                      <Split className="h-4 w-4" />
-                      Start rollout
-                    </Button>
-                  );
-                }
-                return <span className="text-muted-foreground/60">None</span>;
-              },
-            } satisfies TableColumnConfig,
-            {
-              header: 'Created',
-              accessorKey: 'createdAt',
-              cell: ({ row }) => <TimestampCell dateString={row.original.createdAt} />,
-            } satisfies TableColumnConfig,
+              cell: ({ row }: { row: { original: ChannelRecord } }) =>
+                row.original.rollout ? (
+                  <div className="flex items-center gap-2">
+                    <RolloutBar value={row.original.rollout.percentage} />
+                    <span className="text-xs text-muted-foreground">
+                      to {row.original.rollout.rolloutBranchName}
+                    </span>
+                  </div>
+                ) : (
+                  <span className="text-muted-foreground/60">None</span>
+                ),
+            },
           ]
         : []),
-      // Deleting a channel needs its permission (the server enforces it).
+      {
+        header: 'ID',
+        accessorKey: 'releaseChannelId',
+        cell: ({ row }: { row: { original: ChannelRecord } }) => (
+          <div className="flex items-center gap-1">
+            <code className="max-w-32 truncate font-mono text-xs text-muted-foreground">
+              {row.original.releaseChannelId}
+            </code>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-7 w-7"
+              title="Copy channel ID"
+              onClick={event => {
+                event.stopPropagation();
+                void navigator.clipboard.writeText(row.original.releaseChannelId);
+              }}>
+              <Copy className="h-3.5 w-3.5" />
+            </Button>
+          </div>
+        ),
+      },
       ...(CONTROL_PLANE_ENABLED && canDeleteChannel
         ? [
             {
               header: '',
               id: 'actions',
-              cell: ({ row }) => (
-                <div className="text-right pr-2">
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    onClick={() => setChannelToDelete(row.original)}
-                    className="h-8 w-8 p-0 text-muted-foreground hover:text-destructive hover:bg-destructive/10"
-                    title="Delete Release Channel">
-                    <Trash2 />
-                  </Button>
-                </div>
+              cell: ({ row }: { row: { original: ChannelRecord } }) => (
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-8 w-8 text-muted-foreground hover:bg-destructive/10 hover:text-destructive"
+                  title="Delete channel"
+                  onClick={event => {
+                    event.stopPropagation();
+                    setChannelToDelete(row.original);
+                  }}>
+                  <Trash2 className="h-4 w-4" />
+                </Button>
               ),
-            } satisfies TableColumnConfig,
+            },
           ]
         : []),
-    ];
-  }, [
-    CONTROL_PLANE_ENABLED,
-    canDeleteChannel,
-    canEditChannelBranch,
-    canManageRollout,
-    isLoading,
-    loading,
-    onBranchChange,
-  ]);
+    ],
+    [CONTROL_PLANE_ENABLED, canDeleteChannel, navigate]
+  );
+
+  if (channelName) {
+    const decodedChannel = decodeURIComponent(channelName);
+    return (
+      <div className="w-full">
+        <Link
+          to="/channels"
+          className="mb-4 inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground">
+          <ArrowLeft className="h-4 w-4" />
+          All channels
+        </Link>
+        <PageHeader
+          title={decodedChannel}
+          actions={
+            CONTROL_PLANE_ENABLED && canDeleteChannel && selectedChannel ? (
+              <Button variant="outline" onClick={() => setChannelToDelete(selectedChannel)}>
+                <Trash2 className="h-4 w-4" />
+                Delete
+              </Button>
+            ) : undefined
+          }
+        />
+        {!!channelsQuery.error && <ApiError error={channelsQuery.error} />}
+        {!channelsQuery.isLoading && !selectedChannel && !channelsQuery.error && (
+          <div className="rounded-lg border border-dashed p-10 text-center text-muted-foreground">
+            Channel not found.
+          </div>
+        )}
+        {selectedChannel && (
+          <div className="space-y-6">
+            <ChannelBranchMapping
+              branchName={selectedChannel.branchName}
+              channelNames={[selectedChannel.releaseChannelName]}
+              branchStatus={branchStatus}
+              rolloutStatus={rolloutBranchStatus}
+              rollout={
+                selectedChannel.rollout
+                  ? {
+                      branchName: selectedChannel.rollout.rolloutBranchName,
+                      percentage: selectedChannel.rollout.percentage,
+                    }
+                  : undefined
+              }
+              onEdit={
+                canEditChannelBranch && !selectedChannel.rollout
+                  ? () => setEditingMapping(true)
+                  : undefined
+              }
+            />
+            {editingMapping && (
+              <section className="flex flex-col gap-3 rounded-lg border p-4 sm:flex-row sm:items-end">
+                <div className="min-w-0 flex-1 space-y-1.5">
+                  <Label>Branch</Label>
+                  <SelectBranch
+                    className="w-full"
+                    currentBranch={selectedChannel.branchId ?? ''}
+                    loading={mappingMutation.isPending}
+                    onChange={branchId => void remap(branchId)}
+                  />
+                </div>
+                <Button variant="ghost" onClick={() => setEditingMapping(false)}>
+                  Cancel
+                </Button>
+              </section>
+            )}
+            {CONTROL_PLANE_ENABLED && (
+              <section className="rounded-lg border p-5">
+                <div className="flex flex-col justify-between gap-4 sm:flex-row sm:items-center">
+                  <div>
+                    <h2 className="text-sm font-semibold">Progressive rollout</h2>
+                    {selectedChannel.rollout ? (
+                      <div className="mt-2 flex items-center gap-3">
+                        <RolloutBar value={selectedChannel.rollout.percentage} />
+                        <span className="text-sm text-muted-foreground">
+                          to {selectedChannel.rollout.rolloutBranchName}
+                        </span>
+                      </div>
+                    ) : (
+                      <p className="mt-1 text-sm text-muted-foreground">No active rollout</p>
+                    )}
+                  </div>
+                  {canManageRollout && selectedChannel.branchId && (
+                    <Button
+                      variant={selectedChannel.rollout ? 'outline' : 'default'}
+                      onClick={() =>
+                        setRolloutAction(selectedChannel.rollout ? 'manage' : 'start')
+                      }>
+                      <Split className="h-4 w-4" />
+                      {selectedChannel.rollout ? 'Manage rollout' : 'Start rollout'}
+                    </Button>
+                  )}
+                </div>
+              </section>
+            )}
+          </div>
+        )}
+        {selectedChannel && canManageRollout && (
+          <>
+            <StartRolloutDialog
+              channel={rolloutAction === 'start' ? selectedChannel : null}
+              onClose={() => setRolloutAction(null)}
+              onStarted={async () => {
+                await channelsQuery.refetch();
+              }}
+            />
+            <ManageRolloutDialog
+              channel={rolloutAction === 'manage' ? selectedChannel : null}
+              onClose={() => setRolloutAction(null)}
+              onDone={async () => {
+                await channelsQuery.refetch();
+              }}
+            />
+          </>
+        )}
+        {CONTROL_PLANE_ENABLED && canDeleteChannel && (
+          <DeleteDialog
+            isOpen={!!channelToDelete}
+            onClose={() => setChannelToDelete(null)}
+            onConfirm={deleteChannel}
+            isDeleting={deleting}
+            title="Delete channel"
+            resourceName={channelToDelete?.releaseChannelName}
+            descriptionText="Builds configured with this channel will stop receiving updates. This cannot be undone."
+            confirmButtonText="Delete channel"
+            isDeletingButtonText="Deleting..."
+          />
+        )}
+      </div>
+    );
+  }
 
   return (
     <div className="w-full">
       <PageHeader
         title="Channels"
-        description={
-          <>
-            <p>
-              A <span className="font-medium text-foreground">branch</span> is a line of updates you
-              publish to, much like a git branch. A{' '}
-              <span className="font-medium text-foreground">release channel</span> is the name your
-              app asks for when it checks for updates. It is baked into the build and never changes.
-            </p>
-            <p className="mt-2">
-              Mapping a channel to a branch decides which updates an app actually receives. Point{' '}
-              <code className="rounded bg-muted px-1 py-0.5 font-mono text-xs text-foreground">
-                production
-              </code>{' '}
-              at a new branch to roll out, or back at the previous one to roll back, without
-              shipping a new build. Or start a progressive rollout to serve a branch to a fraction
-              of devices first.
-            </p>
-          </>
+        actions={
+          CONTROL_PLANE_ENABLED && canCreateChannel ? (
+            <Button onClick={() => setCreateOpen(true)}>
+              <Plus className="h-4 w-4" />
+              Create channel
+            </Button>
+          ) : undefined
         }
       />
-      {!!error && <ApiError error={error} />}
-
-      <div className="space-y-4">
-        {CONTROL_PLANE_ENABLED &&
-          !canCreateChannel &&
-          !canDeleteChannel &&
-          !canEditChannelBranch &&
-          !canManageRollout && (
-            <AdminOnlyNote>
-              You do not have permission to manage channels on this app. Ask an admin to grant you
-              access.
-            </AdminOnlyNote>
-          )}
-        {CONTROL_PLANE_ENABLED && canCreateChannel && (
-          <Card>
-            <CardContent className="p-5">
-              <form
-                onSubmit={handleCreateChannel}
-                className="grid items-end gap-4 sm:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto]">
-                <div className="space-y-1.5">
-                  <Label htmlFor="channel-name">Channel name</Label>
-                  <Input
-                    id="channel-name"
-                    placeholder="production, staging…"
-                    value={newChannelName}
-                    onChange={e => setNewChannelName(e.target.value)}
-                    disabled={isCreating}
-                  />
-                </div>
-                <div className="space-y-1.5">
-                  <Label>
-                    Branch to serve{' '}
-                    <span className="font-normal text-muted-foreground">(optional)</span>
-                  </Label>
-                  <SelectBranch
-                    className="w-full"
-                    currentBranch={newChannelBranch?.id ?? ''}
-                    loading={isCreating}
-                    onChange={(branchId, branchName) =>
-                      setNewChannelBranch(
-                        branchId && branchName ? { id: branchId, name: branchName } : null
-                      )
-                    }
-                  />
-                </div>
-                <Button type="submit" disabled={isCreating || !newChannelName.trim()}>
-                  <Plus className="h-4 w-4" />
-                  {isCreating ? 'Creating…' : 'Create channel'}
-                </Button>
-              </form>
-              <p className="mt-3 text-xs text-muted-foreground">
-                Pick an existing branch or create one on the fly. You can also leave it empty and
-                map a branch later from the table below.
-              </p>
-            </CardContent>
-          </Card>
-        )}
-
-        <DataTable
-          loading={isLoading}
-          columns={tableColumns}
-          data={data ?? []}
-          emptyMessage="No channels yet. Create one to start serving updates to your builds."
-        />
+      {!!channelsQuery.error && <ApiError error={channelsQuery.error} />}
+      <div className="mb-4 max-w-sm">
+        <div className="relative">
+          <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            aria-label="Search channels"
+            placeholder="Search channels"
+            value={search}
+            onChange={event => setSearch(event.target.value)}
+            className="pl-9"
+          />
+        </div>
       </div>
-
+      <DataTable
+        loading={channelsQuery.isLoading}
+        columns={columns}
+        data={filteredChannels}
+        emptyMessage={search ? 'No channels match this search.' : 'No channels yet.'}
+        onRowClick={channel =>
+          navigate(`/channels/${encodeURIComponent(channel.releaseChannelName)}`)
+        }
+      />
+      {CONTROL_PLANE_ENABLED && canCreateChannel && (
+        <CreateChannelDialog
+          open={createOpen}
+          onClose={() => setCreateOpen(false)}
+          onCreated={async () => {
+            await queryClient.invalidateQueries({ queryKey: ['channels', selectedAppId] });
+          }}
+        />
+      )}
       {CONTROL_PLANE_ENABLED && canDeleteChannel && (
         <DeleteDialog
           isOpen={!!channelToDelete}
           onClose={() => setChannelToDelete(null)}
-          onConfirm={handleExecuteDeletion}
-          isDeleting={isDeleting}
+          onConfirm={deleteChannel}
+          isDeleting={deleting}
           title="Delete channel"
           resourceName={channelToDelete?.releaseChannelName}
           descriptionText="Builds configured with this channel will stop receiving updates. This cannot be undone."
           confirmButtonText="Delete channel"
-          isDeletingButtonText="Deleting…"
+          isDeletingButtonText="Deleting..."
         />
-      )}
-
-      {CONTROL_PLANE_ENABLED && canManageRollout && (
-        <>
-          <StartRolloutDialog
-            channel={rolloutAction?.type === 'start' ? rolloutActionChannel : null}
-            onClose={() => setRolloutAction(null)}
-            onStarted={handleRolloutDone}
-          />
-          <ManageRolloutDialog
-            channel={rolloutAction?.type === 'manage' ? rolloutActionChannel : null}
-            onClose={() => setRolloutAction(null)}
-            onDone={handleRolloutDone}
-          />
-        </>
       )}
     </div>
   );

--- a/apps/dashboard/src/pages/Login/index.tsx
+++ b/apps/dashboard/src/pages/Login/index.tsx
@@ -122,15 +122,21 @@ export const Login = () => {
   }
 
   return (
-    <div className="flex min-h-screen w-full items-center justify-center bg-muted/50 px-4">
+    <div className="flex min-h-screen w-full items-center justify-center bg-background px-4">
       <div className="w-full max-w-sm">
-        <div className="rounded-2xl border bg-background p-8 shadow-elevated">
+        <div className="rounded-lg border bg-card p-8 shadow-elevated">
           <div className="mb-8 flex flex-col items-center gap-3 text-center">
-            <div className="flex h-11 w-11 items-center justify-center rounded-xl bg-primary text-primary-foreground">
+            <div className="flex h-11 w-11 items-center justify-center rounded-lg border border-primary/30 bg-primary/10 text-primary">
               <Radio className="h-5 w-5" strokeWidth={2} />
             </div>
             <div className="space-y-1">
-              <h1 className="text-lg font-semibold tracking-tight">Expo Open OTA</h1>
+              <h1 className="font-display text-lg font-semibold tracking-tight text-foreground">
+                Expo Open OTA
+                <span
+                  aria-hidden
+                  className="ml-1 inline-block h-1.5 w-1.5 rounded-full bg-primary"
+                />
+              </h1>
               <p className="text-sm text-muted-foreground">
                 Sign in to manage your over-the-air updates
               </p>

--- a/apps/dashboard/src/pages/Settings/index.tsx
+++ b/apps/dashboard/src/pages/Settings/index.tsx
@@ -110,9 +110,7 @@ export const Settings = () => {
 
         {!settings.CONTROL_PLANE_ENABLED && (
           <Section icon={UserRound} title="Expo account">
-            <Row
-              label="Account"
-              hint="Resolved from the configured Expo access token.">
+            <Row label="Account" hint="Resolved from the configured Expo access token.">
               {settings.EXPO_ACCOUNT_USERNAME ? (
                 <span className="font-medium">@{settings.EXPO_ACCOUNT_USERNAME}</span>
               ) : (
@@ -227,7 +225,9 @@ export const Settings = () => {
           )}
           {settings.CDN_TYPE === 'gcs-direct' && (
             <>
-              <Row label="Provider" hint="Assets are served through signed Google Cloud Storage URLs.">
+              <Row
+                label="Provider"
+                hint="Assets are served through signed Google Cloud Storage URLs.">
                 <span className="font-medium">Google Cloud Storage</span>
               </Row>
               <Row label="Bucket">
@@ -237,7 +237,9 @@ export const Settings = () => {
           )}
           {settings.CDN_TYPE === 'azure-direct' && (
             <>
-              <Row label="Provider" hint="Assets are served through signed Azure Blob Storage URLs.">
+              <Row
+                label="Provider"
+                hint="Assets are served through signed Azure Blob Storage URLs.">
                 <span className="font-medium">Azure Blob Storage</span>
               </Row>
               <Row label="Container">
@@ -247,7 +249,9 @@ export const Settings = () => {
           )}
           {settings.CDN_TYPE === 'generic' && (
             <>
-              <Row label="Provider" hint="Assets are redirected to a CDN in front of the storage bucket.">
+              <Row
+                label="Provider"
+                hint="Assets are redirected to a CDN in front of the storage bucket.">
                 <span className="font-medium">Custom CDN</span>
               </Row>
               <Row label="Base URL">

--- a/apps/dashboard/src/pages/Updates/components/BranchesTable/index.tsx
+++ b/apps/dashboard/src/pages/Updates/components/BranchesTable/index.tsx
@@ -1,385 +1,257 @@
-import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { api, ApiProblemError, BranchRecord, describeApiError } from '@/lib/api.ts';
-import { ApiError } from '@/components/APIError';
-import { DataTable } from '@/components/DataTable';
-import { GitBranch, Lock, Plus, ShieldAlert, Trash2 } from 'lucide-react';
-import { useSearchParams } from 'react-router';
+import { useMemo, useState } from 'react';
+import { useMutation, useQueries, useQuery, useQueryClient } from '@tanstack/react-query';
+import { Copy, GitBranch, Lock, Search, Trash2 } from 'lucide-react';
+import { useNavigate } from 'react-router';
+import { api, BranchRecord, describeApiError } from '@/lib/api';
 import { useSelectedApp } from '@/lib/SelectedAppContext';
-import { useCallback, useMemo, useState } from 'react';
-import { Button } from '@/components/ui/button';
-import { Badge } from '@/components/ui/badge';
-import { Switch } from '@/components/ui/switch';
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog';
-import { useToast } from '@/hooks/use-toast.ts';
-import { ResourceCreateForm } from '@/components/ui/resource-create-form';
-import { DeleteDialog } from '@/components/ui/delete-dialog';
-import { AdminOnlyNote } from '@/components/ui/admin-only-note';
 import { useSettings } from '@/lib/SettingsContext';
 import { useAppPermission } from '@/ee/lib/PermissionsContext';
-import { EnterpriseExplainerDialog } from '@/ee/components/EnterpriseExplainerDialog';
+import { useToast } from '@/hooks/use-toast';
+import { ApiError } from '@/components/APIError';
+import { DataTable } from '@/components/DataTable';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { Switch } from '@/components/ui/switch';
+import { TimestampCell } from '@/components/ui/timestamp-cell';
+import { DeleteDialog } from '@/components/ui/delete-dialog';
+import { AdminOnlyNote } from '@/components/ui/admin-only-note';
 
-interface TableColumnConfig {
-  header: string;
-  accessorKey?: keyof BranchRecord;
-  id?: string;
-  size?: number;
-  maxSize?: number;
-  cell: (props: { row: { original: BranchRecord } }) => React.ReactNode;
-}
+type BranchSummary = BranchRecord & {
+  latestRuntimeVersion?: string;
+  latestUpdateAt?: string;
+};
 
 export const BranchesTable = () => {
-  const { CONTROL_PLANE_ENABLED } = useSettings();
-  // Display gating only: the server re-checks each of these permissions on
-  // its route (admins always pass, members follow their enterprise grants).
-  const canCreateBranch = useAppPermission('branch:create');
-  const canDeleteBranch = useAppPermission('branch:delete');
-  const canProtectBranch = useAppPermission('branch:protect');
-  const [, setSearchParams] = useSearchParams();
-  const { selectedAppId } = useSelectedApp();
+  const navigate = useNavigate();
   const queryClient = useQueryClient();
   const { toast } = useToast();
-
-  const [newBranchName, setNewBranchName] = useState('');
-  const [isCreating, setIsCreating] = useState(false);
-
+  const { selectedAppId } = useSelectedApp();
+  const { CONTROL_PLANE_ENABLED } = useSettings();
+  const canDeleteBranch = useAppPermission('branch:delete');
+  const canProtectBranch = useAppPermission('branch:protect');
+  const [search, setSearch] = useState('');
   const [branchToDelete, setBranchToDelete] = useState<BranchRecord | null>(null);
+  const [branchBeingToggled, setBranchBeingToggled] = useState<string | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
 
-  // Branch protection is enterprise: without a valid license the toggle opens
-  // the explainer dialog instead of calling the API.
-  const [isExplainerOpen, setIsExplainerOpen] = useState(false);
-  const [branchBeingToggled, setBranchBeingToggled] = useState<string | null>(null);
-  // Protecting a branch can lock out CI tokens, so it goes through a
-  // confirmation; unprotecting is immediate.
-  const [branchToProtect, setBranchToProtect] = useState<BranchRecord | null>(null);
-  const [isProtecting, setIsProtecting] = useState(false);
-
-  const licenseQuery = useQuery({
-    queryKey: ['license'],
-    queryFn: () => api.getLicense(),
-    enabled: CONTROL_PLANE_ENABLED,
-  });
-  const isEnterprise = !!licenseQuery.data?.valid;
-
-  const { data, isLoading, error } = useQuery({
+  const branchesQuery = useQuery({
     queryKey: ['branches', selectedAppId],
     queryFn: () => api.getBranches(),
     enabled: !!selectedAppId,
   });
+  const runtimeQueries = useQueries({
+    queries: CONTROL_PLANE_ENABLED
+      ? []
+      : (branchesQuery.data ?? []).map(branch => ({
+          queryKey: ['runtimeVersions', selectedAppId, branch.branchName],
+          queryFn: () => api.getRuntimeVersions(branch.branchName),
+          enabled: !!selectedAppId,
+        })),
+  });
 
-   const applyProtection = useCallback(async (branch: BranchRecord, nextProtected: boolean) => {
+  const summaries = useMemo<BranchSummary[]>(() => {
+    const normalized = search.trim().toLowerCase();
+    return (branchesQuery.data ?? [])
+      .map((branch, index) => {
+        const latestRuntime = runtimeQueries[index]?.data?.[0];
+        return {
+          ...branch,
+          latestRuntimeVersion:
+            branch.currentUpdate?.runtimeVersion ?? latestRuntime?.runtimeVersion,
+          latestUpdateAt: branch.currentUpdate?.createdAt ?? latestRuntime?.lastUpdatedAt,
+        };
+      })
+      .filter(branch => !normalized || branch.branchName.toLowerCase().includes(normalized));
+  }, [branchesQuery.data, runtimeQueries, search]);
+
+  const protectionMutation = useMutation({
+    mutationFn: ({
+      branchName,
+      protected: isProtected,
+    }: {
+      branchName: string;
+      protected: boolean;
+    }) => api.setBranchProtection(branchName, isProtected),
+  });
+
+  const toggleProtection = async (branch: BranchRecord, next: boolean) => {
     setBranchBeingToggled(branch.branchName);
-    setIsProtecting(true);
     try {
-      await api.setBranchProtection(branch.branchName, nextProtected);
-      queryClient.invalidateQueries({ queryKey: ['branches', selectedAppId] });
+      await protectionMutation.mutateAsync({ branchName: branch.branchName, protected: next });
+      await queryClient.invalidateQueries({ queryKey: ['branches', selectedAppId] });
       toast({
-        title: nextProtected ? 'Branch protected' : 'Branch unprotected',
-        description: nextProtected
-          ? `Only tokens allowed on protected branches can publish to "${branch.branchName}" now.`
-          : `Any token can publish to "${branch.branchName}" again.`,
+        title: next ? 'Branch protected' : 'Branch unprotected',
+        description: `"${branch.branchName}" is now ${next ? 'protected' : 'unprotected'}.`,
       });
-      setBranchToProtect(null);
     } catch (error) {
-      const { title, description } = describeApiError(error, 'Could not update branch protection');
-      toast({ title, description, variant: 'destructive' });
+      const message = describeApiError(error, 'Could not update branch protection');
+      toast({ title: message.title, description: message.description, variant: 'destructive' });
     } finally {
       setBranchBeingToggled(null);
-      setIsProtecting(false);
-    }
-  }, [queryClient, selectedAppId, toast]);
-
-  const handleToggleProtection = useCallback((branch: BranchRecord, nextProtected: boolean) => {
-    if (!isEnterprise) {
-      setIsExplainerOpen(true);
-      return;
-    }
-    if (nextProtected) {
-      setBranchToProtect(branch);
-      return;
-    }
-    applyProtection(branch, false);
-  }, [isEnterprise, applyProtection]);
-
- 
-
-  const handleCreateBranch = async (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!newBranchName.trim()) return;
-
-    setIsCreating(true);
-    try {
-      await api.createBranch(newBranchName.trim());
-      setNewBranchName('');
-      queryClient.invalidateQueries({ queryKey: ['branches', selectedAppId] });
-      toast({
-        title: 'Branch created',
-        description: `"${newBranchName.trim()}" is ready to receive updates.`,
-      });
-    } catch (error) {
-      let errorTitle = 'Error creating branch';
-      let errorMessage = 'An unexpected error occurred.';
-      if (error instanceof ApiProblemError) {
-        errorTitle = error.title;
-        errorMessage = error.detail;
-      } else if (error instanceof Error) {
-        errorMessage = error.message;
-      }
-      toast({
-        title: errorTitle,
-        description: errorMessage,
-        variant: 'destructive',
-      });
-    } finally {
-      setIsCreating(false);
     }
   };
 
-  const handleExecuteDeletion = async () => {
+  const deleteBranch = async () => {
     if (!branchToDelete) return;
     setIsDeleting(true);
     try {
       await api.deleteBranch(branchToDelete.branchName);
-      queryClient.invalidateQueries({ queryKey: ['branches', selectedAppId] });
+      await queryClient.invalidateQueries({ queryKey: ['branches', selectedAppId] });
       toast({
         title: 'Branch deleted',
-        description: `"${branchToDelete.branchName}" and its updates were removed.`,
+        description: `"${branchToDelete.branchName}" was removed.`,
       });
       setBranchToDelete(null);
     } catch (error) {
-      let errorTitle = 'Deletion failed';
-      let errorMessage = 'Could not delete the branch.';
-      if (error instanceof ApiProblemError) {
-        errorTitle = error.title;
-        errorMessage = error.detail;
-      } else if (error instanceof Error) {
-        errorMessage = error.message;
-      }
-      toast({
-        title: errorTitle,
-        description: errorMessage,
-        variant: 'destructive',
-      });
+      const message = describeApiError(error, 'Could not delete branch');
+      toast({ title: message.title, description: message.description, variant: 'destructive' });
     } finally {
       setIsDeleting(false);
     }
   };
 
-  const tableColumns = useMemo<TableColumnConfig[]>(() => {
-    return [
-      {
-        header: 'Branch',
-        accessorKey: 'branchName',
-        cell: ({ row }) => (
-          <span className="flex items-center gap-2.5">
-            <span className="flex h-7 w-7 items-center justify-center rounded-md bg-muted text-muted-foreground">
-              <GitBranch className="h-3.5 w-3.5" />
-            </span>
-            <span className="font-medium">{row.original.branchName}</span>
-          </span>
+  const columns = [
+    {
+      header: 'Branch',
+      accessorKey: 'branchName',
+      cell: ({ row }: { row: { original: BranchSummary } }) => (
+        <span className="flex items-center gap-2.5 font-medium">
+          <GitBranch className="h-4 w-4 text-muted-foreground" />
+          {row.original.branchName}
+          {row.original.protected && (
+            <Lock className="h-3.5 w-3.5 text-emerald-700 dark:text-emerald-300" />
+          )}
+        </span>
+      ),
+    },
+    {
+      header: 'Latest runtime',
+      accessorKey: 'latestRuntimeVersion',
+      cell: ({ row }: { row: { original: BranchSummary } }) =>
+        row.original.latestRuntimeVersion ? (
+          <code className="font-mono text-xs">{row.original.latestRuntimeVersion}</code>
+        ) : (
+          <span className="text-muted-foreground/60">None</span>
         ),
-      },
-      {
-        header: 'Release channel',
-        accessorKey: 'releaseChannel',
-        cell: ({ row }) => {
-          const releaseChannel = row.original.releaseChannel;
-          if (!releaseChannel) {
-            return <span className="text-muted-foreground/60">Not mapped</span>;
-          }
-          return <Badge variant="outline">{releaseChannel}</Badge>;
-        },
-      },
-      ...(CONTROL_PLANE_ENABLED
-        ? [
-            {
-              header: 'Protection',
-              id: 'protection',
-              cell: ({ row }) => {
-                const isProtected = row.original.protected;
-                const label = (
-                  <span
-                    className={
-                      isProtected
-                        ? 'inline-flex items-center gap-1 text-sm font-medium text-emerald-700'
-                        : 'text-sm text-muted-foreground'
-                    }
-                  >
-                    {isProtected && <Lock className="h-3.5 w-3.5" />}
-                    {isProtected ? 'Protected' : 'Unprotected'}
-                  </span>
-                );
-                // Without the permission the state is read-only; the server
-                // gates the write anyway.
-                if (!canProtectBranch) {
-                  return label;
+    },
+    {
+      header: 'Latest update',
+      accessorKey: 'latestUpdateAt',
+      cell: ({ row }: { row: { original: BranchSummary } }) =>
+        row.original.latestUpdateAt ? (
+          <TimestampCell dateString={row.original.latestUpdateAt} />
+        ) : (
+          <span className="text-muted-foreground/60">None</span>
+        ),
+    },
+    {
+      header: 'ID',
+      accessorKey: 'branchId',
+      cell: ({ row }: { row: { original: BranchSummary } }) => (
+        <div className="flex items-center gap-1">
+          <code className="max-w-32 truncate font-mono text-xs text-muted-foreground">
+            {row.original.branchId || 'Legacy'}
+          </code>
+          {row.original.branchId && (
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-7 w-7"
+              title="Copy branch ID"
+              onClick={event => {
+                event.stopPropagation();
+                void navigator.clipboard.writeText(row.original.branchId as string);
+              }}>
+              <Copy className="h-3.5 w-3.5" />
+            </Button>
+          )}
+        </div>
+      ),
+    },
+    ...(CONTROL_PLANE_ENABLED && canProtectBranch
+      ? [
+          {
+            header: 'Protected',
+            id: 'protected',
+            cell: ({ row }: { row: { original: BranchSummary } }) => (
+              <div onClick={event => event.stopPropagation()}>
+                <Switch
+                  checked={row.original.protected}
+                  disabled={branchBeingToggled === row.original.branchName}
+                  onCheckedChange={next => void toggleProtection(row.original, next)}
+                  aria-label={row.original.protected ? 'Unprotect branch' : 'Protect branch'}
+                />
+              </div>
+            ),
+          },
+        ]
+      : []),
+    ...(CONTROL_PLANE_ENABLED && canDeleteBranch
+      ? [
+          {
+            header: '',
+            id: 'actions',
+            cell: ({ row }: { row: { original: BranchSummary } }) => (
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-8 w-8 text-muted-foreground hover:bg-destructive/10 hover:text-destructive"
+                title={
+                  row.original.protected
+                    ? 'Unprotect this branch before deleting it'
+                    : 'Delete branch'
                 }
-                return (
-                  <div className="flex items-center gap-2.5" onClick={e => e.stopPropagation()}>
-                    <Switch
-                      checked={isProtected}
-                      disabled={branchBeingToggled === row.original.branchName}
-                      onCheckedChange={next => handleToggleProtection(row.original, next)}
-                      aria-label={isProtected ? 'Unprotect branch' : 'Protect branch'}
-                    />
-                    {label}
-                  </div>
-                );
-              },
-            } satisfies TableColumnConfig,
-          ]
-        : []),
-      ...(CONTROL_PLANE_ENABLED && canDeleteBranch
-        ? [
-            {
-              header: '',
-              id: 'actions',
-              cell: ({ row }) => {
-                const isProtected = row.original.protected;
-                return (
-                  <div
-                    className="text-right"
-                    title={
-                      isProtected
-                        ? 'Protected branches cannot be deleted. Remove the protection first.'
-                        : undefined
-                    }
-                  >
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      onClick={e => {
-                        e.stopPropagation();
-                        setBranchToDelete(row.original);
-                      }}
-                      disabled={isProtected}
-                      className="h-8 w-8 p-0 text-muted-foreground hover:bg-destructive/10 hover:text-destructive"
-                      title={isProtected ? undefined : 'Delete branch'}
-                    >
-                      <Trash2 />
-                    </Button>
-                  </div>
-                );
-              },
-            } satisfies TableColumnConfig,
-          ]
-        : []),
-    ];
-  }, [
-    CONTROL_PLANE_ENABLED,
-    canDeleteBranch,
-    canProtectBranch,
-    branchBeingToggled,
-    handleToggleProtection,
-  ]);
+                disabled={row.original.protected}
+                onClick={event => {
+                  event.stopPropagation();
+                  setBranchToDelete(row.original);
+                }}>
+                <Trash2 className="h-4 w-4" />
+              </Button>
+            ),
+          },
+        ]
+      : []),
+  ];
 
   return (
-    <div className="w-full flex-1 space-y-4">
-      {!!error && <ApiError error={error} />}
-
-      {CONTROL_PLANE_ENABLED && !canCreateBranch && !canDeleteBranch && !canProtectBranch && (
-        <AdminOnlyNote>
-          You do not have permission to manage branches on this app. Ask an admin to grant you
-          access.
-        </AdminOnlyNote>
+    <div className="space-y-4">
+      {!!branchesQuery.error && <ApiError error={branchesQuery.error} />}
+      {CONTROL_PLANE_ENABLED && !canDeleteBranch && !canProtectBranch && (
+        <AdminOnlyNote>Branch management is read-only for your account.</AdminOnlyNote>
       )}
-      {CONTROL_PLANE_ENABLED && canCreateBranch && (
-        <div className="flex justify-end">
-          <ResourceCreateForm
-            id="branch-name"
-            label="New branch name"
-            placeholder="New branch name, e.g. main"
-            inputValue={newBranchName}
-            onInputChange={setNewBranchName}
-            onSubmit={() => handleCreateBranch({ preventDefault: () => {} } as React.FormEvent)}
-            isSubmitting={isCreating}
-            buttonText="Create branch"
-            icon={Plus}
-          />
-        </div>
-      )}
-
+      <div className="relative max-w-sm">
+        <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+        <Input
+          aria-label="Search branches"
+          placeholder="Search branches"
+          value={search}
+          onChange={event => setSearch(event.target.value)}
+          className="pl-9"
+        />
+      </div>
       <DataTable
-        loading={isLoading}
-        columns={tableColumns}
-        data={data ?? []}
-        emptyMessage="No branches yet. Publish an update or create a branch to get started."
-        onRowClick={row => setSearchParams({ branch: row.branchName })}
+        loading={
+          branchesQuery.isLoading || runtimeQueries.some(runtimeQuery => runtimeQuery.isLoading)
+        }
+        columns={columns}
+        data={summaries}
+        emptyMessage={search ? 'No branches match this search.' : 'No branches yet.'}
+        onRowClick={row => navigate(`/branches/${encodeURIComponent(row.branchName)}`)}
       />
-
       {CONTROL_PLANE_ENABLED && canDeleteBranch && (
         <DeleteDialog
           isOpen={!!branchToDelete}
           onClose={() => setBranchToDelete(null)}
-          onConfirm={handleExecuteDeletion}
+          onConfirm={deleteBranch}
           isDeleting={isDeleting}
           title="Delete branch"
           resourceName={branchToDelete?.branchName}
-          descriptionText="Every update published to this branch will be permanently deleted. Apps pointing at a channel mapped to this branch will stop receiving updates."
+          descriptionText="Updates on this branch will no longer be reachable from the dashboard. This cannot be undone."
           confirmButtonText="Delete branch"
-          isDeletingButtonText="Deleting…"
+          isDeletingButtonText="Deleting..."
         />
       )}
-
-      <Dialog
-        open={!!branchToProtect}
-        onOpenChange={open => !open && !isProtecting && setBranchToProtect(null)}
-      >
-        <DialogContent className="sm:max-w-[420px]">
-          <DialogHeader className="flex flex-col items-start gap-2">
-            <div className="flex h-9 w-9 items-center justify-center rounded-full border border-emerald-200 bg-emerald-50 text-emerald-600">
-              <ShieldAlert className="h-5 w-5" />
-            </div>
-            <DialogTitle className="mt-2 text-lg font-semibold tracking-tight">
-              Protect this branch?
-            </DialogTitle>
-            <DialogDescription className="pt-1 text-left text-muted-foreground">
-              Once{' '}
-              <strong className="font-semibold text-foreground">
-                "{branchToProtect?.branchName}"
-              </strong>{' '}
-              is protected, only API tokens explicitly allowed on protected branches can publish,
-              roll back or republish on it. Tokens handed to developers will be blocked, and the
-              branch cannot be deleted until the protection is lifted.
-            </DialogDescription>
-          </DialogHeader>
-          <DialogFooter className="mt-4 gap-2 border-t pt-3 sm:gap-0">
-            <Button
-              type="button"
-              variant="outline"
-              onClick={() => setBranchToProtect(null)}
-              disabled={isProtecting}
-            >
-              Cancel
-            </Button>
-            <Button
-              type="button"
-              onClick={() => branchToProtect && applyProtection(branchToProtect, true)}
-              disabled={isProtecting}
-              className="bg-emerald-600 text-white hover:bg-emerald-700"
-            >
-              {isProtecting ? 'Protecting…' : 'Protect branch'}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-
-      <EnterpriseExplainerDialog
-        open={isExplainerOpen}
-        onOpenChange={setIsExplainerOpen}
-        feature={{
-          name: 'Branch protection',
-          description:
-            'Protect critical branches like production. Once a branch is protected, only API tokens you explicitly allow can publish, roll back or republish on it, so a token handed to a developer for staging can never ship to production.',
-        }}
-      />
     </div>
   );
 };

--- a/apps/dashboard/src/pages/Updates/components/RuntimeVersionsTable/index.tsx
+++ b/apps/dashboard/src/pages/Updates/components/RuntimeVersionsTable/index.tsx
@@ -3,14 +3,17 @@ import { api } from '@/lib/api.ts';
 import { ApiError } from '@/components/APIError';
 import { DataTable } from '@/components/DataTable';
 import { Milestone } from 'lucide-react';
-import { useSearchParams } from 'react-router';
 import { Badge } from '@/components/ui/badge.tsx';
 import { useSelectedApp } from '@/lib/SelectedAppContext';
 import { TimestampCell } from '@/components/ui/timestamp-cell';
-import { UpdatesBreadcrumb } from '@/pages/Updates/components/UpdatesBreadcrumb';
 
-export const RuntimeVersionsTable = ({ branch }: { branch: string }) => {
-  const [, setSearchParams] = useSearchParams();
+export const RuntimeVersionsTable = ({
+  branch,
+  onSelectRuntime,
+}: {
+  branch: string;
+  onSelectRuntime: (runtimeVersion: string) => void;
+}) => {
   const { selectedAppId } = useSelectedApp();
   const { data, isLoading, error } = useQuery({
     queryKey: ['runtimeVersions', selectedAppId, branch],
@@ -20,7 +23,6 @@ export const RuntimeVersionsTable = ({ branch }: { branch: string }) => {
 
   return (
     <div className="w-full flex-1">
-      <UpdatesBreadcrumb branch={branch} />
       {!!error && <ApiError error={error} />}
       <DataTable
         loading={isLoading}
@@ -34,9 +36,11 @@ export const RuntimeVersionsTable = ({ branch }: { branch: string }) => {
                   <Milestone className="h-3.5 w-3.5" />
                 </span>
                 <span className="font-medium">{row.original.runtimeVersion}</span>
-                {row.original.activeRollout && (
-                  <Badge className="border-transparent bg-emerald-100 text-emerald-700">
-                    Rollout
+                {(row.original.rolloutPercentage != null || row.original.activeRollout) && (
+                  <Badge className="border-emerald-400/25 bg-emerald-400/10 text-emerald-700 dark:text-emerald-300">
+                    {row.original.rolloutPercentage != null
+                      ? `${row.original.rolloutPercentage}% rollout`
+                      : 'Rollout'}
                   </Badge>
                 )}
               </span>
@@ -45,9 +49,7 @@ export const RuntimeVersionsTable = ({ branch }: { branch: string }) => {
           {
             header: 'Created',
             accessorKey: 'createdAt',
-            cell: ({ row }) => (
-              <TimestampCell dateString={row.original.createdAt} showSeconds />
-            ),
+            cell: ({ row }) => <TimestampCell dateString={row.original.createdAt} showSeconds />,
           },
           {
             header: 'Last update',
@@ -67,7 +69,7 @@ export const RuntimeVersionsTable = ({ branch }: { branch: string }) => {
         data={data ?? []}
         defaultSorting={[{ id: 'createdAt', desc: true }]}
         emptyMessage="No runtime versions on this branch yet."
-        onRowClick={row => setSearchParams({ branch, runtimeVersion: row.runtimeVersion })}
+        onRowClick={row => onSelectRuntime(row.runtimeVersion)}
       />
     </div>
   );

--- a/apps/dashboard/src/pages/Updates/components/UpdateRolloutCard.tsx
+++ b/apps/dashboard/src/pages/Updates/components/UpdateRolloutCard.tsx
@@ -6,7 +6,7 @@ import { useSelectedApp } from '@/lib/SelectedAppContext';
 import { useToast } from '@/hooks/use-toast';
 import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
+import { PercentInput } from '@/components/rollout/PercentInput';
 import {
   Dialog,
   DialogContent,
@@ -51,15 +51,16 @@ export const UpdateRolloutCard = ({
 
   const [confirm, setConfirm] = useState<'finish' | 'revert' | null>(null);
 
-  const invalidate = (endsRollout: boolean) => {
+  const invalidate = () => {
     queryClient.invalidateQueries({ queryKey: ['updates', selectedAppId, branch, runtimeVersion] });
     queryClient.invalidateQueries({
       queryKey: ['update-rollout', selectedAppId, branch, runtimeVersion],
     });
+    queryClient.invalidateQueries({ queryKey: ['update-feed', selectedAppId] });
+    queryClient.invalidateQueries({ queryKey: ['runtimeVersions', selectedAppId, branch] });
     queryClient.invalidateQueries({ queryKey: ['update-details', selectedAppId] });
-    if (endsRollout) {
-      queryClient.invalidateQueries({ queryKey: ['runtimeVersions', selectedAppId, branch] });
-    }
+    queryClient.invalidateQueries({ queryKey: ['branches', selectedAppId] });
+    queryClient.invalidateQueries({ queryKey: ['channels', selectedAppId] });
   };
 
   const isValidNextPercentage =
@@ -77,7 +78,7 @@ export const UpdateRolloutCard = ({
         title: 'Rollout updated',
         description: `Update ${updateId} now rolls out to ${nextPercentage}% of devices.`,
       });
-      invalidate(false);
+      invalidate();
     } catch (error) {
       const { title, description } = describeApiError(error, 'Could not update the rollout');
       toast({ title, description, variant: 'destructive' });
@@ -97,7 +98,7 @@ export const UpdateRolloutCard = ({
         title: 'Rollout finished',
         description: `Update ${updateId} is now delivered to all devices.`,
       });
-      invalidate(true);
+      invalidate();
       setConfirm(null);
     } catch (error) {
       const { title, description } = describeApiError(error, 'Could not finish the rollout');
@@ -116,7 +117,7 @@ export const UpdateRolloutCard = ({
         description:
           'The previous update was republished. Devices return to it after their next update check.',
       });
-      invalidate(true);
+      invalidate();
       setConfirm(null);
     } catch (error) {
       const { title, description } = describeApiError(error, 'Could not revert the rollout');
@@ -130,10 +131,10 @@ export const UpdateRolloutCard = ({
 
   return (
     <>
-      <Card className="mb-4 border-emerald-200 bg-emerald-50/40">
-        <CardContent className="flex flex-col gap-4 p-4 sm:flex-row sm:items-center sm:justify-between">
+      <Card className="mb-4 border-emerald-400/25 bg-emerald-400/[0.07]">
+        <CardContent className="space-y-5 p-4">
           <div className="space-y-1.5">
-            <span className="inline-flex items-center gap-1.5 rounded-full border border-emerald-200 bg-emerald-50 px-2.5 py-0.5 text-xs font-medium text-emerald-700">
+            <span className="inline-flex items-center gap-1.5 rounded-full border border-emerald-400/25 bg-emerald-400/10 px-2.5 py-0.5 text-xs font-medium text-emerald-700 dark:text-emerald-300">
               <Split className="h-3.5 w-3.5" />
               Rollout in progress
             </span>
@@ -145,45 +146,48 @@ export const UpdateRolloutCard = ({
           </div>
 
           {canManageRollout && (
-            <div className="flex flex-wrap items-center gap-2">
+            <div className="space-y-4 border-t pt-4">
               {canIncrease && (
-                <div className="flex items-center gap-1.5">
-                  <Input
-                    type="number"
-                    min={percentage + 1}
-                    max={99}
+                <div className="space-y-3">
+                  <div>
+                    <p className="text-sm font-medium text-foreground">Increase rollout</p>
+                    <p className="text-xs text-muted-foreground">
+                      Choose a larger audience. Rollouts cannot be decreased.
+                    </p>
+                  </div>
+                  <PercentInput
                     value={nextPercentage}
                     disabled={isBusy}
-                    onChange={e => setNextPercentage(Number(e.target.value))}
-                    className="h-8 w-16"
+                    min={percentage + 1}
+                    max={99}
+                    onChange={setNextPercentage}
                   />
                   <Button
                     type="button"
-                    size="sm"
-                    variant="outline"
+                    className="w-full"
                     disabled={isBusy || !isValidNextPercentage}
                     onClick={handleIncrease}>
-                    Increase
+                    Increase to {nextPercentage}%
                   </Button>
                 </div>
               )}
-              <Button
-                type="button"
-                size="sm"
-                disabled={isBusy}
-                onClick={() => setConfirm('finish')}
-                className="bg-emerald-600 text-white hover:bg-emerald-700">
-                Finish rollout
-              </Button>
-              <Button
-                type="button"
-                size="sm"
-                variant="ghost"
-                disabled={isBusy}
-                onClick={() => setConfirm('revert')}
-                className="text-destructive hover:bg-destructive/10 hover:text-destructive">
-                Revert
-              </Button>
+              <div className="grid grid-cols-2 gap-2">
+                <Button
+                  type="button"
+                  variant="outline"
+                  disabled={isBusy}
+                  onClick={() => setConfirm('finish')}>
+                  Finish rollout
+                </Button>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  disabled={isBusy}
+                  onClick={() => setConfirm('revert')}
+                  className="text-destructive hover:bg-destructive/10 hover:text-destructive">
+                  Revert
+                </Button>
+              </div>
             </div>
           )}
         </CardContent>
@@ -194,7 +198,7 @@ export const UpdateRolloutCard = ({
         onOpenChange={open => !open && !isBusy && setConfirm(null)}>
         <DialogContent className="sm:max-w-[420px]">
           <DialogHeader className="flex flex-col items-start gap-2">
-            <div className="flex h-9 w-9 items-center justify-center rounded-full border border-emerald-200 bg-emerald-50 text-emerald-600">
+            <div className="flex h-9 w-9 items-center justify-center rounded-full border border-emerald-400/25 bg-emerald-400/10 text-emerald-700 dark:text-emerald-300">
               <CheckCircle2 className="h-5 w-5" />
             </div>
             <DialogTitle className="mt-2 text-lg font-semibold tracking-tight">
@@ -213,11 +217,7 @@ export const UpdateRolloutCard = ({
               disabled={isBusy}>
               Cancel
             </Button>
-            <Button
-              type="button"
-              onClick={handleFinish}
-              disabled={isBusy}
-              className="bg-emerald-600 text-white hover:bg-emerald-700">
+            <Button type="button" onClick={handleFinish} disabled={isBusy}>
               {isBusy ? 'Finishing…' : 'Finish rollout'}
             </Button>
           </DialogFooter>

--- a/apps/dashboard/src/pages/Updates/components/UpdateRolloutManagerSheet.tsx
+++ b/apps/dashboard/src/pages/Updates/components/UpdateRolloutManagerSheet.tsx
@@ -1,0 +1,87 @@
+import { useQuery } from '@tanstack/react-query';
+import { Gauge } from 'lucide-react';
+import { api } from '@/lib/api';
+import { useSelectedApp } from '@/lib/SelectedAppContext';
+import { ApiError } from '@/components/APIError';
+import { Skeleton } from '@/components/ui/skeleton';
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from '@/components/ui/sheet';
+import { UpdateRolloutCard } from '@/pages/Updates/components/UpdateRolloutCard';
+
+export type ManagedUpdateRollout = {
+  branch: string;
+  runtimeVersion: string;
+};
+
+export const UpdateRolloutManagerSheet = ({
+  rollout,
+  onClose,
+  canManageRollout,
+}: {
+  rollout: ManagedUpdateRollout | null;
+  onClose: () => void;
+  canManageRollout: boolean;
+}) => {
+  const { selectedAppId } = useSelectedApp();
+  const rolloutQuery = useQuery({
+    queryKey: ['update-rollout', selectedAppId, rollout?.branch, rollout?.runtimeVersion],
+    queryFn: () => api.getUpdateRollout(rollout!.branch, rollout!.runtimeVersion),
+    enabled: !!selectedAppId && !!rollout,
+  });
+  const activeUpdates = rolloutQuery.data?.active ? rolloutQuery.data.updates : [];
+
+  return (
+    <Sheet open={!!rollout} onOpenChange={open => !open && onClose()}>
+      <SheetContent className="w-full overflow-y-auto sm:max-w-lg">
+        <SheetHeader className="border-b pb-5 pr-8">
+          <div className="mb-2 flex h-9 w-9 items-center justify-center rounded-md border border-emerald-400/25 bg-emerald-400/10 text-emerald-700 dark:text-emerald-300">
+            <Gauge className="h-4 w-4" />
+          </div>
+          <SheetTitle>Manage update rollout</SheetTitle>
+          <SheetDescription>
+            {rollout ? (
+              <>
+                <span className="font-medium text-foreground">{rollout.branch}</span>
+                <span className="px-1.5">·</span>
+                {rollout.runtimeVersion}
+              </>
+            ) : (
+              'Update rollout'
+            )}
+          </SheetDescription>
+        </SheetHeader>
+
+        <div className="pt-5">
+          {rolloutQuery.isLoading && (
+            <div className="space-y-3">
+              <Skeleton className="h-6 w-40" />
+              <Skeleton className="h-24 w-full" />
+            </div>
+          )}
+          {!!rolloutQuery.error && <ApiError error={rolloutQuery.error} />}
+          {!rolloutQuery.isLoading && !rolloutQuery.error && activeUpdates.length === 0 && (
+            <div className="rounded-lg border border-dashed p-6 text-center">
+              <p className="font-medium text-foreground">This rollout has ended</p>
+              <p className="mt-1 text-sm text-muted-foreground">
+                Refresh the feed to see the current update state.
+              </p>
+            </div>
+          )}
+          {rollout && activeUpdates.length > 0 && (
+            <UpdateRolloutCard
+              branch={rollout.branch}
+              runtimeVersion={rollout.runtimeVersion}
+              updates={activeUpdates}
+              canManageRollout={canManageRollout}
+            />
+          )}
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+};

--- a/apps/dashboard/src/pages/Updates/components/UpdatesTable/index.tsx
+++ b/apps/dashboard/src/pages/Updates/components/UpdatesTable/index.tsx
@@ -17,9 +17,11 @@ import { UpdateRolloutCard } from '@/pages/Updates/components/UpdateRolloutCard'
 export const UpdatesTable = ({
   branch,
   runtimeVersion,
+  showBreadcrumb = true,
 }: {
   branch: string;
   runtimeVersion: string;
+  showBreadcrumb?: boolean;
 }) => {
   const sheetRef = useRef<UpdateDetailsRef>(null);
   const { selectedAppId } = useSelectedApp();
@@ -43,7 +45,7 @@ export const UpdatesTable = ({
 
   return (
     <div className="w-full flex-1">
-      <UpdatesBreadcrumb branch={branch} runtimeVersion={runtimeVersion} />
+      {showBreadcrumb && <UpdatesBreadcrumb branch={branch} runtimeVersion={runtimeVersion} />}
       {!!error && <ApiError error={error} />}
       {!!rolloutQuery.error && <ApiError error={rolloutQuery.error} />}
       {CONTROL_PLANE_ENABLED && activeRollout.length > 0 && (
@@ -80,8 +82,10 @@ export const UpdatesTable = ({
               const isAndroid = row.original.platform === 'android';
               return (
                 <div className="flex items-center gap-2">
-                  {isIos && <img src={apple} className="w-4" alt="iOS" />}
-                  {isAndroid && <img src={android} className="w-4" alt="Android" />}
+                  {isIos && <img src={apple} className="w-4 brightness-0 dark:invert" alt="iOS" />}
+                  {isAndroid && (
+                    <img src={android} className="w-4 brightness-0 dark:invert" alt="Android" />
+                  )}
                 </div>
               );
             },
@@ -120,7 +124,7 @@ export const UpdatesTable = ({
                     const update = row.original;
                     if (update.rolloutPercentage != null) {
                       return (
-                        <Badge className="border-transparent bg-emerald-100 text-emerald-700">
+                        <Badge className="border-emerald-400/25 bg-emerald-400/10 text-emerald-700 dark:text-emerald-300">
                           {update.rolloutPercentage}% rollout
                         </Badge>
                       );

--- a/apps/dashboard/src/pages/Updates/index.tsx
+++ b/apps/dashboard/src/pages/Updates/index.tsx
@@ -1,32 +1,669 @@
-import { useSearchParams } from 'react-router';
-import { useMemo } from 'react';
-import { BranchesTable } from '@/pages/Updates/components/BranchesTable';
-import { RuntimeVersionsTable } from '@/pages/Updates/components/RuntimeVersionsTable';
-import { UpdatesTable } from '@/pages/Updates/components/UpdatesTable';
+import { Fragment, ReactNode, useMemo, useRef, useState } from 'react';
+import { useInfiniteQuery, useQuery } from '@tanstack/react-query';
+import {
+  ChevronDown,
+  ChevronRight,
+  Box,
+  Gauge,
+  GitBranch,
+  GitCommitHorizontal,
+  Layers3,
+  Loader2,
+  Search,
+  SlidersHorizontal,
+  X,
+} from 'lucide-react';
+import { Link, useSearchParams } from 'react-router';
+import { api, UpdateFeedRecord } from '@/lib/api';
+import { useSelectedApp } from '@/lib/SelectedAppContext';
+import { useAppPermission } from '@/ee/lib/PermissionsContext';
 import { PageHeader } from '@/components/PageHeader';
+import { ApiError } from '@/components/APIError';
+import { Combobox } from '@/components/Combobox';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { Skeleton } from '@/components/ui/skeleton';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { TimestampCell } from '@/components/ui/timestamp-cell';
+import { UpdateDetailsRef, UpdateDetailsSheet } from '@/components/UpdateDetailsSheet';
+import {
+  ManagedUpdateRollout,
+  UpdateRolloutManagerSheet,
+} from '@/pages/Updates/components/UpdateRolloutManagerSheet';
+import apple from '@/assets/apple.svg';
+import android from '@/assets/android.svg';
+
+type FeedGroup = {
+  key: string;
+  publishGroup?: string;
+  updates: UpdateFeedRecord[];
+};
+
+type FeedFilterKey =
+  | 'branch'
+  | 'runtimeVersion'
+  | 'platform'
+  | 'uuid'
+  | 'groupId'
+  | 'commitHash'
+  | 'from'
+  | 'to';
+
+type FeedFilters = Record<FeedFilterKey, string>;
+
+const FilterField = ({ label, children }: { label: string; children: ReactNode }) => (
+  <label className="min-w-0 space-y-1.5">
+    <span className="block text-xs font-medium text-muted-foreground">{label}</span>
+    {children}
+  </label>
+);
+
+const ClearableInput = ({
+  value,
+  onValueChange,
+  onClear,
+  icon,
+  ...props
+}: {
+  value: string;
+  onValueChange: (value: string) => void;
+  onClear: () => void;
+  icon?: ReactNode;
+} & Omit<React.ComponentProps<typeof Input>, 'value' | 'onChange'>) => (
+  <div className="relative">
+    {icon && (
+      <span className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground">
+        {icon}
+      </span>
+    )}
+    <Input
+      {...props}
+      value={value}
+      onChange={event => onValueChange(event.target.value)}
+      className={`${icon ? 'pl-9' : ''} pr-9 ${props.className ?? ''}`}
+    />
+    {value && (
+      <button
+        type="button"
+        aria-label="Clear field"
+        onClick={onClear}
+        className="absolute right-2 top-1/2 flex h-6 w-6 -translate-y-1/2 items-center justify-center rounded text-muted-foreground hover:bg-accent hover:text-foreground">
+        <X className="h-3.5 w-3.5" />
+      </button>
+    )}
+  </div>
+);
+
+const PlatformIcon = ({ platform }: { platform: string }) => {
+  const src = platform === 'ios' ? apple : platform === 'android' ? android : null;
+  if (!src) return <span className="text-xs text-muted-foreground">{platform}</span>;
+  return (
+    <span
+      className="inline-flex h-7 w-7 items-center justify-center rounded-md border bg-secondary"
+      title={platform === 'ios' ? 'iOS' : 'Android'}>
+      <img
+        src={src}
+        className="h-3.5 w-3.5 brightness-0 opacity-80 dark:invert"
+        alt={platform === 'ios' ? 'iOS' : 'Android'}
+      />
+    </span>
+  );
+};
+
+const shortId = (value: string) => (value.length > 10 ? value.slice(0, 8) : value);
+
+const UpdateRolloutBadge = ({ percentage }: { percentage: number }) => (
+  <Badge className="h-5 whitespace-nowrap border-emerald-400/25 bg-emerald-400/10 px-1.5 text-[11px] text-emerald-700 dark:text-emerald-300">
+    <Gauge className="h-2.5 w-2.5" />
+    {percentage}% rollout
+  </Badge>
+);
+
+const RuntimeLabel = ({ value }: { value: string }) => (
+  <span
+    className="inline-flex max-w-full items-center gap-1.5 rounded-md border border-amber-400/25 bg-amber-400/[0.08] px-2 py-1 text-xs font-medium text-amber-800 dark:border-amber-300/20 dark:bg-amber-300/[0.07] dark:text-amber-100"
+    title={value}>
+    <Box className="h-3 w-3 shrink-0 text-amber-600 dark:text-amber-300/80" />
+    <span className="truncate">{value}</span>
+  </span>
+);
+
+const CommitLabel = ({ value }: { value: string }) => (
+  <span className="inline-flex items-center gap-1.5 rounded-md border border-primary/20 bg-primary/[0.07] px-2 py-1 text-xs font-medium text-link">
+    <GitCommitHorizontal className="h-3 w-3 text-link/80" />
+    {shortId(value)}
+  </span>
+);
+
+const BranchLink = ({ branch }: { branch: string }) => (
+  <Link
+    to={`/branches/${encodeURIComponent(branch)}`}
+    onClick={event => event.stopPropagation()}
+    className="inline-flex max-w-full items-center gap-1.5 font-medium text-foreground transition-colors hover:text-link">
+    <GitBranch className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+    <span className="truncate">{branch}</span>
+  </Link>
+);
 
 export const Updates = () => {
-  const [searchParams] = useSearchParams();
-  const currentBranch = searchParams.get('branch');
-  const runtimeVersion = searchParams.get('runtimeVersion');
+  const { selectedAppId } = useSelectedApp();
+  const canManageUpdateRollout = useAppPermission('update-rollout:manage');
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [expandedGroups, setExpandedGroups] = useState<Set<string>>(new Set());
+  const [managedRollout, setManagedRollout] = useState<ManagedUpdateRollout | null>(null);
+  const sheetRef = useRef<UpdateDetailsRef>(null);
 
-  const component = useMemo(() => {
-    if (!currentBranch) {
-      return <BranchesTable />;
+  const filters: FeedFilters = {
+    branch: searchParams.get('branch') ?? '',
+    runtimeVersion: searchParams.get('runtimeVersion') ?? '',
+    platform: searchParams.get('platform') ?? '',
+    uuid: searchParams.get('uuid') ?? '',
+    groupId: searchParams.get('groupId') ?? '',
+    commitHash: searchParams.get('commitHash') ?? '',
+    from: searchParams.get('from') ?? '',
+    to: searchParams.get('to') ?? '',
+  };
+  const filterKey = [
+    filters.branch,
+    filters.runtimeVersion,
+    filters.platform,
+    filters.uuid,
+    filters.groupId,
+    filters.commitHash,
+    filters.from,
+    filters.to,
+  ];
+
+  const query = useInfiniteQuery({
+    queryKey: ['update-feed', selectedAppId, ...filterKey],
+    queryFn: ({ pageParam }) =>
+      api.getUpdateFeed({
+        ...filters,
+        cursor: pageParam || undefined,
+        limit: 50,
+      }),
+    initialPageParam: '',
+    getNextPageParam: page => page.nextCursor,
+    enabled: !!selectedAppId,
+  });
+  const branchesQuery = useQuery({
+    queryKey: ['branches', selectedAppId],
+    queryFn: () => api.getBranches(),
+    enabled: !!selectedAppId,
+  });
+  const runtimeVersionsQuery = useQuery({
+    queryKey: ['runtimeVersions', selectedAppId, filters.branch],
+    queryFn: () => api.getRuntimeVersions(filters.branch),
+    enabled: !!selectedAppId && !!filters.branch,
+  });
+
+  const updates = useMemo(() => query.data?.pages.flatMap(page => page.items) ?? [], [query.data]);
+  const branchOptions = useMemo(
+    () =>
+      (branchesQuery.data ?? [])
+        .map(branch => ({ value: branch.branchName, label: branch.branchName }))
+        .sort((a, b) => a.label.localeCompare(b.label)),
+    [branchesQuery.data]
+  );
+  const platformOptions = [
+    { value: 'ios', label: 'iOS' },
+    { value: 'android', label: 'Android' },
+  ];
+  const runtimeVersionOptions = useMemo(
+    () =>
+      (runtimeVersionsQuery.data ?? [])
+        .map(runtime => ({
+          value: runtime.runtimeVersion,
+          label: runtime.runtimeVersion,
+        }))
+        .sort((a, b) => a.label.localeCompare(b.label)),
+    [runtimeVersionsQuery.data]
+  );
+
+  const setFilters = (values: Partial<FeedFilters>) => {
+    const next = new URLSearchParams(searchParams);
+    for (const [key, value] of Object.entries(values)) {
+      if (value) next.set(key, value);
+      else next.delete(key);
     }
-    if (!runtimeVersion) {
-      return <RuntimeVersionsTable branch={currentBranch} />;
+    setSearchParams(next, { replace: true });
+  };
+  const setFilter = (key: FeedFilterKey, value: string) => setFilters({ [key]: value });
+
+  const groups = useMemo(() => {
+    const byKey = new Map<string, FeedGroup>();
+    for (const update of updates) {
+      const key = update.publishGroup
+        ? `group:${update.publishGroup}`
+        : `update:${update.updateId}:${update.branch}`;
+      const current = byKey.get(key);
+      if (current) current.updates.push(update);
+      else
+        byKey.set(key, { key, publishGroup: update.publishGroup ?? undefined, updates: [update] });
     }
-    return <UpdatesTable branch={currentBranch} runtimeVersion={runtimeVersion} />;
-  }, [currentBranch, runtimeVersion]);
+    return Array.from(byKey.values());
+  }, [updates]);
+  const activeRollouts = useMemo(() => {
+    const byBranchAndRuntime = new Map<
+      string,
+      { branch: string; runtimeVersion: string; percentage: number; commitHash: string }
+    >();
+    for (const update of updates) {
+      if (update.rolloutPercentage == null) continue;
+      const key = `${update.branch}:${update.runtimeVersion}`;
+      if (!byBranchAndRuntime.has(key)) {
+        byBranchAndRuntime.set(key, {
+          branch: update.branch,
+          runtimeVersion: update.runtimeVersion,
+          percentage: update.rolloutPercentage,
+          commitHash: update.commitHash,
+        });
+      }
+    }
+    return Array.from(byBranchAndRuntime.values());
+  }, [updates]);
+
+  const hasFilters = filterKey.some(Boolean);
+  const advancedFilterCount = [
+    filters.groupId,
+    filters.commitHash,
+    filters.from,
+    filters.to,
+  ].filter(Boolean).length;
+  const activeFilters = (
+    [
+      ['branch', 'Branch', filters.branch],
+      ['runtimeVersion', 'Runtime', filters.runtimeVersion],
+      ['platform', 'Platform', filters.platform],
+      ['uuid', 'Update ID', filters.uuid],
+      ['groupId', 'Group', filters.groupId],
+      ['commitHash', 'Commit', filters.commitHash],
+      ['from', 'From', filters.from],
+      ['to', 'To', filters.to],
+    ] as const
+  ).filter(([, , value]) => value);
+  const toggleGroup = (key: string) => {
+    setExpandedGroups(current => {
+      const next = new Set(current);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  };
 
   return (
     <div className="w-full">
-      <PageHeader
-        title="Branches & updates"
-        description="Browse your release branches, drill into a runtime version, and audit every OTA update you have published."
+      <PageHeader title="Updates" />
+      <UpdateDetailsSheet ref={sheetRef} />
+      <UpdateRolloutManagerSheet
+        rollout={managedRollout}
+        onClose={() => setManagedRollout(null)}
+        canManageRollout={canManageUpdateRollout}
       />
-      {component}
+      {!!query.error && <ApiError error={query.error} />}
+
+      <section className="mb-5 overflow-hidden rounded-lg border bg-card shadow-card">
+        <div className="flex flex-col gap-2.5 p-3 xl:flex-row xl:flex-wrap xl:items-center 2xl:flex-nowrap">
+          <div className="w-full xl:w-[22rem] xl:shrink-0">
+            <ClearableInput
+              aria-label="Filter by update UUID"
+              placeholder="Find an update by ID"
+              autoComplete="off"
+              spellCheck={false}
+              data-1p-ignore="true"
+              value={filters.uuid}
+              onValueChange={value => setFilter('uuid', value)}
+              onClear={() => setFilter('uuid', '')}
+              icon={<Search className="h-4 w-4" />}
+            />
+          </div>
+          <div className="grid flex-1 grid-cols-1 gap-2.5 sm:grid-cols-[minmax(13rem,1.35fr)_minmax(10rem,1fr)_minmax(10rem,1fr)]">
+            <Combobox
+              className="w-full"
+              label="All branches"
+              loading={branchesQuery.isLoading}
+              options={branchOptions}
+              value={filters.branch}
+              clearable
+              onChange={value =>
+                setFilters({
+                  branch: value,
+                  runtimeVersion: value === filters.branch ? filters.runtimeVersion : '',
+                })
+              }
+            />
+            <Combobox
+              className="w-full"
+              label={filters.branch ? 'All runtimes' : 'Select a branch first'}
+              loading={runtimeVersionsQuery.isLoading}
+              disabled={!filters.branch}
+              options={runtimeVersionOptions}
+              value={filters.runtimeVersion}
+              clearable
+              onChange={value => setFilter('runtimeVersion', value)}
+            />
+            <Combobox
+              className="w-full"
+              label="All platforms"
+              options={platformOptions}
+              value={filters.platform}
+              clearable
+              onChange={value => setFilter('platform', value)}
+            />
+          </div>
+          <div className="flex items-center gap-2">
+            <Popover>
+              <PopoverTrigger asChild>
+                <Button variant="outline" className="flex-1 lg:flex-none">
+                  <SlidersHorizontal className="h-4 w-4" />
+                  More filters
+                  {advancedFilterCount > 0 && (
+                    <Badge variant="secondary" className="ml-0.5 h-5 min-w-5 justify-center px-1.5">
+                      {advancedFilterCount}
+                    </Badge>
+                  )}
+                </Button>
+              </PopoverTrigger>
+              <PopoverContent align="end" className="w-[min(26rem,calc(100vw-2rem))] space-y-4">
+                <div>
+                  <h2 className="text-sm font-semibold text-foreground">More filters</h2>
+                  <p className="mt-0.5 text-xs text-muted-foreground">
+                    Narrow the feed using publication metadata.
+                  </p>
+                </div>
+                <div className="grid gap-3 sm:grid-cols-2">
+                  <FilterField label="Publish group ID">
+                    <ClearableInput
+                      aria-label="Filter by publish group ID"
+                      placeholder="Group ID"
+                      value={filters.groupId}
+                      onValueChange={value => setFilter('groupId', value)}
+                      onClear={() => setFilter('groupId', '')}
+                    />
+                  </FilterField>
+                  <FilterField label="Commit hash">
+                    <ClearableInput
+                      aria-label="Filter by commit hash"
+                      placeholder="Commit hash"
+                      value={filters.commitHash}
+                      onValueChange={value => setFilter('commitHash', value)}
+                      onClear={() => setFilter('commitHash', '')}
+                    />
+                  </FilterField>
+                  <FilterField label="Published from">
+                    <ClearableInput
+                      type="date"
+                      aria-label="Filter updates published from date"
+                      value={filters.from}
+                      onValueChange={value => setFilter('from', value)}
+                      onClear={() => setFilter('from', '')}
+                    />
+                  </FilterField>
+                  <FilterField label="Published to">
+                    <ClearableInput
+                      type="date"
+                      aria-label="Filter updates published to date"
+                      value={filters.to}
+                      onValueChange={value => setFilter('to', value)}
+                      onClear={() => setFilter('to', '')}
+                    />
+                  </FilterField>
+                </div>
+              </PopoverContent>
+            </Popover>
+            {hasFilters && (
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => setSearchParams({}, { replace: true })}>
+                Clear all
+              </Button>
+            )}
+          </div>
+        </div>
+        {activeFilters.length > 0 && (
+          <div className="flex flex-wrap items-center gap-2 border-t px-3 py-2.5">
+            {activeFilters.map(([key, label, value]) => (
+              <button
+                key={key}
+                type="button"
+                title={`Clear ${label.toLowerCase()} filter`}
+                onClick={() => setFilter(key, '')}
+                className="inline-flex max-w-full items-center gap-1.5 rounded-md border bg-secondary px-2 py-1 text-xs text-muted-foreground transition-colors hover:border-input hover:text-foreground">
+                <span className="font-medium text-foreground">{label}</span>
+                <span className="max-w-48 truncate">{value}</span>
+                <X className="h-3 w-3 shrink-0" />
+              </button>
+            ))}
+          </div>
+        )}
+      </section>
+
+      {activeRollouts.length > 0 && (
+        <section className="mb-4 animate-in overflow-hidden rounded-lg border border-emerald-400/25 bg-emerald-400/[0.05] fade-in slide-in-from-top-1 duration-200 motion-reduce:animate-none">
+          {activeRollouts.map((rollout, index) => (
+            <div
+              key={`${rollout.branch}:${rollout.runtimeVersion}`}
+              className={`flex flex-col gap-3 px-4 py-3 sm:flex-row sm:items-center sm:justify-between ${
+                index > 0 ? 'border-t border-emerald-400/15' : ''
+              }`}>
+              <div className="flex min-w-0 items-center gap-3">
+                <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md border border-emerald-400/25 bg-emerald-400/10 text-emerald-700 dark:text-emerald-300">
+                  <Gauge className="h-4 w-4" />
+                </span>
+                <div className="min-w-0">
+                  <p className="text-sm font-semibold text-foreground">
+                    Update rollout in progress
+                  </p>
+                  <div className="mt-0.5 flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-muted-foreground">
+                    <span className="font-medium text-emerald-700 dark:text-emerald-300">
+                      {rollout.percentage}%
+                    </span>
+                    <span>{rollout.branch}</span>
+                    <span aria-hidden="true">·</span>
+                    <span>{rollout.runtimeVersion}</span>
+                    <span aria-hidden="true">·</span>
+                    <span>{shortId(rollout.commitHash)}</span>
+                  </div>
+                </div>
+              </div>
+              {canManageUpdateRollout && (
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="outline"
+                  className="shrink-0"
+                  onClick={() =>
+                    setManagedRollout({
+                      branch: rollout.branch,
+                      runtimeVersion: rollout.runtimeVersion,
+                    })
+                  }>
+                  Manage rollout
+                </Button>
+              )}
+            </div>
+          ))}
+        </section>
+      )}
+
+      <div className="overflow-hidden rounded-lg border bg-card shadow-card">
+        <Table className="min-w-[1050px] table-fixed">
+          <TableHeader>
+            <TableRow>
+              <TableHead className="w-[38%]">Update</TableHead>
+              <TableHead className="w-[13%]">Branch</TableHead>
+              <TableHead className="w-[14%]">Runtime</TableHead>
+              <TableHead className="w-[9%]">Platform</TableHead>
+              <TableHead className="w-[11%]">Commit</TableHead>
+              <TableHead className="w-[15%]">Published</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {query.isLoading &&
+              Array.from({ length: 8 }).map((_, index) => (
+                <TableRow key={index}>
+                  {Array.from({ length: 6 }).map((__, cell) => (
+                    <TableCell key={cell}>
+                      <Skeleton className="h-4 w-full" />
+                    </TableCell>
+                  ))}
+                </TableRow>
+              ))}
+            {!query.isLoading &&
+              groups.map(group => {
+                const primary = group.updates[0];
+                const isGroup = !!group.publishGroup;
+                const expanded = expandedGroups.has(group.key);
+                const platforms = Array.from(new Set(group.updates.map(update => update.platform)));
+                const rolloutPercentage = group.updates.find(
+                  update => update.rolloutPercentage != null
+                )?.rolloutPercentage;
+                return (
+                  <Fragment key={group.key}>
+                    <TableRow
+                      className="cursor-pointer"
+                      onClick={() =>
+                        isGroup ? toggleGroup(group.key) : sheetRef.current?.openSheet(primary)
+                      }>
+                      <TableCell className="min-w-0 overflow-hidden">
+                        <div className="flex min-w-0 items-start gap-2.5">
+                          <span className="mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center text-muted-foreground">
+                            {isGroup ? (
+                              expanded ? (
+                                <ChevronDown className="h-4 w-4" />
+                              ) : (
+                                <ChevronRight className="h-4 w-4" />
+                              )
+                            ) : (
+                              <span className="h-1.5 w-1.5 rounded-full bg-muted-foreground/50" />
+                            )}
+                          </span>
+                          <div className="min-w-0">
+                            <p
+                              className="block max-w-full truncate font-medium text-foreground"
+                              title={primary.message || `Update ${primary.updateId}`}>
+                              {primary.message || `Update ${primary.updateId}`}
+                            </p>
+                            <div className="mt-1 flex min-w-0 items-center gap-2 text-xs text-muted-foreground">
+                              {isGroup && (
+                                <Badge variant="secondary" className="px-1.5 py-0">
+                                  <Layers3 className="h-3 w-3" />
+                                  {group.updates.length}
+                                </Badge>
+                              )}
+                              {rolloutPercentage != null && (
+                                <UpdateRolloutBadge percentage={rolloutPercentage} />
+                              )}
+                              <span
+                                className="truncate"
+                                title={group.publishGroup ?? primary.updateUUID}>
+                                {isGroup ? `group:${group.publishGroup}` : primary.updateUUID}
+                              </span>
+                            </div>
+                          </div>
+                        </div>
+                      </TableCell>
+                      <TableCell>
+                        <BranchLink branch={primary.branch} />
+                      </TableCell>
+                      <TableCell className="min-w-0">
+                        <RuntimeLabel value={primary.runtimeVersion} />
+                      </TableCell>
+                      <TableCell>
+                        <div className="flex items-center gap-2">
+                          {platforms.map(value => (
+                            <PlatformIcon key={value} platform={value} />
+                          ))}
+                        </div>
+                      </TableCell>
+                      <TableCell>
+                        <CommitLabel value={primary.commitHash} />
+                      </TableCell>
+                      <TableCell>
+                        <TimestampCell dateString={primary.createdAt} />
+                      </TableCell>
+                    </TableRow>
+                    {isGroup &&
+                      expanded &&
+                      group.updates.map(update => (
+                        <TableRow
+                          key={`${group.key}:${update.updateId}`}
+                          className="animate-in cursor-pointer bg-muted/20 fade-in slide-in-from-top-1 duration-150 motion-reduce:animate-none"
+                          onClick={() => sheetRef.current?.openSheet(update)}>
+                          <TableCell>
+                            <div className="ml-9 min-w-0 border-l-2 border-link/40 pl-4">
+                              <div className="flex flex-wrap items-center gap-2">
+                                <p className="font-medium text-foreground">
+                                  {update.platform === 'ios'
+                                    ? 'iOS update'
+                                    : update.platform === 'android'
+                                      ? 'Android update'
+                                      : `${update.platform} update`}
+                                </p>
+                                {update.rolloutPercentage != null && (
+                                  <UpdateRolloutBadge percentage={update.rolloutPercentage} />
+                                )}
+                              </div>
+                              <p className="mt-0.5 truncate text-xs text-muted-foreground">
+                                {update.updateUUID}
+                              </p>
+                            </div>
+                          </TableCell>
+                          <TableCell>
+                            <BranchLink branch={update.branch} />
+                          </TableCell>
+                          <TableCell className="min-w-0">
+                            <RuntimeLabel value={update.runtimeVersion} />
+                          </TableCell>
+                          <TableCell>
+                            <PlatformIcon platform={update.platform} />
+                          </TableCell>
+                          <TableCell>
+                            <CommitLabel value={update.commitHash} />
+                          </TableCell>
+                          <TableCell>
+                            <TimestampCell dateString={update.createdAt} />
+                          </TableCell>
+                        </TableRow>
+                      ))}
+                  </Fragment>
+                );
+              })}
+            {!query.isLoading && groups.length === 0 && (
+              <TableRow>
+                <TableCell colSpan={6} className="h-28 text-center text-muted-foreground">
+                  {hasFilters ? 'No updates match these filters.' : 'No updates published yet.'}
+                </TableCell>
+              </TableRow>
+            )}
+          </TableBody>
+        </Table>
+        {query.hasNextPage && (
+          <div className="flex justify-center border-t p-3">
+            <Button
+              variant="outline"
+              onClick={() => void query.fetchNextPage()}
+              disabled={query.isFetchingNextPage}>
+              {query.isFetchingNextPage ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <ChevronDown className="h-4 w-4" />
+              )}
+              Load more
+            </Button>
+          </div>
+        )}
+      </div>
     </div>
   );
 };

--- a/apps/dashboard/src/pages/Users/index.tsx
+++ b/apps/dashboard/src/pages/Users/index.tsx
@@ -164,7 +164,7 @@ export const Users = () => {
                     {hasNoAccess && (
                       <Badge
                         variant="outline"
-                        className="border-amber-300/80 bg-amber-50 font-normal text-amber-800"
+                        className="border-amber-400/25 bg-amber-400/10 font-normal text-amber-700 dark:text-amber-300"
                         title="This member holds no grant: they see an empty dashboard. Open Roles to give them access.">
                         No app access
                       </Badge>

--- a/apps/dashboard/tailwind.config.js
+++ b/apps/dashboard/tailwind.config.js
@@ -1,68 +1,61 @@
 /** @type {import('tailwindcss').Config} */
 export default {
-  content: ["./index.html", "./src/**/*.{ts,tsx,js,jsx}"],
+  darkMode: 'class',
+  content: ['./index.html', './src/**/*.{ts,tsx,js,jsx}'],
   theme: {
     extend: {
       fontFamily: {
-        sans: [
-          '"Inter Variable"',
-          'Inter',
-          'system-ui',
-          '-apple-system',
-          'Segoe UI',
-          'sans-serif',
-        ],
+        sans: ['"Inter Variable"', 'Inter', 'system-ui', '-apple-system', 'Segoe UI', 'sans-serif'],
+        display: ['"Inter Variable"', 'Inter', 'system-ui', 'sans-serif'],
+        mono: ['ui-monospace', 'SFMono-Regular', 'Menlo', 'Consolas', 'monospace'],
       },
       borderRadius: {
-        lg: 'var(--radius)',
-        md: 'calc(var(--radius) - 4px)',
-        sm: 'calc(var(--radius) - 6px)',
+        sm: '5px',
+        md: '8px',
+        lg: '10px',
+        xl: '14px',
       },
       boxShadow: {
-        // Expo-like soft elevations: barely-there on resting cards, a wide
-        // diffuse drop for floating surfaces (login card, popovers).
-        card: '0 1px 2px 0 rgb(16 24 40 / 0.04)',
-        elevated:
-          '0 1px 2px 0 rgb(16 24 40 / 0.06), 0 16px 40px -12px rgb(16 24 40 / 0.14)',
+        card: '0 1px 2px rgb(0 0 0 / 0.28), inset 0 1px 0 rgb(255 255 255 / 0.025)',
+        elevated: '0 20px 50px -18px rgb(0 0 0 / 0.62), inset 0 1px 0 rgb(255 255 255 / 0.035)',
       },
       colors: {
         background: 'hsl(var(--background))',
         foreground: 'hsl(var(--foreground))',
         card: {
           DEFAULT: 'hsl(var(--card))',
-          foreground: 'hsl(var(--card-foreground))'
+          foreground: 'hsl(var(--card-foreground))',
         },
         popover: {
           DEFAULT: 'hsl(var(--popover))',
-          foreground: 'hsl(var(--popover-foreground))'
+          foreground: 'hsl(var(--popover-foreground))',
         },
         primary: {
           DEFAULT: 'hsl(var(--primary))',
-          foreground: 'hsl(var(--primary-foreground))'
+          foreground: 'hsl(var(--primary-foreground))',
         },
         secondary: {
           DEFAULT: 'hsl(var(--secondary))',
-          foreground: 'hsl(var(--secondary-foreground))'
+          foreground: 'hsl(var(--secondary-foreground))',
         },
         muted: {
           DEFAULT: 'hsl(var(--muted))',
-          foreground: 'hsl(var(--muted-foreground))'
+          foreground: 'hsl(var(--muted-foreground))',
         },
         accent: {
           DEFAULT: 'hsl(var(--accent))',
-          foreground: 'hsl(var(--accent-foreground))'
+          foreground: 'hsl(var(--accent-foreground))',
         },
         destructive: {
           DEFAULT: 'hsl(var(--destructive))',
-          foreground: 'hsl(var(--destructive-foreground))'
+          foreground: 'hsl(var(--destructive-foreground))',
         },
         border: 'hsl(var(--border))',
         input: 'hsl(var(--input))',
         ring: 'hsl(var(--ring))',
-        // Expo blue — links and informational touches only.
-        link: '#0081f1',
+        link: 'hsl(var(--link))',
       },
-    }
+    },
   },
-  plugins: [require("tailwindcss-animate")],
-}
+  plugins: [require('tailwindcss-animate')],
+};

--- a/apps/eoas/src/commands/__tests__/republish.test.ts
+++ b/apps/eoas/src/commands/__tests__/republish.test.ts
@@ -1,0 +1,181 @@
+// End-to-end flow of the republish command, prompts included: the oclif
+// command runs for real, with the project/auth/network seams mocked. Pins the
+// mode question (publish group vs single update), the group POST wire format,
+// and the fallbacks that skip the question.
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { fetchWithRetries } from '../../lib/fetch';
+import { promptAsync } from '../../lib/prompts';
+import { fetchRuntimeVersions, fetchUpdates } from '../../lib/serverUpdates';
+import Republish from '../republish';
+
+vi.mock('../../lib/fetch', () => ({
+  fetchWithRetries: vi.fn(),
+}));
+vi.mock('../../lib/prompts', () => ({
+  promptAsync: vi.fn(),
+}));
+vi.mock('../../lib/auth', () => ({
+  retrieveCredentials: () => ({ token: 'test-token' }),
+  validateCredentials: () => true,
+  getAuthHeaders: () => ({ Authorization: 'Bearer test-token' }),
+}));
+vi.mock('../../lib/vcs', () => ({
+  resolveVcsClient: () => ({ ensureRepoExistsAsync: async () => {} }),
+}));
+vi.mock('../../lib/package', () => ({
+  isExpoInstalled: () => true,
+}));
+vi.mock('../../lib/expoConfig', () => ({
+  getPrivateExpoConfigAsync: async () => ({}),
+  getExpoConfigUpdateUrl: () => 'https://ota.example.com/manifest',
+  requireExpoAppId: () => 'app-1',
+}));
+vi.mock('../../lib/serverUpdates', async importOriginal => {
+  const original = await importOriginal<typeof import('../../lib/serverUpdates')>();
+  return {
+    ...original,
+    fetchRuntimeVersions: vi.fn(),
+    fetchUpdates: vi.fn(),
+  };
+});
+
+const eoasRoot = path.resolve(__dirname, '../../..');
+
+const runtimeVersionsPayload = [
+  {
+    runtimeVersion: '1.0.0',
+    lastUpdatedAt: '2026-07-24T10:00:00Z',
+    createdAt: '2026-07-01T10:00:00Z',
+    numberOfUpdates: 3,
+  },
+];
+
+function serverUpdate(overrides: Record<string, unknown>): any {
+  return {
+    updateUUID: 'a0000000-0000-0000-0000-000000000001',
+    createdAt: '2026-07-24T10:00:00Z',
+    updateId: '100',
+    platform: 'ios',
+    commitHash: 'abc1234def',
+    message: 'Fix crash',
+    ...overrides,
+  };
+}
+
+// Answers each prompt by name; a function receives the question (with its
+// choices) and returns the value, mimicking a user selection.
+type PromptAnswer = unknown | ((question: any) => unknown);
+function answerPrompts(answers: Record<string, PromptAnswer>): void {
+  vi.mocked(promptAsync).mockImplementation(async (questions: any) => {
+    const question = Array.isArray(questions) ? questions[0] : questions;
+    if (!(question.name in answers)) {
+      throw new Error(`Unexpected prompt: ${question.name}`);
+    }
+    const answer = answers[question.name];
+    const value = typeof answer === 'function' ? (answer as (q: any) => unknown)(question) : answer;
+    return { [question.name]: value };
+  });
+}
+
+function promptedNames(): string[] {
+  return vi
+    .mocked(promptAsync)
+    .mock.calls.map(([questions]) => (Array.isArray(questions) ? questions[0] : questions).name);
+}
+
+function lastPostUrl(): URL {
+  const calls = vi.mocked(fetchWithRetries).mock.calls;
+  return new URL(String(calls[calls.length - 1][0]));
+}
+
+describe('republish command flow', () => {
+  beforeEach(() => {
+    vi.mocked(fetchRuntimeVersions).mockResolvedValue(runtimeVersionsPayload);
+    vi.mocked(fetchWithRetries).mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ publishGroup: 'new-group', updates: [] }),
+    } as Response);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('offers the publish group mode and republishes the group in one call', async () => {
+    vi.mocked(fetchUpdates).mockResolvedValue([
+      serverUpdate({ updateId: '100', platform: 'ios', publishGroup: 'group-a' }),
+      serverUpdate({ updateId: '200', platform: 'android', publishGroup: 'group-a' }),
+      serverUpdate({ updateId: '300', platform: 'ios', publishGroup: undefined }),
+    ]);
+    answerPrompts({
+      runtimeVersion: '1.0.0',
+      mode: 'group',
+      group: (question: any) => question.choices[0].value,
+    });
+
+    await Republish.run(['--branch', 'main'], eoasRoot);
+
+    expect(promptedNames()).toEqual(['runtimeVersion', 'mode', 'group']);
+    const url = lastPostUrl();
+    expect(url.pathname).toBe('/app-1/republish/main');
+    expect(url.searchParams.get('publishGroup')).toBe('group-a');
+    expect(url.searchParams.get('runtimeVersion')).toBe('1.0.0');
+    expect(url.searchParams.has('updateId')).toBe(false);
+    expect(url.searchParams.has('platform')).toBe(false);
+  });
+
+  it('republishes a single update through the historical wire format', async () => {
+    vi.mocked(fetchUpdates).mockResolvedValue([
+      serverUpdate({ updateId: '100', platform: 'ios', publishGroup: 'group-a' }),
+      serverUpdate({ updateId: '200', platform: 'android', publishGroup: 'group-a' }),
+    ]);
+    answerPrompts({
+      runtimeVersion: '1.0.0',
+      mode: 'single',
+      update: (question: any) => question.choices[0].value,
+    });
+
+    await Republish.run(['--branch', 'main'], eoasRoot);
+
+    const url = lastPostUrl();
+    expect(url.searchParams.get('updateId')).toBe('100');
+    expect(url.searchParams.get('platform')).toBe('ios');
+    expect(url.searchParams.get('commitHash')).toBe('abc1234def');
+    expect(url.searchParams.has('publishGroup')).toBe(false);
+  });
+
+  it('skips the mode question when --platform narrows the run', async () => {
+    vi.mocked(fetchUpdates).mockResolvedValue([
+      serverUpdate({ updateId: '100', platform: 'ios', publishGroup: 'group-a' }),
+      serverUpdate({ updateId: '200', platform: 'android', publishGroup: 'group-a' }),
+    ]);
+    answerPrompts({
+      runtimeVersion: '1.0.0',
+      update: (question: any) => question.choices[0].value,
+    });
+
+    await Republish.run(['--branch', 'main', '--platform', 'android'], eoasRoot);
+
+    expect(promptedNames()).toEqual(['runtimeVersion', 'update']);
+    // The platform filter reached the picker: only the android update remained.
+    expect(lastPostUrl().searchParams.get('updateId')).toBe('200');
+  });
+
+  it('skips the mode question when the branch has no publish groups', async () => {
+    vi.mocked(fetchUpdates).mockResolvedValue([
+      serverUpdate({ updateId: '100', platform: 'ios', publishGroup: undefined }),
+    ]);
+    answerPrompts({
+      runtimeVersion: '1.0.0',
+      update: (question: any) => question.choices[0].value,
+    });
+
+    await Republish.run(['--branch', 'main'], eoasRoot);
+
+    expect(promptedNames()).toEqual(['runtimeVersion', 'update']);
+    expect(lastPostUrl().searchParams.get('updateId')).toBe('100');
+  });
+});

--- a/apps/eoas/src/commands/publish.ts
+++ b/apps/eoas/src/commands/publish.ts
@@ -1,6 +1,7 @@
 import { Env, Platform } from '@expo/eas-build-job';
 import spawnAsync from '@expo/spawn-async';
 import { Command, Flags } from '@oclif/core';
+import { randomUUID } from 'crypto';
 import FormData from 'form-data';
 import fs from 'fs-extra';
 import mime from 'mime';
@@ -300,7 +301,11 @@ export default class Publish extends Command {
       platform: string;
       runtimeVersion: string;
       rolloutPercentage?: number;
+      publishGroup?: string;
     }[] = [];
+    // One group id for the whole run: every platform update of this publish
+    // shares it, so control plane servers list them as a single publish.
+    const publishGroupId = randomUUID();
     try {
       uploadUrls = await Promise.all(
         runtimeVersions.map(async ({ runtimeVersion, platform }) => {
@@ -319,6 +324,7 @@ export default class Publish extends Command {
               commitHash,
               message: resolvedMessage,
               rolloutPercentage,
+              publishGroup: publishGroupId,
               branch,
             })),
             runtimeVersion,
@@ -461,6 +467,16 @@ export default class Publish extends Command {
     if (hasSuccess) {
       Log.withInfo(`🌿 Branch: \`${branch}\``);
       Log.withInfo(`⏳ Deployed at: \`${new Date().toUTCString()}\`\n`);
+      const groupAcknowledged = uploadUrls.every(u => u.publishGroup === publishGroupId);
+      if (groupAcknowledged) {
+        Log.withInfo(`📦 Publish group: \`${publishGroupId}\``);
+      } else if (uploadUrls.length > 1) {
+        // Only worth a note when several platforms were published: a single
+        // update has nothing to group anyway.
+        Log.withInfo(
+          'ℹ️ Platform updates were published without grouping (publish groups require a server in control plane mode).'
+        );
+      }
       Log.withInfo('🔥 Your users will receive the latest update automatically!');
     }
   }

--- a/apps/eoas/src/commands/republish.ts
+++ b/apps/eoas/src/commands/republish.ts
@@ -12,6 +12,13 @@ import { fetchWithRetries } from '../lib/fetch';
 import Log from '../lib/log';
 import { isExpoInstalled } from '../lib/package';
 import { promptAsync } from '../lib/prompts';
+import {
+  ServerUpdateItem,
+  describePublishGroup,
+  fetchRuntimeVersions,
+  fetchUpdates,
+  groupPublishedUpdates,
+} from '../lib/serverUpdates';
 import { resolveVcsClient } from '../lib/vcs';
 
 export default class Publish extends Command {
@@ -59,7 +66,6 @@ export default class Publish extends Command {
     }
     const vcsClient = resolveVcsClient(true);
     await vcsClient.ensureRepoExistsAsync();
-    // const commitHash = await vcsClient.getCommitHashAsync();
     const projectDir = process.cwd();
     const hasExpo = isExpoInstalled(projectDir);
     if (!hasExpo) {
@@ -85,23 +91,13 @@ export default class Publish extends Command {
       Log.error('Invalid URL', e);
       process.exit(1);
     }
-    const runtimeVersionsEndpoint = `${baseUrl}/api/apps/${appId}/branch/${branch}/runtimeVersions`;
-    const response = await fetchWithRetries(runtimeVersionsEndpoint, {
-      headers: {
-        ...getAuthHeaders(credentials),
-        'use-cli-auth': 'true',
-      },
-    });
-    if (!response.ok) {
-      Log.error(`Failed to fetch runtime versions: ${await response.text()}`);
+    let runtimeVersions;
+    try {
+      runtimeVersions = await fetchRuntimeVersions({ baseUrl, appId, branch, credentials });
+    } catch (e) {
+      Log.error(e instanceof Error ? e.message : e);
       process.exit(1);
     }
-    const runtimeVersions = (await response.json()) as {
-      runtimeVersion: string;
-      lastUpdatedAt: string;
-      createdAt: string;
-      numberOfUpdates: number;
-    }[];
     const filteredRuntimeVersions = runtimeVersions.filter(
       runtimeVersion => runtimeVersion.numberOfUpdates > 1
     );
@@ -109,7 +105,6 @@ export default class Publish extends Command {
       Log.error('No runtime versions found');
       process.exit(1);
     }
-    // Ask the user to select a runtime version
     const selectedRuntimeVersion = await promptAsync({
       type: 'select',
       name: 'runtimeVersion',
@@ -120,31 +115,94 @@ export default class Publish extends Command {
       })),
     });
     Log.log(`Selected runtime version: ${selectedRuntimeVersion.runtimeVersion}`);
-    const updatesEndpoint = `${baseUrl}/api/apps/${appId}/branch/${branch}/runtimeVersion/${selectedRuntimeVersion.runtimeVersion}/updates`;
-    const updatesResponse = await fetchWithRetries(updatesEndpoint, {
-      headers: {
-        ...getAuthHeaders(credentials),
-        'use-cli-auth': 'true',
-      },
-    });
-    if (!updatesResponse.ok) {
-      Log.error(`Failed to fetch updates: ${await updatesResponse.text()}`);
+    let allUpdates: ServerUpdateItem[];
+    try {
+      allUpdates = await fetchUpdates({
+        baseUrl,
+        appId,
+        branch,
+        runtimeVersion: selectedRuntimeVersion.runtimeVersion,
+        credentials,
+      });
+    } catch (e) {
+      Log.error(e instanceof Error ? e.message : e);
       process.exit(1);
     }
-    const updates = (
-      (await updatesResponse.json()) as {
-        updateUUID: string;
-        createdAt: string;
-        updateId: string;
-        platform: string;
-        commitHash: string;
-      }[]
-    ).filter(u => {
-      return (
-        u.updateUUID !== 'Rollback to embedded' && (platform === 'all' || u.platform === platform)
-      );
-    });
+    // Rollback markers have no files to republish.
+    const updates = allUpdates.filter(u => u.updateUUID !== 'Rollback to embedded');
     if (updates.length === 0) {
+      Log.error(
+        `No republishable updates found for runtime version ${selectedRuntimeVersion.runtimeVersion}.`
+      );
+      process.exit(1);
+    }
+
+    const { groups } = groupPublishedUpdates(updates);
+    // Offer the group mode only when there is something to group and the user
+    // did not already narrow the run to one platform.
+    let mode: 'group' | 'single' = 'single';
+    if (platform === 'all' && groups.length > 0) {
+      const selectedMode = await promptAsync({
+        type: 'select',
+        name: 'mode',
+        message: 'What do you want to republish?',
+        choices: [
+          {
+            title: 'A full publish (all its platforms together)',
+            description: 'Only for servers in control plane mode',
+            value: 'group',
+          },
+          {
+            title: 'A single platform update',
+            description: 'Pick one iOS or Android update',
+            value: 'single',
+          },
+        ],
+      });
+      mode = selectedMode.mode;
+    }
+
+    if (mode === 'group') {
+      const selectedGroup = await promptAsync({
+        type: 'select',
+        name: 'group',
+        message: 'Select a publish to republish',
+        choices: groups.map(group => ({
+          ...describePublishGroup(group),
+          value: group,
+        })),
+      });
+      const group = selectedGroup.group;
+      const republishUrl = new URL(`${baseUrl}/${appId}/republish/${branch}`);
+      republishUrl.searchParams.set('runtimeVersion', selectedRuntimeVersion.runtimeVersion);
+      republishUrl.searchParams.set('publishGroup', group.publishGroup);
+      const republishSpinner = ora(
+        `🔄 Republishing ${group.platforms.join(' + ')} updates...`
+      ).start();
+      const response = await fetchWithRetries(republishUrl.toString(), {
+        method: 'POST',
+        headers: {
+          ...getAuthHeaders(credentials),
+          'use-cli-auth': 'true',
+          'Content-Type': 'application/json',
+        },
+      });
+      if (!response.ok) {
+        republishSpinner.fail('❌ Republish failed');
+        Log.error(`Failed to republish publish group: ${await response.text()}`);
+        process.exit(1);
+      }
+      const result = (await response.json()) as { publishGroup?: string };
+      republishSpinner.succeed(
+        result.publishGroup
+          ? `✅ Republished ${group.platforms.join(' + ')} as publish group ${result.publishGroup}`
+          : `✅ Republished ${group.platforms.join(' + ')}`
+      );
+      return;
+    }
+
+    const platformUpdates = updates.filter(u => platform === 'all' || u.platform === platform);
+    if (platformUpdates.length === 0) {
       Log.error(
         `No republishable updates found for runtime version ${selectedRuntimeVersion.runtimeVersion} on platform ${platform}.`
       );
@@ -154,7 +212,7 @@ export default class Publish extends Command {
       type: 'select',
       name: 'update',
       message: 'Select an update to republish',
-      choices: updates.map(update => ({
+      choices: platformUpdates.map(update => ({
         title: update.updateUUID,
         value: update,
         description: `Created at: ${update.createdAt}, Platform: ${update.platform}, Commit hash: ${update.commitHash}`,

--- a/apps/eoas/src/lib/__tests__/assets.test.ts
+++ b/apps/eoas/src/lib/__tests__/assets.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { activeRolloutConflictMessage, requestUploadUrls } from '../assets';
+import { fetchWithRetries } from '../fetch';
+
+vi.mock('../fetch', () => ({
+  fetchWithRetries: vi.fn(),
+}));
+
+const credentials = { token: 'test-token', sessionSecret: undefined };
+
+function baseParams(): Parameters<typeof requestUploadUrls>[0] {
+  return {
+    body: { fileNames: ['bundle.js'] },
+    requestUploadUrl: 'https://ota.example.com/app-1/requestUploadUrl/main',
+    auth: credentials,
+    runtimeVersion: '1.0.0',
+    platform: 'ios',
+    commitHash: 'abc1234',
+    branch: 'main',
+  };
+}
+
+function respondWith(payload: unknown): void {
+  vi.mocked(fetchWithRetries).mockResolvedValueOnce({
+    ok: true,
+    status: 200,
+    json: async () => payload,
+  } as Response);
+}
+
+function requestedUrl(): URL {
+  const calls = vi.mocked(fetchWithRetries).mock.calls;
+  return new URL(String(calls[calls.length - 1][0]));
+}
+
+describe('requestUploadUrls publish group wire contract', () => {
+  it('sends the publish group as a query parameter and returns the acknowledgment', async () => {
+    respondWith({ updateId: '1', uploadRequests: [], publishGroup: 'group-a' });
+    const result = await requestUploadUrls({ ...baseParams(), publishGroup: 'group-a' });
+    expect(requestedUrl().searchParams.get('publishGroup')).toBe('group-a');
+    expect(result.publishGroup).toBe('group-a');
+  });
+
+  it('omits the parameter entirely when no group is provided', async () => {
+    respondWith({ updateId: '1', uploadRequests: [] });
+    const result = await requestUploadUrls(baseParams());
+    expect(requestedUrl().searchParams.has('publishGroup')).toBe(false);
+    expect(result.publishGroup).toBeUndefined();
+  });
+
+  it('leaves the acknowledgment undefined when the server ignores the group', async () => {
+    // Old server or stateless mode: no echo. The publish command reads this
+    // to print the ungrouped note instead of a publish group line.
+    respondWith({ updateId: '1', uploadRequests: [] });
+    const result = await requestUploadUrls({ ...baseParams(), publishGroup: 'group-a' });
+    expect(result.publishGroup).toBeUndefined();
+  });
+});
+
+describe('requestUploadUrls rollout guardrails', () => {
+  it('aborts when the server does not echo the rollout percentage', async () => {
+    respondWith({ updateId: '1', uploadRequests: [] });
+    await expect(requestUploadUrls({ ...baseParams(), rolloutPercentage: 10 })).rejects.toThrow(
+      /ignored --rollout-percentage/
+    );
+  });
+
+  it('continues when the rollout percentage is echoed', async () => {
+    respondWith({ updateId: '1', uploadRequests: [], rolloutPercentage: 10 });
+    const result = await requestUploadUrls({ ...baseParams(), rolloutPercentage: 10 });
+    expect(result.rolloutPercentage).toBe(10);
+  });
+
+  it('surfaces an active rollout conflict as the dedicated message', async () => {
+    vi.mocked(fetchWithRetries).mockResolvedValueOnce({
+      ok: false,
+      status: 409,
+      text: async () => 'conflict',
+    } as Response);
+    await expect(requestUploadUrls(baseParams())).rejects.toThrow(
+      activeRolloutConflictMessage('main')
+    );
+  });
+});

--- a/apps/eoas/src/lib/__tests__/serverUpdates.test.ts
+++ b/apps/eoas/src/lib/__tests__/serverUpdates.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { fetchWithRetries } from '../fetch';
+import {
+  ServerUpdateItem,
+  describePublishGroup,
+  fetchRuntimeVersions,
+  fetchUpdates,
+  groupPublishedUpdates,
+} from '../serverUpdates';
+
+vi.mock('../fetch', () => ({
+  fetchWithRetries: vi.fn(),
+}));
+
+const credentials = { token: 'test-token', sessionSecret: undefined };
+
+function update(overrides: Partial<ServerUpdateItem>): ServerUpdateItem {
+  return {
+    updateUUID: 'uuid',
+    createdAt: '2026-07-24T10:00:00Z',
+    updateId: '1',
+    platform: 'ios',
+    commitHash: 'abc1234def',
+    ...overrides,
+  };
+}
+
+describe('groupPublishedUpdates', () => {
+  it('splits grouped updates from ungrouped ones', () => {
+    const { groups, ungrouped } = groupPublishedUpdates([
+      update({ updateId: '1', platform: 'ios', publishGroup: 'group-a' }),
+      update({ updateId: '2', platform: 'android', publishGroup: 'group-a' }),
+      update({ updateId: '3', platform: 'ios' }),
+    ]);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].publishGroup).toBe('group-a');
+    expect(groups[0].platforms).toEqual(['ios', 'android']);
+    expect(groups[0].updates).toHaveLength(2);
+    expect(ungrouped).toHaveLength(1);
+    expect(ungrouped[0].updateId).toBe('3');
+  });
+
+  it('sorts groups newest first and dates each group by its freshest member', () => {
+    const { groups } = groupPublishedUpdates([
+      update({ updateId: '1', publishGroup: 'old', createdAt: '2026-07-20T10:00:00Z' }),
+      update({ updateId: '2', publishGroup: 'recent', createdAt: '2026-07-22T10:00:00Z' }),
+      update({
+        updateId: '3',
+        platform: 'android',
+        publishGroup: 'recent',
+        createdAt: '2026-07-23T10:00:00Z',
+      }),
+    ]);
+    expect(groups.map(group => group.publishGroup)).toEqual(['recent', 'old']);
+    expect(groups[0].createdAt).toBe('2026-07-23T10:00:00Z');
+  });
+
+  it('does not duplicate a platform listed twice in one group', () => {
+    const { groups } = groupPublishedUpdates([
+      update({ updateId: '1', platform: 'ios', publishGroup: 'group-a' }),
+      update({ updateId: '2', platform: 'ios', publishGroup: 'group-a' }),
+    ]);
+    expect(groups[0].platforms).toEqual(['ios']);
+    expect(groups[0].updates).toHaveLength(2);
+  });
+});
+
+describe('describePublishGroup', () => {
+  it('titles the group with its message and platforms', () => {
+    const { groups } = groupPublishedUpdates([
+      update({ publishGroup: 'group-a', message: 'Fix crash on startup' }),
+      update({ platform: 'android', publishGroup: 'group-a', message: 'Fix crash on startup' }),
+    ]);
+    const { title, description } = describePublishGroup(groups[0]);
+    expect(title).toBe('Fix crash on startup (ios + android)');
+    expect(description).toContain('abc1234');
+  });
+
+  it('falls back to the short commit hash when there is no message', () => {
+    const { groups } = groupPublishedUpdates([update({ publishGroup: 'group-a' })]);
+    expect(describePublishGroup(groups[0]).title).toBe('Commit abc1234 (ios)');
+  });
+});
+
+describe('fetchUpdates and fetchRuntimeVersions', () => {
+  it('calls the listing endpoints with CLI auth and returns the parsed body', async () => {
+    const payload = [update({ updateId: '10', publishGroup: 'group-a' })];
+    vi.mocked(fetchWithRetries).mockResolvedValueOnce({
+      ok: true,
+      json: async () => payload,
+    } as Response);
+
+    const updates = await fetchUpdates({
+      baseUrl: 'https://ota.example.com',
+      appId: 'app-1',
+      branch: 'main',
+      runtimeVersion: '1.0.0',
+      credentials,
+    });
+    expect(updates).toEqual(payload);
+    const [url, options] = vi.mocked(fetchWithRetries).mock.calls[0];
+    expect(url).toBe(
+      'https://ota.example.com/api/apps/app-1/branch/main/runtimeVersion/1.0.0/updates'
+    );
+    expect((options?.headers as Record<string, string>)['use-cli-auth']).toBe('true');
+  });
+
+  it('throws with the server text on a failed listing', async () => {
+    vi.mocked(fetchWithRetries).mockResolvedValueOnce({
+      ok: false,
+      text: async () => 'boom',
+    } as Response);
+    await expect(
+      fetchRuntimeVersions({
+        baseUrl: 'https://ota.example.com',
+        appId: 'app-1',
+        branch: 'main',
+        credentials,
+      })
+    ).rejects.toThrow('Failed to fetch runtime versions: boom');
+  });
+});

--- a/apps/eoas/src/lib/__tests__/serverUpdates.test.ts
+++ b/apps/eoas/src/lib/__tests__/serverUpdates.test.ts
@@ -77,6 +77,32 @@ describe('describePublishGroup', () => {
     expect(description).toContain('abc1234');
   });
 
+  it('truncates long messages so the platforms stay visible', () => {
+    const longMessage =
+      'Fix the crash on startup that happens when the bundle cache is corrupted after an OTA';
+    const { groups } = groupPublishedUpdates([
+      update({ publishGroup: 'group-a', message: longMessage }),
+    ]);
+    const { title } = describePublishGroup(groups[0]);
+    expect(title).toBe('Fix the crash on startup that happens when the… (ios)');
+    expect(title.length).toBeLessThan(longMessage.length);
+  });
+
+  it('describes each sub-update with its platform and release time', () => {
+    const { groups } = groupPublishedUpdates([
+      update({ publishGroup: 'group-a', createdAt: '2026-07-24T10:00:12Z' }),
+      update({
+        platform: 'android',
+        publishGroup: 'group-a',
+        createdAt: '2026-07-24T10:01:47Z',
+      }),
+    ]);
+    const { description } = describePublishGroup(groups[0]);
+    expect(description).toBe(
+      'ios 2026-07-24 10:00 UTC, android 2026-07-24 10:01 UTC (commit abc1234)'
+    );
+  });
+
   it('falls back to the short commit hash when there is no message', () => {
     const { groups } = groupPublishedUpdates([update({ publishGroup: 'group-a' })]);
     expect(describePublishGroup(groups[0]).title).toBe('Commit abc1234 (ios)');

--- a/apps/eoas/src/lib/assets.ts
+++ b/apps/eoas/src/lib/assets.ts
@@ -114,6 +114,7 @@ export async function requestUploadUrls({
   commitHash,
   message,
   rolloutPercentage,
+  publishGroup,
   branch,
 }: {
   body: { fileNames: string[] };
@@ -124,11 +125,16 @@ export async function requestUploadUrls({
   commitHash?: string;
   message?: string;
   rolloutPercentage?: number;
+  // One UUID minted per publish run and shared by every platform call, so the
+  // server can group the resulting updates as a single publish. Control plane
+  // servers echo it back; a missing echo means the rows were not grouped.
+  publishGroup?: string;
   branch: string;
 }): Promise<{
   uploadRequests: RequestUploadUrlItem[];
   updateId: string;
   rolloutPercentage?: number;
+  publishGroup?: string;
 }> {
   const uploadUrl = new URL(requestUploadUrl);
   uploadUrl.searchParams.set('runtimeVersion', runtimeVersion);
@@ -136,6 +142,9 @@ export async function requestUploadUrls({
   uploadUrl.searchParams.set('commitHash', commitHash ?? '');
   if (rolloutPercentage !== undefined) {
     uploadUrl.searchParams.set('rolloutPercentage', String(rolloutPercentage));
+  }
+  if (publishGroup) {
+    uploadUrl.searchParams.set('publishGroup', publishGroup);
   }
 
   const requestBody: { fileNames: string[]; message?: string } = { ...body };

--- a/apps/eoas/src/lib/serverUpdates.ts
+++ b/apps/eoas/src/lib/serverUpdates.ts
@@ -124,8 +124,31 @@ export function groupPublishedUpdates(updates: ServerUpdateItem[]): {
   return { groups, ungrouped };
 }
 
-// describePublishGroup renders one picker line: the message (or commit) plus
-// the platforms it covers.
+// A commit message can be a full paragraph; past this length the picker line
+// wraps and drowns the platforms suffix.
+const MAX_TITLE_MESSAGE_LENGTH = 48;
+
+function truncateMessage(message: string): string {
+  if (message.length <= MAX_TITLE_MESSAGE_LENGTH) {
+    return message;
+  }
+  return `${message.slice(0, MAX_TITLE_MESSAGE_LENGTH - 1).trimEnd()}…`;
+}
+
+// Compact deterministic timestamp (no locale, no seconds): publishes made in
+// the same run are seconds apart, minute precision is enough to tell runs
+// apart without flooding the line.
+function formatPublishedAt(createdAt: string): string {
+  const parsed = new Date(createdAt);
+  if (Number.isNaN(parsed.getTime())) {
+    return createdAt;
+  }
+  return `${parsed.toISOString().slice(0, 16).replace('T', ' ')} UTC`;
+}
+
+// describePublishGroup renders one picker entry: a truncated message (or
+// commit) plus the platforms as the title, and each sub-update with its
+// platform and release time as the description.
 export function describePublishGroup(group: PublishGroupSummary): {
   title: string;
   description: string;
@@ -134,13 +157,16 @@ export function describePublishGroup(group: PublishGroupSummary): {
   // back to the date so the picker never renders an empty label.
   const shortCommit = group.commitHash.slice(0, 7);
   const label = group.message?.trim()
-    ? group.message
+    ? truncateMessage(group.message.trim())
     : shortCommit
       ? `Commit ${shortCommit}`
-      : `Published ${new Date(group.createdAt).toUTCString()}`;
-  const commitSuffix = shortCommit ? `, commit ${shortCommit}` : '';
+      : `Published ${formatPublishedAt(group.createdAt)}`;
+  const members = group.updates
+    .map(update => `${update.platform} ${formatPublishedAt(update.createdAt)}`)
+    .join(', ');
+  const commitSuffix = shortCommit ? ` (commit ${shortCommit})` : '';
   return {
     title: `${label} (${group.platforms.join(' + ')})`,
-    description: `Published ${new Date(group.createdAt).toUTCString()}${commitSuffix}`,
+    description: `${members}${commitSuffix}`,
   };
 }

--- a/apps/eoas/src/lib/serverUpdates.ts
+++ b/apps/eoas/src/lib/serverUpdates.ts
@@ -1,0 +1,146 @@
+import { Credentials, getAuthHeaders } from './auth';
+import { fetchWithRetries } from './fetch';
+
+// Read helpers for the server's update listing endpoints, shared by the
+// republish and rollback commands (runtime version picker, update picker,
+// publish group picker).
+
+export interface RuntimeVersionInfo {
+  runtimeVersion: string;
+  lastUpdatedAt: string;
+  createdAt: string;
+  numberOfUpdates: number;
+}
+
+export interface ServerUpdateItem {
+  updateUUID: string;
+  createdAt: string;
+  updateId: string;
+  platform: string;
+  commitHash: string;
+  message?: string;
+  publishGroup?: string;
+}
+
+export async function fetchRuntimeVersions({
+  baseUrl,
+  appId,
+  branch,
+  credentials,
+}: {
+  baseUrl: string;
+  appId: string;
+  branch: string;
+  credentials: Credentials;
+}): Promise<RuntimeVersionInfo[]> {
+  const response = await fetchWithRetries(
+    `${baseUrl}/api/apps/${appId}/branch/${branch}/runtimeVersions`,
+    {
+      headers: {
+        ...getAuthHeaders(credentials),
+        'use-cli-auth': 'true',
+      },
+    }
+  );
+  if (!response.ok) {
+    throw new Error(`Failed to fetch runtime versions: ${await response.text()}`);
+  }
+  return (await response.json()) as RuntimeVersionInfo[];
+}
+
+export async function fetchUpdates({
+  baseUrl,
+  appId,
+  branch,
+  runtimeVersion,
+  credentials,
+}: {
+  baseUrl: string;
+  appId: string;
+  branch: string;
+  runtimeVersion: string;
+  credentials: Credentials;
+}): Promise<ServerUpdateItem[]> {
+  const response = await fetchWithRetries(
+    `${baseUrl}/api/apps/${appId}/branch/${branch}/runtimeVersion/${runtimeVersion}/updates`,
+    {
+      headers: {
+        ...getAuthHeaders(credentials),
+        'use-cli-auth': 'true',
+      },
+    }
+  );
+  if (!response.ok) {
+    throw new Error(`Failed to fetch updates: ${await response.text()}`);
+  }
+  return (await response.json()) as ServerUpdateItem[];
+}
+
+export interface PublishGroupSummary {
+  publishGroup: string;
+  platforms: string[];
+  commitHash: string;
+  message?: string;
+  createdAt: string;
+  updates: ServerUpdateItem[];
+}
+
+// groupPublishedUpdates splits a listing into publish groups (newest first)
+// and the leftover ungrouped updates (older CLIs, stateless servers). Filter
+// out rollback markers before calling if they should not be offered.
+export function groupPublishedUpdates(updates: ServerUpdateItem[]): {
+  groups: PublishGroupSummary[];
+  ungrouped: ServerUpdateItem[];
+} {
+  const groupsById = new Map<string, PublishGroupSummary>();
+  const ungrouped: ServerUpdateItem[] = [];
+  for (const update of updates) {
+    if (!update.publishGroup) {
+      ungrouped.push(update);
+      continue;
+    }
+    const existing = groupsById.get(update.publishGroup);
+    if (!existing) {
+      groupsById.set(update.publishGroup, {
+        publishGroup: update.publishGroup,
+        platforms: [update.platform],
+        commitHash: update.commitHash,
+        message: update.message,
+        createdAt: update.createdAt,
+        updates: [update],
+      });
+      continue;
+    }
+    existing.updates.push(update);
+    if (!existing.platforms.includes(update.platform)) {
+      existing.platforms.push(update.platform);
+    }
+    // The freshest member dates the group in the picker.
+    if (update.createdAt > existing.createdAt) {
+      existing.createdAt = update.createdAt;
+    }
+  }
+  const groups = [...groupsById.values()].sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+  return { groups, ungrouped };
+}
+
+// describePublishGroup renders one picker line: the message (or commit) plus
+// the platforms it covers.
+export function describePublishGroup(group: PublishGroupSummary): {
+  title: string;
+  description: string;
+} {
+  // A publish made outside a git repository stores an empty commit hash; fall
+  // back to the date so the picker never renders an empty label.
+  const shortCommit = group.commitHash.slice(0, 7);
+  const label = group.message?.trim()
+    ? group.message
+    : shortCommit
+      ? `Commit ${shortCommit}`
+      : `Published ${new Date(group.createdAt).toUTCString()}`;
+  const commitSuffix = shortCommit ? `, commit ${shortCommit}` : '';
+  return {
+    title: `${label} (${group.platforms.join(' + ')})`,
+    description: `Published ${new Date(group.createdAt).toUTCString()}${commitSuffix}`,
+  };
+}

--- a/apps/example-app/app.config.ts
+++ b/apps/example-app/app.config.ts
@@ -14,7 +14,7 @@ export default ({ config }: ConfigContext): ExpoConfig => {
 
       "requestHeaders": {
         "expo-channel-name": process.env.RELEASE_CHANNEL,
-        "expo-app-id": "b97123c0-7e77-48cf-826c-90e38e175aba",
+        "expo-app-id": "d3a60200-4574-4781-9734-c174b511fb55",
       },
     },
   };

--- a/internal/database/postgres/migrations/20260724120000_publish_group.sql
+++ b/internal/database/postgres/migrations/20260724120000_publish_group.sql
@@ -1,0 +1,15 @@
+-- +goose Up
+
+-- One eoas publish produces one update row per platform (iOS then Android),
+-- each with its own id and uuid; nothing ties them together. The CLI now mints
+-- a single UUID per publish run and sends it with each per-platform call
+-- (group republishes get a server-minted one), stored here so consumers
+-- (dashboard grouping, per-publish health) can treat the set as one publish.
+-- NULL for rows created by older CLIs, rollback markers (branch-level
+-- operations, never grouped) and stateless mode, which degrade to the
+-- ungrouped per-platform display. No index: readers fetch the branch listing
+-- and group in memory; add one when a query filters on it.
+ALTER TABLE updates ADD COLUMN publish_group UUID;
+
+-- +goose Down
+ALTER TABLE updates DROP COLUMN publish_group;

--- a/internal/database/postgres/migrations/20260724120000_publish_group.sql
+++ b/internal/database/postgres/migrations/20260724120000_publish_group.sql
@@ -7,9 +7,15 @@
 -- (dashboard grouping, per-publish health) can treat the set as one publish.
 -- NULL for rows created by older CLIs, rollback markers (branch-level
 -- operations, never grouped) and stateless mode, which degrade to the
--- ungrouped per-platform display. No index: readers fetch the branch listing
--- and group in memory; add one when a query filters on it.
+-- ungrouped per-platform display.
 ALTER TABLE updates ADD COLUMN publish_group UUID;
 
+-- Serves the group-republish member resolution (and future group-scoped
+-- reads). Partial on both predicates so the index only holds grouped, served
+-- rows; ungrouped history costs nothing.
+CREATE INDEX idx_updates_publish_group ON updates (publish_group)
+    WHERE publish_group IS NOT NULL AND checked_at IS NOT NULL;
+
 -- +goose Down
+DROP INDEX idx_updates_publish_group;
 ALTER TABLE updates DROP COLUMN publish_group;

--- a/internal/database/postgres/migrations/20260724130000_dashboard_branch_summaries.sql
+++ b/internal/database/postgres/migrations/20260724130000_dashboard_branch_summaries.sql
@@ -1,0 +1,17 @@
+-- +goose Up
+-- +goose StatementBegin
+
+-- Supports the branch/channel dashboard summaries: once the newest runtime for
+-- a branch is known, its active rollout or latest checked update is read in
+-- descending publication order.
+CREATE INDEX idx_updates_branch_runtime_created
+    ON updates(branch_id, runtime_version_id, created_at DESC, id DESC)
+    INCLUDE (commit_hash, rollout_percentage)
+    WHERE checked_at IS NOT NULL;
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP INDEX IF EXISTS idx_updates_branch_runtime_created;
+-- +goose StatementEnd

--- a/internal/database/postgres/pgdb/models.go
+++ b/internal/database/postgres/pgdb/models.go
@@ -146,6 +146,7 @@ type Update struct {
 	CheckedAt         pgtype.Timestamptz `json:"checked_at"`
 	RolloutPercentage *int32             `json:"rollout_percentage"`
 	ControlUpdateID   *int64             `json:"control_update_id"`
+	PublishGroup      pgtype.UUID        `json:"publish_group"`
 }
 
 type User struct {

--- a/internal/database/postgres/pgdb/queries.sql.go
+++ b/internal/database/postgres/pgdb/queries.sql.go
@@ -509,21 +509,60 @@ func (q *Queries) GetBranchByName(ctx context.Context, arg GetBranchByNameParams
 }
 
 const getBranchesByAppID = `-- name: GetBranchesByAppID :many
+WITH latest_runtime AS (
+    SELECT DISTINCT ON (u.branch_id)
+        u.branch_id,
+        u.runtime_version_id,
+        rv.version
+    FROM updates u
+    JOIN branches b ON b.id = u.branch_id
+    JOIN runtime_versions rv ON rv.id = u.runtime_version_id
+    WHERE b.app_id = $1 AND u.checked_at IS NOT NULL
+    ORDER BY u.branch_id, rv.created_at DESC, rv.id DESC
+),
+current_updates AS (
+    SELECT DISTINCT ON (u.branch_id)
+        u.branch_id,
+        lr.version AS runtime_version,
+        u.commit_hash,
+        u.created_at,
+        u.rollout_percentage
+    FROM latest_runtime lr
+    JOIN updates u
+      ON u.branch_id = lr.branch_id
+     AND u.runtime_version_id = lr.runtime_version_id
+    WHERE u.checked_at IS NOT NULL
+    ORDER BY
+        u.branch_id,
+        (u.rollout_percentage IS NOT NULL) DESC,
+        u.created_at DESC,
+        u.id DESC
+)
 SELECT DISTINCT ON (branches.id) 
     branches.id, branches.app_id, branches.name, branches.created_at, branches.protected, 
-    channels.name AS channel_name 
+    channels.name AS channel_name,
+    cu.runtime_version AS current_runtime_version,
+    cu.commit_hash AS current_commit_hash,
+    cu.created_at AS current_update_created_at,
+    cu.rollout_percentage AS current_rollout_percentage
 FROM branches
 LEFT JOIN channels ON branches.id = channels.branch_id AND channels.app_id = branches.app_id
+LEFT JOIN current_updates cu ON cu.branch_id = branches.id
 WHERE branches.app_id = $1
+ORDER BY branches.id, channels.created_at ASC NULLS LAST
 `
 
 type GetBranchesByAppIDRow struct {
-	ID          int64              `json:"id"`
-	AppID       pgtype.UUID        `json:"app_id"`
-	Name        string             `json:"name"`
-	CreatedAt   pgtype.Timestamptz `json:"created_at"`
-	Protected   bool               `json:"protected"`
-	ChannelName *string            `json:"channel_name"`
+	ID                       int64              `json:"id"`
+	AppID                    pgtype.UUID        `json:"app_id"`
+	Name                     string             `json:"name"`
+	CreatedAt                pgtype.Timestamptz `json:"created_at"`
+	Protected                bool               `json:"protected"`
+	ChannelName              *string            `json:"channel_name"`
+	CurrentRuntimeVersion    *string            `json:"current_runtime_version"`
+	CurrentCommitHash        *string            `json:"current_commit_hash"`
+	CurrentUpdateCreatedAt   pgtype.Timestamptz `json:"current_update_created_at"`
+	CurrentRolloutPercentage *int32             `json:"current_rollout_percentage"`
 }
 
 func (q *Queries) GetBranchesByAppID(ctx context.Context, appID pgtype.UUID) ([]GetBranchesByAppIDRow, error) {
@@ -542,6 +581,10 @@ func (q *Queries) GetBranchesByAppID(ctx context.Context, appID pgtype.UUID) ([]
 			&i.CreatedAt,
 			&i.Protected,
 			&i.ChannelName,
+			&i.CurrentRuntimeVersion,
+			&i.CurrentCommitHash,
+			&i.CurrentUpdateCreatedAt,
+			&i.CurrentRolloutPercentage,
 		); err != nil {
 			return nil, err
 		}
@@ -705,32 +748,79 @@ func (q *Queries) GetChannelRolloutsByBranch(ctx context.Context, arg GetChannel
 }
 
 const getChannelsByAppID = `-- name: GetChannelsByAppID :many
+WITH latest_runtime AS (
+    SELECT DISTINCT ON (u.branch_id)
+        u.branch_id,
+        u.runtime_version_id,
+        rv.version
+    FROM updates u
+    JOIN branches b ON b.id = u.branch_id
+    JOIN runtime_versions rv ON rv.id = u.runtime_version_id
+    WHERE b.app_id = $1 AND u.checked_at IS NOT NULL
+    ORDER BY u.branch_id, rv.created_at DESC, rv.id DESC
+),
+current_updates AS (
+    SELECT DISTINCT ON (u.branch_id)
+        u.branch_id,
+        lr.version AS runtime_version,
+        u.commit_hash,
+        u.created_at,
+        u.rollout_percentage
+    FROM latest_runtime lr
+    JOIN updates u
+      ON u.branch_id = lr.branch_id
+     AND u.runtime_version_id = lr.runtime_version_id
+    WHERE u.checked_at IS NOT NULL
+    ORDER BY
+        u.branch_id,
+        (u.rollout_percentage IS NOT NULL) DESC,
+        u.created_at DESC,
+        u.id DESC
+)
 SELECT channels.id, channels.app_id, channels.branch_id, channels.name, channels.created_at, branches.name as branch_name,
     cr.id AS rollout_id,
     rb.name AS rollout_branch_name,
     cr.percentage AS rollout_percentage,
     cr.created_at AS rollout_created_at,
-    cr.updated_at AS rollout_updated_at
+    cr.updated_at AS rollout_updated_at,
+    bcu.runtime_version AS branch_current_runtime_version,
+    bcu.commit_hash AS branch_current_commit_hash,
+    bcu.created_at AS branch_current_update_created_at,
+    bcu.rollout_percentage AS branch_current_rollout_percentage,
+    rcu.runtime_version AS rollout_branch_current_runtime_version,
+    rcu.commit_hash AS rollout_branch_current_commit_hash,
+    rcu.created_at AS rollout_branch_current_update_created_at,
+    rcu.rollout_percentage AS rollout_branch_current_rollout_percentage
 FROM channels
 LEFT JOIN branches ON channels.branch_id = branches.id AND branches.app_id = channels.app_id
 LEFT JOIN channel_rollouts cr ON cr.channel_id = channels.id
 LEFT JOIN branches rb ON cr.rollout_branch_id = rb.id
+LEFT JOIN current_updates bcu ON bcu.branch_id = channels.branch_id
+LEFT JOIN current_updates rcu ON rcu.branch_id = cr.rollout_branch_id
 WHERE channels.app_id = $1
 ORDER BY channels.created_at ASC
 `
 
 type GetChannelsByAppIDRow struct {
-	ID                int64              `json:"id"`
-	AppID             pgtype.UUID        `json:"app_id"`
-	BranchID          *int64             `json:"branch_id"`
-	Name              string             `json:"name"`
-	CreatedAt         pgtype.Timestamptz `json:"created_at"`
-	BranchName        *string            `json:"branch_name"`
-	RolloutID         pgtype.UUID        `json:"rollout_id"`
-	RolloutBranchName *string            `json:"rollout_branch_name"`
-	RolloutPercentage *int32             `json:"rollout_percentage"`
-	RolloutCreatedAt  pgtype.Timestamptz `json:"rollout_created_at"`
-	RolloutUpdatedAt  pgtype.Timestamptz `json:"rollout_updated_at"`
+	ID                                    int64              `json:"id"`
+	AppID                                 pgtype.UUID        `json:"app_id"`
+	BranchID                              *int64             `json:"branch_id"`
+	Name                                  string             `json:"name"`
+	CreatedAt                             pgtype.Timestamptz `json:"created_at"`
+	BranchName                            *string            `json:"branch_name"`
+	RolloutID                             pgtype.UUID        `json:"rollout_id"`
+	RolloutBranchName                     *string            `json:"rollout_branch_name"`
+	RolloutPercentage                     *int32             `json:"rollout_percentage"`
+	RolloutCreatedAt                      pgtype.Timestamptz `json:"rollout_created_at"`
+	RolloutUpdatedAt                      pgtype.Timestamptz `json:"rollout_updated_at"`
+	BranchCurrentRuntimeVersion           *string            `json:"branch_current_runtime_version"`
+	BranchCurrentCommitHash               *string            `json:"branch_current_commit_hash"`
+	BranchCurrentUpdateCreatedAt          pgtype.Timestamptz `json:"branch_current_update_created_at"`
+	BranchCurrentRolloutPercentage        *int32             `json:"branch_current_rollout_percentage"`
+	RolloutBranchCurrentRuntimeVersion    *string            `json:"rollout_branch_current_runtime_version"`
+	RolloutBranchCurrentCommitHash        *string            `json:"rollout_branch_current_commit_hash"`
+	RolloutBranchCurrentUpdateCreatedAt   pgtype.Timestamptz `json:"rollout_branch_current_update_created_at"`
+	RolloutBranchCurrentRolloutPercentage *int32             `json:"rollout_branch_current_rollout_percentage"`
 }
 
 func (q *Queries) GetChannelsByAppID(ctx context.Context, appID pgtype.UUID) ([]GetChannelsByAppIDRow, error) {
@@ -754,6 +844,14 @@ func (q *Queries) GetChannelsByAppID(ctx context.Context, appID pgtype.UUID) ([]
 			&i.RolloutPercentage,
 			&i.RolloutCreatedAt,
 			&i.RolloutUpdatedAt,
+			&i.BranchCurrentRuntimeVersion,
+			&i.BranchCurrentCommitHash,
+			&i.BranchCurrentUpdateCreatedAt,
+			&i.BranchCurrentRolloutPercentage,
+			&i.RolloutBranchCurrentRuntimeVersion,
+			&i.RolloutBranchCurrentCommitHash,
+			&i.RolloutBranchCurrentUpdateCreatedAt,
+			&i.RolloutBranchCurrentRolloutPercentage,
 		); err != nil {
 			return nil, err
 		}
@@ -959,7 +1057,16 @@ SELECT
         JOIN branches b ON u.branch_id = b.id
         WHERE u.runtime_version_id = rv.id 
           AND b.name = $2 AND u.checked_at IS NOT NULL
-    ) AS update_count
+    ) AS update_count,
+    (
+        SELECT MAX(u.rollout_percentage)
+        FROM updates u
+        JOIN branches b ON u.branch_id = b.id
+        WHERE u.runtime_version_id = rv.id
+          AND b.name = $2
+          AND u.checked_at IS NOT NULL
+          AND u.rollout_percentage IS NOT NULL
+    ) AS rollout_percentage
 FROM runtime_versions rv
 WHERE rv.app_id = $1
   -- Only allow rows where at least one matching update exists
@@ -980,11 +1087,12 @@ type GetRuntimeVersionsWithUpdateCountParams struct {
 }
 
 type GetRuntimeVersionsWithUpdateCountRow struct {
-	ID          int64              `json:"id"`
-	Version     string             `json:"version"`
-	CreatedAt   pgtype.Timestamptz `json:"created_at"`
-	UpdatedAt   pgtype.Timestamptz `json:"updated_at"`
-	UpdateCount int64              `json:"update_count"`
+	ID                int64              `json:"id"`
+	Version           string             `json:"version"`
+	CreatedAt         pgtype.Timestamptz `json:"created_at"`
+	UpdatedAt         pgtype.Timestamptz `json:"updated_at"`
+	UpdateCount       int64              `json:"update_count"`
+	RolloutPercentage interface{}        `json:"rollout_percentage"`
 }
 
 func (q *Queries) GetRuntimeVersionsWithUpdateCount(ctx context.Context, arg GetRuntimeVersionsWithUpdateCountParams) ([]GetRuntimeVersionsWithUpdateCountRow, error) {
@@ -1002,6 +1110,7 @@ func (q *Queries) GetRuntimeVersionsWithUpdateCount(ctx context.Context, arg Get
 			&i.CreatedAt,
 			&i.UpdatedAt,
 			&i.UpdateCount,
+			&i.RolloutPercentage,
 		); err != nil {
 			return nil, err
 		}
@@ -1179,6 +1288,114 @@ func (q *Queries) GetUpdateCheckedAt(ctx context.Context, arg GetUpdateCheckedAt
 	var checked_at pgtype.Timestamptz
 	err := row.Scan(&checked_at)
 	return checked_at, err
+}
+
+const getUpdateFeed = `-- name: GetUpdateFeed :many
+SELECT u.id, u.update_uuid, u.update_type, u.created_at, u.commit_hash,
+       u.platform, u.message, u.rollout_percentage, u.control_update_id,
+       u.publish_group, u.branch_id, b.name AS branch_name,
+       rv.version AS runtime_version
+FROM updates u
+JOIN branches b ON u.branch_id = b.id
+JOIN runtime_versions rv ON u.runtime_version_id = rv.id
+WHERE b.app_id = $1
+  AND u.checked_at IS NOT NULL
+  AND ($2::text = '' OR b.name = $2)
+  AND ($3::text = '' OR rv.version = $3)
+  AND ($4::text = '' OR u.platform = $4)
+  AND ($5::text = '' OR u.update_uuid::text ILIKE '%' || $5 || '%')
+  AND ($6::text = '' OR u.publish_group::text ILIKE '%' || $6 || '%')
+  AND ($7::text = '' OR u.commit_hash ILIKE '%' || $7 || '%')
+  AND ($8::timestamptz IS NULL OR u.created_at >= $8)
+  AND ($9::timestamptz IS NULL OR u.created_at <= $9)
+  AND (
+    NOT $10::boolean
+    OR (u.created_at, u.branch_id, u.id) < ($11::timestamptz, $12::bigint, $13::bigint)
+  )
+ORDER BY u.created_at DESC, u.branch_id DESC, u.id DESC
+LIMIT $14::int
+`
+
+type GetUpdateFeedParams struct {
+	AppID           pgtype.UUID        `json:"app_id"`
+	Branch          string             `json:"branch"`
+	RuntimeVersion  string             `json:"runtime_version"`
+	Platform        string             `json:"platform"`
+	UpdateUuid      string             `json:"update_uuid"`
+	PublishGroup    string             `json:"publish_group"`
+	CommitHash      string             `json:"commit_hash"`
+	CreatedFrom     pgtype.Timestamptz `json:"created_from"`
+	CreatedTo       pgtype.Timestamptz `json:"created_to"`
+	HasCursor       bool               `json:"has_cursor"`
+	CursorCreatedAt pgtype.Timestamptz `json:"cursor_created_at"`
+	CursorBranchID  int64              `json:"cursor_branch_id"`
+	CursorUpdateID  int64              `json:"cursor_update_id"`
+	RowLimit        int32              `json:"row_limit"`
+}
+
+type GetUpdateFeedRow struct {
+	ID                int64              `json:"id"`
+	UpdateUuid        pgtype.UUID        `json:"update_uuid"`
+	UpdateType        int32              `json:"update_type"`
+	CreatedAt         pgtype.Timestamptz `json:"created_at"`
+	CommitHash        string             `json:"commit_hash"`
+	Platform          string             `json:"platform"`
+	Message           *string            `json:"message"`
+	RolloutPercentage *int32             `json:"rollout_percentage"`
+	ControlUpdateID   *int64             `json:"control_update_id"`
+	PublishGroup      pgtype.UUID        `json:"publish_group"`
+	BranchID          int64              `json:"branch_id"`
+	BranchName        string             `json:"branch_name"`
+	RuntimeVersion    string             `json:"runtime_version"`
+}
+
+func (q *Queries) GetUpdateFeed(ctx context.Context, arg GetUpdateFeedParams) ([]GetUpdateFeedRow, error) {
+	rows, err := q.db.Query(ctx, getUpdateFeed,
+		arg.AppID,
+		arg.Branch,
+		arg.RuntimeVersion,
+		arg.Platform,
+		arg.UpdateUuid,
+		arg.PublishGroup,
+		arg.CommitHash,
+		arg.CreatedFrom,
+		arg.CreatedTo,
+		arg.HasCursor,
+		arg.CursorCreatedAt,
+		arg.CursorBranchID,
+		arg.CursorUpdateID,
+		arg.RowLimit,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []GetUpdateFeedRow
+	for rows.Next() {
+		var i GetUpdateFeedRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.UpdateUuid,
+			&i.UpdateType,
+			&i.CreatedAt,
+			&i.CommitHash,
+			&i.Platform,
+			&i.Message,
+			&i.RolloutPercentage,
+			&i.ControlUpdateID,
+			&i.PublishGroup,
+			&i.BranchID,
+			&i.BranchName,
+			&i.RuntimeVersion,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
 }
 
 const getUpdateMetadata = `-- name: GetUpdateMetadata :one

--- a/internal/database/postgres/pgdb/queries.sql.go
+++ b/internal/database/postgres/pgdb/queries.sql.go
@@ -1240,7 +1240,7 @@ func (q *Queries) GetUpdateType(ctx context.Context, arg GetUpdateTypeParams) (i
 }
 
 const getUpdatesByByBranchNameAndRuntimeVersion = `-- name: GetUpdatesByByBranchNameAndRuntimeVersion :many
-SELECT u.id, u.update_uuid, u.update_type, u.created_at, u.commit_hash, u.platform, u.message, u.checked_at, u.rollout_percentage, u.control_update_id
+SELECT u.id, u.update_uuid, u.update_type, u.created_at, u.commit_hash, u.platform, u.message, u.checked_at, u.rollout_percentage, u.control_update_id, u.publish_group
 FROM updates u
 JOIN runtime_versions rv ON u.runtime_version_id = rv.id
 JOIN branches b ON u.branch_id = b.id
@@ -1269,6 +1269,7 @@ type GetUpdatesByByBranchNameAndRuntimeVersionRow struct {
 	CheckedAt         pgtype.Timestamptz `json:"checked_at"`
 	RolloutPercentage *int32             `json:"rollout_percentage"`
 	ControlUpdateID   *int64             `json:"control_update_id"`
+	PublishGroup      pgtype.UUID        `json:"publish_group"`
 }
 
 func (q *Queries) GetUpdatesByByBranchNameAndRuntimeVersion(ctx context.Context, arg GetUpdatesByByBranchNameAndRuntimeVersionParams) ([]GetUpdatesByByBranchNameAndRuntimeVersionRow, error) {
@@ -1291,7 +1292,62 @@ func (q *Queries) GetUpdatesByByBranchNameAndRuntimeVersion(ctx context.Context,
 			&i.CheckedAt,
 			&i.RolloutPercentage,
 			&i.ControlUpdateID,
+			&i.PublishGroup,
 		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const getUpdatesByPublishGroup = `-- name: GetUpdatesByPublishGroup :many
+SELECT u.id, u.platform, u.commit_hash
+FROM updates u
+JOIN branches b ON u.branch_id = b.id
+JOIN runtime_versions rv ON u.runtime_version_id = rv.id
+WHERE b.app_id = $1
+  AND b.name = $2
+  AND rv.version = $3
+  AND u.publish_group = $4
+  AND u.checked_at IS NOT NULL
+ORDER BY u.id
+`
+
+type GetUpdatesByPublishGroupParams struct {
+	AppID        pgtype.UUID `json:"app_id"`
+	Name         string      `json:"name"`
+	Version      string      `json:"version"`
+	PublishGroup pgtype.UUID `json:"publish_group"`
+}
+
+type GetUpdatesByPublishGroupRow struct {
+	ID         int64  `json:"id"`
+	Platform   string `json:"platform"`
+	CommitHash string `json:"commit_hash"`
+}
+
+// The members of one publish group on a branch and runtime version, for the
+// group republish (republish every platform of one eoas publish). Only
+// checked rows: an unchecked row is an unfinished upload, not a served update.
+func (q *Queries) GetUpdatesByPublishGroup(ctx context.Context, arg GetUpdatesByPublishGroupParams) ([]GetUpdatesByPublishGroupRow, error) {
+	rows, err := q.db.Query(ctx, getUpdatesByPublishGroup,
+		arg.AppID,
+		arg.Name,
+		arg.Version,
+		arg.PublishGroup,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []GetUpdatesByPublishGroupRow
+	for rows.Next() {
+		var i GetUpdatesByPublishGroupRow
+		if err := rows.Scan(&i.ID, &i.Platform, &i.CommitHash); err != nil {
 			return nil, err
 		}
 		items = append(items, i)
@@ -1796,13 +1852,14 @@ WITH resolved_names AS (
       AND b.app_id = $3
 )
 INSERT INTO updates (
-    id, 
-    branch_id, 
-    runtime_version_id, 
-    update_type, 
-    platform, 
-    commit_hash, 
-    message
+    id,
+    branch_id,
+    runtime_version_id,
+    update_type,
+    platform,
+    commit_hash,
+    message,
+    publish_group
 ) VALUES (
     $1,
     (SELECT resolved_branch_id FROM resolved_names),
@@ -1810,13 +1867,14 @@ INSERT INTO updates (
     $5,
     $6,
     $7,
-    $8
+    $8,
+    $9
 )
-RETURNING 
-    id, 
-    platform, 
-    commit_hash, 
-    message, 
+RETURNING
+    id,
+    platform,
+    commit_hash,
+    message,
     created_at,
     (SELECT app_id FROM resolved_names) AS app_id,
     (SELECT branch_name FROM resolved_names) AS branch_name,
@@ -1824,14 +1882,15 @@ RETURNING
 `
 
 type InsertUpdateParams struct {
-	ID         int64       `json:"id"`
-	Name       string      `json:"name"`
-	AppID      pgtype.UUID `json:"app_id"`
-	Version    string      `json:"version"`
-	UpdateType int32       `json:"update_type"`
-	Platform   string      `json:"platform"`
-	CommitHash string      `json:"commit_hash"`
-	Message    *string     `json:"message"`
+	ID           int64       `json:"id"`
+	Name         string      `json:"name"`
+	AppID        pgtype.UUID `json:"app_id"`
+	Version      string      `json:"version"`
+	UpdateType   int32       `json:"update_type"`
+	Platform     string      `json:"platform"`
+	CommitHash   string      `json:"commit_hash"`
+	Message      *string     `json:"message"`
+	PublishGroup pgtype.UUID `json:"publish_group"`
 }
 
 type InsertUpdateRow struct {
@@ -1855,6 +1914,7 @@ func (q *Queries) InsertUpdate(ctx context.Context, arg InsertUpdateParams) (Ins
 		arg.Platform,
 		arg.CommitHash,
 		arg.Message,
+		arg.PublishGroup,
 	)
 	var i InsertUpdateRow
 	err := row.Scan(
@@ -1903,7 +1963,8 @@ INSERT INTO updates (
     commit_hash,
     message,
     rollout_percentage,
-    control_update_id
+    control_update_id,
+    publish_group
 ) VALUES (
     $1,
     (SELECT resolved_branch_id FROM resolved_names),
@@ -1913,7 +1974,8 @@ INSERT INTO updates (
     $7,
     $8,
     $9,
-    (SELECT control_id FROM resolved_control)
+    (SELECT control_id FROM resolved_control),
+    $10
 )
 RETURNING
     id,
@@ -1938,6 +2000,7 @@ type InsertUpdateWithRolloutParams struct {
 	CommitHash        string      `json:"commit_hash"`
 	Message           *string     `json:"message"`
 	RolloutPercentage *int32      `json:"rollout_percentage"`
+	PublishGroup      pgtype.UUID `json:"publish_group"`
 }
 
 type InsertUpdateWithRolloutRow struct {
@@ -1967,6 +2030,7 @@ func (q *Queries) InsertUpdateWithRollout(ctx context.Context, arg InsertUpdateW
 		arg.CommitHash,
 		arg.Message,
 		arg.RolloutPercentage,
+		arg.PublishGroup,
 	)
 	var i InsertUpdateWithRolloutRow
 	err := row.Scan(

--- a/internal/database/postgres/queries/queries.sql
+++ b/internal/database/postgres/queries/queries.sql
@@ -141,7 +141,7 @@ VALUES ($1, $2)
 RETURNING id;
 
 -- name: GetUpdatesByByBranchNameAndRuntimeVersion :many
-SELECT u.id, u.update_uuid, u.update_type, u.created_at, u.commit_hash, u.platform, u.message, u.checked_at, u.rollout_percentage, u.control_update_id
+SELECT u.id, u.update_uuid, u.update_type, u.created_at, u.commit_hash, u.platform, u.message, u.checked_at, u.rollout_percentage, u.control_update_id, u.publish_group
 FROM updates u
 JOIN runtime_versions rv ON u.runtime_version_id = rv.id
 JOIN branches b ON u.branch_id = b.id
@@ -167,6 +167,21 @@ JOIN branches b ON u.branch_id = b.id
 WHERE b.app_id = $1
   AND b.name = $2
   AND u.id = $3;
+
+-- name: GetUpdatesByPublishGroup :many
+-- The members of one publish group on a branch and runtime version, for the
+-- group republish (republish every platform of one eoas publish). Only
+-- checked rows: an unchecked row is an unfinished upload, not a served update.
+SELECT u.id, u.platform, u.commit_hash
+FROM updates u
+JOIN branches b ON u.branch_id = b.id
+JOIN runtime_versions rv ON u.runtime_version_id = rv.id
+WHERE b.app_id = $1
+  AND b.name = $2
+  AND rv.version = $3
+  AND u.publish_group = $4
+  AND u.checked_at IS NOT NULL
+ORDER BY u.id;
 
 -- name: GetUpdateMetadata :one
 SELECT updates.id, update_uuid, platform, commit_hash, message
@@ -306,13 +321,14 @@ WITH resolved_names AS (
       AND b.app_id = $3
 )
 INSERT INTO updates (
-    id, 
-    branch_id, 
-    runtime_version_id, 
-    update_type, 
-    platform, 
-    commit_hash, 
-    message
+    id,
+    branch_id,
+    runtime_version_id,
+    update_type,
+    platform,
+    commit_hash,
+    message,
+    publish_group
 ) VALUES (
     $1,
     (SELECT resolved_branch_id FROM resolved_names),
@@ -320,13 +336,14 @@ INSERT INTO updates (
     $5,
     $6,
     $7,
-    $8
+    $8,
+    $9
 )
-RETURNING 
-    id, 
-    platform, 
-    commit_hash, 
-    message, 
+RETURNING
+    id,
+    platform,
+    commit_hash,
+    message,
     created_at,
     (SELECT app_id FROM resolved_names) AS app_id,
     (SELECT branch_name FROM resolved_names) AS branch_name,
@@ -755,7 +772,8 @@ INSERT INTO updates (
     commit_hash,
     message,
     rollout_percentage,
-    control_update_id
+    control_update_id,
+    publish_group
 ) VALUES (
     $1,
     (SELECT resolved_branch_id FROM resolved_names),
@@ -765,7 +783,8 @@ INSERT INTO updates (
     $7,
     $8,
     $9,
-    (SELECT control_id FROM resolved_control)
+    (SELECT control_id FROM resolved_control),
+    $10
 )
 RETURNING
     id,

--- a/internal/database/postgres/queries/queries.sql
+++ b/internal/database/postgres/queries/queries.sql
@@ -31,16 +31,55 @@ DELETE FROM channels
 WHERE name = $1 AND app_id = $2;
 
 -- name: GetChannelsByAppID :many
+WITH latest_runtime AS (
+    SELECT DISTINCT ON (u.branch_id)
+        u.branch_id,
+        u.runtime_version_id,
+        rv.version
+    FROM updates u
+    JOIN branches b ON b.id = u.branch_id
+    JOIN runtime_versions rv ON rv.id = u.runtime_version_id
+    WHERE b.app_id = $1 AND u.checked_at IS NOT NULL
+    ORDER BY u.branch_id, rv.created_at DESC, rv.id DESC
+),
+current_updates AS (
+    SELECT DISTINCT ON (u.branch_id)
+        u.branch_id,
+        lr.version AS runtime_version,
+        u.commit_hash,
+        u.created_at,
+        u.rollout_percentage
+    FROM latest_runtime lr
+    JOIN updates u
+      ON u.branch_id = lr.branch_id
+     AND u.runtime_version_id = lr.runtime_version_id
+    WHERE u.checked_at IS NOT NULL
+    ORDER BY
+        u.branch_id,
+        (u.rollout_percentage IS NOT NULL) DESC,
+        u.created_at DESC,
+        u.id DESC
+)
 SELECT channels.*, branches.name as branch_name,
     cr.id AS rollout_id,
     rb.name AS rollout_branch_name,
     cr.percentage AS rollout_percentage,
     cr.created_at AS rollout_created_at,
-    cr.updated_at AS rollout_updated_at
+    cr.updated_at AS rollout_updated_at,
+    bcu.runtime_version AS branch_current_runtime_version,
+    bcu.commit_hash AS branch_current_commit_hash,
+    bcu.created_at AS branch_current_update_created_at,
+    bcu.rollout_percentage AS branch_current_rollout_percentage,
+    rcu.runtime_version AS rollout_branch_current_runtime_version,
+    rcu.commit_hash AS rollout_branch_current_commit_hash,
+    rcu.created_at AS rollout_branch_current_update_created_at,
+    rcu.rollout_percentage AS rollout_branch_current_rollout_percentage
 FROM channels
 LEFT JOIN branches ON channels.branch_id = branches.id AND branches.app_id = channels.app_id
 LEFT JOIN channel_rollouts cr ON cr.channel_id = channels.id
 LEFT JOIN branches rb ON cr.rollout_branch_id = rb.id
+LEFT JOIN current_updates bcu ON bcu.branch_id = channels.branch_id
+LEFT JOIN current_updates rcu ON rcu.branch_id = cr.rollout_branch_id
 WHERE channels.app_id = $1
 ORDER BY channels.created_at ASC;
 
@@ -83,12 +122,47 @@ DELETE FROM branches
 WHERE name = $1 AND app_id = $2 AND NOT protected;
 
 -- name: GetBranchesByAppID :many
+WITH latest_runtime AS (
+    SELECT DISTINCT ON (u.branch_id)
+        u.branch_id,
+        u.runtime_version_id,
+        rv.version
+    FROM updates u
+    JOIN branches b ON b.id = u.branch_id
+    JOIN runtime_versions rv ON rv.id = u.runtime_version_id
+    WHERE b.app_id = $1 AND u.checked_at IS NOT NULL
+    ORDER BY u.branch_id, rv.created_at DESC, rv.id DESC
+),
+current_updates AS (
+    SELECT DISTINCT ON (u.branch_id)
+        u.branch_id,
+        lr.version AS runtime_version,
+        u.commit_hash,
+        u.created_at,
+        u.rollout_percentage
+    FROM latest_runtime lr
+    JOIN updates u
+      ON u.branch_id = lr.branch_id
+     AND u.runtime_version_id = lr.runtime_version_id
+    WHERE u.checked_at IS NOT NULL
+    ORDER BY
+        u.branch_id,
+        (u.rollout_percentage IS NOT NULL) DESC,
+        u.created_at DESC,
+        u.id DESC
+)
 SELECT DISTINCT ON (branches.id) 
     branches.*, 
-    channels.name AS channel_name 
+    channels.name AS channel_name,
+    cu.runtime_version AS current_runtime_version,
+    cu.commit_hash AS current_commit_hash,
+    cu.created_at AS current_update_created_at,
+    cu.rollout_percentage AS current_rollout_percentage
 FROM branches
 LEFT JOIN channels ON branches.id = channels.branch_id AND channels.app_id = branches.app_id
-WHERE branches.app_id = $1;
+LEFT JOIN current_updates cu ON cu.branch_id = branches.id
+WHERE branches.app_id = $1
+ORDER BY branches.id, channels.created_at ASC NULLS LAST;
 
 -- name: UpdateChannelBranchMapping :execresult
 -- The EXISTS clause scopes the *target* branch to the caller's app. fk_channels_branch
@@ -121,7 +195,16 @@ SELECT
         JOIN branches b ON u.branch_id = b.id
         WHERE u.runtime_version_id = rv.id 
           AND b.name = $2 AND u.checked_at IS NOT NULL
-    ) AS update_count
+    ) AS update_count,
+    (
+        SELECT MAX(u.rollout_percentage)
+        FROM updates u
+        JOIN branches b ON u.branch_id = b.id
+        WHERE u.runtime_version_id = rv.id
+          AND b.name = $2
+          AND u.checked_at IS NOT NULL
+          AND u.rollout_percentage IS NOT NULL
+    ) AS rollout_percentage
 FROM runtime_versions rv
 WHERE rv.app_id = $1
   -- Only allow rows where at least one matching update exists
@@ -151,6 +234,31 @@ WHERE a.id = $1
   AND b.name = $3
   AND u.checked_at IS NOT NULL
 ORDER BY u.created_at DESC;
+
+-- name: GetUpdateFeed :many
+SELECT u.id, u.update_uuid, u.update_type, u.created_at, u.commit_hash,
+       u.platform, u.message, u.rollout_percentage, u.control_update_id,
+       u.publish_group, u.branch_id, b.name AS branch_name,
+       rv.version AS runtime_version
+FROM updates u
+JOIN branches b ON u.branch_id = b.id
+JOIN runtime_versions rv ON u.runtime_version_id = rv.id
+WHERE b.app_id = @app_id
+  AND u.checked_at IS NOT NULL
+  AND (@branch::text = '' OR b.name = @branch)
+  AND (@runtime_version::text = '' OR rv.version = @runtime_version)
+  AND (@platform::text = '' OR u.platform = @platform)
+  AND (@update_uuid::text = '' OR u.update_uuid::text ILIKE '%' || @update_uuid || '%')
+  AND (@publish_group::text = '' OR u.publish_group::text ILIKE '%' || @publish_group || '%')
+  AND (@commit_hash::text = '' OR u.commit_hash ILIKE '%' || @commit_hash || '%')
+  AND (@created_from::timestamptz IS NULL OR u.created_at >= @created_from)
+  AND (@created_to::timestamptz IS NULL OR u.created_at <= @created_to)
+  AND (
+    NOT @has_cursor::boolean
+    OR (u.created_at, u.branch_id, u.id) < (@cursor_created_at::timestamptz, @cursor_branch_id::bigint, @cursor_update_id::bigint)
+  )
+ORDER BY u.created_at DESC, u.branch_id DESC, u.id DESC
+LIMIT @row_limit::int;
 
 -- name: GetUpdateType :one
 SELECT u.update_type 

--- a/internal/handlers/dashboard/rollouts_handler.go
+++ b/internal/handlers/dashboard/rollouts_handler.go
@@ -81,6 +81,9 @@ func (h *RolloutHandler) invalidateUpdateRolloutCaches(appId string, branchName 
 		update2.ComputeLastUpdateCacheKey(appId, branchName, runtimeVersion, "ios"),
 		update2.ComputeLastUpdateCacheKey(appId, branchName, runtimeVersion, "android"),
 		dashboard.ComputeGetUpdatesCacheKey(appId, branchName, runtimeVersion),
+		dashboard.ComputeGetRuntimeVersionsCacheKey(appId, branchName),
+		dashboard.ComputeGetBranchesCacheKey(appId),
+		dashboard.ComputeGetChannelsCacheKey(appId),
 	}
 	for _, affectedRollout := range affectedRollouts {
 		cacheKeys = append(cacheKeys, dashboard.ComputeGetUpdateDetailsCacheKey(appId, branchName, runtimeVersion, affectedRollout.UpdateId))

--- a/internal/handlers/dashboard/updates_handler.go
+++ b/internal/handlers/dashboard/updates_handler.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	cache2 "expo-open-ota/internal/cache"
@@ -10,9 +11,68 @@ import (
 	"expo-open-ota/internal/types"
 	"expo-open-ota/internal/validation"
 	"net/http"
+	"strconv"
+	"time"
 
 	"github.com/gorilla/mux"
 )
+
+const (
+	defaultUpdateFeedLimit = 50
+	maxUpdateFeedLimit     = 100
+)
+
+type updateFeedCursor struct {
+	CreatedAt time.Time `json:"createdAt"`
+	BranchID  int64     `json:"branchId"`
+	UpdateID  int64     `json:"updateId"`
+}
+
+func parseUpdateFeedDate(raw string, endOfDay bool) (*time.Time, error) {
+	if raw == "" {
+		return nil, nil
+	}
+	if parsed, err := time.Parse(time.RFC3339, raw); err == nil {
+		return &parsed, nil
+	}
+	parsed, err := time.Parse("2006-01-02", raw)
+	if err != nil {
+		return nil, err
+	}
+	if endOfDay {
+		parsed = parsed.Add(24*time.Hour - time.Nanosecond)
+	}
+	return &parsed, nil
+}
+
+func decodeUpdateFeedCursor(raw string) (*updateFeedCursor, error) {
+	if raw == "" {
+		return nil, nil
+	}
+	decoded, err := base64.RawURLEncoding.DecodeString(raw)
+	if err != nil {
+		return nil, err
+	}
+	var cursor updateFeedCursor
+	if err := json.Unmarshal(decoded, &cursor); err != nil {
+		return nil, err
+	}
+	return &cursor, nil
+}
+
+func encodeUpdateFeedCursor(item types.UpdateFeedItem) string {
+	encoded, _ := json.Marshal(updateFeedCursor{
+		CreatedAt: item.FeedCreatedAt,
+		BranchID:  item.BranchID,
+		UpdateID:  mustParseUpdateID(item.UpdateId),
+	})
+	return base64.RawURLEncoding.EncodeToString(encoded)
+}
+
+func mustParseUpdateID(value string) int64 {
+	parsed, _ := strconv.ParseInt(value, 10, 64)
+	return parsed
+}
 
 type UpdateHandler struct {
 	updateService *services.UpdateService
@@ -119,4 +179,65 @@ func (h *UpdateHandler) GetUpdatesHandler(w http.ResponseWriter, r *http.Request
 
 	ttl := 3600
 	cache.Set(cacheKey, string(marshaledResponse), &ttl)
+}
+
+func (h *UpdateHandler) GetUpdateFeedHandler(w http.ResponseWriter, r *http.Request) {
+	appId := mux.Vars(r)["APP_ID"]
+	params := r.URL.Query()
+	limit := defaultUpdateFeedLimit
+	if rawLimit := params.Get("limit"); rawLimit != "" {
+		parsed, err := strconv.Atoi(rawLimit)
+		if err != nil || parsed < 1 || parsed > maxUpdateFeedLimit {
+			handlers.RenderError(w, http.StatusBadRequest, "limit must be between 1 and 100")
+			return
+		}
+		limit = parsed
+	}
+	from, err := parseUpdateFeedDate(params.Get("from"), false)
+	if err != nil {
+		handlers.RenderError(w, http.StatusBadRequest, "from must be an RFC3339 timestamp or YYYY-MM-DD date")
+		return
+	}
+	to, err := parseUpdateFeedDate(params.Get("to"), true)
+	if err != nil {
+		handlers.RenderError(w, http.StatusBadRequest, "to must be an RFC3339 timestamp or YYYY-MM-DD date")
+		return
+	}
+	cursor, err := decodeUpdateFeedCursor(params.Get("cursor"))
+	if err != nil {
+		handlers.RenderError(w, http.StatusBadRequest, "cursor is invalid")
+		return
+	}
+	query := types.UpdateFeedQuery{
+		Branch:         params.Get("branch"),
+		RuntimeVersion: params.Get("runtimeVersion"),
+		Platform:       params.Get("platform"),
+		UpdateUUID:     params.Get("uuid"),
+		PublishGroup:   params.Get("groupId"),
+		CommitHash:     params.Get("commitHash"),
+		From:           from,
+		To:             to,
+		Limit:          limit + 1,
+	}
+	if cursor != nil {
+		query.CursorCreatedAt = &cursor.CreatedAt
+		query.CursorBranchID = cursor.BranchID
+		query.CursorUpdateID = cursor.UpdateID
+	}
+	updates, err := h.updateService.GetUpdateFeed(r.Context(), appId, query)
+	if err != nil {
+		handlers.RenderError(w, http.StatusInternalServerError, "An internal error occurred while fetching the update feed.")
+		return
+	}
+	if updates == nil {
+		updates = []types.UpdateFeedItem{}
+	}
+	page := types.UpdateFeedPage{Items: updates}
+	if len(updates) > limit {
+		page.Items = updates[:limit]
+		page.NextCursor = encodeUpdateFeedCursor(page.Items[len(page.Items)-1])
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(page)
 }

--- a/internal/handlers/publish_group_params_test.go
+++ b/internal/handlers/publish_group_params_test.go
@@ -1,0 +1,86 @@
+// The wire contract of the publishGroup parameter, which has two distinct
+// readings: a STAMP on the publish route (ignorable: worst case the rows list
+// ungrouped) and a TARGET on the rollback/republish routes (never ignorable:
+// it selects what the operation acts on).
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func publishGroupRequest(t *testing.T, rawValue string) *http.Request {
+	t.Helper()
+	request := httptest.NewRequest(http.MethodPost, "/app/requestUploadUrl/main", nil)
+	if rawValue != "" {
+		query := request.URL.Query()
+		query.Set("publishGroup", rawValue)
+		request.URL.RawQuery = query.Encode()
+	}
+	return request
+}
+
+func TestParsePublishGroupStampControlPlane(t *testing.T) {
+	t.Setenv("DB_URL", "postgres://test")
+
+	parsed, err := parsePublishGroup(publishGroupRequest(t, "8A3C66C1-8D66-44BC-A03C-2C4C5F4B2E7B"))
+	require.NoError(t, err)
+	require.NotNil(t, parsed)
+	// Normalized: the row and its acknowledgment always carry the canonical form.
+	assert.Equal(t, "8a3c66c1-8d66-44bc-a03c-2c4c5f4b2e7b", *parsed)
+
+	_, err = parsePublishGroup(publishGroupRequest(t, "not-a-uuid"))
+	require.Error(t, err)
+
+	parsed, err = parsePublishGroup(publishGroupRequest(t, ""))
+	require.NoError(t, err)
+	assert.Nil(t, parsed)
+}
+
+func TestParsePublishGroupStampStateless(t *testing.T) {
+	t.Setenv("DB_URL", "")
+
+	// The stamp is ignored entirely in stateless mode, malformed included: the
+	// missing acknowledgment is what tells the CLI nothing was grouped.
+	for _, rawValue := range []string{"8a3c66c1-8d66-44bc-a03c-2c4c5f4b2e7b", "not-a-uuid", ""} {
+		parsed, err := parsePublishGroup(publishGroupRequest(t, rawValue))
+		require.NoError(t, err, rawValue)
+		assert.Nil(t, parsed, rawValue)
+	}
+}
+
+func TestParsePublishGroupTargetControlPlane(t *testing.T) {
+	t.Setenv("DB_URL", "postgres://test")
+
+	parsed, err := parsePublishGroupTarget(publishGroupRequest(t, "8A3C66C1-8D66-44BC-A03C-2C4C5F4B2E7B"))
+	require.NoError(t, err)
+	require.NotNil(t, parsed)
+	assert.Equal(t, "8a3c66c1-8d66-44bc-a03c-2c4c5f4b2e7b", *parsed)
+
+	_, err = parsePublishGroupTarget(publishGroupRequest(t, "not-a-uuid"))
+	require.Error(t, err)
+
+	parsed, err = parsePublishGroupTarget(publishGroupRequest(t, ""))
+	require.NoError(t, err)
+	assert.Nil(t, parsed)
+}
+
+func TestParsePublishGroupTargetStateless(t *testing.T) {
+	t.Setenv("DB_URL", "")
+
+	// A target cannot be silently dropped: ignoring it would run a DIFFERENT
+	// operation than the one requested, so stateless mode refuses outright.
+	for _, rawValue := range []string{"8a3c66c1-8d66-44bc-a03c-2c4c5f4b2e7b", "not-a-uuid"} {
+		_, err := parsePublishGroupTarget(publishGroupRequest(t, rawValue))
+		require.Error(t, err, rawValue)
+	}
+
+	// Absent stays absent: the historical single-target flows are untouched.
+	parsed, err := parsePublishGroupTarget(publishGroupRequest(t, ""))
+	require.NoError(t, err)
+	assert.Nil(t, parsed)
+}

--- a/internal/handlers/republish_handler.go
+++ b/internal/handlers/republish_handler.go
@@ -25,13 +25,29 @@ func NewRepublishHandler(cliAuthService *services.CliAuthService, deploymentServ
 	}
 }
 
+// HandleRepublish re-publishes previous updates, in one of two modes:
+// ?updateId=<id>&platform=ios|android republishes that single update
+// (historical behavior), ?publishGroup=<uuid> republishes every member of that
+// publish group on its own platform, the new rows sharing a new server-minted
+// group returned in the response.
 func (h *RepublishHandler) HandleRepublish(w http.ResponseWriter, r *http.Request) {
 	requestID := uuid.New().String()
 	vars := mux.Vars(r)
 	appId := vars["APP_ID"]
 	branchName := vars["BRANCH"]
 	platform := r.URL.Query().Get("platform")
-	if platform == "" || (platform != "ios" && platform != "android") {
+	publishGroup, err := parsePublishGroupTarget(r)
+	if err != nil {
+		log.Printf("[RequestID: %s] %v", requestID, err)
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	if publishGroup != nil && (platform != "" || r.URL.Query().Get("updateId") != "") {
+		log.Printf("[RequestID: %s] Both updateId/platform and publishGroup provided", requestID)
+		http.Error(w, "Provide either an updateId and platform or a publishGroup, not both", http.StatusBadRequest)
+		return
+	}
+	if publishGroup == nil && (platform == "" || (platform != "ios" && platform != "android")) {
 		log.Printf("[RequestID: %s] Invalid platform: %s", requestID, platform)
 		http.Error(w, "Invalid platform", http.StatusBadRequest)
 		return
@@ -56,6 +72,43 @@ func (h *RepublishHandler) HandleRepublish(w http.ResponseWriter, r *http.Reques
 		return
 	}
 	commitHash := r.URL.Query().Get("commitHash")
+
+	if publishGroup != nil {
+		result, err := h.deploymentService.RepublishPublishGroup(r.Context(), appId, branchName, runtimeVersion, *publishGroup)
+		if err != nil {
+			if errors.Is(err, services.ErrActiveRolloutBlocksPublish) {
+				log.Printf("[RequestID: %s] Group republish blocked by active rollout: %v", requestID, err)
+				http.Error(w, activeRolloutConflictMessage, http.StatusConflict)
+				return
+			}
+			if errors.Is(err, services.ErrPublishGroupNotFound) {
+				log.Printf("[RequestID: %s] Publish group %s not found", requestID, *publishGroup)
+				http.Error(w, err.Error(), http.StatusNotFound)
+				return
+			}
+			var rErr *services.RepublishError
+			if errors.As(err, &rErr) {
+				log.Printf("[RequestID: %s] Group republish error: %v", requestID, err)
+				http.Error(w, err.Error(), rErr.Status)
+				return
+			}
+			log.Printf("[RequestID: %s] Unexpected error during group republish: %v", requestID, err)
+			http.Error(w, "An unexpected error occurred during republish", http.StatusInternalServerError)
+			return
+		}
+		log.Printf("[RequestID: %s] Publish group %s republished as group %s (%d platforms)", requestID, *publishGroup, result.PublishGroup, len(result.Updates))
+		// The new group of the created rows; its presence is also how the CLI
+		// knows the server understood the group semantics.
+		w.Header().Set("expo-publish-group", result.PublishGroup)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"publishGroup": result.PublishGroup,
+			"updates":      result.Updates,
+		})
+		return
+	}
+
 	updateId := r.URL.Query().Get("updateId")
 	if updateId == "" {
 		log.Printf("[RequestID: %s] No updateId provided", requestID)
@@ -68,7 +121,7 @@ func (h *RepublishHandler) HandleRepublish(w http.ResponseWriter, r *http.Reques
 		RuntimeVersion: runtimeVersion,
 		UpdateId:       updateId,
 	}
-	newUpdate, err := h.deploymentService.RepublishUpdate(r.Context(), previousUpdate, platform, commitHash)
+	newUpdate, err := h.deploymentService.RepublishUpdate(r.Context(), previousUpdate, platform, commitHash, nil)
 	if err != nil {
 		if errors.Is(err, services.ErrActiveRolloutBlocksPublish) {
 			log.Printf("[RequestID: %s] Republish blocked by active rollout: %v", requestID, err)

--- a/internal/handlers/upload_handler.go
+++ b/internal/handlers/upload_handler.go
@@ -34,6 +34,44 @@ type FileNamesRequest struct {
 	Message   string   `json:"message,omitempty"`
 }
 
+// parsePublishGroup reads the optional CLI-minted id grouping the per-platform
+// rows of one eoas publish run. In stateless mode the parameter is ignored
+// entirely: the feature does not exist there, and the missing acknowledgment
+// (echo or header) is how the CLI knows. In control-plane mode a malformed
+// value is rejected so a buggy CLI cannot silently create ungrouped rows.
+func parsePublishGroup(r *http.Request) (*string, error) {
+	raw := r.URL.Query().Get("publishGroup")
+	if raw == "" || !config.IsDBMode() {
+		return nil, nil
+	}
+	parsed, err := uuid.Parse(raw)
+	if err != nil {
+		return nil, fmt.Errorf("invalid publishGroup: must be a UUID")
+	}
+	normalized := parsed.String()
+	return &normalized, nil
+}
+
+// parsePublishGroupTarget reads the publish group TARGETED by a group-wide
+// republish. Unlike the stamp above, a target cannot be ignored in stateless
+// mode: it selects what the operation acts on, so without the control plane
+// it is rejected outright rather than silently degraded.
+func parsePublishGroupTarget(r *http.Request) (*string, error) {
+	raw := r.URL.Query().Get("publishGroup")
+	if raw == "" {
+		return nil, nil
+	}
+	if !config.IsDBMode() {
+		return nil, fmt.Errorf("publish groups require the database control plane")
+	}
+	parsed, err := uuid.Parse(raw)
+	if err != nil {
+		return nil, fmt.Errorf("invalid publishGroup: must be a UUID")
+	}
+	normalized := parsed.String()
+	return &normalized, nil
+}
+
 func (h *UploadHandler) MarkUpdateAsUploadedHandler(w http.ResponseWriter, r *http.Request) {
 	requestID := uuid.New().String()
 	vars := mux.Vars(r)
@@ -245,6 +283,13 @@ func (h *UploadHandler) RequestUploadUrlHandler(w http.ResponseWriter, r *http.R
 		}
 	}
 
+	publishGroup, err := parsePublishGroup(r)
+	if err != nil {
+		log.Printf("[RequestID: %s] %v", requestID, err)
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
 	var bodyReq FileNamesRequest
 	if err := json.NewDecoder(r.Body).Decode(&bodyReq); err != nil {
 		log.Printf("[RequestID: %s] Error decoding JSON body: %v", requestID, err)
@@ -269,6 +314,7 @@ func (h *UploadHandler) RequestUploadUrlHandler(w http.ResponseWriter, r *http.R
 		FileNames:         bodyReq.FileNames,
 		Message:           bodyReq.Message,
 		RolloutPercentage: rolloutPercentage,
+		PublishGroupID:    publishGroup,
 	}
 
 	result, err := h.deploymentService.RequestUploadURLs(r.Context(), params)
@@ -290,6 +336,12 @@ func (h *UploadHandler) RequestUploadUrlHandler(w http.ResponseWriter, r *http.R
 	// old server silently ignores it and would publish to every device).
 	if rolloutPercentage != nil {
 		response["rolloutPercentage"] = *rolloutPercentage
+	}
+	// Same detection contract for grouping: no echo means the group was not
+	// stored (old server or stateless mode) and the CLI warns instead of
+	// pretending the rows are grouped.
+	if publishGroup != nil {
+		response["publishGroup"] = *publishGroup
 	}
 
 	w.Header().Set("Content-Type", "application/json")

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -222,6 +222,7 @@ func NewRouter(container *AppContainer) *mux.Router {
 	appAuthSubrouter.Handle("/branch/{BRANCH}/runtimeVersion/{RUNTIME_VERSION}/rollout", requirePermission(rbac.PermUpdateRolloutManage)(http.HandlerFunc(container.RolloutHandler.SetUpdateRolloutPercentageHandler))).Methods(http.MethodPut)
 	appAuthSubrouter.Handle("/branch/{BRANCH}/runtimeVersion/{RUNTIME_VERSION}/rollout/revert", requirePermission(rbac.PermUpdateRolloutManage)(http.HandlerFunc(container.RolloutHandler.RevertUpdateRolloutHandler))).Methods(http.MethodPost)
 	appAuthSubrouter.HandleFunc("/branch/{BRANCH}/runtimeVersions", container.BranchHandler.GetRuntimeVersionsHandler).Methods(http.MethodGet)
+	appAuthSubrouter.HandleFunc("/updates", container.UpdateHandler.GetUpdateFeedHandler).Methods(http.MethodGet)
 	appAuthSubrouter.HandleFunc("/branch/{BRANCH}/runtimeVersion/{RUNTIME_VERSION}/updates", container.UpdateHandler.GetUpdatesHandler).Methods(http.MethodGet)
 	appAuthSubrouter.HandleFunc("/branch/{BRANCH}/runtimeVersion/{RUNTIME_VERSION}/updates/{UPDATE_ID}", container.UpdateHandler.GetUpdateDetailsHandler).Methods(http.MethodGet)
 	appAuthSubrouter.Handle("/branch/{BRANCH_ID}/updateChannelBranchMapping", requirePermission(rbac.PermChannelEditBranch)(http.HandlerFunc(container.BranchHandler.UpdateChannelBranchMappingHandler))).Methods(http.MethodPost)

--- a/internal/services/delivery_audit_test.go
+++ b/internal/services/delivery_audit_test.go
@@ -85,7 +85,7 @@ func TestCliRollbackAndRepublishEmitAuditEvents(t *testing.T) {
 	}, rolledBack.Metadata)
 
 	_, err = h.deploymentService.RepublishUpdate(cliPublishCtx(),
-		&types.Update{AppId: h.appId, Branch: "main", RuntimeVersion: "1", UpdateId: "100"}, "ios", "def5678")
+		&types.Update{AppId: h.appId, Branch: "main", RuntimeVersion: "1", UpdateId: "100"}, "ios", "def5678", nil)
 	require.NoError(t, err)
 	require.Len(t, recorder.events, 2)
 	republished := recorder.events[1]

--- a/internal/services/deployment_service.go
+++ b/internal/services/deployment_service.go
@@ -220,6 +220,7 @@ func getUpdateUUIDFromMetadata(update types.Update) string {
 func (s *DeploymentService) MarkUpdateAsChecked(ctx context.Context, update types.Update, updateType types.UpdateType) error {
 	cache := cache.GetCache()
 	branchesCacheKey := dashboard.ComputeGetBranchesCacheKey(update.AppId)
+	channelsCacheKey := dashboard.ComputeGetChannelsCacheKey(update.AppId)
 	runTimeVersionsCacheKey := dashboard.ComputeGetRuntimeVersionsCacheKey(update.AppId, update.Branch)
 	updatesCacheKey := dashboard.ComputeGetUpdatesCacheKey(update.AppId, update.Branch, update.RuntimeVersion)
 	storedMetadata, err := s.updateRepo.RetrieveUpdateStoredMetadata(ctx, update)
@@ -260,7 +261,13 @@ func (s *DeploymentService) MarkUpdateAsChecked(ctx context.Context, update type
 		}
 		return err
 	}
-	cacheKeys := []string{update2.ComputeLastUpdateCacheKey(update.AppId, update.Branch, update.RuntimeVersion, storedMetadata.Platform), branchesCacheKey, runTimeVersionsCacheKey, updatesCacheKey}
+	cacheKeys := []string{
+		update2.ComputeLastUpdateCacheKey(update.AppId, update.Branch, update.RuntimeVersion, storedMetadata.Platform),
+		branchesCacheKey,
+		channelsCacheKey,
+		runTimeVersionsCacheKey,
+		updatesCacheKey,
+	}
 	for _, cacheKey := range cacheKeys {
 		cache.Delete(cacheKey)
 	}

--- a/internal/services/deployment_service.go
+++ b/internal/services/deployment_service.go
@@ -17,6 +17,8 @@ import (
 	"mime/multipart"
 	"net/http"
 	"strconv"
+
+	"github.com/google/uuid"
 )
 
 var (
@@ -34,6 +36,9 @@ var (
 	// checked update landed on the same (branch, runtime version, platform) during
 	// its upload: activating it would advertise a rollout that is never served.
 	ErrRolloutSuperseded = errors.New("another update was published on this branch while this one was uploading; the rollout was not started, republish to retry")
+	// ErrPublishGroupNotFound refuses a group operation whose target has no
+	// checked member on this branch and runtime version. Handlers map it to 404.
+	ErrPublishGroupNotFound = errors.New("no published updates found for this publish group on this branch and runtime version")
 )
 
 type ProcessUpdateParams struct {
@@ -66,6 +71,10 @@ type RequestUploadURLParams struct {
 	// Non-nil publishes the update as a progressive rollout served to this share of
 	// devices (1-99, validated by the handler, which also requires a platform).
 	RolloutPercentage *int
+	// Non-nil groups this update row with the other per-platform rows of the
+	// same eoas run (CLI-minted UUID, validated by the handler). Control-plane
+	// only: the bucket store ignores it.
+	PublishGroupID *string
 }
 
 type RequestUploadURLResponse struct {
@@ -340,6 +349,7 @@ func (s *DeploymentService) RequestUploadURLs(ctx context.Context, params Reques
 			params.CommitHash,
 			params.Message,
 			*params.RolloutPercentage,
+			params.PublishGroupID,
 		)
 	} else {
 		newUpdate, err = s.updateRepo.CreateUpdate(
@@ -351,6 +361,7 @@ func (s *DeploymentService) RequestUploadURLs(ctx context.Context, params Reques
 			params.Platform,
 			params.CommitHash,
 			params.Message,
+			params.PublishGroupID,
 		)
 	}
 	if err != nil {
@@ -389,6 +400,45 @@ func (s *DeploymentService) CreateRollback(ctx context.Context, appId, platform,
 	return rollback, nil
 }
 
+// GroupOperationResult carries the outcome of a publish-group-wide republish:
+// the server-minted group shared by the created rows, and the rows themselves
+// (one per acted-on member).
+type GroupOperationResult struct {
+	PublishGroup string
+	Updates      []types.Update
+}
+
+// RepublishPublishGroup republishes every member of one publish group on its
+// own platform, the new rows sharing a new server-minted group. A group of
+// rollback markers is refused member by member through the same validation as
+// a single republish. Fails fast on the first platform error; rows already
+// created by the run stay, the same partial-completion contract as a
+// per-platform CLI loop.
+func (s *DeploymentService) RepublishPublishGroup(ctx context.Context, appId, branchName, runtimeVersion, publishGroup string) (*GroupOperationResult, error) {
+	members, err := s.updateRepo.GetUpdatesByPublishGroup(ctx, appId, branchName, runtimeVersion, publishGroup)
+	if err != nil {
+		return nil, err
+	}
+	if len(members) == 0 {
+		return nil, ErrPublishGroupNotFound
+	}
+	result := &GroupOperationResult{PublishGroup: uuid.NewString()}
+	for _, member := range members {
+		previousUpdate := &types.Update{
+			AppId:          appId,
+			Branch:         branchName,
+			RuntimeVersion: runtimeVersion,
+			UpdateId:       member.UpdateId,
+		}
+		newUpdate, err := s.RepublishUpdate(ctx, previousUpdate, member.Platform, member.CommitHash, &result.PublishGroup)
+		if err != nil {
+			return nil, fmt.Errorf("republish of platform %s failed: %w", member.Platform, err)
+		}
+		result.Updates = append(result.Updates, *newUpdate)
+	}
+	return result, nil
+}
+
 // createRollbackInternal is CreateRollback without the active-rollout guard; the
 // guard-free path exists for RolloutService, whose revert legitimately writes while
 // the rollout is still active.
@@ -418,7 +468,7 @@ type RepublishError struct {
 
 func (e *RepublishError) Error() string { return e.Message }
 
-func (s *DeploymentService) RepublishUpdate(ctx context.Context, previousUpdate *types.Update, platform, commitHash string) (*types.Update, error) {
+func (s *DeploymentService) RepublishUpdate(ctx context.Context, previousUpdate *types.Update, platform, commitHash string, publishGroup *string) (*types.Update, error) {
 	hasActiveRollout, err := s.updateRepo.HasActiveRolloutUpdate(ctx, previousUpdate.AppId, previousUpdate.Branch, previousUpdate.RuntimeVersion)
 	if err != nil {
 		return nil, err
@@ -426,7 +476,7 @@ func (s *DeploymentService) RepublishUpdate(ctx context.Context, previousUpdate 
 	if hasActiveRollout {
 		return nil, ErrActiveRolloutBlocksPublish
 	}
-	newUpdate, err := s.republishUpdateInternal(ctx, previousUpdate, platform, commitHash)
+	newUpdate, err := s.republishUpdateInternal(ctx, previousUpdate, platform, commitHash, publishGroup)
 	if err != nil {
 		return nil, err
 	}
@@ -439,7 +489,7 @@ func (s *DeploymentService) RepublishUpdate(ctx context.Context, previousUpdate 
 
 // republishUpdateInternal is RepublishUpdate without the active-rollout guard; see
 // createRollbackInternal.
-func (s *DeploymentService) republishUpdateInternal(ctx context.Context, previousUpdate *types.Update, platform, commitHash string) (*types.Update, error) {
+func (s *DeploymentService) republishUpdateInternal(ctx context.Context, previousUpdate *types.Update, platform, commitHash string, publishGroup *string) (*types.Update, error) {
 	// Validate the source update before cloning it. Done through the injected
 	// repo so it is correct on both backends: type/metadata/validity come from
 	// Postgres on the DB control plane and from the stored files on the bucket
@@ -483,7 +533,7 @@ func (s *DeploymentService) republishUpdateInternal(ctx context.Context, previou
 	if err != nil {
 		return nil, err
 	}
-	newUpdate, err := s.updateRepo.CreateUpdate(ctx, previousUpdate.AppId, updateId, previousUpdate.Branch, previousUpdate.RuntimeVersion, platform, commitHash, "")
+	newUpdate, err := s.updateRepo.CreateUpdate(ctx, previousUpdate.AppId, updateId, previousUpdate.Branch, previousUpdate.RuntimeVersion, platform, commitHash, "", publishGroup)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/publish_group_test.go
+++ b/internal/services/publish_group_test.go
@@ -1,0 +1,197 @@
+// Service-level tests for publish-group-wide operations: the fan-out of one
+// group rollback or republish into per-platform rows sharing a fresh
+// server-minted group. SQL persistence is covered by the store integration
+// tests; here the fake repo exercises the orchestration.
+package services
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"expo-open-ota/internal/bucket"
+	"expo-open-ota/internal/types"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// seedGrouped seeds one row and stamps it with a publish group, as if a
+// group-aware CLI had published it.
+func (h *rolloutTestHarness) seedGrouped(row seedRow, publishGroup string) types.Update {
+	update := h.seed(row)
+	h.updateRepo.mu.Lock()
+	defer h.updateRepo.mu.Unlock()
+	if stored := h.updateRepo.findRowLocked(h.appId, row.branch, update.UpdateId); stored != nil {
+		stored.publishGroup = &publishGroup
+	}
+	return update
+}
+
+// rowsInGroup returns the fake rows stamped with the given group, keyed by platform.
+func (h *rolloutTestHarness) rowsInGroup(publishGroup string) map[string]*fakeStoredUpdate {
+	h.updateRepo.mu.Lock()
+	defer h.updateRepo.mu.Unlock()
+	rows := map[string]*fakeStoredUpdate{}
+	for _, row := range h.updateRepo.rows {
+		if row.publishGroup != nil && *row.publishGroup == publishGroup {
+			rows[row.platform] = row
+		}
+	}
+	return rows
+}
+
+func TestRepublishPublishGroup(t *testing.T) {
+	ctx := context.Background()
+	const branch, rtv = "main", "1"
+
+	t.Run("republishes every member on its platform under one new group", func(t *testing.T) {
+		h := newRolloutTestHarness(t)
+		sourceGroup := uuid.NewString()
+		h.seedGrouped(seedRow{branch: branch, rtv: rtv, platform: "ios", id: 100, checked: true, uuid: uuid.NewString()}, sourceGroup)
+		h.seedGrouped(seedRow{branch: branch, rtv: rtv, platform: "android", id: 200, checked: true, uuid: uuid.NewString()}, sourceGroup)
+
+		result, err := h.deploymentService.RepublishPublishGroup(ctx, h.appId, branch, rtv, sourceGroup)
+		require.NoError(t, err)
+		assert.NotEqual(t, sourceGroup, result.PublishGroup)
+		require.Len(t, result.Updates, 2)
+
+		created := h.rowsInGroup(result.PublishGroup)
+		require.Len(t, created, 2)
+		for _, platform := range []string{"ios", "android"} {
+			require.Contains(t, created, platform)
+			assert.Equal(t, types.NormalUpdate, created[platform].updateType)
+			assert.True(t, created[platform].checked)
+			// New rows, not the sources restamped.
+			assert.NotContains(t, []string{"100", "200"}, created[platform].update.UpdateId)
+		}
+	})
+
+	t.Run("a group of rollback markers is refused", func(t *testing.T) {
+		h := newRolloutTestHarness(t)
+		markerGroup := uuid.NewString()
+		h.seedGrouped(seedRow{branch: branch, rtv: rtv, platform: "ios", id: 100, updateType: types.Rollback, checked: true}, markerGroup)
+
+		_, err := h.deploymentService.RepublishPublishGroup(ctx, h.appId, branch, rtv, markerGroup)
+		var rErr *RepublishError
+		require.ErrorAs(t, err, &rErr)
+	})
+
+	t.Run("unknown group answers ErrPublishGroupNotFound", func(t *testing.T) {
+		h := newRolloutTestHarness(t)
+		_, err := h.deploymentService.RepublishPublishGroup(ctx, h.appId, branch, rtv, uuid.NewString())
+		require.ErrorIs(t, err, ErrPublishGroupNotFound)
+	})
+
+	t.Run("fails fast on the first bad member and keeps the completed ones", func(t *testing.T) {
+		h := newRolloutTestHarness(t)
+		sourceGroup := uuid.NewString()
+		// Members run in id order: the valid iOS update republishes first, then
+		// the degenerate rollback marker in the same group refuses.
+		h.seedGrouped(seedRow{branch: branch, rtv: rtv, platform: "ios", id: 100, checked: true, uuid: uuid.NewString()}, sourceGroup)
+		h.seedGrouped(seedRow{branch: branch, rtv: rtv, platform: "android", id: 200, updateType: types.Rollback, checked: true}, sourceGroup)
+
+		_, err := h.deploymentService.RepublishPublishGroup(ctx, h.appId, branch, rtv, sourceGroup)
+		var rErr *RepublishError
+		require.ErrorAs(t, err, &rErr)
+		assert.Contains(t, err.Error(), "android")
+
+		// The partial-completion contract: the platform that succeeded before
+		// the failure stays published.
+		var created int
+		for _, event := range h.events.snapshot() {
+			if strings.HasPrefix(event, "createUpdate:") {
+				created++
+			}
+		}
+		assert.Equal(t, 1, created)
+	})
+
+	t.Run("active rollout blocks the group republish", func(t *testing.T) {
+		h := newRolloutTestHarness(t)
+		sourceGroup := uuid.NewString()
+		h.seedGrouped(seedRow{branch: branch, rtv: rtv, platform: "ios", id: 100, checked: true, uuid: uuid.NewString()}, sourceGroup)
+		h.seed(seedRow{branch: branch, rtv: rtv, platform: "ios", id: 300, checked: true, percentage: 20, controlId: 100})
+
+		_, err := h.deploymentService.RepublishPublishGroup(ctx, h.appId, branch, rtv, sourceGroup)
+		require.ErrorIs(t, err, ErrActiveRolloutBlocksPublish)
+	})
+}
+
+// TestRequestUploadURLsStampsPublishGroup covers the publish path plumbing: the
+// CLI-minted group reaches the created row, through both the plain insert and
+// the rollout insert.
+func TestRequestUploadURLsStampsPublishGroup(t *testing.T) {
+	t.Setenv("STORAGE_MODE", "local")
+	t.Setenv("LOCAL_BUCKET_BASE_PATH", t.TempDir())
+	t.Setenv("BASE_URL", "http://localhost:3000")
+	t.Setenv("JWT_SECRET", "test_jwt_secret")
+	bucket.ResetBucketInstance()
+	t.Cleanup(bucket.ResetBucketInstance)
+
+	ctx := context.Background()
+	h := newRolloutTestHarness(t)
+	group := uuid.NewString()
+
+	_, err := h.deploymentService.RequestUploadURLs(ctx, RequestUploadURLParams{
+		RequestID:      "test",
+		AppID:          h.appId,
+		BranchName:     "main",
+		Platform:       "ios",
+		RuntimeVersion: "1",
+		FileNames:      []string{"bundle.js"},
+		PublishGroupID: &group,
+	})
+	require.NoError(t, err)
+
+	pct := 25
+	_, err = h.deploymentService.RequestUploadURLs(ctx, RequestUploadURLParams{
+		RequestID:         "test",
+		AppID:             h.appId,
+		BranchName:        "main",
+		Platform:          "android",
+		RuntimeVersion:    "1",
+		FileNames:         []string{"bundle.js"},
+		RolloutPercentage: &pct,
+		PublishGroupID:    &group,
+	})
+	require.NoError(t, err)
+
+	rows := h.rowsInGroup(group)
+	require.Len(t, rows, 2)
+	assert.Nil(t, rows["ios"].rolloutPercentage)
+	require.NotNil(t, rows["android"].rolloutPercentage)
+	assert.Equal(t, 25, *rows["android"].rolloutPercentage)
+}
+
+// TestPublishGroupRolloutActivatesEveryPlatform pins the sequential worst case
+// of one grouped rollout publish: iOS's rollout is already ACTIVE when
+// Android's activation lands. Every activation guard is scoped per platform,
+// so the second platform of the same run must not be blocked by the first.
+func TestPublishGroupRolloutActivatesEveryPlatform(t *testing.T) {
+	ctx := context.Background()
+	h := newRolloutTestHarness(t)
+	group := uuid.NewString()
+
+	ios, err := h.updateRepo.CreateUpdateWithRollout(ctx, h.appId, 100, "main", "1", "ios", "abc123", "", 10, &group)
+	require.NoError(t, err)
+	android, err := h.updateRepo.CreateUpdateWithRollout(ctx, h.appId, 200, "main", "1", "android", "abc123", "", 10, &group)
+	require.NoError(t, err)
+
+	require.NoError(t, h.deploymentService.MarkUpdateAsChecked(ctx, *ios, types.NormalUpdate))
+	require.NoError(t, h.deploymentService.MarkUpdateAsChecked(ctx, *android, types.NormalUpdate))
+
+	active, err := h.updateRepo.HasActiveRolloutUpdate(ctx, h.appId, "main", "1")
+	require.NoError(t, err)
+	assert.True(t, active)
+
+	rows := h.rowsInGroup(group)
+	require.Len(t, rows, 2)
+	for _, platform := range []string{"ios", "android"} {
+		require.Contains(t, rows, platform)
+		assert.True(t, rows[platform].checked)
+		require.NotNil(t, rows[platform].rolloutPercentage)
+		assert.Equal(t, 10, *rows[platform].rolloutPercentage)
+	}
+}

--- a/internal/services/rollout_resolution_test.go
+++ b/internal/services/rollout_resolution_test.go
@@ -57,6 +57,7 @@ type fakeStoredUpdate struct {
 	rolloutPercentage *int
 	controlUpdateId   *string
 	updateUUID        string
+	publishGroup      *string
 }
 
 type fakeUpdateRepo struct {
@@ -225,10 +226,11 @@ func (r *fakeUpdateRepo) IsUpdateValid(_ context.Context, update types.Update) (
 	return row != nil && row.checked, nil
 }
 
-func (r *fakeUpdateRepo) CreateUpdate(_ context.Context, appId string, updateId int64, branchName, runtimeVersion, platform, _, _ string) (*types.Update, error) {
+func (r *fakeUpdateRepo) CreateUpdate(_ context.Context, appId string, updateId int64, branchName, runtimeVersion, platform, _, _ string, publishGroup *string) (*types.Update, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	row := r.appendRowLocked(appId, updateId, branchName, runtimeVersion, platform, types.NormalUpdate)
+	row.publishGroup = publishGroup
 	if r.events != nil {
 		r.events.add("createUpdate:" + row.update.UpdateId)
 	}
@@ -236,7 +238,7 @@ func (r *fakeUpdateRepo) CreateUpdate(_ context.Context, appId string, updateId 
 	return &updateCopy, nil
 }
 
-func (r *fakeUpdateRepo) CreateUpdateWithRollout(_ context.Context, appId string, updateId int64, branchName, runtimeVersion, platform, _, _ string, rolloutPercentage int) (*types.Update, error) {
+func (r *fakeUpdateRepo) CreateUpdateWithRollout(_ context.Context, appId string, updateId int64, branchName, runtimeVersion, platform, _, _ string, rolloutPercentage int, publishGroup *string) (*types.Update, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	// The control resolves at insert time to the latest checked update of the same
@@ -249,6 +251,7 @@ func (r *fakeUpdateRepo) CreateUpdateWithRollout(_ context.Context, appId string
 	row := r.appendRowLocked(appId, updateId, branchName, runtimeVersion, platform, types.NormalUpdate)
 	row.rolloutPercentage = &rolloutPercentage
 	row.controlUpdateId = controlId
+	row.publishGroup = publishGroup
 	if r.events != nil {
 		r.events.add("createUpdateWithRollout:" + row.update.UpdateId)
 	}
@@ -273,6 +276,32 @@ func (r *fakeUpdateRepo) GetUpdateByBranchNameAndRuntime(_ context.Context, _ st
 
 func (r *fakeUpdateRepo) GetUpdatesByRunTimeVersionAndBranchName(_ context.Context, _, _, _ string) ([]types.UpdateItem, error) {
 	return nil, nil
+}
+
+// GetUpdatesByPublishGroup mirrors the SQL: checked members of the group on
+// (branch, rtv), ordered by numeric id.
+func (r *fakeUpdateRepo) GetUpdatesByPublishGroup(_ context.Context, appId, branchName, runtimeVersion, publishGroup string) ([]types.PublishGroupMember, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	var members []types.PublishGroupMember
+	for _, row := range r.rows {
+		if row.update.AppId != appId || row.update.Branch != branchName ||
+			row.update.RuntimeVersion != runtimeVersion || !row.checked ||
+			row.publishGroup == nil || *row.publishGroup != publishGroup {
+			continue
+		}
+		members = append(members, types.PublishGroupMember{
+			UpdateId:   row.update.UpdateId,
+			Platform:   row.platform,
+			CommitHash: "abc123",
+		})
+	}
+	sort.Slice(members, func(i, j int) bool {
+		a, _ := strconv.ParseInt(members[i].UpdateId, 10, 64)
+		b, _ := strconv.ParseInt(members[j].UpdateId, 10, 64)
+		return a < b
+	})
+	return members, nil
 }
 
 func (r *fakeUpdateRepo) RetrieveUpdateStoredMetadata(_ context.Context, update types.Update) (*types.UpdateStoredMetadata, error) {
@@ -798,7 +827,7 @@ func TestPublishRepublishRollbackBlockedDuringActiveRollout(t *testing.T) {
 	_, err = h.deploymentService.CreateRollback(ctx, h.appId, "ios", "", "1", "main")
 	assert.ErrorIs(t, err, ErrActiveRolloutBlocksPublish)
 
-	_, err = h.deploymentService.RepublishUpdate(ctx, &control, "ios", "")
+	_, err = h.deploymentService.RepublishUpdate(ctx, &control, "ios", "", nil)
 	assert.ErrorIs(t, err, ErrActiveRolloutBlocksPublish)
 
 	// A branch without an active rollout is not affected by the guard.
@@ -814,7 +843,7 @@ func TestUncheckedRolloutRowIsInert(t *testing.T) {
 	h := newRolloutTestHarness(t)
 	control := h.seed(seedRow{branch: "main", rtv: "1", platform: "ios", id: 100, checked: true})
 
-	_, err := h.updateRepo.CreateUpdateWithRollout(ctx, h.appId, 200, "main", "1", "ios", "abc123", "", 25)
+	_, err := h.updateRepo.CreateUpdateWithRollout(ctx, h.appId, 200, "main", "1", "ios", "abc123", "", 25, nil)
 	require.NoError(t, err)
 
 	salt := rollout.UpdateSalt(h.appId, "main", "1", "200")
@@ -826,7 +855,7 @@ func TestUncheckedRolloutRowIsInert(t *testing.T) {
 	}
 
 	// The publish guard stays open: the abandoned row has no active rollout.
-	_, err = h.deploymentService.RepublishUpdate(ctx, &control, "ios", "")
+	_, err = h.deploymentService.RepublishUpdate(ctx, &control, "ios", "", nil)
 	assert.NoError(t, err)
 }
 
@@ -839,7 +868,7 @@ func TestMarkUpdateAsCheckedMapsUniqueViolationToRolloutConflict(t *testing.T) {
 	h.seed(seedRow{branch: "main", rtv: "1", platform: "ios", id: 100, checked: true})
 	h.seed(seedRow{branch: "main", rtv: "1", platform: "ios", id: 200, checked: true, percentage: 20, controlId: 100})
 
-	racingUpdate, err := h.updateRepo.CreateUpdateWithRollout(ctx, h.appId, 300, "main", "1", "ios", "abc123", "", 30)
+	racingUpdate, err := h.updateRepo.CreateUpdateWithRollout(ctx, h.appId, 300, "main", "1", "ios", "abc123", "", 30, nil)
 	require.NoError(t, err)
 
 	err = h.deploymentService.MarkUpdateAsChecked(ctx, *racingUpdate, types.NormalUpdate)

--- a/internal/services/rollout_resolution_test.go
+++ b/internal/services/rollout_resolution_test.go
@@ -278,6 +278,10 @@ func (r *fakeUpdateRepo) GetUpdatesByRunTimeVersionAndBranchName(_ context.Conte
 	return nil, nil
 }
 
+func (r *fakeUpdateRepo) GetUpdateFeed(_ context.Context, _ string, _ types.UpdateFeedQuery) ([]types.UpdateFeedItem, error) {
+	return nil, nil
+}
+
 // GetUpdatesByPublishGroup mirrors the SQL: checked members of the group on
 // (branch, rtv), ordered by numeric id.
 func (r *fakeUpdateRepo) GetUpdatesByPublishGroup(_ context.Context, appId, branchName, runtimeVersion, publishGroup string) ([]types.PublishGroupMember, error) {

--- a/internal/services/rollout_service.go
+++ b/internal/services/rollout_service.go
@@ -389,6 +389,6 @@ func (s *RolloutService) revertSingleRolloutUpdate(ctx context.Context, appId st
 		_, err = s.deploymentService.createRollbackInternal(ctx, appId, activeRollout.Platform, "", runtimeVersion, branchName)
 		return err
 	}
-	_, err = s.deploymentService.republishUpdateInternal(ctx, controlUpdate, activeRollout.Platform, "")
+	_, err = s.deploymentService.republishUpdateInternal(ctx, controlUpdate, activeRollout.Platform, "", nil)
 	return err
 }

--- a/internal/services/update_service.go
+++ b/internal/services/update_service.go
@@ -38,6 +38,7 @@ type UpdateRepository interface {
 	GetUpdatesByPublishGroup(ctx context.Context, appId string, branchName string, runtimeVersion string, publishGroup string) ([]types.PublishGroupMember, error)
 	GetUpdateByBranchNameAndRuntime(ctx context.Context, appId string, updateId int64, branchName string, runtimeVersion string) (pgdb.GetUpdateByBranchNameAndRuntimeRow, error)
 	GetUpdatesByRunTimeVersionAndBranchName(ctx context.Context, appId string, runtimeVersion string, branchName string) ([]types.UpdateItem, error)
+	GetUpdateFeed(ctx context.Context, appId string, query types.UpdateFeedQuery) ([]types.UpdateFeedItem, error)
 	RetrieveUpdateStoredMetadata(ctx context.Context, update types.Update) (*types.UpdateStoredMetadata, error)
 	StoreUpdateUUIDInMetadata(ctx context.Context, update types.Update, updateUUID string) error
 }
@@ -149,4 +150,8 @@ func (s *UpdateService) GetUpdatesByRunTimeVersionAndBranchName(ctx context.Cont
 		return nil, err
 	}
 	return s.updateRepo.GetUpdatesByRunTimeVersionAndBranchName(ctx, appId, runtimeVersion, branchName)
+}
+
+func (s *UpdateService) GetUpdateFeed(ctx context.Context, appId string, query types.UpdateFeedQuery) ([]types.UpdateFeedItem, error) {
+	return s.updateRepo.GetUpdateFeed(ctx, appId, query)
 }

--- a/internal/services/update_service.go
+++ b/internal/services/update_service.go
@@ -24,9 +24,18 @@ type UpdateRepository interface {
 	HasActiveRolloutUpdate(ctx context.Context, appId string, branchName string, runtimeVersion string) (bool, error)
 	GetUpdateType(ctx context.Context, update types.Update) (types.UpdateType, error)
 	IsUpdateValid(ctx context.Context, update types.Update) (bool, error)
-	CreateUpdate(ctx context.Context, appId string, updateId int64, branchName string, runtimeVersion string, platform string, commitHash string, message string) (*types.Update, error)
-	CreateUpdateWithRollout(ctx context.Context, appId string, updateId int64, branchName string, runtimeVersion string, platform string, commitHash string, message string, rolloutPercentage int) (*types.Update, error)
+	// publishGroup, when non-nil, is the UUID shared by every per-platform
+	// update row of one eoas run (CLI-minted on publish, server-minted on
+	// group republish) so consumers can treat them as a single publish. Nil
+	// (older CLIs, rollbacks, internal callers) leaves the rows ungrouped;
+	// the bucket store ignores it entirely (no grouping in stateless mode).
+	CreateUpdate(ctx context.Context, appId string, updateId int64, branchName string, runtimeVersion string, platform string, commitHash string, message string, publishGroup *string) (*types.Update, error)
+	CreateUpdateWithRollout(ctx context.Context, appId string, updateId int64, branchName string, runtimeVersion string, platform string, commitHash string, message string, rolloutPercentage int, publishGroup *string) (*types.Update, error)
 	CreateRollback(ctx context.Context, appId string, updateId int64, branchName string, runtimeVersion string, platform string, commitHash string) (*types.Update, error)
+	// GetUpdatesByPublishGroup resolves the checked members of one publish
+	// group on (branch, runtime version), for the group republish.
+	// Control-plane only: the bucket store answers ErrNotSupportedInStatelessMode.
+	GetUpdatesByPublishGroup(ctx context.Context, appId string, branchName string, runtimeVersion string, publishGroup string) ([]types.PublishGroupMember, error)
 	GetUpdateByBranchNameAndRuntime(ctx context.Context, appId string, updateId int64, branchName string, runtimeVersion string) (pgdb.GetUpdateByBranchNameAndRuntimeRow, error)
 	GetUpdatesByRunTimeVersionAndBranchName(ctx context.Context, appId string, runtimeVersion string, branchName string) ([]types.UpdateItem, error)
 	RetrieveUpdateStoredMetadata(ctx context.Context, update types.Update) (*types.UpdateStoredMetadata, error)

--- a/internal/store/app_postgres.go
+++ b/internal/store/app_postgres.go
@@ -35,6 +35,14 @@ func ToPgUUID(id string) pgtype.UUID {
 	}
 }
 
+// ToPgUUIDPtr maps a nil pointer to the SQL NULL uuid.
+func ToPgUUIDPtr(id *string) pgtype.UUID {
+	if id == nil {
+		return pgtype.UUID{}
+	}
+	return ToPgUUID(*id)
+}
+
 type InsertAppParameters struct {
 	ID                 string
 	Name               string

--- a/internal/store/branch_postgres.go
+++ b/internal/store/branch_postgres.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"strconv"
 	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
 )
 
 type PostgresBranchStore struct {
@@ -91,9 +93,32 @@ func (s *PostgresBranchStore) GetBranches(ctx context.Context, appId string) ([]
 			ReleaseChannel: branch.ChannelName,
 			CreatedAt:      createdAtStr,
 			Protected:      branch.Protected,
+			CurrentUpdate: branchUpdateState(
+				branch.CurrentRuntimeVersion,
+				branch.CurrentCommitHash,
+				branch.CurrentUpdateCreatedAt,
+				branch.CurrentRolloutPercentage,
+			),
 		}
 	}
 	return branches, nil
+}
+
+func branchUpdateState(runtimeVersion *string, commitHash *string, createdAt pgtype.Timestamptz, rolloutPercentage *int32) *types.BranchUpdateState {
+	if runtimeVersion == nil || commitHash == nil || !createdAt.Valid {
+		return nil
+	}
+	var percentage *int
+	if rolloutPercentage != nil {
+		value := int(*rolloutPercentage)
+		percentage = &value
+	}
+	return &types.BranchUpdateState{
+		RuntimeVersion:    *runtimeVersion,
+		CommitHash:        *commitHash,
+		CreatedAt:         createdAt.Time.Format(time.RFC3339),
+		RolloutPercentage: percentage,
+	}
 }
 
 func (s *PostgresBranchStore) UpsertBranchAndRuntimeVersion(ctx context.Context, appId string, branchName string, runtimeVersion string) error {
@@ -143,12 +168,20 @@ func (s *PostgresBranchStore) GetRuntimeVersionsWithUpdateStats(ctx context.Cont
 		} else {
 			createdAtStr = ""
 		}
-		runtimeVersions[i] = types.RuntimeVersionWithStats{
+		runtimeVersion := types.RuntimeVersionWithStats{
 			RuntimeVersion:  row.Version,
 			LastUpdatedAt:   lastUpdatedAtStr,
 			CreatedAt:       createdAtStr,
 			NumberOfUpdates: int(row.UpdateCount),
 		}
+		// sqlc cannot type an aggregate subquery, so RolloutPercentage comes
+		// back as interface{}: pgx yields int32 for a value, nil for SQL NULL.
+		if pct, ok := row.RolloutPercentage.(int32); ok {
+			percentage := int(pct)
+			runtimeVersion.ActiveRollout = true
+			runtimeVersion.RolloutPercentage = &percentage
+		}
+		runtimeVersions[i] = runtimeVersion
 	}
 	return runtimeVersions, nil
 }

--- a/internal/store/channel_postgres.go
+++ b/internal/store/channel_postgres.go
@@ -87,6 +87,18 @@ func (s *PostgresChannelStore) GetChannels(ctx context.Context, appId string) ([
 			BranchName:         channel.BranchName,
 			BranchId:           branchIdPtr,
 			CreatedAt:          createdAtStr,
+			BranchCurrentUpdate: branchUpdateState(
+				channel.BranchCurrentRuntimeVersion,
+				channel.BranchCurrentCommitHash,
+				channel.BranchCurrentUpdateCreatedAt,
+				channel.BranchCurrentRolloutPercentage,
+			),
+			RolloutBranchCurrentUpdate: branchUpdateState(
+				channel.RolloutBranchCurrentRuntimeVersion,
+				channel.RolloutBranchCurrentCommitHash,
+				channel.RolloutBranchCurrentUpdateCreatedAt,
+				channel.RolloutBranchCurrentRolloutPercentage,
+			),
 		}
 		if channel.RolloutID.Valid && channel.BranchName != nil && channel.RolloutBranchName != nil && channel.RolloutPercentage != nil {
 			mapping.Rollout = &types.ChannelRollout{

--- a/internal/store/publish_group_postgres_test.go
+++ b/internal/store/publish_group_postgres_test.go
@@ -5,6 +5,8 @@ package store_test
 
 import (
 	"context"
+	"expo-open-ota/internal/types"
+	"strconv"
 	"testing"
 
 	"github.com/google/uuid"
@@ -93,6 +95,61 @@ func TestGetUpdatesByPublishGroupPostgres(t *testing.T) {
 	assert.Empty(t, none)
 }
 
+func TestGetUpdateFeedPostgres(t *testing.T) {
+	fixture := newRolloutFixture(t)
+	ctx := context.Background()
+
+	group := uuid.NewString()
+	fixture.checkedUpdate(t, 100, "ios", &group)
+	fixture.checkedUpdate(t, 200, "android", &group)
+	next, err := fixture.updates.CreateUpdate(ctx, fixture.appId, 300, rolloutTestRolloutBranch, rolloutTestRuntime, "ios", "def456", "next branch", nil)
+	require.NoError(t, err)
+	require.NoError(t, fixture.updates.MarkUpdateAsChecked(ctx, *next))
+	nextUUID := uuid.NewString()
+	require.NoError(t, fixture.updates.StoreUpdateUUIDInMetadata(ctx, *next, nextUUID))
+	_, err = fixture.updates.CreateUpdate(ctx, fixture.appId, 400, rolloutTestDefaultBranch, rolloutTestRuntime, "ios", "unfinished", "", nil)
+	require.NoError(t, err)
+
+	items, err := fixture.updates.GetUpdateFeed(ctx, fixture.appId, types.UpdateFeedQuery{Limit: 100})
+	require.NoError(t, err)
+	require.Len(t, items, 3, "unchecked uploads must stay out of the dashboard feed")
+
+	byID := make(map[string]types.UpdateFeedItem, len(items))
+	for _, item := range items {
+		byID[item.UpdateId] = item
+	}
+	assert.Equal(t, rolloutTestDefaultBranch, byID["100"].Branch)
+	assert.Equal(t, rolloutTestRuntime, byID["100"].RuntimeVersion)
+	require.NotNil(t, byID["100"].PublishGroup)
+	assert.Equal(t, group, *byID["100"].PublishGroup)
+	assert.Equal(t, rolloutTestRolloutBranch, byID["300"].Branch)
+	assert.Equal(t, nextUUID, byID["300"].UpdateUUID)
+	assert.Equal(t, "next branch", byID["300"].Message)
+
+	groupItems, err := fixture.updates.GetUpdateFeed(ctx, fixture.appId, types.UpdateFeedQuery{
+		PublishGroup: group,
+		Limit:        100,
+	})
+	require.NoError(t, err)
+	require.Len(t, groupItems, 2)
+
+	firstPage, err := fixture.updates.GetUpdateFeed(ctx, fixture.appId, types.UpdateFeedQuery{Limit: 2})
+	require.NoError(t, err)
+	require.Len(t, firstPage, 2)
+	cursorUpdateID, err := strconv.ParseInt(firstPage[1].UpdateId, 10, 64)
+	require.NoError(t, err)
+	secondPage, err := fixture.updates.GetUpdateFeed(ctx, fixture.appId, types.UpdateFeedQuery{
+		CursorCreatedAt: &firstPage[1].FeedCreatedAt,
+		CursorBranchID:  firstPage[1].BranchID,
+		CursorUpdateID:  cursorUpdateID,
+		Limit:           2,
+	})
+	require.NoError(t, err)
+	require.Len(t, secondPage, 1)
+	assert.NotEqual(t, firstPage[0].UpdateId, secondPage[0].UpdateId)
+	assert.NotEqual(t, firstPage[1].UpdateId, secondPage[0].UpdateId)
+}
+
 // TestPublishGroupRolloutActivationPostgres pins the sequential worst case of
 // one grouped rollout publish against the real SQL guards: iOS's rollout is
 // already active (checked) when Android's stamp runs. Both the conditional
@@ -125,6 +182,17 @@ func TestPublishGroupRolloutActivationPostgres(t *testing.T) {
 	for _, item := range items {
 		require.NotNil(t, item.PublishGroup)
 		assert.Equal(t, group, *item.PublishGroup)
+		require.NotNil(t, item.RolloutPercentage)
+		assert.Equal(t, 10, *item.RolloutPercentage)
+	}
+
+	feed, err := fixture.updates.GetUpdateFeed(ctx, fixture.appId, types.UpdateFeedQuery{
+		PublishGroup: group,
+		Limit:        10,
+	})
+	require.NoError(t, err)
+	require.Len(t, feed, 2)
+	for _, item := range feed {
 		require.NotNil(t, item.RolloutPercentage)
 		assert.Equal(t, 10, *item.RolloutPercentage)
 	}

--- a/internal/store/publish_group_postgres_test.go
+++ b/internal/store/publish_group_postgres_test.go
@@ -1,0 +1,131 @@
+// Integration tests for publish_group persistence: the column is written by
+// both insert paths (plain publish, rollout publish) and surfaced by the
+// branch listing. Same TEST_DATABASE_URL gating as the rollout store tests.
+package store_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// checkedUpdate publishes and checks one update, stamping a stored uuid so the
+// listing resolves it without reaching for bucket metadata.
+func (f *rolloutFixture) checkedUpdate(t *testing.T, updateId int64, platform string, publishGroup *string) {
+	t.Helper()
+	ctx := context.Background()
+	created, err := f.updates.CreateUpdate(ctx, f.appId, updateId, rolloutTestDefaultBranch, rolloutTestRuntime, platform, "abc123", "", publishGroup)
+	require.NoError(t, err)
+	require.NoError(t, f.updates.MarkUpdateAsChecked(ctx, *created))
+	require.NoError(t, f.updates.StoreUpdateUUIDInMetadata(ctx, *created, uuid.NewString()))
+}
+
+func TestPublishGroupPersistencePostgres(t *testing.T) {
+	fixture := newRolloutFixture(t)
+	ctx := context.Background()
+
+	// One publish run: two platform rows sharing the CLI-minted group. A row
+	// published without one (older CLI) stays ungrouped.
+	publishGroup := uuid.NewString()
+	fixture.checkedUpdate(t, 100, "ios", &publishGroup)
+	fixture.checkedUpdate(t, 200, "android", &publishGroup)
+	fixture.checkedUpdate(t, 300, "ios", nil)
+
+	// Rollbacks are branch-level operations, never grouped: the marker row
+	// must list with no publish group.
+	rollback, err := fixture.updates.CreateRollback(ctx, fixture.appId, 400, rolloutTestDefaultBranch, rolloutTestRuntime, "android", "abc123")
+	require.NoError(t, err)
+	require.NoError(t, fixture.updates.MarkUpdateAsChecked(ctx, *rollback))
+
+	// A rollout publish goes through the dedicated insert; group stored the same.
+	rolloutGroup := uuid.NewString()
+	rolloutUpdate, err := fixture.updates.CreateUpdateWithRollout(ctx, fixture.appId, 500, rolloutTestDefaultBranch, rolloutTestRuntime, "ios", "abc123", "", 25, &rolloutGroup)
+	require.NoError(t, err)
+	require.NoError(t, fixture.updates.MarkUpdateAsChecked(ctx, *rolloutUpdate))
+	require.NoError(t, fixture.updates.StoreUpdateUUIDInMetadata(ctx, *rolloutUpdate, uuid.NewString()))
+
+	items, err := fixture.updates.GetUpdatesByRunTimeVersionAndBranchName(ctx, fixture.appId, rolloutTestRuntime, rolloutTestDefaultBranch)
+	require.NoError(t, err)
+	require.Len(t, items, 5)
+
+	groupsById := map[string]*string{}
+	for _, item := range items {
+		groupsById[item.UpdateId] = item.PublishGroup
+	}
+	require.NotNil(t, groupsById["100"])
+	require.NotNil(t, groupsById["200"])
+	assert.Equal(t, publishGroup, *groupsById["100"])
+	assert.Equal(t, publishGroup, *groupsById["200"])
+	assert.Nil(t, groupsById["300"])
+	assert.Nil(t, groupsById["400"])
+	require.NotNil(t, groupsById["500"])
+	assert.Equal(t, rolloutGroup, *groupsById["500"])
+}
+
+func TestGetUpdatesByPublishGroupPostgres(t *testing.T) {
+	fixture := newRolloutFixture(t)
+	ctx := context.Background()
+
+	group := uuid.NewString()
+	fixture.checkedUpdate(t, 100, "ios", &group)
+	fixture.checkedUpdate(t, 200, "android", &group)
+	// An unchecked member is an unfinished upload: invisible to group operations.
+	_, err := fixture.updates.CreateUpdate(ctx, fixture.appId, 300, rolloutTestDefaultBranch, rolloutTestRuntime, "ios", "abc123", "", &group)
+	require.NoError(t, err)
+	// Another group on the same branch stays out of the result.
+	otherGroup := uuid.NewString()
+	fixture.checkedUpdate(t, 400, "ios", &otherGroup)
+
+	members, err := fixture.updates.GetUpdatesByPublishGroup(ctx, fixture.appId, rolloutTestDefaultBranch, rolloutTestRuntime, group)
+	require.NoError(t, err)
+	require.Len(t, members, 2)
+	assert.Equal(t, "100", members[0].UpdateId)
+	assert.Equal(t, "ios", members[0].Platform)
+	assert.Equal(t, "abc123", members[0].CommitHash)
+	assert.Equal(t, "200", members[1].UpdateId)
+	assert.Equal(t, "android", members[1].Platform)
+
+	none, err := fixture.updates.GetUpdatesByPublishGroup(ctx, fixture.appId, rolloutTestDefaultBranch, rolloutTestRuntime, uuid.NewString())
+	require.NoError(t, err)
+	assert.Empty(t, none)
+}
+
+// TestPublishGroupRolloutActivationPostgres pins the sequential worst case of
+// one grouped rollout publish against the real SQL guards: iOS's rollout is
+// already active (checked) when Android's stamp runs. Both the conditional
+// stamp and the partial unique index are scoped per (branch, rtv, platform),
+// so the second platform of the same run must activate, leaving two active
+// rollouts under one publish group.
+func TestPublishGroupRolloutActivationPostgres(t *testing.T) {
+	fixture := newRolloutFixture(t)
+	ctx := context.Background()
+
+	group := uuid.NewString()
+	ios, err := fixture.updates.CreateUpdateWithRollout(ctx, fixture.appId, 600, rolloutTestDefaultBranch, rolloutTestRuntime, "ios", "abc123", "", 10, &group)
+	require.NoError(t, err)
+	android, err := fixture.updates.CreateUpdateWithRollout(ctx, fixture.appId, 700, rolloutTestDefaultBranch, rolloutTestRuntime, "android", "abc123", "", 10, &group)
+	require.NoError(t, err)
+
+	require.NoError(t, fixture.updates.MarkUpdateAsChecked(ctx, *ios))
+	require.NoError(t, fixture.updates.MarkUpdateAsChecked(ctx, *android),
+		"the second platform of a grouped rollout publish must not be blocked by the first one's active rollout")
+
+	active, err := fixture.updates.HasActiveRolloutUpdate(ctx, fixture.appId, rolloutTestDefaultBranch, rolloutTestRuntime)
+	require.NoError(t, err)
+	assert.True(t, active)
+
+	require.NoError(t, fixture.updates.StoreUpdateUUIDInMetadata(ctx, *ios, uuid.NewString()))
+	require.NoError(t, fixture.updates.StoreUpdateUUIDInMetadata(ctx, *android, uuid.NewString()))
+	items, err := fixture.updates.GetUpdatesByRunTimeVersionAndBranchName(ctx, fixture.appId, rolloutTestRuntime, rolloutTestDefaultBranch)
+	require.NoError(t, err)
+	require.Len(t, items, 2)
+	for _, item := range items {
+		require.NotNil(t, item.PublishGroup)
+		assert.Equal(t, group, *item.PublishGroup)
+		require.NotNil(t, item.RolloutPercentage)
+		assert.Equal(t, 10, *item.RolloutPercentage)
+	}
+}

--- a/internal/store/rollout_postgres_test.go
+++ b/internal/store/rollout_postgres_test.go
@@ -107,7 +107,7 @@ func (f *rolloutFixture) startChannelRollout(t *testing.T, percentage int) strin
 
 func (f *rolloutFixture) createUpdate(t *testing.T, branch string, updateId int64, platform string, checked bool) types.Update {
 	t.Helper()
-	created, err := f.updates.CreateUpdate(context.Background(), f.appId, updateId, branch, rolloutTestRuntime, platform, "abc123", "")
+	created, err := f.updates.CreateUpdate(context.Background(), f.appId, updateId, branch, rolloutTestRuntime, platform, "abc123", "", nil)
 	require.NoError(t, err)
 	if checked {
 		require.NoError(t, f.updates.MarkUpdateAsChecked(context.Background(), *created))
@@ -117,7 +117,7 @@ func (f *rolloutFixture) createUpdate(t *testing.T, branch string, updateId int6
 
 func (f *rolloutFixture) createRolloutUpdate(t *testing.T, branch string, updateId int64, platform string, percentage int) types.Update {
 	t.Helper()
-	created, err := f.updates.CreateUpdateWithRollout(context.Background(), f.appId, updateId, branch, rolloutTestRuntime, platform, "abc123", "", percentage)
+	created, err := f.updates.CreateUpdateWithRollout(context.Background(), f.appId, updateId, branch, rolloutTestRuntime, platform, "abc123", "", percentage, nil)
 	require.NoError(t, err)
 	return *created
 }

--- a/internal/store/rollout_postgres_test.go
+++ b/internal/store/rollout_postgres_test.go
@@ -174,7 +174,20 @@ func TestChannelRolloutLifecyclePostgres(t *testing.T) {
 	fixture := newRolloutFixture(t)
 	ctx := context.Background()
 
+	fixture.createUpdate(t, rolloutTestDefaultBranch, 900, "ios", true)
+	fixture.createUpdate(t, rolloutTestRolloutBranch, 901, "ios", true)
 	fixture.startChannelRollout(t, 10)
+
+	channels, err := fixture.channels.GetChannels(ctx, fixture.appId)
+	require.NoError(t, err)
+	require.Len(t, channels, 1)
+	require.NotNil(t, channels[0].BranchCurrentUpdate)
+	assert.Equal(t, rolloutTestRuntime, channels[0].BranchCurrentUpdate.RuntimeVersion)
+	assert.Equal(t, "abc123", channels[0].BranchCurrentUpdate.CommitHash)
+	require.NotNil(t, channels[0].RolloutBranchCurrentUpdate)
+	assert.Equal(t, rolloutTestRuntime, channels[0].RolloutBranchCurrentUpdate.RuntimeVersion)
+	assert.Equal(t, "abc123", channels[0].RolloutBranchCurrentUpdate.CommitHash)
+
 	rows, err := fixture.rollouts.UpdateChannelRolloutPercentage(ctx, fixture.appId, rolloutTestChannel, 50)
 	require.NoError(t, err)
 	require.EqualValues(t, 1, rows)
@@ -335,6 +348,36 @@ func TestPerUpdateRolloutRowsAndCountsPostgres(t *testing.T) {
 	require.NoError(t, fixture.updates.MarkUpdateAsChecked(ctx, iosRollout))
 	require.NoError(t, fixture.updates.MarkUpdateAsChecked(ctx, androidRollout))
 
+	runtimeVersions, err := fixture.branches.GetRuntimeVersionsWithUpdateStats(ctx, fixture.appId, rolloutTestDefaultBranch)
+	require.NoError(t, err)
+	require.Len(t, runtimeVersions, 1)
+	assert.True(t, runtimeVersions[0].ActiveRollout)
+	require.NotNil(t, runtimeVersions[0].RolloutPercentage)
+	assert.Equal(t, 20, *runtimeVersions[0].RolloutPercentage)
+
+	branches, err := fixture.branches.GetBranches(ctx, fixture.appId)
+	require.NoError(t, err)
+	var defaultBranch *types.BranchMapping
+	for i := range branches {
+		if branches[i].BranchName == rolloutTestDefaultBranch {
+			defaultBranch = &branches[i]
+			break
+		}
+	}
+	require.NotNil(t, defaultBranch)
+	require.NotNil(t, defaultBranch.CurrentUpdate)
+	assert.Equal(t, rolloutTestRuntime, defaultBranch.CurrentUpdate.RuntimeVersion)
+	assert.Equal(t, "abc123", defaultBranch.CurrentUpdate.CommitHash)
+	require.NotNil(t, defaultBranch.CurrentUpdate.RolloutPercentage)
+	assert.Equal(t, 20, *defaultBranch.CurrentUpdate.RolloutPercentage)
+
+	channels, err := fixture.channels.GetChannels(ctx, fixture.appId)
+	require.NoError(t, err)
+	require.Len(t, channels, 1)
+	require.NotNil(t, channels[0].BranchCurrentUpdate)
+	require.NotNil(t, channels[0].BranchCurrentUpdate.RolloutPercentage)
+	assert.Equal(t, 20, *channels[0].BranchCurrentUpdate.RolloutPercentage)
+
 	activeRollouts, err := fixture.rollouts.GetActiveRolloutUpdates(ctx, fixture.appId, rolloutTestDefaultBranch, rolloutTestRuntime)
 	require.NoError(t, err)
 	require.Len(t, activeRollouts, 2)
@@ -356,6 +399,10 @@ func TestPerUpdateRolloutRowsAndCountsPostgres(t *testing.T) {
 	require.Len(t, activeRollouts, 2)
 	assert.Equal(t, 55, activeRollouts[0].Percentage)
 	assert.Equal(t, 55, activeRollouts[1].Percentage)
+	runtimeVersions, err = fixture.branches.GetRuntimeVersionsWithUpdateStats(ctx, fixture.appId, rolloutTestDefaultBranch)
+	require.NoError(t, err)
+	require.NotNil(t, runtimeVersions[0].RolloutPercentage)
+	assert.Equal(t, 55, *runtimeVersions[0].RolloutPercentage)
 
 	rows, err = fixture.rollouts.ClearUpdateRollout(ctx, fixture.appId, rolloutTestDefaultBranch, rolloutTestRuntime)
 	require.NoError(t, err)
@@ -366,6 +413,19 @@ func TestPerUpdateRolloutRowsAndCountsPostgres(t *testing.T) {
 	hasActive, err := fixture.updates.HasActiveRolloutUpdate(ctx, fixture.appId, rolloutTestDefaultBranch, rolloutTestRuntime)
 	require.NoError(t, err)
 	assert.False(t, hasActive)
+	runtimeVersions, err = fixture.branches.GetRuntimeVersionsWithUpdateStats(ctx, fixture.appId, rolloutTestDefaultBranch)
+	require.NoError(t, err)
+	assert.False(t, runtimeVersions[0].ActiveRollout)
+	assert.Nil(t, runtimeVersions[0].RolloutPercentage)
+	branches, err = fixture.branches.GetBranches(ctx, fixture.appId)
+	require.NoError(t, err)
+	for i := range branches {
+		if branches[i].BranchName != rolloutTestDefaultBranch {
+			continue
+		}
+		require.NotNil(t, branches[i].CurrentUpdate)
+		assert.Nil(t, branches[i].CurrentUpdate.RolloutPercentage)
+	}
 
 	// Once cleared, the guarded mutations report 0 rows (the concurrent-end race).
 	rows, err = fixture.rollouts.SetUpdateRolloutPercentage(ctx, fixture.appId, rolloutTestDefaultBranch, rolloutTestRuntime, 60)

--- a/internal/store/update_bucket.go
+++ b/internal/store/update_bucket.go
@@ -353,6 +353,10 @@ func (s *BucketUpdateStore) GetUpdatesByPublishGroup(ctx context.Context, appId 
 	return nil, ErrNotSupportedInStatelessMode
 }
 
+func (s *BucketUpdateStore) GetUpdateFeed(ctx context.Context, appId string, query types.UpdateFeedQuery) ([]types.UpdateFeedItem, error) {
+	return nil, ErrNotSupportedInStatelessMode
+}
+
 // GetUpdateByUUID returns (nil, nil) in stateless mode rather than an error so the assets
 // fallback keeps its current path: no Expo-Requested-Update-ID resolution, straight to the
 // latest-update decision, byte-identical to today.

--- a/internal/store/update_bucket.go
+++ b/internal/store/update_bucket.go
@@ -130,7 +130,9 @@ func updateMetadataReader(platform, commitHash, message string) (*bytes.Reader, 
 	return bytes.NewReader(marshalledMetadata), nil
 }
 
-func (s *BucketUpdateStore) CreateUpdate(ctx context.Context, appId string, updateId int64, branchName string, runtimeVersion string, platform string, commitHash string, message string) (*types.Update, error) {
+// publishGroup is ignored: stateless mode has no publish grouping, rows always
+// list ungrouped there.
+func (s *BucketUpdateStore) CreateUpdate(ctx context.Context, appId string, updateId int64, branchName string, runtimeVersion string, platform string, commitHash string, message string, publishGroup *string) (*types.Update, error) {
 	metadataReader, err := updateMetadataReader(platform, commitHash, message)
 	if err != nil {
 		return nil, err
@@ -343,7 +345,11 @@ func (s *BucketUpdateStore) HasActiveRolloutUpdate(ctx context.Context, appId st
 	return false, nil
 }
 
-func (s *BucketUpdateStore) CreateUpdateWithRollout(ctx context.Context, appId string, updateId int64, branchName string, runtimeVersion string, platform string, commitHash string, message string, rolloutPercentage int) (*types.Update, error) {
+func (s *BucketUpdateStore) CreateUpdateWithRollout(ctx context.Context, appId string, updateId int64, branchName string, runtimeVersion string, platform string, commitHash string, message string, rolloutPercentage int, publishGroup *string) (*types.Update, error) {
+	return nil, ErrNotSupportedInStatelessMode
+}
+
+func (s *BucketUpdateStore) GetUpdatesByPublishGroup(ctx context.Context, appId string, branchName string, runtimeVersion string, publishGroup string) ([]types.PublishGroupMember, error) {
 	return nil, ErrNotSupportedInStatelessMode
 }
 

--- a/internal/store/update_postgres.go
+++ b/internal/store/update_postgres.go
@@ -10,6 +10,7 @@ import (
 	update2 "expo-open-ota/internal/update"
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgtype"
@@ -321,6 +322,104 @@ func (s *PostgresUpdateStore) GetUpdatesByRunTimeVersionAndBranchName(ctx contex
 		updatesResponse = append(updatesResponse, item)
 	}
 	return updatesResponse, nil
+}
+
+// escapeLikePattern neutralizes the ILIKE escape character in user-supplied
+// search terms: a term ending in "\" makes Postgres reject the whole pattern
+// ("LIKE pattern must not end with escape character"), surfacing as a 500.
+// "%" and "_" stay live wildcards on purpose (search semantics).
+func escapeLikePattern(term string) string {
+	return strings.ReplaceAll(term, `\`, `\\`)
+}
+
+func (s *PostgresUpdateStore) GetUpdateFeed(ctx context.Context, appId string, query types.UpdateFeedQuery) ([]types.UpdateFeedItem, error) {
+	from := pgtype.Timestamptz{}
+	if query.From != nil {
+		from = pgtype.Timestamptz{Time: *query.From, Valid: true}
+	}
+	to := pgtype.Timestamptz{}
+	if query.To != nil {
+		to = pgtype.Timestamptz{Time: *query.To, Valid: true}
+	}
+	cursorCreatedAt := pgtype.Timestamptz{}
+	if query.CursorCreatedAt != nil {
+		cursorCreatedAt = pgtype.Timestamptz{Time: *query.CursorCreatedAt, Valid: true}
+	}
+	rows, err := s.engine.Queries.GetUpdateFeed(ctx, pgdb.GetUpdateFeedParams{
+		AppID:           ToPgUUID(appId),
+		Branch:          query.Branch,
+		RuntimeVersion:  query.RuntimeVersion,
+		Platform:        query.Platform,
+		UpdateUuid:      escapeLikePattern(query.UpdateUUID),
+		PublishGroup:    escapeLikePattern(query.PublishGroup),
+		CommitHash:      escapeLikePattern(query.CommitHash),
+		CreatedFrom:     from,
+		CreatedTo:       to,
+		HasCursor:       query.CursorCreatedAt != nil,
+		CursorCreatedAt: cursorCreatedAt,
+		CursorBranchID:  query.CursorBranchID,
+		CursorUpdateID:  query.CursorUpdateID,
+		RowLimit:        int32(query.Limit),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve update feed from database: %w", err)
+	}
+	items := make([]types.UpdateFeedItem, 0, len(rows))
+	for _, row := range rows {
+		updateUUID := "Rollback to embedded"
+		if row.UpdateType == int32(types.NormalUpdate) {
+			if row.UpdateUuid.Valid {
+				updateUUID = row.UpdateUuid.String()
+			} else {
+				metadata, metadataErr := update2.GetMetadata(types.Update{
+					Branch:         row.BranchName,
+					RuntimeVersion: row.RuntimeVersion,
+					UpdateId:       strconv.FormatInt(row.ID, 10),
+					CreatedAt:      time.Duration(row.CreatedAt.Time.UnixNano()),
+					AppId:          appId,
+				})
+				if metadataErr != nil && !errors.Is(metadataErr, update2.ErrUpdateMetadataMissing) {
+					// Dropping the row here would shrink the page below the
+					// handler's limit+1 sentinel and silently end pagination.
+					return nil, fmt.Errorf("failed to resolve metadata for update ID %d: %w", row.ID, metadataErr)
+				}
+				updateUUID = crypto.ConvertSHA256HashToUUID(metadata.ID)
+			}
+		} else if row.UpdateType != int32(types.Rollback) {
+			return nil, fmt.Errorf("unknown update type %d for update ID %d", row.UpdateType, row.ID)
+		}
+
+		item := types.UpdateFeedItem{
+			UpdateItem: types.UpdateItem{
+				UpdateUUID: updateUUID,
+				UpdateId:   strconv.FormatInt(row.ID, 10),
+				CreatedAt:  row.CreatedAt.Time.Format(time.RFC3339),
+				CommitHash: row.CommitHash,
+				Platform:   row.Platform,
+			},
+			Branch:         row.BranchName,
+			RuntimeVersion: row.RuntimeVersion,
+			BranchID:       row.BranchID,
+			FeedCreatedAt:  row.CreatedAt.Time,
+		}
+		if row.Message != nil {
+			item.Message = *row.Message
+		}
+		if row.RolloutPercentage != nil {
+			percentage := int(*row.RolloutPercentage)
+			item.RolloutPercentage = &percentage
+		}
+		if row.ControlUpdateID != nil {
+			controlID := strconv.FormatInt(*row.ControlUpdateID, 10)
+			item.ControlUpdateId = &controlID
+		}
+		if row.PublishGroup.Valid {
+			group := row.PublishGroup.String()
+			item.PublishGroup = &group
+		}
+		items = append(items, item)
+	}
+	return items, nil
 }
 
 func (s *PostgresUpdateStore) RetrieveUpdateStoredMetadata(ctx context.Context, update types.Update) (*types.UpdateStoredMetadata, error) {

--- a/internal/store/update_postgres.go
+++ b/internal/store/update_postgres.go
@@ -176,21 +176,22 @@ func (s *PostgresUpdateStore) MarkUpdateAsChecked(ctx context.Context, update ty
 	return nil
 }
 
-func (s *PostgresUpdateStore) CreateUpdate(ctx context.Context, appId string, updateId int64, branchName string, runtimeVersion string, platform string, commitHash string, message string) (*types.Update, error) {
+func (s *PostgresUpdateStore) CreateUpdate(ctx context.Context, appId string, updateId int64, branchName string, runtimeVersion string, platform string, commitHash string, message string, publishGroup *string) (*types.Update, error) {
 	messagePtr := &message
 	if message == "" {
 		messagePtr = (*string)(nil)
 	}
 	pgAppID := ToPgUUID(appId)
 	row, err := s.engine.InsertUpdate(ctx, pgdb.InsertUpdateParams{
-		AppID:      pgAppID,
-		ID:         updateId,
-		Name:       branchName,
-		Version:    runtimeVersion,
-		UpdateType: int32(types.NormalUpdate),
-		Platform:   platform,
-		CommitHash: commitHash,
-		Message:    messagePtr,
+		AppID:        pgAppID,
+		ID:           updateId,
+		Name:         branchName,
+		Version:      runtimeVersion,
+		UpdateType:   int32(types.NormalUpdate),
+		Platform:     platform,
+		CommitHash:   commitHash,
+		Message:      messagePtr,
+		PublishGroup: ToPgUUIDPtr(publishGroup),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to insert update into database: %w", err)
@@ -232,6 +233,27 @@ func (s *PostgresUpdateStore) GetUpdateByBranchNameAndRuntime(ctx context.Contex
 		Name:    branchName,
 		Version: runtimeVersion,
 	})
+}
+
+func (s *PostgresUpdateStore) GetUpdatesByPublishGroup(ctx context.Context, appId string, branchName string, runtimeVersion string, publishGroup string) ([]types.PublishGroupMember, error) {
+	rows, err := s.engine.Queries.GetUpdatesByPublishGroup(ctx, pgdb.GetUpdatesByPublishGroupParams{
+		AppID:        ToPgUUID(appId),
+		Name:         branchName,
+		Version:      runtimeVersion,
+		PublishGroup: ToPgUUID(publishGroup),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve updates by publish group from database: %w", err)
+	}
+	members := make([]types.PublishGroupMember, 0, len(rows))
+	for _, row := range rows {
+		members = append(members, types.PublishGroupMember{
+			UpdateId:   strconv.FormatInt(row.ID, 10),
+			Platform:   row.Platform,
+			CommitHash: row.CommitHash,
+		})
+	}
+	return members, nil
 }
 
 func (s *PostgresUpdateStore) GetUpdatesByRunTimeVersionAndBranchName(ctx context.Context, appId string, runtimeVersion string, branchName string) ([]types.UpdateItem, error) {
@@ -291,6 +313,10 @@ func (s *PostgresUpdateStore) GetUpdatesByRunTimeVersionAndBranchName(ctx contex
 		if row.ControlUpdateID != nil {
 			control := strconv.FormatInt(*row.ControlUpdateID, 10)
 			item.ControlUpdateId = &control
+		}
+		if row.PublishGroup.Valid {
+			group := row.PublishGroup.String()
+			item.PublishGroup = &group
 		}
 		updatesResponse = append(updatesResponse, item)
 	}
@@ -423,7 +449,7 @@ func (s *PostgresUpdateStore) GetUpdateByUUID(ctx context.Context, appId string,
 // CreateUpdateWithRollout inserts a normal update carrying a rollout percentage. The
 // control (previous checked update of the same branch/rtv/platform) is resolved inside
 // the same statement and may be NULL for the first update of a branch.
-func (s *PostgresUpdateStore) CreateUpdateWithRollout(ctx context.Context, appId string, updateId int64, branchName string, runtimeVersion string, platform string, commitHash string, message string, rolloutPercentage int) (*types.Update, error) {
+func (s *PostgresUpdateStore) CreateUpdateWithRollout(ctx context.Context, appId string, updateId int64, branchName string, runtimeVersion string, platform string, commitHash string, message string, rolloutPercentage int, publishGroup *string) (*types.Update, error) {
 	messagePtr := &message
 	if message == "" {
 		messagePtr = (*string)(nil)
@@ -440,6 +466,7 @@ func (s *PostgresUpdateStore) CreateUpdateWithRollout(ctx context.Context, appId
 		CommitHash:        commitHash,
 		Message:           messagePtr,
 		RolloutPercentage: &pct,
+		PublishGroup:      ToPgUUIDPtr(publishGroup),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to insert update with rollout into database: %w", err)

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -51,6 +51,37 @@ type UpdateItem struct {
 	PublishGroup *string `json:"publishGroup,omitempty"`
 }
 
+// UpdateFeedItem is the control-plane read model for the dashboard's global
+// update feed. Stateless storage cannot produce this efficiently because its
+// branch and runtime hierarchy lives in bucket folders.
+type UpdateFeedItem struct {
+	UpdateItem
+	Branch         string    `json:"branch"`
+	RuntimeVersion string    `json:"runtimeVersion"`
+	BranchID       int64     `json:"-"`
+	FeedCreatedAt  time.Time `json:"-"`
+}
+
+type UpdateFeedQuery struct {
+	Branch          string
+	RuntimeVersion  string
+	Platform        string
+	UpdateUUID      string
+	PublishGroup    string
+	CommitHash      string
+	From            *time.Time
+	To              *time.Time
+	CursorCreatedAt *time.Time
+	CursorBranchID  int64
+	CursorUpdateID  int64
+	Limit           int
+}
+
+type UpdateFeedPage struct {
+	Items      []UpdateFeedItem `json:"items"`
+	NextCursor string           `json:"nextCursor,omitempty"`
+}
+
 // PublishGroupMember is one update row of a publish group, as needed to fan
 // the group republish out to its per-platform members. No update type here:
 // republishing validates the member (normal, valid, right platform) through
@@ -174,12 +205,23 @@ type RolloutUpdate struct {
 	CreatedAt       string  `json:"createdAt"`
 }
 
+type BranchUpdateState struct {
+	RuntimeVersion    string `json:"runtimeVersion"`
+	CommitHash        string `json:"commitHash"`
+	CreatedAt         string `json:"createdAt"`
+	RolloutPercentage *int   `json:"rolloutPercentage,omitempty"`
+}
+
 type ChannelMapping struct {
 	ReleaseChannelName string  `json:"releaseChannelName"`
 	ReleaseChannelId   string  `json:"releaseChannelId"`
 	BranchName         *string `json:"branchName"`
 	BranchId           *string `json:"branchId"`
 	CreatedAt          *string `json:"createdAt"`
+	// Current update state for the default branch and, during a channel rollout,
+	// its rollout branch. Populated in control-plane mode only.
+	BranchCurrentUpdate        *BranchUpdateState `json:"branchCurrentUpdate,omitempty"`
+	RolloutBranchCurrentUpdate *BranchUpdateState `json:"rolloutBranchCurrentUpdate,omitempty"`
 	// Active channel rollout, if any (control-plane mode only); nil otherwise.
 	Rollout *ChannelRollout `json:"rollout,omitempty"`
 }
@@ -191,13 +233,18 @@ type BranchMapping struct {
 	CreatedAt      *string `json:"createdAt"`
 	// Enterprise branch protection; always false in stateless mode.
 	Protected bool `json:"protected"`
+	// Latest runtime's active rollout update, or its latest checked update.
+	// Populated in control-plane mode only.
+	CurrentUpdate *BranchUpdateState `json:"currentUpdate,omitempty"`
 }
 
 type RuntimeVersionWithStats struct {
-	RuntimeVersion  string `json:"runtimeVersion"`
-	LastUpdatedAt   string `json:"lastUpdatedAt"`
-	CreatedAt       string `json:"createdAt"`
-	NumberOfUpdates int    `json:"numberOfUpdates"`
+	RuntimeVersion    string `json:"runtimeVersion"`
+	LastUpdatedAt     string `json:"lastUpdatedAt"`
+	CreatedAt         string `json:"createdAt"`
+	NumberOfUpdates   int    `json:"numberOfUpdates"`
+	ActiveRollout     bool   `json:"activeRollout,omitempty"`
+	RolloutPercentage *int   `json:"rolloutPercentage,omitempty"`
 }
 
 type BucketFile struct {

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -45,6 +45,20 @@ type UpdateItem struct {
 	// mode and for non-rollout updates, so listings there serialize byte-identically.
 	RolloutPercentage *int    `json:"rolloutPercentage,omitempty"`
 	ControlUpdateId   *string `json:"controlUpdateId,omitempty"`
+	// CLI-minted UUID shared by the per-platform rows of one eoas run
+	// (control-plane mode only); nil for rows created by older CLIs and in
+	// stateless mode, which consumers display ungrouped.
+	PublishGroup *string `json:"publishGroup,omitempty"`
+}
+
+// PublishGroupMember is one update row of a publish group, as needed to fan
+// the group republish out to its per-platform members. No update type here:
+// republishing validates the member (normal, valid, right platform) through
+// the same path as a single republish.
+type PublishGroupMember struct {
+	UpdateId   string
+	Platform   string
+	CommitHash string
 }
 
 type UpdateStoredMetadata struct {


### PR DESCRIPTION
- Added support for publish groups in upload handler, allowing CLI-minted UUIDs to group per-platform updates.
- Introduced parsePublishGroup and parsePublishGroupTarget functions to handle publish group parsing from requests.
- Updated RequestUploadURLs to accept and store publish group IDs.
- Enhanced deployment service with RepublishPublishGroup to handle republishing of grouped updates.
- Implemented tests for publish group functionality, ensuring correct behavior for republish and rollback scenarios.
- Updated database interactions to support publish group storage and retrieval in both Postgres and bucket stores.
- Added integration tests for publish group persistence and retrieval.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Publishes can now group updates across platforms under a shared publish group, and republishing can target either the whole group or a specific update.
  * The dashboard now includes a unified updates feed with filters, cursor pagination, and improved “current” runtime/rollout context, plus an in-place rollout manager.
  * Dashboard routing and navigation adapt to control-plane availability, including a command palette.
* **Bug Fixes**
  * Republish prompts and selection now adapt to available groups/platforms/runtime versions and avoid showing rollback entries.
  * Improved error handling for active rollouts and missing/unsupported grouping situations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->