### PR TITLE
feat: add overwrite confirmation on eoas and change write mode

### DIFF
--- a/apps/eoas/src/commands/__tests__/generate-certs.test.ts
+++ b/apps/eoas/src/commands/__tests__/generate-certs.test.ts
@@ -1,0 +1,126 @@
+// Disk behaviour of the generate-certs command: the private key lands as 0600,
+// and an existing one is only replaced after an explicit confirmation. Key
+// generation is stubbed, the prompts are answered from the test.
+import fs from 'fs-extra';
+import os from 'os';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { confirmAsync, promptAsync } from '../../lib/prompts';
+import GenerateCerts from '../generate-certs';
+
+vi.mock('../../lib/prompts', () => ({
+  promptAsync: vi.fn(),
+  confirmAsync: vi.fn(),
+}));
+vi.mock('@expo/code-signing-certificates', () => ({
+  generateKeyPair: () => ({}),
+  generateSelfSignedCodeSigningCertificate: () => ({}),
+  convertKeyPairToPEM: () => ({ publicKeyPEM: 'PUBLIC KEY', privateKeyPEM: 'PRIVATE KEY' }),
+  convertCertificateToCertificatePEM: () => 'CERTIFICATE',
+}));
+
+const eoasRoot = path.resolve(__dirname, '../../..');
+const onWindows = process.platform === 'win32';
+
+let projectDir: string;
+let certsDir: string;
+let privateKeyPath: string;
+
+const answers: Record<string, unknown> = {
+  certificateOutputDir: './certs',
+  keyOutputDir: './certs',
+  certificateCommonName: 'Test Org',
+  certificateValidityDurationYears: 10,
+};
+
+function promptedNames(): string[] {
+  return vi
+    .mocked(promptAsync)
+    .mock.calls.map(([questions]) =>
+      String((Array.isArray(questions) ? questions[0] : questions).name)
+    );
+}
+
+function permissions(filePath: string): string {
+  // eslint-disable-next-line node/no-sync
+  return (fs.statSync(filePath).mode & 0o777).toString(8);
+}
+
+// Permissions a plain fs write gets in this environment, so the assertions on
+// the public files do not depend on the umask of the machine running the tests.
+function defaultPermissions(): string {
+  const probePath = path.join(projectDir, 'probe');
+  // eslint-disable-next-line node/no-sync
+  fs.writeFileSync(probePath, 'probe');
+  return permissions(probePath);
+}
+
+describe('generate-certs command', () => {
+  beforeEach(() => {
+    // eslint-disable-next-line node/no-sync
+    projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'eoas-generate-certs-'));
+    certsDir = path.join(projectDir, 'certs');
+    privateKeyPath = path.join(certsDir, 'private-key.pem');
+    // eslint-disable-next-line node/no-sync
+    fs.ensureDirSync(certsDir);
+    vi.spyOn(process, 'cwd').mockReturnValue(projectDir);
+    vi.mocked(promptAsync).mockImplementation(async (questions: any) => {
+      const question = Array.isArray(questions) ? questions[0] : questions;
+      if (!(question.name in answers)) {
+        throw new Error(`Unexpected prompt: ${question.name}`);
+      }
+      return { [question.name]: answers[question.name] };
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+    // eslint-disable-next-line node/no-sync
+    fs.removeSync(projectDir);
+  });
+
+  it.skipIf(onWindows)('writes the private key readable by its owner only', async () => {
+    await GenerateCerts.run([], eoasRoot);
+
+    // eslint-disable-next-line node/no-sync
+    expect(fs.readFileSync(privateKeyPath, 'utf8')).toBe('PRIVATE KEY');
+    expect(permissions(privateKeyPath)).toBe('600');
+    // Public material keeps the permissions any other file would get.
+    expect(permissions(path.join(certsDir, 'public-key.pem'))).toBe(defaultPermissions());
+    expect(permissions(path.join(certsDir, 'certificate.pem'))).toBe(defaultPermissions());
+    expect(confirmAsync).not.toHaveBeenCalled();
+  });
+
+  it('keeps the existing private key when the overwrite is declined', async () => {
+    // eslint-disable-next-line node/no-sync
+    fs.writeFileSync(privateKeyPath, 'EXISTING KEY');
+    vi.mocked(confirmAsync).mockResolvedValue(false);
+
+    await GenerateCerts.run([], eoasRoot);
+
+    // eslint-disable-next-line node/no-sync
+    expect(fs.readFileSync(privateKeyPath, 'utf8')).toBe('EXISTING KEY');
+    // eslint-disable-next-line node/no-sync
+    expect(fs.existsSync(path.join(certsDir, 'certificate.pem'))).toBe(false);
+    expect(confirmAsync).toHaveBeenCalledTimes(1);
+    // Aborted before asking anything else.
+    expect(promptedNames()).toEqual(['certificateOutputDir', 'keyOutputDir']);
+  });
+
+  it.skipIf(onWindows)(
+    'replaces a loosely permissioned private key with a 0600 one when confirmed',
+    async () => {
+      // eslint-disable-next-line node/no-sync
+      fs.writeFileSync(privateKeyPath, 'EXISTING KEY', { mode: 0o644 });
+      vi.mocked(confirmAsync).mockResolvedValue(true);
+
+      await GenerateCerts.run([], eoasRoot);
+
+      // eslint-disable-next-line node/no-sync
+      expect(fs.readFileSync(privateKeyPath, 'utf8')).toBe('PRIVATE KEY');
+      expect(permissions(privateKeyPath)).toBe('600');
+    }
+  );
+});

