### PR TITLE
fix: update permissions to read-only for workflows 

### DIFF
--- a/.github/workflows/promote-latest.yml
+++ b/.github/workflows/promote-latest.yml
@@ -11,6 +11,12 @@ on:
         description: "Stable release tag to promote (e.g. v3.0.0)"
         required: true
 
+# The GHCR push authenticates with its own token, so this workflow never needs
+# anything from GITHUB_TOKEN. Stated explicitly rather than inherited from the
+# org-wide default.
+permissions:
+  contents: read
+
 jobs:
   promote:
     runs-on: ubuntu-latest

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -6,7 +6,7 @@ on:
       - '**'
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   lint:
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-go@v5
         with:
@@ -118,6 +120,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-go@v5
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,10 +112,16 @@ jobs:
           node-version: "24.x"
           registry-url: "https://registry.npmjs.org"
 
+      # REF_NAME goes through env rather than a ${{ }} interpolation inside the
+      # script: git allows quotes and semicolons in tag names, so interpolating
+      # one straight into the shell would let whoever pushes the tag run
+      # arbitrary commands in this job, which holds the npm publishing identity.
       - name: Publish NPM package
+        env:
+          REF_NAME: ${{ github.ref_name }}
         run: |
           cd apps/eoas
-          VERSION=$(echo "${{ github.ref_name }}" | sed 's/^v//')
+          VERSION=$(echo "$REF_NAME" | sed 's/^v//')
           npm ci
           npm run build
           npm version "$VERSION" --no-git-tag-version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,17 +5,22 @@ on:
     tags:
       - "v*"
 
+# Write scopes are granted per job, only where the job actually publishes
+# something. Everything else runs read-only.
 permissions:
-  id-token: write
-  contents: write
-  packages: write
+  contents: read
 
 jobs:
   docker:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -46,9 +51,14 @@ jobs:
   helm:
     runs-on: ubuntu-latest
     needs: docker
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Update Helm values.yaml
         run: |
@@ -86,9 +96,15 @@ jobs:
 
   npm:
     runs-on: ubuntu-latest
+    # npm publish --provenance signs through Sigstore and needs an OIDC token.
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -115,9 +131,13 @@ jobs:
   github-release:
     runs-on: ubuntu-latest
     needs: [helm, npm]
+    permissions:
+      contents: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Download chart artifact
         uses: actions/download-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,7 +121,7 @@ jobs:
           REF_NAME: ${{ github.ref_name }}
         run: |
           cd apps/eoas
-          VERSION=$(echo "$REF_NAME" | sed 's/^v//')
+          VERSION="${REF_NAME#v}"
           npm ci
           npm run build
           npm version "$VERSION" --no-git-tag-version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -53,7 +52,6 @@ jobs:
     needs: docker
     permissions:
       contents: read
-      packages: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
This pull request improves the security and clarity of the GitHub Actions workflows by refining permissions and credential handling. The main changes involve reducing the default permissions for workflows, granting elevated permissions only to jobs that require them, and ensuring that credentials are not persisted unnecessarily during code checkout.

**Workflow permissions hardening:**

* Default permissions for both `push.yml` and `release.yml` workflows were reduced from `write` to `read`, limiting what jobs can do unless explicitly overridden. [[1]](diffhunk://#diff-f3fc934cf0d89bdf07de358896ff90f1202585df812cf606206d1830a9949811L9-R9) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R8-R23)
* Individual jobs in `release.yml` (`docker`, `helm`, `npm`, `github-release`) now explicitly declare only the permissions they need, such as `packages: write` or `id-token: write`, following the principle of least privilege. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R54-R61) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R99-R107) [[3]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R134-R140)

**Credential management improvements:**

* All `actions/checkout@v4` steps in both workflows now use `persist-credentials: false` to prevent the GitHub token from being stored in the local git config, reducing the risk of accidental credential leakage. [[1]](diffhunk://#diff-f3fc934cf0d89bdf07de358896ff90f1202585df812cf606206d1830a9949811R18-R19) [[2]](diffhunk://#diff-f3fc934cf0d89bdf07de358896ff90f1202585df812cf606206d1830a9949811R123-R124) [[3]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R8-R23) [[4]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R54-R61) [[5]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R99-R107) [[6]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R134-R140)

These changes enhance workflow security by ensuring jobs run with only the permissions they need and by minimizing the exposure of credentials.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Strengthened automated workflow security by applying least-privilege permissions across publishing and promotion pipelines.
  * Reduced the risk of credential leakage by disabling persistence of default checkout credentials after code retrieval.
  * Improved npm release integrity by enabling provenance signing.
  * Ensured publishing steps continue using the appropriate authorization model for registry operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->