--- a/apps/eoas/src/commands/generate-certs.ts
+++ b/apps/eoas/src/commands/generate-certs.ts
@@ -5,12 +5,16 @@ import {
   generateSelfSignedCodeSigningCertificate,
 } from '@expo/code-signing-certificates';
 import { Command } from '@oclif/core';
-import { ensureDirSync, writeFile } from 'fs-extra';
+import { ensureDirSync, existsSync, remove, writeFile } from 'fs-extra';
 import path from 'path';
 
 import Log from '../lib/log';
-import { promptAsync } from '../lib/prompts';
+import { confirmAsync, promptAsync } from '../lib/prompts';
 import { ensurePrivateKeyIgnored } from '../lib/utils';
+
+// Owner read/write only: the private key signs every update served by the OTA
+// server.
+const PRIVATE_KEY_MODE = 0o600;
 
 export default class GenerateCerts extends Command {
   static override args = {};
@@ -50,6 +54,20 @@ export default class GenerateCerts extends Command {
         }
       },
     });
+    const keyOutput = path.resolve(process.cwd(), keyOutputDir);
+    const privateKeyPath = path.join(keyOutput, 'private-key.pem');
+    if (existsSync(privateKeyPath)) {
+      const overwrite = await confirmAsync({
+        message: `${privateKeyPath} already exists. Overwrite it? Updates signed with the current key will no longer be accepted by apps embedding the matching certificate.`,
+        name: 'overwritePrivateKey',
+        type: 'confirm',
+        initial: false,
+      });
+      if (!overwrite) {
+        Log.warn('Aborted: no certificate or key was written.');
+        return;
+      }
+    }
     const { certificateCommonName } = await promptAsync({
       message: 'Please enter your Organization name',
       name: 'certificateCommonName',
@@ -70,7 +88,6 @@ export default class GenerateCerts extends Command {
     });
     const validityDurationYears = Math.floor(Number(certificateValidityDurationYears));
     const certificateOutput = path.resolve(process.cwd(), certificateOutputDir);
-    const keyOutput = path.resolve(process.cwd(), keyOutputDir);
     const validityNotBefore = new Date();
     const validityNotAfter = new Date();
     validityNotAfter.setFullYear(validityNotAfter.getFullYear() + validityDurationYears);
@@ -86,9 +103,13 @@ export default class GenerateCerts extends Command {
     // Before the key touches the disk, so there is no window where it exists
     // uncovered by the ignore rule.
     ensurePrivateKeyIgnored(process.cwd());
+    // Removed first: writeFile only applies the mode when it creates the file,
+    // so overwriting an existing key would keep its (possibly world readable)
+    // permissions.
+    await remove(privateKeyPath);
     await Promise.all([
       writeFile(path.join(keyOutput, 'public-key.pem'), keyPairPEM.publicKeyPEM),
-      writeFile(path.join(keyOutput, 'private-key.pem'), keyPairPEM.privateKeyPEM),
+      writeFile(privateKeyPath, keyPairPEM.privateKeyPEM, { mode: PRIVATE_KEY_MODE }),
       writeFile(path.join(certificateOutput, 'certificate.pem'), certificatePEM),
     ]);
     Log.succeed(


### PR DESCRIPTION
This pull request adds robust handling for private key file permissions and overwrite behavior in the `generate-certs` command. It ensures that private keys are only readable by their owner, prevents accidental overwriting of existing keys without explicit confirmation, and provides comprehensive tests for these scenarios.

**Security and overwrite handling:**
- The command now prompts the user for confirmation before overwriting an existing `private-key.pem` file, aborting the operation if declined.
- When overwriting, the old private key file is removed before writing the new one to ensure the correct (0600) permissions are set, preventing insecure permissions from persisting.
- The private key is always written with owner-only read/write permissions (`0600`). [[1]](diffhunk://#diff-c46da7e5c80b7fc6175433145267c28fd34ade70ea177989b393ad5b84ab7eceL8-R18) [[2]](diffhunk://#diff-c46da7e5c80b7fc6175433145267c28fd34ade70ea177989b393ad5b84ab7eceR106-R112)

**Testing improvements:**
- Added a comprehensive test suite (`generate-certs.test.ts`) that verifies correct permissions, overwrite confirmation, and abort behavior, including stubbing prompts and simulating file system interactions.