### PR TITLE
Implement session revocation and refresh token management

### DIFF
--- a/apps/dashboard/src/lib/api.ts
+++ b/apps/dashboard/src/lib/api.ts
@@ -779,16 +779,34 @@ export class ApiClient {
       headers.set('Authorization', `Bearer ${token}`);
     }
   }
-  private async request<T>(endpoint: string, options: RequestInit = {}): Promise<T> {
+  // Every endpoint answers JSON except the certificate route, which serves a
+  // PEM. That one exception used to justify a second fetch site with its own
+  // copy of the auth handling below; naming the body format here keeps the
+  // retry, the token refresh and the error mapping in one place.
+  private async request<T>(
+    endpoint: string,
+    options: RequestInit = {},
+    parse: 'json' | 'text' = 'json'
+  ): Promise<T> {
     const url = `${this.baseUrl}${endpoint}`;
-    const headers = new Headers(options.headers);
-    this.populateHeaders(headers);
+    // Rebuilt per attempt, so the retry below picks up the token the refresh
+    // just stored rather than the one that was already refused.
+    const send = () => {
+      const headers = new Headers(options.headers);
+      this.populateHeaders(headers);
+      return fetch(url, { ...options, headers });
+    };
 
-    const response = await fetch(url, { ...options, headers });
+    let response = await send();
     const refreshToken = getRefreshToken();
     if (response.status === 401 && refreshToken) {
       await this.refreshTokens(refreshToken);
-      return this.request<T>(endpoint, options);
+      // Exactly one retry, and it is the shape of the code that says so rather
+      // than a counter. It has to be bounded: a refresh that fails on an
+      // unreachable server deliberately keeps the tokens (see performRefresh),
+      // so a loop conditioned on "a token is present" would spin forever
+      // against a server that is down.
+      response = await send();
     }
 
     if (!response.ok) {
@@ -805,13 +823,31 @@ export class ApiClient {
     }
 
     if (response.status === 204) {
-      return {} as T;
+      return (parse === 'text' ? '' : {}) as T;
     }
 
-    return response.json() as Promise<T>;
+    return (parse === 'text' ? response.text() : response.json()) as Promise<T>;
   }
 
+  // Refresh tokens are single-use on the server: presenting one retires it and
+  // returns a successor. A page typically has several requests in flight, so
+  // an access token expiring produces a burst of 401s that would each spend
+  // the same refresh token — the server tolerates that for a few seconds, but
+  // relying on its tolerance is not a design. This collapses the burst into
+  // one call every waiter shares.
+  private pendingRefresh: Promise<void> | null = null;
+
   private async refreshTokens(refreshToken: string) {
+    if (this.pendingRefresh) {
+      return this.pendingRefresh;
+    }
+    this.pendingRefresh = this.performRefresh(refreshToken).finally(() => {
+      this.pendingRefresh = null;
+    });
+    return this.pendingRefresh;
+  }
+
+  private async performRefresh(refreshToken: string) {
     try {
       const form = new URLSearchParams();
       form.append('refreshToken', refreshToken);
@@ -822,18 +858,42 @@ export class ApiClient {
       });
 
       if (!response.ok) {
-        throw new Error('Failed to refresh token');
+        // Only the server saying "this credential is no longer valid" ends the
+        // session. A 500 means it could not reach its database and a 429 means
+        // it is throttling — /auth/refreshToken distinguishes them precisely so
+        // that a blip or a shared office IP does not throw away a perfectly
+        // good refresh token. Keep it and let the caller surface the failure.
+        if (response.status !== 401 && response.status !== 403) {
+          throw new Error(`Refresh unavailable (${response.status})`);
+        }
+        this.endSession(refreshToken);
+        return;
       }
 
       const data = await response.json();
       setTokens(data.token, data.refreshToken);
-
-      localStorage.setItem('accessToken', data.token);
-      localStorage.setItem('refreshToken', data.refreshToken);
     } catch (error) {
+      // A network failure is the same story as a 5xx: unreachable, not revoked.
       console.error('Failed to refresh token:', error);
-      logout();
     }
+  }
+
+  // endSession is what a revocation looks like from the client: the account was
+  // disabled, deleted, demoted, changed its password elsewhere, or a replay was
+  // detected. All of those now arrive mid-session, so clearing the tokens is
+  // not enough — nothing in the app re-reads them, and the tab would otherwise
+  // keep rendering a dashboard whose every request 401s. A full navigation is
+  // the only thing that drops the in-memory state along with the credential.
+  //
+  // spentToken guards a race between tabs: they share localStorage, so a tab
+  // whose refresh is rejected must not delete the pair a sibling has just
+  // stored (a password change, or its own successful rotation).
+  private endSession(spentToken: string) {
+    if (getRefreshToken() !== spentToken) {
+      return;
+    }
+    logout();
+    window.location.assign('/login');
   }
 
   public async login(email: string, password: string) {
@@ -870,12 +930,24 @@ export class ApiClient {
     });
   }
 
+  // Changing the password revokes every session the account held, this one
+  // included, so the server hands back a replacement pair. A 204 means it
+  // could not, and the only way forward is signing in again.
   public async changeMyPassword(payload: { currentPassword: string; newPassword: string }) {
-    return this.request<void>(`/api/me/password`, {
-      method: 'PUT',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(payload),
-    });
+    const session = await this.request<{ token?: string; refreshToken?: string }>(
+      `/api/me/password`,
+      {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      }
+    );
+    if (session?.token && session?.refreshToken) {
+      setTokens(session.token, session.refreshToken);
+      return true;
+    }
+    logout();
+    return false;
   }
 
   public async getUsers() {
@@ -1144,20 +1216,13 @@ export class ApiClient {
     );
   }
 
+  // The one route that answers something other than JSON.
   public async downloadAppCertificate(appId: string): Promise<string> {
-    const url = `${this.baseUrl}/api/apps/${encodeURIComponent(appId)}/certificate`;
-    const headers = new Headers();
-    this.populateHeaders(headers);
-    const response = await fetch(url, { method: 'GET', headers });
-    const refreshToken = getRefreshToken();
-    if (response.status === 401 && refreshToken) {
-      await this.refreshTokens(refreshToken);
-      return this.downloadAppCertificate(appId);
-    }
-    if (!response.ok) {
-      throw new Error(`HTTP error! Status: ${response.status}`);
-    }
-    return response.text();
+    return this.request<string>(
+      `/api/apps/${encodeURIComponent(appId)}/certificate`,
+      { method: 'GET' },
+      'text'
+    );
   }
 
   public async getChannels() {

--- a/apps/dashboard/src/pages/Account/index.tsx
+++ b/apps/dashboard/src/pages/Account/index.tsx
@@ -1,5 +1,4 @@
 import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
 import { api, describeApiError } from '@/lib/api';
 import { useSettings } from '@/lib/SettingsContext';
 import { useCurrentUser } from '@/lib/CurrentUserContext';
@@ -17,7 +16,6 @@ export const Account = () => {
   const { CONTROL_PLANE_ENABLED } = useSettings();
   const { user } = useCurrentUser();
   const { toast } = useToast();
-  const navigate = useNavigate();
 
   const [currentPassword, setCurrentPassword] = useState('');
   const [newPassword, setNewPassword] = useState('');
@@ -39,12 +37,11 @@ export const Account = () => {
       setConfirmPassword('');
       if (!stillSignedIn) {
         // The password changed, but no replacement session came back: every
-        // session the account held is gone, this tab included.
-        toast({
-          title: 'Password updated',
-          description: 'Sign in again with your new password.',
-        });
-        navigate('/login');
+        // session the account held is gone, this tab included. A full
+        // navigation rather than a router transition, for the reason endSession
+        // gives in lib/api.ts: the state held above the router never re-reads
+        // the cleared tokens, and would keep issuing unauthenticated requests.
+        window.location.assign('/login?notice=password_changed');
         return;
       }
       toast({

--- a/apps/dashboard/src/pages/Account/index.tsx
+++ b/apps/dashboard/src/pages/Account/index.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { api, describeApiError } from '@/lib/api';
 import { useSettings } from '@/lib/SettingsContext';
 import { useCurrentUser } from '@/lib/CurrentUserContext';
@@ -16,6 +17,7 @@ export const Account = () => {
   const { CONTROL_PLANE_ENABLED } = useSettings();
   const { user } = useCurrentUser();
   const { toast } = useToast();
+  const navigate = useNavigate();
 
   const [currentPassword, setCurrentPassword] = useState('');
   const [newPassword, setNewPassword] = useState('');
@@ -31,13 +33,23 @@ export const Account = () => {
     if (!canSubmit) return;
     setIsSubmitting(true);
     try {
-      await api.changeMyPassword({ currentPassword, newPassword });
+      const stillSignedIn = await api.changeMyPassword({ currentPassword, newPassword });
       setCurrentPassword('');
       setNewPassword('');
       setConfirmPassword('');
+      if (!stillSignedIn) {
+        // The password changed, but no replacement session came back: every
+        // session the account held is gone, this tab included.
+        toast({
+          title: 'Password updated',
+          description: 'Sign in again with your new password.',
+        });
+        navigate('/login');
+        return;
+      }
       toast({
         title: 'Password updated',
-        description: 'Use your new password the next time you sign in.',
+        description: 'Your other sessions have been signed out.',
       });
     } catch (error) {
       toast({ ...describeApiError(error, 'Error updating password'), variant: 'destructive' });

--- a/apps/dashboard/src/pages/Account/index.tsx
+++ b/apps/dashboard/src/pages/Account/index.tsx
@@ -41,7 +41,7 @@ export const Account = () => {
         // navigation rather than a router transition, for the reason endSession
         // gives in lib/api.ts: the state held above the router never re-reads
         // the cleared tokens, and would keep issuing unauthenticated requests.
-        window.location.assign('/login?notice=password_changed');
+        window.location.assign('/login');
         return;
       }
       toast({

--- a/apps/dashboard/src/pages/Login/index.tsx
+++ b/apps/dashboard/src/pages/Login/index.tsx
@@ -38,8 +38,7 @@ const SSO_ERROR_MESSAGES: Record<string, string> = {
     'Your account has been created and is waiting for an administrator to approve it. You will be able to sign in once it is approved.',
   sso_failed:
     'SSO sign-in failed. Try again, and contact your administrator if it keeps happening.',
-  sso_throttled:
-    'Too many sign-in attempts from your network. Wait a few minutes and try again.',
+  sso_throttled: 'Too many sign-in attempts from your network. Wait a few minutes and try again.',
 };
 
 export const Login = () => {
@@ -82,6 +81,18 @@ export const Login = () => {
     }
     setSignInNotice(SSO_ERROR_MESSAGES[errorCode ?? ''] ?? SSO_ERROR_MESSAGES.sso_failed);
   }, [navigate]);
+
+  // Changing a password revokes every session of the account. When the server
+  // could not hand back a replacement, the Account page lands here with a full
+  // navigation, which discards any toast it might have shown: this notice is
+  // the only thing left to say the change did go through.
+  useEffect(() => {
+    if (new URLSearchParams(window.location.search).get('notice') !== 'password_changed') {
+      return;
+    }
+    window.history.replaceState(null, '', window.location.pathname);
+    setSignInNotice('Your password was changed. Sign in again with the new one.');
+  }, []);
 
   const onSubmit = useCallback(
     async (data: z.infer<typeof FormSchema>) => {

--- a/apps/dashboard/src/pages/Login/index.tsx
+++ b/apps/dashboard/src/pages/Login/index.tsx
@@ -82,18 +82,6 @@ export const Login = () => {
     setSignInNotice(SSO_ERROR_MESSAGES[errorCode ?? ''] ?? SSO_ERROR_MESSAGES.sso_failed);
   }, [navigate]);
 
-  // Changing a password revokes every session of the account. When the server
-  // could not hand back a replacement, the Account page lands here with a full
-  // navigation, which discards any toast it might have shown: this notice is
-  // the only thing left to say the change did go through.
-  useEffect(() => {
-    if (new URLSearchParams(window.location.search).get('notice') !== 'password_changed') {
-      return;
-    }
-    window.history.replaceState(null, '', window.location.pathname);
-    setSignInNotice('Your password was changed. Sign in again with the new one.');
-  }, []);
-
   const onSubmit = useCallback(
     async (data: z.infer<typeof FormSchema>) => {
       try {

--- a/ee/sso/service_test.go
+++ b/ee/sso/service_test.go
@@ -104,6 +104,16 @@ func (r *fakeUserRepo) UpdateUserEnabled(_ context.Context, id string, enabled b
 	return nil
 }
 
+func (r *fakeUserRepo) BumpUserSessionVersion(_ context.Context, id string) error {
+	user, ok := r.users[id]
+	if !ok {
+		return &store.ErrResourceNotFound{Resource: "user", Identifier: id}
+	}
+	user.SessionVersion++
+	r.users[id] = user
+	return nil
+}
+
 func (r *fakeUserRepo) TouchUserLastConnected(_ context.Context, id string) error {
 	user, ok := r.users[id]
 	if !ok {
@@ -292,7 +302,7 @@ func newTestService(t *testing.T, repo SSORepository, users *fakeUserRepo) (*SSO
 	t.Helper()
 	t.Setenv("JWT_SECRET", "test-secret")
 	t.Setenv("BASE_URL", "http://localhost:3000")
-	sessions := services.NewDashboardAuthService(users)
+	sessions := services.NewDashboardAuthService(users, nil)
 	service := NewSSOService(repo, users, sessions)
 	service.licenseValid = func() bool { return true }
 	return service, sessions

--- a/ee/sso/store_postgres.go
+++ b/ee/sso/store_postgres.go
@@ -193,6 +193,12 @@ func userFromPgdbRow(row pgdb.User) store.User {
 		IsAdmin:      row.IsAdmin,
 		Enabled:      row.Enabled,
 		CreatedAt:    row.CreatedAt.Time,
+		// Load-bearing: this row feeds IssueSession, which stamps the account's
+		// security generation into both JWTs. Dropping it here would mint every
+		// returning SSO session at generation 0, and any account whose sessions
+		// were ever revoked would sign in successfully and then be refused on
+		// its very next request, forever.
+		SessionVersion: row.SessionVersion,
 	}
 	if row.LastConnectedAt.Valid {
 		lastConnected := row.LastConnectedAt.Time

--- a/ee/sso/store_postgres_test.go
+++ b/ee/sso/store_postgres_test.go
@@ -183,6 +183,17 @@ func TestSSOIdentityLifecycle(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, found.Enabled)
 
+	// The account's security generation must survive this lookup too. It is
+	// what IssueSession stamps into both JWTs, so reading it back as 0 for an
+	// account whose sessions were ever revoked would mint a session that the
+	// very next request refuses: a sign-in that succeeds and then bounces
+	// straight back to the login page, with no way out but a manual UPDATE.
+	_, err = pool.Exec(ctx, "UPDATE users SET session_version = 3 WHERE id = $1", memberID)
+	require.NoError(t, err)
+	found, err = ssoStore.FindUserBySubject(ctx, issuer, "subject-1")
+	require.NoError(t, err)
+	assert.EqualValues(t, 3, found.SessionVersion)
+
 	// Unknown subject answers the typed not-found error.
 	_, err = ssoStore.FindUserBySubject(ctx, issuer, "unknown-subject")
 	notFoundErr := (*store.ErrResourceNotFound)(nil)

--- a/internal/database/postgres/migrations/20260728120000_session_revocation.sql
+++ b/internal/database/postgres/migrations/20260728120000_session_revocation.sql
@@ -1,0 +1,61 @@
+-- +goose Up
+-- +goose StatementBegin
+
+-- The account's security generation. Every dashboard JWT carries the value it
+-- was minted with, and both the per-request check and the refresh path compare
+-- that claim against this column: a single UPDATE kills every access and
+-- refresh token the account holds, with no token blacklist to maintain and no
+-- extra read (the request already resolves the row to check `enabled`).
+--
+-- Bumped when the account's security state changes under its own sessions:
+-- disabled, demoted, password changed. Deleting the account needs no bump, the
+-- row is gone and the per-request lookup fails.
+ALTER TABLE users ADD COLUMN session_version INTEGER NOT NULL DEFAULT 0;
+
+-- One row per refresh token ever issued to a live sign-in, so refreshing can
+-- ROTATE instead of handing the same 7-day credential back: the presented
+-- token is consumed (used_at) and a successor is issued in its place. A stolen
+-- refresh token is therefore only worth one use, and the theft is detectable:
+-- a token that comes back after it was spent means two parties hold the chain,
+-- so the whole family goes.
+--
+-- Control-plane only. Stateless deployments (ADMIN_EMAIL/ADMIN_PASSWORD) have
+-- no database and keep the unrotated refresh they always had.
+CREATE TABLE refresh_tokens (
+    -- The jti claim of the refresh JWT. The token is signed, so possession of
+    -- it is what proves the caller owns this row; the id itself is not a
+    -- secret and is safe to log.
+    id UUID PRIMARY KEY,
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    -- The sign-in this token descends from. Rotation carries it over, so one
+    -- DELETE revokes a leaked chain and only that chain, leaving the account's
+    -- other devices signed in.
+    family_id UUID NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    expires_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    -- NULL while this is the family's live token; stamped when it is rotated.
+    -- A second attempt to consume a stamped row is the replay signal.
+    used_at TIMESTAMP WITH TIME ZONE,
+    -- The token this one was rotated into, written in the same transaction as
+    -- used_at. It exists for the replay grace: a client whose parallel
+    -- requests all refresh at once presents the same token twice, and the
+    -- second call is answered with the successor ALREADY issued rather than
+    -- with a second live token. Minting a second one would fork the chain into
+    -- two unconsumed tokens, after which neither holder ever presents a
+    -- consumed token again and the family becomes undetectable.
+    replaced_by UUID
+);
+
+-- Revoking a family walks it by family_id.
+CREATE INDEX idx_refresh_tokens_family ON refresh_tokens (family_id);
+-- Issuing a token purges that user's expired rows in the same request, which
+-- is what keeps the table bounded without a background job.
+CREATE INDEX idx_refresh_tokens_user ON refresh_tokens (user_id);
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP TABLE IF EXISTS refresh_tokens;
+ALTER TABLE users DROP COLUMN IF EXISTS session_version;
+-- +goose StatementEnd

--- a/internal/database/postgres/pgdb/models.go
+++ b/internal/database/postgres/pgdb/models.go
@@ -161,6 +161,16 @@ type IdentityValueStat struct {
 	LastSeenAt  pgtype.Timestamptz `json:"last_seen_at"`
 }
 
+type RefreshToken struct {
+	ID         pgtype.UUID        `json:"id"`
+	UserID     pgtype.UUID        `json:"user_id"`
+	FamilyID   pgtype.UUID        `json:"family_id"`
+	CreatedAt  pgtype.Timestamptz `json:"created_at"`
+	ExpiresAt  pgtype.Timestamptz `json:"expires_at"`
+	UsedAt     pgtype.Timestamptz `json:"used_at"`
+	ReplacedBy pgtype.UUID        `json:"replaced_by"`
+}
+
 type Role struct {
 	ID          pgtype.UUID        `json:"id"`
 	Name        string             `json:"name"`
@@ -228,6 +238,7 @@ type User struct {
 	UpdatedAt       pgtype.Timestamptz `json:"updated_at"`
 	LastConnectedAt pgtype.Timestamptz `json:"last_connected_at"`
 	Enabled         bool               `json:"enabled"`
+	SessionVersion  int32              `json:"session_version"`
 }
 
 type UserAppGrant struct {

--- a/internal/database/postgres/pgdb/queries.sql.go
+++ b/internal/database/postgres/pgdb/queries.sql.go
@@ -5313,7 +5313,10 @@ WITH admins AS (
     SELECT id FROM users WHERE is_admin AND enabled ORDER BY id FOR UPDATE
 )
 UPDATE users
-SET enabled = $2, updated_at = CURRENT_TIMESTAMP
+SET enabled = $2,
+    session_version = session_version
+        + CASE WHEN users.enabled AND NOT $2::boolean THEN 1 ELSE 0 END,
+    updated_at = CURRENT_TIMESTAMP
 WHERE users.id = $1
   AND ($2::boolean
        OR users.id NOT IN (SELECT id FROM admins)
@@ -5329,6 +5332,10 @@ type UpdateUserEnabledByIDParams struct {
 // admin matches no row, so approving/revoking accounts can never lock the
 // dashboard out. Enabling ($2 true) always passes the guard but still takes
 // the lock, so it serializes with concurrent disables.
+//
+// Losing access also ends the account's sessions, same reasoning and same
+// shape as UpdateUserIsAdminByID: the version moves only when an enabled
+// account is being disabled, so approving one never signs anybody out.
 func (q *Queries) UpdateUserEnabledByID(ctx context.Context, arg UpdateUserEnabledByIDParams) (pgconn.CommandTag, error) {
 	return q.db.Exec(ctx, updateUserEnabledByID, arg.ID, arg.Enabled)
 }
@@ -5338,7 +5345,10 @@ WITH admins AS (
     SELECT id FROM users WHERE is_admin AND enabled ORDER BY id FOR UPDATE
 )
 UPDATE users
-SET is_admin = $2, updated_at = CURRENT_TIMESTAMP
+SET is_admin = $2,
+    session_version = session_version
+        + CASE WHEN users.is_admin AND NOT $2::boolean THEN 1 ELSE 0 END,
+    updated_at = CURRENT_TIMESTAMP
 WHERE users.id = $1
   AND ($2::boolean
        OR users.id NOT IN (SELECT id FROM admins)
@@ -5353,13 +5363,21 @@ type UpdateUserIsAdminByIDParams struct {
 // Same admin-row lock as DeleteUserByID: demoting the last remaining admin
 // matches no row. Promotions ($2 true) always pass the guard but still take
 // the lock, so they serialize with concurrent demotions.
+//
+// Losing the admin flag also ends the account's sessions, in this statement so
+// that the revocation cannot be skipped by a stale read or lost to a failure
+// between two calls. The CASE reads users.is_admin, which in a SET expression
+// is the value BEFORE the update: the version therefore moves only on a real
+// demotion, never on a promotion and never on an idempotent PATCH.
 func (q *Queries) UpdateUserIsAdminByID(ctx context.Context, arg UpdateUserIsAdminByIDParams) (pgconn.CommandTag, error) {
 	return q.db.Exec(ctx, updateUserIsAdminByID, arg.ID, arg.IsAdmin)
 }
 
 const updateUserPasswordByID = `-- name: UpdateUserPasswordByID :execresult
 UPDATE users
-SET password_hash = $2, updated_at = CURRENT_TIMESTAMP
+SET password_hash = $2,
+    session_version = session_version + 1,
+    updated_at = CURRENT_TIMESTAMP
 WHERE id = $1
 `
 
@@ -5368,6 +5386,11 @@ type UpdateUserPasswordByIDParams struct {
 	PasswordHash string      `json:"password_hash"`
 }
 
+// The session version moves with the password, in the same statement. A second
+// call could fail after this one committed, which would leave the sessions
+// minted under the old password alive behind the new one. Nothing else retires
+// them: the account stays enabled and keeps its admin flag, so the version is
+// the only thing that ends those sessions.
 func (q *Queries) UpdateUserPasswordByID(ctx context.Context, arg UpdateUserPasswordByIDParams) (pgconn.CommandTag, error) {
 	return q.db.Exec(ctx, updateUserPasswordByID, arg.ID, arg.PasswordHash)
 }

--- a/internal/database/postgres/pgdb/queries.sql.go
+++ b/internal/database/postgres/pgdb/queries.sql.go
@@ -124,6 +124,18 @@ func (q *Queries) ApplyIdentityValueStats(ctx context.Context, arg ApplyIdentity
 	return err
 }
 
+const bumpUserSessionVersion = `-- name: BumpUserSessionVersion :execresult
+UPDATE users
+SET session_version = session_version + 1, updated_at = CURRENT_TIMESTAMP
+WHERE id = $1
+`
+
+// Invalidates every token the account holds at once: both the per-request
+// check and the refresh path compare the JWT's sv claim to this column.
+func (q *Queries) BumpUserSessionVersion(ctx context.Context, id pgtype.UUID) (pgconn.CommandTag, error) {
+	return q.db.Exec(ctx, bumpUserSessionVersion, id)
+}
+
 const clearUpdateRollout = `-- name: ClearUpdateRollout :execrows
 UPDATE updates
 SET rollout_percentage = NULL
@@ -150,6 +162,39 @@ func (q *Queries) ClearUpdateRollout(ctx context.Context, arg ClearUpdateRollout
 		return 0, err
 	}
 	return result.RowsAffected(), nil
+}
+
+const consumeRefreshToken = `-- name: ConsumeRefreshToken :one
+UPDATE refresh_tokens
+SET used_at = CURRENT_TIMESTAMP, replaced_by = $1
+WHERE id = $2
+  AND used_at IS NULL
+  AND expires_at > CURRENT_TIMESTAMP
+RETURNING id, user_id, family_id, created_at, expires_at, used_at, replaced_by
+`
+
+type ConsumeRefreshTokenParams struct {
+	ReplacedBy pgtype.UUID `json:"replaced_by"`
+	ID         pgtype.UUID `json:"id"`
+}
+
+// Single-use claim, atomic on purpose: two requests presenting the same token
+// concurrently must not both succeed, or rotation would hand out two live
+// successors and replay detection would never fire. The loser gets no row and
+// goes look at why (see GetRefreshToken).
+func (q *Queries) ConsumeRefreshToken(ctx context.Context, arg ConsumeRefreshTokenParams) (RefreshToken, error) {
+	row := q.db.QueryRow(ctx, consumeRefreshToken, arg.ReplacedBy, arg.ID)
+	var i RefreshToken
+	err := row.Scan(
+		&i.ID,
+		&i.UserID,
+		&i.FamilyID,
+		&i.CreatedAt,
+		&i.ExpiresAt,
+		&i.UsedAt,
+		&i.ReplacedBy,
+	)
+	return i, err
 }
 
 const countAuditLogEvents = `-- name: CountAuditLogEvents :one
@@ -472,6 +517,19 @@ func (q *Queries) DeleteEnterpriseLicense(ctx context.Context) error {
 	return err
 }
 
+const deleteExpiredRefreshTokensForUser = `-- name: DeleteExpiredRefreshTokensForUser :exec
+DELETE FROM refresh_tokens
+WHERE user_id = $1
+  AND expires_at <= CURRENT_TIMESTAMP
+`
+
+// Runs whenever the account is issued a token, which bounds the table to the
+// live tokens of accounts that still sign in, without a background job.
+func (q *Queries) DeleteExpiredRefreshTokensForUser(ctx context.Context, userID pgtype.UUID) error {
+	_, err := q.db.Exec(ctx, deleteExpiredRefreshTokensForUser, userID)
+	return err
+}
+
 const deleteIdentitySchemaKey = `-- name: DeleteIdentitySchemaKey :execresult
 DELETE FROM identity_schema
 WHERE app_id = $1 AND key = $2
@@ -501,6 +559,16 @@ type DeleteIdentityValueStatsForKeyParams struct {
 // values already merged into device_identity.metadata are left in place.
 func (q *Queries) DeleteIdentityValueStatsForKey(ctx context.Context, arg DeleteIdentityValueStatsForKeyParams) error {
 	_, err := q.db.Exec(ctx, deleteIdentityValueStatsForKey, arg.AppID, arg.Key)
+	return err
+}
+
+const deleteRefreshTokenFamily = `-- name: DeleteRefreshTokenFamily :exec
+DELETE FROM refresh_tokens
+WHERE family_id = $1
+`
+
+func (q *Queries) DeleteRefreshTokenFamily(ctx context.Context, familyID pgtype.UUID) error {
+	_, err := q.db.Exec(ctx, deleteRefreshTokenFamily, familyID)
 	return err
 }
 
@@ -1497,6 +1565,51 @@ func (q *Queries) GetLatestUpdateWithRollout(ctx context.Context, arg GetLatestU
 	return i, err
 }
 
+const getRefreshToken = `-- name: GetRefreshToken :one
+SELECT id, user_id, family_id, created_at, expires_at, used_at, replaced_by,
+       (used_at IS NOT NULL AND used_at > CURRENT_TIMESTAMP - $1::interval) AS used_recently
+FROM refresh_tokens
+WHERE id = $2
+`
+
+type GetRefreshTokenParams struct {
+	ReplayGrace pgtype.Interval `json:"replay_grace"`
+	ID          pgtype.UUID     `json:"id"`
+}
+
+type GetRefreshTokenRow struct {
+	ID           pgtype.UUID        `json:"id"`
+	UserID       pgtype.UUID        `json:"user_id"`
+	FamilyID     pgtype.UUID        `json:"family_id"`
+	CreatedAt    pgtype.Timestamptz `json:"created_at"`
+	ExpiresAt    pgtype.Timestamptz `json:"expires_at"`
+	UsedAt       pgtype.Timestamptz `json:"used_at"`
+	ReplacedBy   pgtype.UUID        `json:"replaced_by"`
+	UsedRecently *bool              `json:"used_recently"`
+}
+
+// used_recently answers "was this token rotated within the replay grace" using
+// the DATABASE clock on both sides. Comparing used_at (stamped by
+// CURRENT_TIMESTAMP) against the application's clock would straddle two
+// machines: a database running ahead would make the window always true and
+// silently disable replay detection, one running behind would read every
+// legitimate concurrent refresh as a replay.
+func (q *Queries) GetRefreshToken(ctx context.Context, arg GetRefreshTokenParams) (GetRefreshTokenRow, error) {
+	row := q.db.QueryRow(ctx, getRefreshToken, arg.ReplayGrace, arg.ID)
+	var i GetRefreshTokenRow
+	err := row.Scan(
+		&i.ID,
+		&i.UserID,
+		&i.FamilyID,
+		&i.CreatedAt,
+		&i.ExpiresAt,
+		&i.UsedAt,
+		&i.ReplacedBy,
+		&i.UsedRecently,
+	)
+	return i, err
+}
+
 const getRoleByID = `-- name: GetRoleByID :one
 SELECT id, name, permissions, created_at, updated_at FROM roles
 WHERE id = $1 LIMIT 1
@@ -2150,7 +2263,7 @@ func (q *Queries) GetUserAppGrant(ctx context.Context, arg GetUserAppGrantParams
 }
 
 const getUserByEmail = `-- name: GetUserByEmail :one
-SELECT id, email, password_hash, is_admin, created_at, updated_at, last_connected_at, enabled FROM users
+SELECT id, email, password_hash, is_admin, created_at, updated_at, last_connected_at, enabled, session_version FROM users
 WHERE email = $1 LIMIT 1
 `
 
@@ -2166,12 +2279,13 @@ func (q *Queries) GetUserByEmail(ctx context.Context, email string) (User, error
 		&i.UpdatedAt,
 		&i.LastConnectedAt,
 		&i.Enabled,
+		&i.SessionVersion,
 	)
 	return i, err
 }
 
 const getUserByID = `-- name: GetUserByID :one
-SELECT id, email, password_hash, is_admin, created_at, updated_at, last_connected_at, enabled FROM users
+SELECT id, email, password_hash, is_admin, created_at, updated_at, last_connected_at, enabled, session_version FROM users
 WHERE id = $1 LIMIT 1
 `
 
@@ -2187,12 +2301,13 @@ func (q *Queries) GetUserByID(ctx context.Context, id pgtype.UUID) (User, error)
 		&i.UpdatedAt,
 		&i.LastConnectedAt,
 		&i.Enabled,
+		&i.SessionVersion,
 	)
 	return i, err
 }
 
 const getUserBySSOSubject = `-- name: GetUserBySSOSubject :one
-SELECT u.id, u.email, u.password_hash, u.is_admin, u.created_at, u.updated_at, u.last_connected_at, u.enabled FROM users u
+SELECT u.id, u.email, u.password_hash, u.is_admin, u.created_at, u.updated_at, u.last_connected_at, u.enabled, u.session_version FROM users u
 JOIN sso_identities si ON si.user_id = u.id
 WHERE si.issuer = $1 AND si.subject = $2
 `
@@ -2214,6 +2329,7 @@ func (q *Queries) GetUserBySSOSubject(ctx context.Context, arg GetUserBySSOSubje
 		&i.UpdatedAt,
 		&i.LastConnectedAt,
 		&i.Enabled,
+		&i.SessionVersion,
 	)
 	return i, err
 }
@@ -2484,6 +2600,28 @@ func (q *Queries) InsertChannelRollout(ctx context.Context, arg InsertChannelRol
 		return 0, err
 	}
 	return result.RowsAffected(), nil
+}
+
+const insertRefreshToken = `-- name: InsertRefreshToken :exec
+INSERT INTO refresh_tokens (id, user_id, family_id, expires_at)
+VALUES ($1, $2, $3, $4)
+`
+
+type InsertRefreshTokenParams struct {
+	ID        pgtype.UUID        `json:"id"`
+	UserID    pgtype.UUID        `json:"user_id"`
+	FamilyID  pgtype.UUID        `json:"family_id"`
+	ExpiresAt pgtype.Timestamptz `json:"expires_at"`
+}
+
+func (q *Queries) InsertRefreshToken(ctx context.Context, arg InsertRefreshTokenParams) error {
+	_, err := q.db.Exec(ctx, insertRefreshToken,
+		arg.ID,
+		arg.UserID,
+		arg.FamilyID,
+		arg.ExpiresAt,
+	)
+	return err
 }
 
 const insertRole = `-- name: InsertRole :one

--- a/internal/database/postgres/queries/queries.sql
+++ b/internal/database/postgres/queries/queries.sql
@@ -530,19 +530,35 @@ WHERE users.id = $1
   AND (users.id NOT IN (SELECT id FROM admins) OR (SELECT COUNT(*) FROM admins) > 1);
 
 -- name: UpdateUserPasswordByID :execresult
+-- The session version moves with the password, in the same statement. A second
+-- call could fail after this one committed, which would leave the sessions
+-- minted under the old password alive behind the new one. Nothing else retires
+-- them: the account stays enabled and keeps its admin flag, so the version is
+-- the only thing that ends those sessions.
 UPDATE users
-SET password_hash = $2, updated_at = CURRENT_TIMESTAMP
+SET password_hash = $2,
+    session_version = session_version + 1,
+    updated_at = CURRENT_TIMESTAMP
 WHERE id = $1;
 
 -- name: UpdateUserIsAdminByID :execresult
 -- Same admin-row lock as DeleteUserByID: demoting the last remaining admin
 -- matches no row. Promotions ($2 true) always pass the guard but still take
 -- the lock, so they serialize with concurrent demotions.
+--
+-- Losing the admin flag also ends the account's sessions, in this statement so
+-- that the revocation cannot be skipped by a stale read or lost to a failure
+-- between two calls. The CASE reads users.is_admin, which in a SET expression
+-- is the value BEFORE the update: the version therefore moves only on a real
+-- demotion, never on a promotion and never on an idempotent PATCH.
 WITH admins AS (
     SELECT id FROM users WHERE is_admin AND enabled ORDER BY id FOR UPDATE
 )
 UPDATE users
-SET is_admin = $2, updated_at = CURRENT_TIMESTAMP
+SET is_admin = $2,
+    session_version = session_version
+        + CASE WHEN users.is_admin AND NOT $2::boolean THEN 1 ELSE 0 END,
+    updated_at = CURRENT_TIMESTAMP
 WHERE users.id = $1
   AND ($2::boolean
        OR users.id NOT IN (SELECT id FROM admins)
@@ -553,11 +569,18 @@ WHERE users.id = $1
 -- admin matches no row, so approving/revoking accounts can never lock the
 -- dashboard out. Enabling ($2 true) always passes the guard but still takes
 -- the lock, so it serializes with concurrent disables.
+--
+-- Losing access also ends the account's sessions, same reasoning and same
+-- shape as UpdateUserIsAdminByID: the version moves only when an enabled
+-- account is being disabled, so approving one never signs anybody out.
 WITH admins AS (
     SELECT id FROM users WHERE is_admin AND enabled ORDER BY id FOR UPDATE
 )
 UPDATE users
-SET enabled = $2, updated_at = CURRENT_TIMESTAMP
+SET enabled = $2,
+    session_version = session_version
+        + CASE WHEN users.enabled AND NOT $2::boolean THEN 1 ELSE 0 END,
+    updated_at = CURRENT_TIMESTAMP
 WHERE users.id = $1
   AND ($2::boolean
        OR users.id NOT IN (SELECT id FROM admins)

--- a/internal/database/postgres/queries/queries.sql
+++ b/internal/database/postgres/queries/queries.sql
@@ -563,6 +563,52 @@ WHERE users.id = $1
        OR users.id NOT IN (SELECT id FROM admins)
        OR (SELECT COUNT(*) FROM admins) > 1);
 
+-- name: BumpUserSessionVersion :execresult
+-- Invalidates every token the account holds at once: both the per-request
+-- check and the refresh path compare the JWT's sv claim to this column.
+UPDATE users
+SET session_version = session_version + 1, updated_at = CURRENT_TIMESTAMP
+WHERE id = $1;
+
+-- name: InsertRefreshToken :exec
+INSERT INTO refresh_tokens (id, user_id, family_id, expires_at)
+VALUES ($1, $2, $3, $4);
+
+-- name: ConsumeRefreshToken :one
+-- Single-use claim, atomic on purpose: two requests presenting the same token
+-- concurrently must not both succeed, or rotation would hand out two live
+-- successors and replay detection would never fire. The loser gets no row and
+-- goes look at why (see GetRefreshToken).
+UPDATE refresh_tokens
+SET used_at = CURRENT_TIMESTAMP, replaced_by = sqlc.arg(replaced_by)
+WHERE id = sqlc.arg(id)
+  AND used_at IS NULL
+  AND expires_at > CURRENT_TIMESTAMP
+RETURNING *;
+
+-- name: GetRefreshToken :one
+-- used_recently answers "was this token rotated within the replay grace" using
+-- the DATABASE clock on both sides. Comparing used_at (stamped by
+-- CURRENT_TIMESTAMP) against the application's clock would straddle two
+-- machines: a database running ahead would make the window always true and
+-- silently disable replay detection, one running behind would read every
+-- legitimate concurrent refresh as a replay.
+SELECT *,
+       (used_at IS NOT NULL AND used_at > CURRENT_TIMESTAMP - sqlc.arg(replay_grace)::interval) AS used_recently
+FROM refresh_tokens
+WHERE id = sqlc.arg(id);
+
+-- name: DeleteRefreshTokenFamily :exec
+DELETE FROM refresh_tokens
+WHERE family_id = $1;
+
+-- name: DeleteExpiredRefreshTokensForUser :exec
+-- Runs whenever the account is issued a token, which bounds the table to the
+-- live tokens of accounts that still sign in, without a background job.
+DELETE FROM refresh_tokens
+WHERE user_id = $1
+  AND expires_at <= CURRENT_TIMESTAMP;
+
 -- name: MigrateLegacyApp :exec
 INSERT INTO apps (
     id, 

--- a/internal/handlers/dashboard/password_change_handler_test.go
+++ b/internal/handlers/dashboard/password_change_handler_test.go
@@ -31,9 +31,6 @@ import (
 // path shows up as a failure instead of as a plausible-looking answer.
 type fakePasswordUserRepo struct {
 	user store.User
-	// bumpFailed makes the revocation fail, the case where the server must not
-	// pretend the sessions are gone.
-	bumpFailed bool
 }
 
 func (r *fakePasswordUserRepo) GetUserByID(_ context.Context, id string) (store.User, error) {
@@ -43,15 +40,14 @@ func (r *fakePasswordUserRepo) GetUserByID(_ context.Context, id string) (store.
 	return r.user, nil
 }
 
+// Mirrors the SQL: the new password and the revocation land in one statement.
 func (r *fakePasswordUserRepo) UpdateUserPassword(_ context.Context, _ string, passwordHash string) error {
 	r.user.PasswordHash = passwordHash
+	r.user.SessionVersion++
 	return nil
 }
 
 func (r *fakePasswordUserRepo) BumpUserSessionVersion(_ context.Context, _ string) error {
-	if r.bumpFailed {
-		return assert.AnError
-	}
 	r.user.SessionVersion++
 	return nil
 }
@@ -165,18 +161,6 @@ func TestChangePasswordAnswers204WhenNoReplacementCanBeIssued(t *testing.T) {
 	assert.Equal(t, http.StatusNoContent, recorder.Code)
 	assert.Empty(t, recorder.Body.String())
 	assert.EqualValues(t, 1, fixture.repo.user.SessionVersion, "the revocation still happened")
-}
-
-// A revocation that fails is different: nothing else retires the credentials
-// minted under the old password, so the caller has to learn about it.
-func TestChangePasswordSurfacesAFailedRevocation(t *testing.T) {
-	fixture := newPasswordFixture(t)
-	fixture.repo.bumpFailed = true
-
-	recorder := changePassword(t, fixture.handler, fixture.principal,
-		`{"currentPassword":"Sup3rSecret!","newPassword":"An0therSecret!"}`)
-
-	assert.Equal(t, http.StatusInternalServerError, recorder.Code)
 }
 
 func TestChangePasswordRejectsAWrongCurrentPassword(t *testing.T) {

--- a/internal/handlers/dashboard/password_change_handler_test.go
+++ b/internal/handlers/dashboard/password_change_handler_test.go
@@ -1,0 +1,192 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	cache2 "expo-open-ota/internal/cache"
+	"expo-open-ota/internal/crypto"
+	"expo-open-ota/internal/ratelimit"
+	"expo-open-ota/internal/services"
+	"expo-open-ota/internal/store"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Changing a password revokes every session of the account, the caller's
+// included, so this endpoint hands back a replacement pair. Both halves of the
+// change depend on that contract: the dashboard reads the pair and stays
+// signed in, and falls back to the login page when the body is empty. Nothing
+// tested it on either side, so a silent regression to 204 would sign every
+// account out on a password change with only a log line to say so.
+
+// fakePasswordUserRepo is the users table, reduced to what this endpoint
+// touches. The rest panics rather than returning zero values, so a future call
+// path shows up as a failure instead of as a plausible-looking answer.
+type fakePasswordUserRepo struct {
+	user store.User
+	// bumpFailed makes the revocation fail, the case where the server must not
+	// pretend the sessions are gone.
+	bumpFailed bool
+}
+
+func (r *fakePasswordUserRepo) GetUserByID(_ context.Context, id string) (store.User, error) {
+	if id != r.user.Id {
+		return store.User{}, &store.ErrResourceNotFound{Resource: "user", Identifier: id}
+	}
+	return r.user, nil
+}
+
+func (r *fakePasswordUserRepo) UpdateUserPassword(_ context.Context, _ string, passwordHash string) error {
+	r.user.PasswordHash = passwordHash
+	return nil
+}
+
+func (r *fakePasswordUserRepo) BumpUserSessionVersion(_ context.Context, _ string) error {
+	if r.bumpFailed {
+		return assert.AnError
+	}
+	r.user.SessionVersion++
+	return nil
+}
+
+func (r *fakePasswordUserRepo) TouchUserLastConnected(_ context.Context, _ string) error { return nil }
+
+func (r *fakePasswordUserRepo) InsertUser(context.Context, store.InsertUserParameters) (store.User, error) {
+	panic("unused")
+}
+func (r *fakePasswordUserRepo) GetUserByEmail(context.Context, string) (store.User, error) {
+	panic("unused")
+}
+func (r *fakePasswordUserRepo) GetUsers(context.Context) ([]store.User, error) { panic("unused") }
+func (r *fakePasswordUserRepo) DeleteUserByID(context.Context, string) error   { panic("unused") }
+func (r *fakePasswordUserRepo) UpdateUserIsAdmin(context.Context, string, bool) error {
+	panic("unused")
+}
+func (r *fakePasswordUserRepo) UpdateUserEnabled(context.Context, string, bool) error {
+	panic("unused")
+}
+
+// fakeLedger is the rotation ledger, in memory. The replacement session needs
+// a row like any other sign-in.
+type fakeLedger struct {
+	tokens    map[string]store.RefreshToken
+	insertErr error
+}
+
+func (l *fakeLedger) InsertRefreshToken(_ context.Context, params store.InsertRefreshTokenParameters) error {
+	if l.insertErr != nil {
+		return l.insertErr
+	}
+	l.tokens[params.ID] = store.RefreshToken{Id: params.ID, UserId: params.UserID, FamilyId: params.FamilyID, ExpiresAt: params.ExpiresAt}
+	return nil
+}
+func (l *fakeLedger) DeleteExpiredRefreshTokens(context.Context, string) error { return nil }
+func (l *fakeLedger) RotateRefreshToken(context.Context, store.RotateRefreshTokenParameters) (store.RefreshToken, error) {
+	panic("unused")
+}
+func (l *fakeLedger) GetRefreshToken(context.Context, string, time.Duration) (store.RefreshToken, error) {
+	panic("unused")
+}
+func (l *fakeLedger) DeleteRefreshTokenFamily(context.Context, string) error { panic("unused") }
+
+func changePassword(t *testing.T, handler *UsersHandler, principal *services.DashboardPrincipal, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	request := httptest.NewRequest(http.MethodPut, "/api/me/password", strings.NewReader(body))
+	request = request.WithContext(services.WithPrincipal(context.Background(), principal))
+	recorder := httptest.NewRecorder()
+	handler.ChangeMyPasswordHandler(recorder, request)
+	return recorder
+}
+
+type passwordFixture struct {
+	handler   *UsersHandler
+	repo      *fakePasswordUserRepo
+	ledger    *fakeLedger
+	auth      *services.DashboardAuthService
+	principal *services.DashboardPrincipal
+}
+
+func newPasswordFixture(t *testing.T) *passwordFixture {
+	t.Helper()
+	t.Setenv("JWT_SECRET", "test-secret")
+	hash, err := crypto.HashPassword("Sup3rSecret!")
+	require.NoError(t, err)
+	repo := &fakePasswordUserRepo{user: store.User{
+		Id: "11111111-1111-1111-1111-111111111111", Email: "member@example.com", PasswordHash: hash, Enabled: true,
+	}}
+	ledger := &fakeLedger{tokens: map[string]store.RefreshToken{}}
+	authService := services.NewDashboardAuthService(repo, ledger)
+	return &passwordFixture{
+		handler:   NewUsersHandler(services.NewUserService(repo), authService, ratelimit.New(cache2.GetCache())),
+		repo:      repo,
+		ledger:    ledger,
+		auth:      authService,
+		principal: &services.DashboardPrincipal{UserId: repo.user.Id, Email: repo.user.Email},
+	}
+}
+
+func TestChangePasswordReturnsAWorkingReplacementSession(t *testing.T) {
+	fixture := newPasswordFixture(t)
+
+	recorder := changePassword(t, fixture.handler, fixture.principal,
+		`{"currentPassword":"Sup3rSecret!","newPassword":"An0therSecret!"}`)
+
+	require.Equal(t, http.StatusOK, recorder.Code)
+	var session services.DashboardSession
+	require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &session))
+	require.NotEmpty(t, session.Token)
+	require.NotEmpty(t, session.RefreshToken)
+
+	// The replacement carries the NEW generation, so it survives the very
+	// revocation the password change just performed. Handing back a pair
+	// minted before the bump would be worse than handing back nothing.
+	_, err := fixture.auth.AuthenticateSession(context.Background(), session.Token)
+	assert.NoError(t, err)
+	assert.EqualValues(t, 1, fixture.repo.user.SessionVersion)
+}
+
+// The 204 the client's fallback branch exists for: the password changed and
+// the sessions were revoked, only the replacement could not be minted. Saying
+// "error" here would tell the client the opposite of what happened.
+func TestChangePasswordAnswers204WhenNoReplacementCanBeIssued(t *testing.T) {
+	fixture := newPasswordFixture(t)
+	fixture.ledger.insertErr = assert.AnError
+
+	recorder := changePassword(t, fixture.handler, fixture.principal,
+		`{"currentPassword":"Sup3rSecret!","newPassword":"An0therSecret!"}`)
+
+	assert.Equal(t, http.StatusNoContent, recorder.Code)
+	assert.Empty(t, recorder.Body.String())
+	assert.EqualValues(t, 1, fixture.repo.user.SessionVersion, "the revocation still happened")
+}
+
+// A revocation that fails is different: nothing else retires the credentials
+// minted under the old password, so the caller has to learn about it.
+func TestChangePasswordSurfacesAFailedRevocation(t *testing.T) {
+	fixture := newPasswordFixture(t)
+	fixture.repo.bumpFailed = true
+
+	recorder := changePassword(t, fixture.handler, fixture.principal,
+		`{"currentPassword":"Sup3rSecret!","newPassword":"An0therSecret!"}`)
+
+	assert.Equal(t, http.StatusInternalServerError, recorder.Code)
+}
+
+func TestChangePasswordRejectsAWrongCurrentPassword(t *testing.T) {
+	fixture := newPasswordFixture(t)
+	before := fixture.repo.user.PasswordHash
+
+	recorder := changePassword(t, fixture.handler, fixture.principal,
+		`{"currentPassword":"wrong","newPassword":"An0therSecret!"}`)
+
+	assert.Equal(t, http.StatusBadRequest, recorder.Code)
+	assert.Equal(t, before, fixture.repo.user.PasswordHash, "the stored password must not have moved")
+	assert.EqualValues(t, 0, fixture.repo.user.SessionVersion, "and no session may have been revoked")
+}

--- a/internal/handlers/dashboard/users_handler.go
+++ b/internal/handlers/dashboard/users_handler.go
@@ -7,6 +7,7 @@ import (
 	"expo-open-ota/internal/ratelimit"
 	"expo-open-ota/internal/services"
 	"expo-open-ota/internal/store"
+	"log"
 	"net/http"
 	"time"
 
@@ -15,13 +16,17 @@ import (
 
 type UsersHandler struct {
 	userService *services.UserService
-	limiter     *ratelimit.Limiter
+	// dashboardAuthService mints the replacement session handed back when an
+	// account changes its own password, which revokes every session it held.
+	dashboardAuthService *services.DashboardAuthService
+	limiter              *ratelimit.Limiter
 }
 
-func NewUsersHandler(userService *services.UserService, limiter *ratelimit.Limiter) *UsersHandler {
+func NewUsersHandler(userService *services.UserService, dashboardAuthService *services.DashboardAuthService, limiter *ratelimit.Limiter) *UsersHandler {
 	return &UsersHandler{
-		userService: userService,
-		limiter:     limiter,
+		userService:          userService,
+		dashboardAuthService: dashboardAuthService,
+		limiter:              limiter,
 	}
 }
 
@@ -149,6 +154,24 @@ func (h *UsersHandler) ChangeMyPasswordHandler(w http.ResponseWriter, r *http.Re
 		return
 	}
 	h.limiter.RecordPasswordChangeSuccess(principal.UserId)
+	// Changing the password revoked every session the account held, including
+	// the one that just made this call. Handing back a fresh pair keeps the
+	// person who typed the password signed in, while every OTHER session stays
+	// dead: the forgotten laptop, the attacker's stolen token. Doing it here
+	// rather than in the service keeps the account rules and the session
+	// plumbing apart.
+	user, err := h.userService.GetMe(r.Context(), principal.UserId, principal.Email)
+	if err == nil {
+		var session *services.DashboardSession
+		if session, err = h.dashboardAuthService.IssueSession(r.Context(), user); err == nil {
+			handlers.RenderJSON(w, http.StatusOK, session)
+			return
+		}
+	}
+	// The password DID change, so answering an error would tell the client the
+	// opposite of what happened. 204 is the same success with no renewed
+	// session attached, which sends the client to the sign-in page.
+	log.Printf("password changed for user %s but the session could not be renewed: %v", principal.UserId, err)
 	w.WriteHeader(http.StatusNoContent)
 }
 

--- a/internal/middleware/auth_middleware.go
+++ b/internal/middleware/auth_middleware.go
@@ -83,8 +83,18 @@ func NewAuthMiddleware(dashboardAuthService *services.DashboardAuthService, cliA
 				http.Error(w, "No Authorization header provided", http.StatusUnauthorized)
 				return
 			}
-			principal, err := dashboardAuthService.ValidateSession(bearerToken)
+			// Not just "is this token authentic": the account behind it is
+			// re-read here, so a session dies the moment the account is
+			// deleted, disabled or revoked, instead of surviving up to the
+			// token's two hours.
+			principal, err := dashboardAuthService.AuthenticateSession(r.Context(), bearerToken)
 			if err != nil {
+				// A database outage must not read as a dead session, or a blip
+				// would sign every account out at once.
+				if errors.Is(err, services.ErrAuthUnavailable) {
+					http.Error(w, "Could not verify the account", http.StatusInternalServerError)
+					return
+				}
 				http.Error(w, "Invalid token", http.StatusUnauthorized)
 				return
 			}
@@ -128,11 +138,14 @@ func NewDashboardOnlyMiddleware() mux.MiddlewareFunc {
 // only accepts dashboard sessions — a CLI credential is app-scoped publishing
 // access, not an account, so it never reaches admin-gated routes.
 //
-// The flag is re-read from the users table on every call rather than trusted
-// from the JWT: a session token lives 2 hours, and a revoked admin (or deleted
-// user) must lose these routes immediately, not at the next refresh. userRepo
-// is nil in stateless mode, where the single ADMIN_EMAIL account is always an
-// admin and the claim alone is authoritative.
+// The flag is re-read from the users table here even though the principal now
+// carries a fresh one: NewAuthMiddleware resolves the account on every request,
+// so this read agrees with it by construction. It is kept because this gate is
+// the last thing between a member and the administration surface, and a gate
+// that reads its own decision's input is one that cannot be defeated by a
+// future change to how principals are built. userRepo is nil in stateless mode,
+// where the single ADMIN_EMAIL account is always an admin and the claim alone
+// is authoritative.
 func NewAdminMiddleware(userRepo services.UserRepository) mux.MiddlewareFunc {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/middleware/auth_middleware_test.go
+++ b/internal/middleware/auth_middleware_test.go
@@ -20,7 +20,7 @@ import (
 func runAuthMiddleware(t *testing.T, configure func(r *http.Request)) *httptest.ResponseRecorder {
 	t.Helper()
 	router := mux.NewRouter()
-	router.Use(NewAuthMiddleware(services.NewDashboardAuthService(nil), services.NewCliAuthService(nil, nil)))
+	router.Use(NewAuthMiddleware(services.NewDashboardAuthService(nil, nil), services.NewCliAuthService(nil, nil)))
 	router.HandleFunc("/settings", func(w http.ResponseWriter, r *http.Request) {
 		// Surface the principal so tests can assert the middleware propagated
 		// it to the handler, not just that authentication passed.
@@ -54,7 +54,7 @@ func TestAuthMiddleware(t *testing.T) {
 	})
 
 	t.Run("valid dashboard session is accepted", func(t *testing.T) {
-		session, err := services.NewDashboardAuthService(nil).LoginWithEmailPassword(context.Background(), "admin@example.com", "test-password")
+		session, err := services.NewDashboardAuthService(nil, nil).LoginWithEmailPassword(context.Background(), "admin@example.com", "test-password")
 		if err != nil {
 			t.Fatalf("login failed: %v", err)
 		}
@@ -121,7 +121,7 @@ func TestAuthMiddlewareCliBranchStampsMarker(t *testing.T) {
 
 	router := mux.NewRouter()
 	appRouter := router.PathPrefix("/{APP_ID}").Subrouter()
-	appRouter.Use(NewAuthMiddleware(services.NewDashboardAuthService(nil), services.NewCliAuthService(fakeCliAuthRepo{}, nil)))
+	appRouter.Use(NewAuthMiddleware(services.NewDashboardAuthService(nil, nil), services.NewCliAuthService(fakeCliAuthRepo{}, nil)))
 	appRouter.HandleFunc("/branches", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("X-Cli-App", services.CliAuthAppFromContext(r.Context()))
 		if services.PrincipalFromContext(r.Context()) != nil {

--- a/internal/middleware/cli_branch_scope_test.go
+++ b/internal/middleware/cli_branch_scope_test.go
@@ -66,7 +66,7 @@ func TestCliAuthPassesTheRouteBranchToTheAccessPolicy(t *testing.T) {
 
 	router := mux.NewRouter()
 	api := router.PathPrefix("/api").Subrouter()
-	api.Use(NewAuthMiddleware(services.NewDashboardAuthService(nil), cliAuth))
+	api.Use(NewAuthMiddleware(services.NewDashboardAuthService(nil, nil), cliAuth))
 	api.HandleFunc("/apps/{APP_ID}/branch/{BRANCH}/runtimeVersions",
 		func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusOK) }).
 		Methods(http.MethodGet)
@@ -93,7 +93,7 @@ func TestCliAuthPassesNoBranchWhenTheRouteHasNone(t *testing.T) {
 
 	router := mux.NewRouter()
 	api := router.PathPrefix("/api").Subrouter()
-	api.Use(NewAuthMiddleware(services.NewDashboardAuthService(nil), cliAuth))
+	api.Use(NewAuthMiddleware(services.NewDashboardAuthService(nil, nil), cliAuth))
 	api.HandleFunc("/apps/{APP_ID}/updates",
 		func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusOK) }).
 		Methods(http.MethodGet)

--- a/internal/router/wire.go
+++ b/internal/router/wire.go
@@ -78,6 +78,10 @@ func InitDependencies(ctx context.Context) (*AppContainer, func()) {
 	// Stays nil in stateless mode: user accounts only exist on the control
 	// plane, the flat-env dashboard authenticates against ADMIN_EMAIL/ADMIN_PASSWORD.
 	var userRepo services.UserRepository
+	// The refresh-token rotation ledger, nil in stateless mode for the same
+	// reason: it is a table, and there is no database to hold it. Refresh
+	// tokens are then not rotated and a replay cannot be detected.
+	var refreshTokenRepo services.RefreshTokenRepository
 	// Nil in stateless mode as well: progressive rollouts are a control-plane
 	// feature, and every consumer guards the nil.
 	var rolloutRepo services.RolloutRepository
@@ -158,6 +162,7 @@ func InitDependencies(ctx context.Context) (*AppContainer, func()) {
 		authRepo = store.NewPostgresAuthStore(dbEngine)
 		appRepo = store.NewPostgresAppStore(dbEngine)
 		userRepo = store.NewPostgresUserStore(dbEngine)
+		refreshTokenRepo = store.NewPostgresRefreshTokenStore(dbEngine)
 		licenseRepo = licensing.NewPostgresLicenseStore(dbEngine)
 		ssoRepo = sso.NewPostgresSSOStore(dbEngine)
 		apiKeyRestrictionRepo = apikeyrestrictions.NewPostgresApiKeyRestrictionStore(dbEngine)
@@ -261,7 +266,7 @@ func InitDependencies(ctx context.Context) (*AppContainer, func()) {
 	// their AppVisibilityFilter: they filter what a member sees without their
 	// package ever importing ee/rbac.
 	visibleApps := rbacService.VisibleAppsForPrincipal
-	dashboardAuthService := services.NewDashboardAuthService(userRepo)
+	dashboardAuthService := services.NewDashboardAuthService(userRepo, refreshTokenRepo)
 	// The restriction service doubles as the CLI access policy: every CLI
 	// request runs through its enforcement after authenticating.
 	cliAuthService := services.NewCliAuthService(authRepo, apiKeyRestrictionService)
@@ -319,7 +324,7 @@ func InitDependencies(ctx context.Context) (*AppContainer, func()) {
 		SSOHandler:                  sso.NewSSOHandler(ssoService, rateLimiter),
 		UpdateHandler:               dashhandlers.NewUpdateHandler(updateService, deploymentService),
 		UploadHandler:               handlers.NewUploadHandler(cliAuthService, deploymentService),
-		UsersHandler:                dashhandlers.NewUsersHandler(userService, rateLimiter),
+		UsersHandler:                dashhandlers.NewUsersHandler(userService, dashboardAuthService, rateLimiter),
 		UserRepo:                    userRepo,
 		ObserveIngestHandler:        observe.NewIngestHandler(identityService, telemetrySink, branchResolver, checkInRecorder),
 		ObserveHealthHistoryHandler: observe.NewHealthHistoryHandler(healthHistory, stateHistory),

--- a/internal/services/dashboard_auth_audit_test.go
+++ b/internal/services/dashboard_auth_audit_test.go
@@ -32,7 +32,7 @@ func TestLoginSuccessEmitsAuditEvent(t *testing.T) {
 	t.Setenv("JWT_SECRET", "test-secret")
 	repo := newFakeUserRepo()
 	recorder := &fakeAuditRecorder{}
-	authService := NewDashboardAuthService(repo)
+	authService := NewDashboardAuthService(repo, newFakeRefreshTokenRepo())
 	authService.SetOnAuditEvent(recorder.Record)
 	user := seededPasswordUser(t, repo, "axel@example.com", "Sup3rSecret!", true)
 
@@ -53,7 +53,7 @@ func TestLoginFailuresEmitAuditEvents(t *testing.T) {
 	t.Setenv("JWT_SECRET", "test-secret")
 	repo := newFakeUserRepo()
 	recorder := &fakeAuditRecorder{}
-	authService := NewDashboardAuthService(repo)
+	authService := NewDashboardAuthService(repo, newFakeRefreshTokenRepo())
 	authService.SetOnAuditEvent(recorder.Record)
 	seededPasswordUser(t, repo, "pending@example.com", "Sup3rSecret!", false)
 
@@ -100,7 +100,7 @@ func TestRefreshEmitsNoAuditEvent(t *testing.T) {
 	t.Setenv("JWT_SECRET", "test-secret")
 	repo := newFakeUserRepo()
 	recorder := &fakeAuditRecorder{}
-	authService := NewDashboardAuthService(repo)
+	authService := NewDashboardAuthService(repo, newFakeRefreshTokenRepo())
 	authService.SetOnAuditEvent(recorder.Record)
 	seededPasswordUser(t, repo, "axel@example.com", "Sup3rSecret!", true)
 

--- a/internal/services/dashboard_auth_service.go
+++ b/internal/services/dashboard_auth_service.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
+	"github.com/google/uuid"
 )
 
 // DashboardAuthService owns the admin dashboard's own session credentials: a
@@ -24,6 +25,11 @@ import (
 type DashboardAuthService struct {
 	Secret   string
 	userRepo UserRepository
+	// refreshTokens is the rotation ledger: one row per refresh token issued,
+	// which is what makes a refresh single-use and a replay detectable. Nil in
+	// stateless mode, where there is no database to keep it in and the refresh
+	// token stays the unrotated 7-day credential it has always been.
+	refreshTokens RefreshTokenRepository
 	// onAuditEvent is the audit emission seam; nil (community) means sign-ins
 	// are not recorded. Only the password login path emits here — the refresh
 	// path is session upkeep, not an authentication event.
@@ -49,6 +55,27 @@ type DashboardPrincipal struct {
 	UserId  string
 	Email   string
 	IsAdmin bool
+	// SessionVersion is the account's security generation at the time the
+	// session was minted, mirrored into every token as the sv claim. Always 0
+	// in stateless mode, which has no users table to bump.
+	SessionVersion int32
+}
+
+// RefreshTokenRepository is the refresh-token ledger (see the field doc on
+// DashboardAuthService). Like UserRepository it has no bucket implementation:
+// rotation state only exists on the control plane.
+type RefreshTokenRepository interface {
+	InsertRefreshToken(ctx context.Context, params store.InsertRefreshTokenParameters) error
+	// RotateRefreshToken retires one token and issues its successor in the same
+	// family, atomically. store.ErrResourceNotFound means the presented token
+	// was not claimable, which GetRefreshToken then explains: unknown token, or
+	// one already rotated (a replay).
+	RotateRefreshToken(ctx context.Context, params store.RotateRefreshTokenParameters) (store.RefreshToken, error)
+	// GetRefreshToken answers with UsedRecently set relative to replayGrace,
+	// decided by the store's own clock.
+	GetRefreshToken(ctx context.Context, id string, replayGrace time.Duration) (store.RefreshToken, error)
+	DeleteRefreshTokenFamily(ctx context.Context, familyId string) error
+	DeleteExpiredRefreshTokens(ctx context.Context, userId string) error
 }
 
 // ErrAdminEmailNotSet is surfaced verbatim to the login response: an operator
@@ -73,12 +100,41 @@ var ErrAccountPendingApproval = errors.New("this account is waiting for an admin
 // accepted here. Changing this value invalidates sessions already in the wild.
 const dashboardSubject = "admin-dashboard"
 
-// NewDashboardAuthService accepts a nil repository (stateless mode); logins
-// are then checked against ADMIN_EMAIL/ADMIN_PASSWORD.
-func NewDashboardAuthService(userRepo UserRepository) *DashboardAuthService {
+// sessionTokenTTL is short on purpose: it bounds how long a session survives
+// something the per-request check cannot see. refreshTokenTTL is how long a
+// signed-in account may stay away before having to type its password again.
+const (
+	sessionTokenTTL = 2 * time.Hour
+	refreshTokenTTL = 7 * 24 * time.Hour
+)
+
+// A refresh token works once. When the access token expires while the
+// dashboard has several requests in flight, each of them tries to refresh
+// with the same token: the first one gets a new pair, the others arrive after
+// it is already spent. For this long, those late arrivals get that same new
+// pair back instead of counting as a theft. 30 seconds covers a page load; a
+// token that comes back later than that means someone else has a copy of it.
+const refreshReplayGrace = 30 * time.Second
+
+// ErrSessionRevoked is returned when a syntactically valid token no longer
+// matches the account behind it: deleted, disabled, or its security generation
+// moved on (demoted, password changed). Distinct from a malformed token so the
+// middleware can answer 401 without confusing it with an infrastructure fault.
+var ErrSessionRevoked = errors.New("this session is no longer valid: sign in again")
+
+// ErrRefreshTokenReuse marks a refresh token presented after it was already
+// rotated. Two parties hold the chain, so the whole family is revoked before
+// this is returned.
+var ErrRefreshTokenReuse = errors.New("this refresh token was already used: every session from that sign-in has been revoked")
+
+// NewDashboardAuthService accepts nil repositories (stateless mode); logins
+// are then checked against ADMIN_EMAIL/ADMIN_PASSWORD and refresh tokens are
+// not rotated, having nowhere to record the rotation.
+func NewDashboardAuthService(userRepo UserRepository, refreshTokens RefreshTokenRepository) *DashboardAuthService {
 	return &DashboardAuthService{
-		Secret:   config.GetEnv("JWT_SECRET"),
-		userRepo: userRepo,
+		Secret:        config.GetEnv("JWT_SECRET"),
+		userRepo:      userRepo,
+		refreshTokens: refreshTokens,
 	}
 }
 
@@ -87,15 +143,19 @@ func (a *DashboardAuthService) SetSSOEnforced(enforced func(context.Context) boo
 	a.ssoEnforced = enforced
 }
 
+// generateSessionToken mints the access half. It carries isAdmin, but that
+// snapshot is not what authorizes anything: AuthenticateSession re-reads the
+// account on every request and overwrites it.
 func (a *DashboardAuthService) generateSessionToken(principal DashboardPrincipal) (*string, error) {
 	token, err := crypto.GenerateJWTToken(a.Secret, jwt.MapClaims{
 		"sub":     dashboardSubject,
-		"exp":     time.Now().Add(time.Hour * 2).Unix(),
+		"exp":     time.Now().Add(sessionTokenTTL).Unix(),
 		"iat":     time.Now().Unix(),
 		"type":    "token",
 		"userId":  principal.UserId,
 		"email":   principal.Email,
 		"isAdmin": principal.IsAdmin,
+		"sv":      principal.SessionVersion,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("error while generating the jwt token: %w", err)
@@ -106,14 +166,22 @@ func (a *DashboardAuthService) generateSessionToken(principal DashboardPrincipal
 // generateRefreshToken carries only the account's identity, not its isAdmin
 // snapshot: RefreshSession re-resolves the account so a revoked flag or a
 // deleted user takes effect at the next refresh instead of surviving 7 days.
-func (a *DashboardAuthService) generateRefreshToken(principal DashboardPrincipal) (*string, error) {
+//
+// tokenId names the ledger row that makes this token single-use. It is empty
+// in stateless mode, where there is no ledger and the token stays reusable
+// until it expires. The family is deliberately NOT a claim: it is read from
+// the ledger row on every rotation, so nothing a holder presents can steer
+// which chain a revocation walks.
+func (a *DashboardAuthService) generateRefreshToken(principal DashboardPrincipal, tokenId string, expiresAt time.Time) (*string, error) {
 	refreshToken, err := crypto.GenerateJWTToken(a.Secret, jwt.MapClaims{
 		"sub":    dashboardSubject,
-		"exp":    time.Now().Add(time.Hour * 24 * 7).Unix(),
+		"exp":    expiresAt.Unix(),
 		"iat":    time.Now().Unix(),
 		"type":   "refreshToken",
 		"userId": principal.UserId,
 		"email":  principal.Email,
+		"sv":     principal.SessionVersion,
+		"jti":    tokenId,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("error while generating the jwt token: %w", err)
@@ -121,12 +189,16 @@ func (a *DashboardAuthService) generateRefreshToken(principal DashboardPrincipal
 	return &refreshToken, nil
 }
 
-func (a *DashboardAuthService) generateSessionPair(principal DashboardPrincipal) (*DashboardSession, error) {
+// issueSessionPair mints the two JWTs for a refresh token whose ledger row has
+// already been written (or, in stateless mode, for no row at all). Persisting
+// first and signing second is what keeps a token from ever reaching a client
+// without a row that can revoke it.
+func (a *DashboardAuthService) issueSessionPair(principal DashboardPrincipal, tokenId string, expiresAt time.Time) (*DashboardSession, error) {
 	token, err := a.generateSessionToken(principal)
 	if err != nil {
 		return nil, err
 	}
-	refreshToken, err := a.generateRefreshToken(principal)
+	refreshToken, err := a.generateRefreshToken(principal, tokenId, expiresAt)
 	if err != nil {
 		return nil, err
 	}
@@ -134,6 +206,30 @@ func (a *DashboardAuthService) generateSessionPair(principal DashboardPrincipal)
 		Token:        *token,
 		RefreshToken: *refreshToken,
 	}, nil
+}
+
+// startSession opens a new refresh chain: a sign-in, whether by password, by
+// SSO, or the replacement handed back after a password change.
+func (a *DashboardAuthService) startSession(ctx context.Context, principal DashboardPrincipal) (*DashboardSession, error) {
+	expiresAt := time.Now().Add(refreshTokenTTL)
+	if a.refreshTokens == nil {
+		return a.issueSessionPair(principal, "", expiresAt)
+	}
+	tokenId := uuid.New().String()
+	if err := a.refreshTokens.InsertRefreshToken(ctx, store.InsertRefreshTokenParameters{
+		ID:        tokenId,
+		UserID:    principal.UserId,
+		FamilyID:  uuid.New().String(),
+		ExpiresAt: expiresAt,
+	}); err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrAuthUnavailable, err)
+	}
+	if err := a.refreshTokens.DeleteExpiredRefreshTokens(ctx, principal.UserId); err != nil {
+		// Housekeeping, bounded to this account. Not a reason to refuse a valid
+		// sign-in.
+		log.Printf("failed to purge expired refresh tokens for user %s: %v", principal.UserId, err)
+	}
+	return a.issueSessionPair(principal, tokenId, expiresAt)
 }
 
 // resolveStatelessPrincipal checks credentials against ADMIN_EMAIL and
@@ -182,7 +278,12 @@ func (a *DashboardAuthService) principalForUser(ctx context.Context, user store.
 	if err := a.userRepo.TouchUserLastConnected(ctx, user.Id); err != nil {
 		log.Printf("failed to record last connection for user %s: %v", user.Id, err)
 	}
-	return &DashboardPrincipal{UserId: user.Id, Email: user.Email, IsAdmin: user.IsAdmin}, nil
+	return &DashboardPrincipal{
+		UserId:         user.Id,
+		Email:          user.Email,
+		IsAdmin:        user.IsAdmin,
+		SessionVersion: user.SessionVersion,
+	}, nil
 }
 
 func (a *DashboardAuthService) resolveLoginPrincipal(ctx context.Context, email string, password string) (*DashboardPrincipal, error) {
@@ -241,7 +342,7 @@ func (a *DashboardAuthService) LoginWithEmailPassword(ctx context.Context, email
 		return nil, err
 	}
 	a.recordLoginSuccess(ctx, principal)
-	return a.generateSessionPair(*principal)
+	return a.startSession(ctx, *principal)
 }
 
 // SetOnAuditEvent plugs the audit emission seam (see SetSSOEnforced for the
@@ -305,13 +406,14 @@ func (a *DashboardAuthService) IssueSession(ctx context.Context, user store.User
 	if err != nil {
 		return nil, err
 	}
-	return a.generateSessionPair(*principal)
+	return a.startSession(ctx, *principal)
 }
 
 // ValidateSession accepts only a dashboard session JWT — not a refresh token,
 // and not any other JWT signed with the same secret — and returns who it was
-// minted for. Identity is read from the claims, not the database: a session
-// token lives 2h and admin-gated routes re-check the flag against the DB.
+// minted for, purely from the claims. It says the token is authentic, not that
+// the account behind it still exists: authenticating a request goes through
+// AuthenticateSession, which is the only caller outside the tests.
 func (a *DashboardAuthService) ValidateSession(tokenString string) (*DashboardPrincipal, error) {
 	claims := jwt.MapClaims{}
 	_, err := crypto.DecodeAndExtractJWTToken(a.Secret, tokenString, &claims)
@@ -334,16 +436,82 @@ func (a *DashboardAuthService) ValidateSession(tokenString string) (*DashboardPr
 	if isAdmin, ok := claims["isAdmin"].(bool); ok {
 		principal.IsAdmin = isAdmin
 	}
+	principal.SessionVersion = sessionVersionClaim(claims)
 	return &principal, nil
 }
 
-// RefreshSession accepts only a dashboard refresh JWT and mints a fresh pair.
-// The account is re-resolved first, so a user that was deleted — or, in
-// stateless mode, an ADMIN_EMAIL that changed — cannot refresh its way back in.
-func (a *DashboardAuthService) RefreshSession(ctx context.Context, tokenString string) (*DashboardSession, error) {
-	claims := jwt.MapClaims{}
-	_, err := crypto.DecodeAndExtractJWTToken(a.Secret, tokenString, &claims)
+// sessionVersionClaim reads the sv claim. JSON numbers decode as float64, and
+// a token minted before sv existed simply has none: both read as generation 0,
+// which is the default every existing row carries.
+func sessionVersionClaim(claims jwt.MapClaims) int32 {
+	version, _ := claims["sv"].(float64)
+	return int32(version)
+}
+
+// AuthenticateSession is what an authenticated request goes through: it
+// validates the token AND re-reads the account behind it, so a session dies as
+// soon as the account is deleted, disabled, or has its security generation
+// bumped (demoted, password changed). It costs one users read per request,
+// which is the price of not having sessions that outlive the account by up to
+// two hours.
+//
+// The principal it returns carries the account's CURRENT admin flag, read from
+// the row rather than from the token, so nothing downstream has to distrust it.
+// In stateless mode there is no users table and the claims stand alone.
+func (a *DashboardAuthService) AuthenticateSession(ctx context.Context, tokenString string) (*DashboardPrincipal, error) {
+	principal, err := a.ValidateSession(tokenString)
 	if err != nil {
+		return nil, err
+	}
+	if a.userRepo == nil {
+		return principal, nil
+	}
+	// A token minted by a stateless deployment names no user. It cannot
+	// identify an account here, and letting it through would authenticate a
+	// request as nobody.
+	if principal.UserId == "" {
+		return nil, ErrSessionRevoked
+	}
+	user, err := a.userRepo.GetUserByID(ctx, principal.UserId)
+	if err != nil {
+		// Only a missing row means the account is gone; an infrastructure
+		// failure must not read as a dead session, or a database blip would
+		// sign everyone out.
+		if notFoundErr := (*store.ErrResourceNotFound)(nil); errors.As(err, &notFoundErr) {
+			return nil, ErrSessionRevoked
+		}
+		return nil, fmt.Errorf("%w: %v", ErrAuthUnavailable, err)
+	}
+	if !user.Enabled || user.SessionVersion != principal.SessionVersion {
+		return nil, ErrSessionRevoked
+	}
+	return &DashboardPrincipal{
+		UserId:         user.Id,
+		Email:          user.Email,
+		IsAdmin:        user.IsAdmin,
+		SessionVersion: user.SessionVersion,
+	}, nil
+}
+
+// RefreshSession trades a refresh token for a new pair and spends the old one.
+// The whole flow is here, in order, because it is one story:
+//
+//	1. Is the token ours, and is it a refresh token?
+//	2. Does the account still exist, is it still enabled, and are these
+//	   credentials still current? A deleted, disabled, demoted or
+//	   password-changed account cannot refresh its way back in.
+//	3. Spend the token and write its successor, in one transaction.
+//	4. If it could not be spent, find out why. Three answers mean "sign in
+//	   again", one means "this same client already asked", and one means the
+//	   token leaked.
+//
+// Step 2 runs before step 3 so a database outage leaves the caller's token
+// intact. Spending it first would burn a good credential over a blip, and the
+// retry it makes later would then look like the leak in step 4.
+func (a *DashboardAuthService) RefreshSession(ctx context.Context, tokenString string) (*DashboardSession, error) {
+	// 1. The token itself.
+	claims := jwt.MapClaims{}
+	if _, err := crypto.DecodeAndExtractJWTToken(a.Secret, tokenString, &claims); err != nil {
 		return nil, err
 	}
 	if claims["type"] != "refreshToken" {
@@ -352,16 +520,107 @@ func (a *DashboardAuthService) RefreshSession(ctx context.Context, tokenString s
 	if claims["sub"] != dashboardSubject {
 		return nil, errors.New("invalid token subject")
 	}
-	var principal *DashboardPrincipal
+
+	// Stateless mode has no users table and no ledger, so there is nothing to
+	// re-check and nothing to rotate. The token buys a new pair until it
+	// expires, which is the behaviour it has always had.
 	if a.userRepo == nil {
 		email, _ := claims["email"].(string)
-		principal, err = resolveStatelessPrincipal(email, nil)
-	} else {
-		userId, _ := claims["userId"].(string)
-		principal, err = a.resolveRefreshPrincipal(ctx, userId)
+		principal, err := resolveStatelessPrincipal(email, nil)
+		if err != nil {
+			return nil, err
+		}
+		return a.startSession(ctx, *principal)
 	}
+
+	// 2. The account behind it, read fresh.
+	userId, _ := claims["userId"].(string)
+	principal, err := a.resolveRefreshPrincipal(ctx, userId)
 	if err != nil {
 		return nil, err
 	}
-	return a.generateSessionPair(*principal)
+	if principal.SessionVersion != sessionVersionClaim(claims) {
+		// The account changed under this token: demoted, password changed, or
+		// an admin revoked its sessions.
+		return nil, ErrSessionRevoked
+	}
+	if a.refreshTokens == nil {
+		return a.startSession(ctx, *principal)
+	}
+	spentId, _ := claims["jti"].(string)
+	if spentId == "" {
+		// Minted before rotation existed, or forged. With no ledger row naming
+		// it, there is no way to make this token single-use.
+		return nil, ErrSessionRevoked
+	}
+
+	// 3. Spend it. The successor is written in the same transaction, so this
+	// either fully happens or not at all.
+	successorId := uuid.New().String()
+	expiresAt := time.Now().Add(refreshTokenTTL)
+	_, err = a.refreshTokens.RotateRefreshToken(ctx, store.RotateRefreshTokenParameters{
+		OldID:     spentId,
+		NewID:     successorId,
+		ExpiresAt: expiresAt,
+	})
+	if err == nil {
+		if purgeErr := a.refreshTokens.DeleteExpiredRefreshTokens(ctx, principal.UserId); purgeErr != nil {
+			// Housekeeping, bounded to this account. Not a reason to refuse.
+			log.Printf("failed to purge expired refresh tokens for user %s: %v", principal.UserId, purgeErr)
+		}
+		return a.issueSessionPair(*principal, successorId, expiresAt)
+	}
+	notFoundErr := (*store.ErrResourceNotFound)(nil)
+	if !errors.As(err, &notFoundErr) {
+		return nil, fmt.Errorf("%w: %v", ErrAuthUnavailable, err)
+	}
+
+	// 4. It would not spend. The row says why.
+	spent, err := a.refreshTokens.GetRefreshToken(ctx, spentId, refreshReplayGrace)
+	if err != nil {
+		if errors.As(err, &notFoundErr) {
+			// No such row: the family was revoked, or the id was invented.
+			return nil, ErrSessionRevoked
+		}
+		return nil, fmt.Errorf("%w: %v", ErrAuthUnavailable, err)
+	}
+	if spent.UsedAt == nil {
+		// Never spent, yet the rotation refused it: the only other thing it
+		// checks is the expiry.
+		return nil, ErrSessionRevoked
+	}
+	if spent.UsedRecently && spent.ReplacedBy != nil {
+		// The same client asking twice, its parallel requests having all hit a
+		// 401 at once (see refreshReplayGrace). Give it the successor already
+		// written rather than a second one: two live tokens in one family is a
+		// fork, and a fork can never be caught replaying below.
+		successor, err := a.refreshTokens.GetRefreshToken(ctx, *spent.ReplacedBy, refreshReplayGrace)
+		if err != nil {
+			if errors.As(err, &notFoundErr) {
+				return nil, ErrSessionRevoked
+			}
+			return nil, fmt.Errorf("%w: %v", ErrAuthUnavailable, err)
+		}
+		if successor.UsedAt != nil {
+			// The successor has itself been spent since. Which link the caller
+			// should hold is now guesswork; one sign-in is cheaper than a wrong
+			// guess.
+			return nil, ErrSessionRevoked
+		}
+		return a.issueSessionPair(*principal, successor.Id, successor.ExpiresAt)
+	}
+
+	// Spent long ago and presented again: two parties hold this chain.
+	// Deleting the family is not enough, because the access token the replay
+	// produced belongs to no family. Bumping the account's generation is what
+	// kills it, and it signs the account out everywhere. On proof of a stolen
+	// credential that is the right trade, and it is what a demotion does too.
+	if err := a.refreshTokens.DeleteRefreshTokenFamily(ctx, spent.FamilyId); err != nil {
+		log.Printf("failed to revoke refresh token family %s after a replay: %v", spent.FamilyId, err)
+	}
+	if err := a.userRepo.BumpUserSessionVersion(ctx, principal.UserId); err != nil {
+		log.Printf("failed to revoke the sessions of user %s after a replay: %v", principal.UserId, err)
+	}
+	log.Printf("🚨 [AUTH] refresh token replay for user %s: family %s revoked, every session of the account invalidated", spent.UserId, spent.FamilyId)
+	return nil, ErrRefreshTokenReuse
 }

--- a/internal/services/dashboard_auth_service_test.go
+++ b/internal/services/dashboard_auth_service_test.go
@@ -20,7 +20,7 @@ func seededSSOUser(id string, email string) store.InsertUserParameters {
 func TestPasswordLoginRejectsEmptyHashAccounts(t *testing.T) {
 	t.Setenv("JWT_SECRET", "test-secret")
 	repo := newFakeUserRepo()
-	authService := NewDashboardAuthService(repo)
+	authService := NewDashboardAuthService(repo, newFakeRefreshTokenRepo())
 	ctx := context.Background()
 
 	_, err := repo.InsertUser(ctx, seededSSOUser("sso-user", "sso-member@example.com"))
@@ -35,7 +35,7 @@ func TestPasswordLoginRejectsEmptyHashAccounts(t *testing.T) {
 func TestIssueSessionMintsAValidPair(t *testing.T) {
 	t.Setenv("JWT_SECRET", "test-secret")
 	repo := newFakeUserRepo()
-	authService := NewDashboardAuthService(repo)
+	authService := NewDashboardAuthService(repo, newFakeRefreshTokenRepo())
 	ctx := context.Background()
 
 	user, err := repo.InsertUser(ctx, seededSSOUser("sso-user", "sso-member@example.com"))
@@ -60,7 +60,7 @@ func TestIssueSessionMintsAValidPair(t *testing.T) {
 	assert.NotNil(t, stored.LastConnectedAt)
 
 	// Stateless mode has no database accounts to issue sessions for.
-	statelessService := NewDashboardAuthService(nil)
+	statelessService := NewDashboardAuthService(nil, nil)
 	_, err = statelessService.IssueSession(ctx, user)
 	assert.Error(t, err)
 }
@@ -72,7 +72,7 @@ func TestDisabledAccountCannotSignInOrRefresh(t *testing.T) {
 	t.Setenv("JWT_SECRET", "test-secret")
 	repo := newFakeUserRepo()
 	userService := NewUserService(repo)
-	authService := NewDashboardAuthService(repo)
+	authService := NewDashboardAuthService(repo, newFakeRefreshTokenRepo())
 	ctx := context.Background()
 
 	admin, err := userService.CreateUser(ctx, "admin@example.com", "Sup3rSecret!", true)
@@ -110,7 +110,7 @@ func TestSSOEnforcementOnPasswordLogin(t *testing.T) {
 	t.Setenv("JWT_SECRET", "test-secret")
 	repo := newFakeUserRepo()
 	userService := NewUserService(repo)
-	authService := NewDashboardAuthService(repo)
+	authService := NewDashboardAuthService(repo, newFakeRefreshTokenRepo())
 	ctx := context.Background()
 
 	_, err := userService.CreateUser(ctx, "admin@example.com", "Sup3rSecret!", true)

--- a/internal/services/refresh_token_repo_fake_test.go
+++ b/internal/services/refresh_token_repo_fake_test.go
@@ -1,0 +1,98 @@
+package services
+
+import (
+	"context"
+	"expo-open-ota/internal/store"
+	"time"
+)
+
+// fakeRefreshTokenRepo is an in-memory rotation ledger. It deliberately mirrors
+// the real store's semantics rather than a convenient subset: the claim is
+// single-use and atomic with writing the successor, and UsedRecently is decided
+// against the same clock that stamped UsedAt. A fake more permissive than the
+// SQL it stands for would make every service test above it lie.
+type fakeRefreshTokenRepo struct {
+	tokens map[string]store.RefreshToken
+	// rotateErr, when set, fails every rotation: the "an outage must not read
+	// as a revocation" path.
+	rotateErr error
+	// insertErr, when set, fails every ledger write: the "a token must never
+	// leave the server without a row backing it" path.
+	insertErr error
+}
+
+func newFakeRefreshTokenRepo() *fakeRefreshTokenRepo {
+	return &fakeRefreshTokenRepo{tokens: map[string]store.RefreshToken{}}
+}
+
+func (r *fakeRefreshTokenRepo) InsertRefreshToken(_ context.Context, params store.InsertRefreshTokenParameters) error {
+	if r.insertErr != nil {
+		return r.insertErr
+	}
+	r.tokens[params.ID] = store.RefreshToken{
+		Id:        params.ID,
+		UserId:    params.UserID,
+		FamilyId:  params.FamilyID,
+		ExpiresAt: params.ExpiresAt,
+	}
+	return nil
+}
+
+func (r *fakeRefreshTokenRepo) RotateRefreshToken(_ context.Context, params store.RotateRefreshTokenParameters) (store.RefreshToken, error) {
+	if r.rotateErr != nil {
+		return store.RefreshToken{}, r.rotateErr
+	}
+	token, ok := r.tokens[params.OldID]
+	if !ok || token.UsedAt != nil || !token.ExpiresAt.After(time.Now()) {
+		return store.RefreshToken{}, &store.ErrResourceNotFound{Resource: "refresh token", Identifier: params.OldID}
+	}
+	now := time.Now()
+	successorId := params.NewID
+	token.UsedAt = &now
+	token.ReplacedBy = &successorId
+	r.tokens[params.OldID] = token
+	// Same transaction as the claim in the real store: a successor always
+	// exists for a token that was retired.
+	r.tokens[successorId] = store.RefreshToken{
+		Id:        successorId,
+		UserId:    token.UserId,
+		FamilyId:  token.FamilyId,
+		ExpiresAt: params.ExpiresAt,
+	}
+	return token, nil
+}
+
+func (r *fakeRefreshTokenRepo) GetRefreshToken(_ context.Context, id string, replayGrace time.Duration) (store.RefreshToken, error) {
+	token, ok := r.tokens[id]
+	if !ok {
+		return store.RefreshToken{}, &store.ErrResourceNotFound{Resource: "refresh token", Identifier: id}
+	}
+	token.UsedRecently = token.UsedAt != nil && time.Since(*token.UsedAt) <= replayGrace
+	return token, nil
+}
+
+func (r *fakeRefreshTokenRepo) DeleteRefreshTokenFamily(_ context.Context, familyId string) error {
+	for id, token := range r.tokens {
+		if token.FamilyId == familyId {
+			delete(r.tokens, id)
+		}
+	}
+	return nil
+}
+
+func (r *fakeRefreshTokenRepo) DeleteExpiredRefreshTokens(_ context.Context, userId string) error {
+	for id, token := range r.tokens {
+		if token.UserId == userId && !token.ExpiresAt.After(time.Now()) {
+			delete(r.tokens, id)
+		}
+	}
+	return nil
+}
+
+// markUsedAt backdates a token's rotation, the only way a test can reach past
+// the replay grace window without sleeping.
+func (r *fakeRefreshTokenRepo) markUsedAt(id string, usedAt time.Time) {
+	token := r.tokens[id]
+	token.UsedAt = &usedAt
+	r.tokens[id] = token
+}

--- a/internal/services/session_revocation_test.go
+++ b/internal/services/session_revocation_test.go
@@ -179,16 +179,22 @@ func TestChangingThePasswordRevokesEverySessionOfTheAccount(t *testing.T) {
 }
 
 // Nothing else enforces the revocation a password change performs: no flag
-// changes and the row stays enabled. A store that cannot record it must
-// therefore fail the call, rather than leave the old sessions live behind a
-// new password.
-func TestChangingThePasswordFailsWhenSessionsCannotBeRevoked(t *testing.T) {
+// changes and the row stays enabled, so the session version is the only thing
+// ending the old sessions. The store therefore moves both in one write, and a
+// failure must leave neither: a committed password with surviving sessions is
+// the exact hole this ticket closes.
+func TestAFailedPasswordWriteRevokesNothing(t *testing.T) {
 	fixture := newRevocationFixture(t)
-	failing := &bumpFailingUserRepo{fakeUserRepo: fixture.repo}
-	userService := NewUserService(failing)
+	failing := &passwordWriteFailingUserRepo{fakeUserRepo: fixture.repo}
 
-	err := userService.ChangePassword(context.Background(), fixture.member.Id, "Sup3rSecret!", "An0therSecret!")
-	assert.ErrorContains(t, err, "could not be revoked")
+	err := NewUserService(failing).ChangePassword(
+		context.Background(), fixture.member.Id, "Sup3rSecret!", "An0therSecret!")
+	require.Error(t, err)
+
+	stored, getErr := fixture.repo.GetUserByID(context.Background(), fixture.member.Id)
+	require.NoError(t, getErr)
+	assert.EqualValues(t, 0, stored.SessionVersion, "no password, no revocation")
+	assertSessionAlive(t, fixture.auth, fixture.memberSession)
 }
 
 func TestDeletingAnAccountRevokesItsLiveSession(t *testing.T) {
@@ -397,12 +403,13 @@ func TestStatelessRefreshStillWorksWithoutALedger(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-// bumpFailingUserRepo accepts every write except the revocation itself.
-type bumpFailingUserRepo struct {
+// passwordWriteFailingUserRepo refuses the one statement that carries both the
+// new password and the revocation.
+type passwordWriteFailingUserRepo struct {
 	*fakeUserRepo
 }
 
-func (r *bumpFailingUserRepo) BumpUserSessionVersion(context.Context, string) error {
+func (r *passwordWriteFailingUserRepo) UpdateUserPassword(context.Context, string, string) error {
 	return errors.New("database is on fire")
 }
 

--- a/internal/services/session_revocation_test.go
+++ b/internal/services/session_revocation_test.go
@@ -1,0 +1,417 @@
+package services
+
+import (
+	"context"
+	"errors"
+	"expo-open-ota/internal/crypto"
+	"expo-open-ota/internal/store"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// revocationFixture is one control-plane deployment with an admin and a
+// member, each holding a live session. Both are needed by nearly every case
+// below: the admin performs the revocations, the member is the account whose
+// sessions must die, and the admin's own session is what proves administrators
+// are revoked on the same terms as members.
+type revocationFixture struct {
+	auth          *DashboardAuthService
+	users         *UserService
+	repo          *fakeUserRepo
+	refreshTokens *fakeRefreshTokenRepo
+	admin         store.User
+	member        store.User
+	adminSession  *DashboardSession
+	memberSession *DashboardSession
+}
+
+func newRevocationFixture(t *testing.T) *revocationFixture {
+	t.Helper()
+	t.Setenv("JWT_SECRET", "test-secret")
+	ctx := context.Background()
+	repo := newFakeUserRepo()
+	refreshTokens := newFakeRefreshTokenRepo()
+	userService := NewUserService(repo)
+	authService := NewDashboardAuthService(repo, refreshTokens)
+
+	admin, err := userService.CreateUser(ctx, "admin@example.com", "Sup3rSecret!", true)
+	require.NoError(t, err)
+	member, err := userService.CreateUser(ctx, "member@example.com", "Sup3rSecret!", false)
+	require.NoError(t, err)
+
+	adminSession, err := authService.LoginWithEmailPassword(ctx, admin.Email, "Sup3rSecret!")
+	require.NoError(t, err)
+	memberSession, err := authService.LoginWithEmailPassword(ctx, member.Email, "Sup3rSecret!")
+	require.NoError(t, err)
+
+	return &revocationFixture{
+		auth:          authService,
+		users:         userService,
+		repo:          repo,
+		refreshTokens: refreshTokens,
+		admin:         admin,
+		member:        member,
+		adminSession:  adminSession,
+		memberSession: memberSession,
+	}
+}
+
+// assertSessionDead is the whole point of the ticket in one assertion: neither
+// half of the pair may still be worth anything.
+func assertSessionDead(t *testing.T, auth *DashboardAuthService, session *DashboardSession) {
+	t.Helper()
+	ctx := context.Background()
+	_, err := auth.AuthenticateSession(ctx, session.Token)
+	assert.ErrorIs(t, err, ErrSessionRevoked, "the access token should have been revoked")
+	_, err = auth.RefreshSession(ctx, session.RefreshToken)
+	assert.Error(t, err, "the refresh token should have been revoked")
+}
+
+func assertSessionAlive(t *testing.T, auth *DashboardAuthService, session *DashboardSession) {
+	t.Helper()
+	_, err := auth.AuthenticateSession(context.Background(), session.Token)
+	assert.NoError(t, err)
+}
+
+// refreshTokenId reads the jti a refresh token names, so a test can reach the
+// ledger row behind a token it only holds as a string.
+func refreshTokenId(t *testing.T, auth *DashboardAuthService, refreshToken string) string {
+	t.Helper()
+	claims := jwt.MapClaims{}
+	_, err := crypto.DecodeAndExtractJWTToken(auth.Secret, refreshToken, &claims)
+	require.NoError(t, err)
+	id, _ := claims["jti"].(string)
+	require.NotEmpty(t, id, "a refresh token issued on the control plane must name its ledger row")
+	return id
+}
+
+func TestDisablingAMemberRevokesItsLiveSession(t *testing.T) {
+	fixture := newRevocationFixture(t)
+	ctx := context.Background()
+
+	assertSessionAlive(t, fixture.auth, fixture.memberSession)
+	require.NoError(t, fixture.users.SetUserEnabled(ctx, fixture.admin.Id, fixture.member.Id, false))
+
+	assertSessionDead(t, fixture.auth, fixture.memberSession)
+	// The admin who performed the revocation is untouched by it.
+	assertSessionAlive(t, fixture.auth, fixture.adminSession)
+}
+
+// The disable tests above would pass on the pre-existing `enabled` check
+// alone, which is not the mechanism this ticket added. Re-enabling is what
+// tells the two apart: once the account is enabled again, only a bumped
+// session version still refuses the sessions it held while disabled. Those are
+// exactly the sessions an admin revoked access to, usually because one of them
+// was stolen.
+func TestReEnablingAnAccountDoesNotResurrectItsOldSessions(t *testing.T) {
+	fixture := newRevocationFixture(t)
+	ctx := context.Background()
+
+	require.NoError(t, fixture.users.SetUserEnabled(ctx, fixture.admin.Id, fixture.member.Id, false))
+	require.NoError(t, fixture.users.SetUserEnabled(ctx, fixture.admin.Id, fixture.member.Id, true))
+
+	assertSessionDead(t, fixture.auth, fixture.memberSession)
+	// The account itself is usable again, it just needs to sign in.
+	_, err := fixture.auth.LoginWithEmailPassword(ctx, fixture.member.Email, "Sup3rSecret!")
+	assert.NoError(t, err)
+}
+
+func TestDisablingAnAdminRevokesItsLiveSession(t *testing.T) {
+	fixture := newRevocationFixture(t)
+	ctx := context.Background()
+
+	// The last enabled admin cannot be disabled, so promote the member first:
+	// this is the case where the account losing its sessions is an admin.
+	require.NoError(t, fixture.users.SetUserAdmin(ctx, fixture.admin.Id, fixture.member.Id, true))
+	require.NoError(t, fixture.users.SetUserEnabled(ctx, fixture.member.Id, fixture.admin.Id, false))
+
+	assertSessionDead(t, fixture.auth, fixture.adminSession)
+}
+
+func TestDemotingAnAdminRevokesItsLiveSession(t *testing.T) {
+	fixture := newRevocationFixture(t)
+	ctx := context.Background()
+
+	require.NoError(t, fixture.users.SetUserAdmin(ctx, fixture.admin.Id, fixture.member.Id, true))
+	require.NoError(t, fixture.users.SetUserAdmin(ctx, fixture.member.Id, fixture.admin.Id, false))
+
+	// The demoted account keeps its password, so it may sign in again, as a
+	// member. What it must not keep is the session minted while it was admin,
+	// whose isAdmin claim would otherwise stand for another two hours.
+	assertSessionDead(t, fixture.auth, fixture.adminSession)
+	fresh, err := fixture.auth.LoginWithEmailPassword(ctx, fixture.admin.Email, "Sup3rSecret!")
+	require.NoError(t, err)
+	principal, err := fixture.auth.AuthenticateSession(ctx, fresh.Token)
+	require.NoError(t, err)
+	assert.False(t, principal.IsAdmin)
+}
+
+// Promoting is not a revocation: nothing about the account's existing session
+// became untrustworthy, and signing someone out to grant them a flag would be
+// gratuitous.
+func TestPromotingAMemberLeavesItsSessionAlive(t *testing.T) {
+	fixture := newRevocationFixture(t)
+
+	require.NoError(t, fixture.users.SetUserAdmin(context.Background(), fixture.admin.Id, fixture.member.Id, true))
+
+	principal, err := fixture.auth.AuthenticateSession(context.Background(), fixture.memberSession.Token)
+	require.NoError(t, err)
+	// The flag comes from the row, not from the claim minted before the grant.
+	assert.True(t, principal.IsAdmin)
+}
+
+func TestChangingThePasswordRevokesEverySessionOfTheAccount(t *testing.T) {
+	fixture := newRevocationFixture(t)
+	ctx := context.Background()
+
+	// A second sign-in: the forgotten laptop, or the attacker's session.
+	otherSession, err := fixture.auth.LoginWithEmailPassword(ctx, fixture.member.Email, "Sup3rSecret!")
+	require.NoError(t, err)
+
+	require.NoError(t, fixture.users.ChangePassword(ctx, fixture.member.Id, "Sup3rSecret!", "An0therSecret!"))
+
+	assertSessionDead(t, fixture.auth, fixture.memberSession)
+	assertSessionDead(t, fixture.auth, otherSession)
+}
+
+// Nothing else enforces the revocation a password change performs: no flag
+// changes and the row stays enabled. A store that cannot record it must
+// therefore fail the call, rather than leave the old sessions live behind a
+// new password.
+func TestChangingThePasswordFailsWhenSessionsCannotBeRevoked(t *testing.T) {
+	fixture := newRevocationFixture(t)
+	failing := &bumpFailingUserRepo{fakeUserRepo: fixture.repo}
+	userService := NewUserService(failing)
+
+	err := userService.ChangePassword(context.Background(), fixture.member.Id, "Sup3rSecret!", "An0therSecret!")
+	assert.ErrorContains(t, err, "could not be revoked")
+}
+
+func TestDeletingAnAccountRevokesItsLiveSession(t *testing.T) {
+	fixture := newRevocationFixture(t)
+
+	require.NoError(t, fixture.users.DeleteUser(context.Background(), fixture.admin.Id, fixture.member.Id))
+
+	assertSessionDead(t, fixture.auth, fixture.memberSession)
+}
+
+// An outage while resolving the account is not a revocation: reading it as one
+// would sign every account out over a database blip.
+func TestAuthenticateSessionSeparatesAnOutageFromARevocation(t *testing.T) {
+	fixture := newRevocationFixture(t)
+	unavailable := NewDashboardAuthService(&unavailableUserRepo{}, fixture.refreshTokens)
+	unavailable.Secret = fixture.auth.Secret
+
+	_, err := unavailable.AuthenticateSession(context.Background(), fixture.memberSession.Token)
+	assert.ErrorIs(t, err, ErrAuthUnavailable)
+	assert.NotErrorIs(t, err, ErrSessionRevoked)
+}
+
+// A token minted by a stateless deployment names no account. Pointed at a
+// control plane it must not authenticate the request as nobody.
+func TestAuthenticateSessionRejectsATokenWithNoAccount(t *testing.T) {
+	fixture := newRevocationFixture(t)
+	t.Setenv("ADMIN_EMAIL", "admin@example.com")
+	t.Setenv("ADMIN_PASSWORD", "admin")
+
+	stateless := NewDashboardAuthService(nil, nil)
+	statelessSession, err := stateless.LoginWithEmailPassword(context.Background(), "admin@example.com", "admin")
+	require.NoError(t, err)
+
+	_, err = fixture.auth.AuthenticateSession(context.Background(), statelessSession.Token)
+	assert.ErrorIs(t, err, ErrSessionRevoked)
+}
+
+func TestRefreshRotatesTheTokenItWasGiven(t *testing.T) {
+	fixture := newRevocationFixture(t)
+	ctx := context.Background()
+
+	rotated, err := fixture.auth.RefreshSession(ctx, fixture.memberSession.RefreshToken)
+	require.NoError(t, err)
+	assert.NotEqual(t, fixture.memberSession.RefreshToken, rotated.RefreshToken)
+
+	// The successor works, and stays in the same family as its predecessor so
+	// the chain can be revoked as a unit.
+	previous, err := fixture.refreshTokens.GetRefreshToken(ctx, refreshTokenId(t, fixture.auth, fixture.memberSession.RefreshToken), refreshReplayGrace)
+	require.NoError(t, err)
+	successor, err := fixture.refreshTokens.GetRefreshToken(ctx, refreshTokenId(t, fixture.auth, rotated.RefreshToken), refreshReplayGrace)
+	require.NoError(t, err)
+	assert.Equal(t, previous.FamilyId, successor.FamilyId)
+	assert.NotNil(t, previous.UsedAt, "the presented token should have been retired")
+
+	_, err = fixture.auth.RefreshSession(ctx, rotated.RefreshToken)
+	assert.NoError(t, err)
+}
+
+func TestReplayingARotatedRefreshTokenRevokesTheWholeChain(t *testing.T) {
+	fixture := newRevocationFixture(t)
+	ctx := context.Background()
+
+	stolen := fixture.memberSession.RefreshToken
+	rotated, err := fixture.auth.RefreshSession(ctx, stolen)
+	require.NoError(t, err)
+
+	// Past the grace window, a second presentation is a leak, not the same
+	// client asking twice.
+	fixture.refreshTokens.markUsedAt(refreshTokenId(t, fixture.auth, stolen), time.Now().Add(-2*refreshReplayGrace))
+
+	_, err = fixture.auth.RefreshSession(ctx, stolen)
+	assert.ErrorIs(t, err, ErrRefreshTokenReuse)
+
+	// Whichever of the two holders was the thief, neither keeps a refresh: the
+	// successor handed to the legitimate client is gone too.
+	_, err = fixture.auth.RefreshSession(ctx, rotated.RefreshToken)
+	assert.ErrorIs(t, err, ErrSessionRevoked)
+
+	// The account's OTHER sign-ins are a different family and survive.
+	assertSessionAlive(t, fixture.auth, fixture.adminSession)
+}
+
+// A proven replay is proof that a credential of this account leaked, so the
+// response is account-wide, not chain-wide: the access token the replay just
+// produced belongs to no chain, and deleting the family alone would leave the
+// party that replayed with a working dashboard for the rest of its two hours.
+func TestReplayRevokesEverySessionOfTheAccount(t *testing.T) {
+	fixture := newRevocationFixture(t)
+	ctx := context.Background()
+
+	otherDevice, err := fixture.auth.LoginWithEmailPassword(ctx, fixture.member.Email, "Sup3rSecret!")
+	require.NoError(t, err)
+
+	// The access token a thief would have pocketed by rotating the stolen
+	// refresh token, taken here from the same account by the same means.
+	stolen := fixture.memberSession.RefreshToken
+	thiefSession, err := fixture.auth.RefreshSession(ctx, stolen)
+	require.NoError(t, err)
+	assertSessionAlive(t, fixture.auth, thiefSession)
+
+	fixture.refreshTokens.markUsedAt(refreshTokenId(t, fixture.auth, stolen), time.Now().Add(-2*refreshReplayGrace))
+	_, err = fixture.auth.RefreshSession(ctx, stolen)
+	require.ErrorIs(t, err, ErrRefreshTokenReuse)
+
+	// The access token minted from the compromised chain stops working at once.
+	assertSessionDead(t, fixture.auth, thiefSession)
+	// And so does the account's other device: on proof of a stolen credential,
+	// signing the account out everywhere is the right trade.
+	_, err = fixture.auth.RefreshSession(ctx, otherDevice.RefreshToken)
+	assert.ErrorIs(t, err, ErrSessionRevoked)
+
+	// Other ACCOUNTS are untouched.
+	assertSessionAlive(t, fixture.auth, fixture.adminSession)
+}
+
+// The dashboard fires requests in parallel, so one expiring access token
+// produces several refreshes carrying the same token. That is not a leak.
+func TestConcurrentRefreshWithinTheGraceWindowIsNotAReplay(t *testing.T) {
+	fixture := newRevocationFixture(t)
+	ctx := context.Background()
+
+	first, err := fixture.auth.RefreshSession(ctx, fixture.memberSession.RefreshToken)
+	require.NoError(t, err)
+	second, err := fixture.auth.RefreshSession(ctx, fixture.memberSession.RefreshToken)
+	require.NoError(t, err)
+
+	// Both callers get a usable session, and the chain is intact.
+	assertSessionAlive(t, fixture.auth, first)
+	assertSessionAlive(t, fixture.auth, second)
+
+	// Load-bearing: the second caller is handed the successor the first one
+	// already got, not a second live token. Two unconsumed tokens in a family
+	// would mean neither holder ever presents a consumed one again, and the
+	// chain would become permanently undetectable. Consuming it once must
+	// therefore retire it for BOTH.
+	assert.Equal(t,
+		refreshTokenId(t, fixture.auth, first.RefreshToken),
+		refreshTokenId(t, fixture.auth, second.RefreshToken),
+		"a replay inside the grace window must not fork the chain")
+
+	_, err = fixture.auth.RefreshSession(ctx, second.RefreshToken)
+	require.NoError(t, err)
+	fixture.refreshTokens.markUsedAt(refreshTokenId(t, fixture.auth, first.RefreshToken), time.Now().Add(-2*refreshReplayGrace))
+	_, err = fixture.auth.RefreshSession(ctx, first.RefreshToken)
+	assert.ErrorIs(t, err, ErrRefreshTokenReuse, "detection must still work on the forked-into token")
+}
+
+// A refresh token that reaches a client without a ledger row behind it is a
+// credential nothing can rotate, detect a replay on, or revoke. Failing the
+// sign-in is the only safe answer, so the ledger write is not best-effort.
+func TestSignInFailsWhenTheLedgerCannotRecordTheToken(t *testing.T) {
+	fixture := newRevocationFixture(t)
+	fixture.refreshTokens.insertErr = errors.New("connection refused")
+
+	_, err := fixture.auth.LoginWithEmailPassword(context.Background(), fixture.member.Email, "Sup3rSecret!")
+	assert.ErrorIs(t, err, ErrAuthUnavailable)
+}
+
+// A rotation that fails on infrastructure must leave the presented token
+// untouched. Burning it would cost the client its session over a blip, and the
+// retry it would make later would then look like a replay and revoke the
+// account.
+func TestRotationOutageDoesNotBurnTheRefreshToken(t *testing.T) {
+	fixture := newRevocationFixture(t)
+	ctx := context.Background()
+
+	fixture.refreshTokens.rotateErr = errors.New("connection refused")
+	_, err := fixture.auth.RefreshSession(ctx, fixture.memberSession.RefreshToken)
+	assert.ErrorIs(t, err, ErrAuthUnavailable)
+	assert.NotErrorIs(t, err, ErrRefreshTokenReuse)
+
+	fixture.refreshTokens.rotateErr = nil
+	_, err = fixture.auth.RefreshSession(ctx, fixture.memberSession.RefreshToken)
+	assert.NoError(t, err, "the token must survive the outage")
+}
+
+// Sessions minted before rotation existed carry no jti. There is no row to
+// retire, so there is no way to make them single-use: they are refused rather
+// than grandfathered into a chain nothing can revoke.
+func TestRefreshTokenWithoutALedgerRowIsRefused(t *testing.T) {
+	fixture := newRevocationFixture(t)
+	principal := DashboardPrincipal{UserId: fixture.member.Id, Email: fixture.member.Email}
+
+	legacyToken, err := fixture.auth.generateRefreshToken(principal, "", time.Now().Add(refreshTokenTTL))
+	require.NoError(t, err)
+
+	_, err = fixture.auth.RefreshSession(context.Background(), *legacyToken)
+	assert.ErrorIs(t, err, ErrSessionRevoked)
+}
+
+// Stateless deployments have no ledger, so their refresh token is reusable
+// until it expires. That is the behaviour they have always had; the point here
+// is that adding rotation did not break them.
+func TestStatelessRefreshStillWorksWithoutALedger(t *testing.T) {
+	t.Setenv("JWT_SECRET", "test-secret")
+	t.Setenv("ADMIN_EMAIL", "admin@example.com")
+	t.Setenv("ADMIN_PASSWORD", "admin")
+	authService := NewDashboardAuthService(nil, nil)
+	ctx := context.Background()
+
+	session, err := authService.LoginWithEmailPassword(ctx, "admin@example.com", "admin")
+	require.NoError(t, err)
+	_, err = authService.RefreshSession(ctx, session.RefreshToken)
+	require.NoError(t, err)
+	_, err = authService.RefreshSession(ctx, session.RefreshToken)
+	assert.NoError(t, err)
+}
+
+// bumpFailingUserRepo accepts every write except the revocation itself.
+type bumpFailingUserRepo struct {
+	*fakeUserRepo
+}
+
+func (r *bumpFailingUserRepo) BumpUserSessionVersion(context.Context, string) error {
+	return errors.New("database is on fire")
+}
+
+// unavailableUserRepo stands for a database that is down: every read fails
+// with something that is not a missing row.
+type unavailableUserRepo struct {
+	*fakeUserRepo
+}
+
+func (r *unavailableUserRepo) GetUserByID(context.Context, string) (store.User, error) {
+	return store.User{}, errors.New("connection refused")
+}

--- a/internal/services/user_service.go
+++ b/internal/services/user_service.go
@@ -6,8 +6,6 @@ import (
 	"expo-open-ota/internal/auditlog"
 	"expo-open-ota/internal/crypto"
 	"expo-open-ota/internal/store"
-	"fmt"
-	"log"
 	"net/mail"
 
 	"github.com/google/uuid"
@@ -26,12 +24,17 @@ type UserRepository interface {
 	// (store.ErrWouldLeaveNoAdmin): a check-then-write at this level would race
 	// with concurrent demotions/deletions/disables.
 	DeleteUserByID(ctx context.Context, id string) error
+	// The three writes below also retire the account's sessions, in the same
+	// statement, whenever the change is one its live sessions must not survive:
+	// always for a new password, and on the losing direction only for the two
+	// flags. Doing it in the statement is what makes the revocation impossible
+	// to skip on a stale read or lose to a failure between two calls.
 	UpdateUserPassword(ctx context.Context, id string, passwordHash string) error
 	UpdateUserIsAdmin(ctx context.Context, id string, isAdmin bool) error
 	UpdateUserEnabled(ctx context.Context, id string, enabled bool) error
-	// BumpUserSessionVersion revokes every session the account holds. Called
-	// whenever its security state changes under its own sessions: disabled,
-	// demoted, password changed.
+	// BumpUserSessionVersion retires them on their own, with no other change to
+	// the account. Only the replay response needs that: it has proof a
+	// credential leaked, and nothing about the row itself is wrong.
 	BumpUserSessionVersion(ctx context.Context, id string) error
 	TouchUserLastConnected(ctx context.Context, id string) error
 }
@@ -211,14 +214,6 @@ func (s *UserService) SetUserAdmin(ctx context.Context, actorUserId string, targ
 	if targetErr == nil && target.IsAdmin == isAdmin {
 		return nil
 	}
-	if !isAdmin {
-		// A demoted admin must not keep browsing admin routes on the session
-		// it already holds. Belt and braces: every authenticated request also
-		// re-reads the flag, so the demotion is effective either way, which is
-		// why a failure to revoke is logged rather than failing the demotion
-		// that already happened.
-		s.revokeSessions(ctx, targetUserId)
-	}
 	if targetErr != nil {
 		target = store.User{Id: targetUserId, Email: targetUserId}
 	}
@@ -253,12 +248,6 @@ func (s *UserService) SetUserEnabled(ctx context.Context, actorUserId string, ta
 	if targetErr == nil && target.Enabled == enabled {
 		return nil
 	}
-	if !enabled {
-		// Same reasoning as the demotion above: the per-request check already
-		// refuses a disabled account, this makes the revocation explicit
-		// instead of a side effect of where the enabled flag happens to be read.
-		s.revokeSessions(ctx, targetUserId)
-	}
 	if targetErr != nil {
 		target = store.User{Id: targetUserId, Email: targetUserId}
 	}
@@ -270,18 +259,6 @@ func (s *UserService) SetUserEnabled(ctx context.Context, actorUserId string, ta
 		s.recordUserEvent(ctx, auditlog.ActionUserUpdated, target, map[string]any{"enabled": false})
 	}
 	return nil
-}
-
-// revokeSessions retires every token the account holds. Best-effort by
-// design: its two callers (disabling, demoting) are already enforced on every
-// authenticated request by re-reading the account, so this makes the
-// revocation explicit rather than carrying it alone, and a failure must not
-// undo a state change that already succeeded. ChangePassword is the one case
-// where nothing else enforces it, and it propagates the error itself.
-func (s *UserService) revokeSessions(ctx context.Context, targetUserId string) {
-	if err := s.userRepo.BumpUserSessionVersion(ctx, targetUserId); err != nil {
-		log.Printf("failed to revoke the sessions of user %s: %v", targetUserId, err)
-	}
 }
 
 // ChangePassword re-checks the current password even though the caller holds a
@@ -305,15 +282,11 @@ func (s *UserService) ChangePassword(ctx context.Context, userId string, current
 	if err != nil {
 		return err
 	}
+	// The store retires every session of the account in the same statement, so
+	// the new password and the death of the sessions minted under the old one
+	// either both land or neither does.
 	if err := s.userRepo.UpdateUserPassword(ctx, userId, passwordHash); err != nil {
 		return err
-	}
-	// Unlike a disable or a demotion, nothing else notices a rotated password:
-	// the session version is the only thing that retires the credentials minted
-	// under the old one, so this failure is the caller's to see. The password
-	// has already changed, and it is the sessions that survived.
-	if err := s.userRepo.BumpUserSessionVersion(ctx, userId); err != nil {
-		return fmt.Errorf("the password was changed but the existing sessions could not be revoked: %w", err)
 	}
 	if s.onAuditEvent != nil {
 		s.onAuditEvent(ctx, auditlog.Event{

--- a/internal/services/user_service.go
+++ b/internal/services/user_service.go
@@ -6,6 +6,8 @@ import (
 	"expo-open-ota/internal/auditlog"
 	"expo-open-ota/internal/crypto"
 	"expo-open-ota/internal/store"
+	"fmt"
+	"log"
 	"net/mail"
 
 	"github.com/google/uuid"
@@ -27,6 +29,10 @@ type UserRepository interface {
 	UpdateUserPassword(ctx context.Context, id string, passwordHash string) error
 	UpdateUserIsAdmin(ctx context.Context, id string, isAdmin bool) error
 	UpdateUserEnabled(ctx context.Context, id string, enabled bool) error
+	// BumpUserSessionVersion revokes every session the account holds. Called
+	// whenever its security state changes under its own sessions: disabled,
+	// demoted, password changed.
+	BumpUserSessionVersion(ctx context.Context, id string) error
 	TouchUserLastConnected(ctx context.Context, id string) error
 }
 
@@ -205,6 +211,14 @@ func (s *UserService) SetUserAdmin(ctx context.Context, actorUserId string, targ
 	if targetErr == nil && target.IsAdmin == isAdmin {
 		return nil
 	}
+	if !isAdmin {
+		// A demoted admin must not keep browsing admin routes on the session
+		// it already holds. Belt and braces: every authenticated request also
+		// re-reads the flag, so the demotion is effective either way, which is
+		// why a failure to revoke is logged rather than failing the demotion
+		// that already happened.
+		s.revokeSessions(ctx, targetUserId)
+	}
 	if targetErr != nil {
 		target = store.User{Id: targetUserId, Email: targetUserId}
 	}
@@ -239,6 +253,12 @@ func (s *UserService) SetUserEnabled(ctx context.Context, actorUserId string, ta
 	if targetErr == nil && target.Enabled == enabled {
 		return nil
 	}
+	if !enabled {
+		// Same reasoning as the demotion above: the per-request check already
+		// refuses a disabled account, this makes the revocation explicit
+		// instead of a side effect of where the enabled flag happens to be read.
+		s.revokeSessions(ctx, targetUserId)
+	}
 	if targetErr != nil {
 		target = store.User{Id: targetUserId, Email: targetUserId}
 	}
@@ -250,6 +270,18 @@ func (s *UserService) SetUserEnabled(ctx context.Context, actorUserId string, ta
 		s.recordUserEvent(ctx, auditlog.ActionUserUpdated, target, map[string]any{"enabled": false})
 	}
 	return nil
+}
+
+// revokeSessions retires every token the account holds. Best-effort by
+// design: its two callers (disabling, demoting) are already enforced on every
+// authenticated request by re-reading the account, so this makes the
+// revocation explicit rather than carrying it alone, and a failure must not
+// undo a state change that already succeeded. ChangePassword is the one case
+// where nothing else enforces it, and it propagates the error itself.
+func (s *UserService) revokeSessions(ctx context.Context, targetUserId string) {
+	if err := s.userRepo.BumpUserSessionVersion(ctx, targetUserId); err != nil {
+		log.Printf("failed to revoke the sessions of user %s: %v", targetUserId, err)
+	}
 }
 
 // ChangePassword re-checks the current password even though the caller holds a
@@ -275,6 +307,13 @@ func (s *UserService) ChangePassword(ctx context.Context, userId string, current
 	}
 	if err := s.userRepo.UpdateUserPassword(ctx, userId, passwordHash); err != nil {
 		return err
+	}
+	// Unlike a disable or a demotion, nothing else notices a rotated password:
+	// the session version is the only thing that retires the credentials minted
+	// under the old one, so this failure is the caller's to see. The password
+	// has already changed, and it is the sessions that survived.
+	if err := s.userRepo.BumpUserSessionVersion(ctx, userId); err != nil {
+		return fmt.Errorf("the password was changed but the existing sessions could not be revoked: %w", err)
 	}
 	if s.onAuditEvent != nil {
 		s.onAuditEvent(ctx, auditlog.Event{

--- a/internal/services/user_service_test.go
+++ b/internal/services/user_service_test.go
@@ -71,12 +71,17 @@ func (r *fakeUserRepo) DeleteUserByID(_ context.Context, id string) error {
 	return nil
 }
 
+// The three writes below mirror what the SQL does in one statement: they
+// retire the account's sessions along with the change, on the losing direction
+// only for the two flags. A fake that skipped the bump would let every
+// revocation test pass on the enabled/is_admin re-read alone.
 func (r *fakeUserRepo) UpdateUserPassword(_ context.Context, id string, passwordHash string) error {
 	user, ok := r.users[id]
 	if !ok {
 		return &store.ErrResourceNotFound{Resource: "user", Identifier: id}
 	}
 	user.PasswordHash = passwordHash
+	user.SessionVersion++
 	r.users[id] = user
 	return nil
 }
@@ -88,6 +93,9 @@ func (r *fakeUserRepo) UpdateUserIsAdmin(_ context.Context, id string, isAdmin b
 	}
 	if user.IsAdmin && !isAdmin && r.adminCount() <= 1 {
 		return store.ErrWouldLeaveNoAdmin
+	}
+	if user.IsAdmin && !isAdmin {
+		user.SessionVersion++
 	}
 	user.IsAdmin = isAdmin
 	r.users[id] = user
@@ -101,6 +109,9 @@ func (r *fakeUserRepo) UpdateUserEnabled(_ context.Context, id string, enabled b
 	}
 	if user.IsAdmin && user.Enabled && !enabled && r.adminCount() <= 1 {
 		return store.ErrWouldLeaveNoAdmin
+	}
+	if user.Enabled && !enabled {
+		user.SessionVersion++
 	}
 	user.Enabled = enabled
 	r.users[id] = user

--- a/internal/services/user_service_test.go
+++ b/internal/services/user_service_test.go
@@ -107,6 +107,16 @@ func (r *fakeUserRepo) UpdateUserEnabled(_ context.Context, id string, enabled b
 	return nil
 }
 
+func (r *fakeUserRepo) BumpUserSessionVersion(_ context.Context, id string) error {
+	user, ok := r.users[id]
+	if !ok {
+		return &store.ErrResourceNotFound{Resource: "user", Identifier: id}
+	}
+	user.SessionVersion++
+	r.users[id] = user
+	return nil
+}
+
 func (r *fakeUserRepo) TouchUserLastConnected(_ context.Context, id string) error {
 	user, ok := r.users[id]
 	if !ok {
@@ -293,7 +303,7 @@ func TestDashboardAuthServiceWithUserRepo(t *testing.T) {
 	t.Setenv("JWT_SECRET", "test-secret")
 	repo := newFakeUserRepo()
 	userService := NewUserService(repo)
-	authService := NewDashboardAuthService(repo)
+	authService := NewDashboardAuthService(repo, newFakeRefreshTokenRepo())
 	ctx := context.Background()
 
 	user, err := userService.CreateUser(ctx, "admin@example.com", "Sup3rSecret!", true)
@@ -350,7 +360,7 @@ func TestStatelessLoginRequiresAdminEmail(t *testing.T) {
 	t.Setenv("JWT_SECRET", "test-secret")
 	t.Setenv("ADMIN_EMAIL", "")
 	t.Setenv("ADMIN_PASSWORD", "admin")
-	authService := NewDashboardAuthService(nil)
+	authService := NewDashboardAuthService(nil, nil)
 
 	_, err := authService.LoginWithEmailPassword(context.Background(), "admin@example.com", "admin")
 	assert.True(t, errors.Is(err, ErrAdminEmailNotSet))

--- a/internal/store/refresh_token_postgres.go
+++ b/internal/store/refresh_token_postgres.go
@@ -1,0 +1,175 @@
+package store
+
+import (
+	"context"
+	"expo-open-ota/internal/database"
+	"expo-open-ota/internal/database/postgres/pgdb"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+// RefreshToken is one link in a sign-in's refresh chain. The dashboard's
+// refresh JWT names it by id (its jti claim); this row is what makes the
+// credential single-use, and what makes a second presentation of it
+// recognizable as a replay.
+type RefreshToken struct {
+	Id     string
+	UserId string
+	// FamilyId groups every token descended from one sign-in, so a leaked
+	// chain can be revoked without touching the account's other devices.
+	FamilyId  string
+	ExpiresAt time.Time
+	// Nil while this is the family's live token, stamped when it is rotated.
+	UsedAt *time.Time
+	// UsedRecently reports whether UsedAt falls inside the replay grace passed
+	// to GetRefreshToken, decided by the database's clock on both sides of the
+	// comparison. Always false from the other reads, which do not ask.
+	UsedRecently bool
+	// ReplacedBy names the successor this token was rotated into, nil while it
+	// is still live. It is what a replay inside the grace window is answered
+	// with, instead of a second live token that would fork the chain.
+	ReplacedBy *string
+}
+
+type InsertRefreshTokenParameters struct {
+	ID        string
+	UserID    string
+	FamilyID  string
+	ExpiresAt time.Time
+}
+
+// RotateRefreshTokenParameters names the token being retired and the one
+// replacing it. The user and the family are not repeated: both are read from
+// the retired row inside the transaction, so a successor can never land in
+// another account's chain.
+type RotateRefreshTokenParameters struct {
+	OldID     string
+	NewID     string
+	ExpiresAt time.Time
+}
+
+type PostgresRefreshTokenStore struct {
+	engine *database.Engine
+}
+
+func NewPostgresRefreshTokenStore(engine *database.Engine) *PostgresRefreshTokenStore {
+	return &PostgresRefreshTokenStore{
+		engine: engine,
+	}
+}
+
+func (s *PostgresRefreshTokenStore) InsertRefreshToken(ctx context.Context, params InsertRefreshTokenParameters) error {
+	if err := s.engine.Queries.InsertRefreshToken(ctx, pgdb.InsertRefreshTokenParams{
+		ID:        ToPgUUID(params.ID),
+		UserID:    ToPgUUID(params.UserID),
+		FamilyID:  ToPgUUID(params.FamilyID),
+		ExpiresAt: pgtype.Timestamptz{Time: params.ExpiresAt.UTC(), Valid: true},
+	}); err != nil {
+		return fmt.Errorf("failed to insert refresh token into database: %w", err)
+	}
+	return nil
+}
+
+// RotateRefreshToken retires params.OldID and issues params.NewID in the same
+// family, both in ONE transaction. Atomicity is the whole point: retiring the
+// old token and failing to write its successor would burn a credential the
+// client still holds, and the client's later retry would then present a
+// consumed token and be punished as a replay.
+//
+// It returns the row it retired, so the caller learns the family. As with the
+// claim it wraps, ErrResourceNotFound means the old token was not claimable:
+// it is unknown, expired, or already rotated. The caller then looks the row up
+// to tell a replay apart from a token that simply no longer exists.
+func (s *PostgresRefreshTokenStore) RotateRefreshToken(ctx context.Context, params RotateRefreshTokenParameters) (RefreshToken, error) {
+	var rotated RefreshToken
+	err := s.engine.WithTx(ctx, func(q *pgdb.Queries) error {
+		row, err := q.ConsumeRefreshToken(ctx, pgdb.ConsumeRefreshTokenParams{
+			ID:         ToPgUUID(params.OldID),
+			ReplacedBy: ToPgUUID(params.NewID),
+		})
+		if err != nil {
+			if database.IsNoRows(err) {
+				return &ErrResourceNotFound{Resource: "refresh token", Identifier: params.OldID}
+			}
+			return fmt.Errorf("failed to consume refresh token in database: %w", err)
+		}
+		rotated = refreshTokenFromRow(row)
+		if err := q.InsertRefreshToken(ctx, pgdb.InsertRefreshTokenParams{
+			ID:        ToPgUUID(params.NewID),
+			UserID:    row.UserID,
+			FamilyID:  row.FamilyID,
+			ExpiresAt: pgtype.Timestamptz{Time: params.ExpiresAt.UTC(), Valid: true},
+		}); err != nil {
+			return fmt.Errorf("failed to insert the rotated refresh token into database: %w", err)
+		}
+		return nil
+	})
+	if err != nil {
+		return RefreshToken{}, err
+	}
+	return rotated, nil
+}
+
+// GetRefreshToken explains why a token could not be claimed. replayGrace is
+// how recent a rotation still counts as the same client asking twice; the
+// answer comes back as UsedRecently, computed against the database's own clock
+// so the decision never straddles two machines' notions of now.
+func (s *PostgresRefreshTokenStore) GetRefreshToken(ctx context.Context, id string, replayGrace time.Duration) (RefreshToken, error) {
+	row, err := s.engine.Queries.GetRefreshToken(ctx, pgdb.GetRefreshTokenParams{
+		ID:          ToPgUUID(id),
+		ReplayGrace: pgtype.Interval{Microseconds: replayGrace.Microseconds(), Valid: true},
+	})
+	if err != nil {
+		if database.IsNoRows(err) {
+			return RefreshToken{}, &ErrResourceNotFound{Resource: "refresh token", Identifier: id}
+		}
+		return RefreshToken{}, fmt.Errorf("failed to retrieve refresh token from database: %w", err)
+	}
+	token := refreshTokenFromRow(pgdb.RefreshToken{
+		ID:         row.ID,
+		UserID:     row.UserID,
+		FamilyID:   row.FamilyID,
+		CreatedAt:  row.CreatedAt,
+		ExpiresAt:  row.ExpiresAt,
+		UsedAt:     row.UsedAt,
+		ReplacedBy: row.ReplacedBy,
+	})
+	// The computed column is nullable to sqlc; only a NULL used_at makes it so,
+	// and that case is "not used at all", which is exactly false.
+	token.UsedRecently = row.UsedRecently != nil && *row.UsedRecently
+	return token, nil
+}
+
+// DeleteRefreshTokenFamily revokes a whole sign-in chain, the response to a
+// replayed token: whichever of the two holders is the thief, neither keeps a
+// usable refresh.
+func (s *PostgresRefreshTokenStore) DeleteRefreshTokenFamily(ctx context.Context, familyId string) error {
+	if err := s.engine.Queries.DeleteRefreshTokenFamily(ctx, ToPgUUID(familyId)); err != nil {
+		return fmt.Errorf("failed to delete refresh token family from database: %w", err)
+	}
+	return nil
+}
+
+func (s *PostgresRefreshTokenStore) DeleteExpiredRefreshTokens(ctx context.Context, userId string) error {
+	if err := s.engine.Queries.DeleteExpiredRefreshTokensForUser(ctx, ToPgUUID(userId)); err != nil {
+		return fmt.Errorf("failed to delete expired refresh tokens from database: %w", err)
+	}
+	return nil
+}
+
+func refreshTokenFromRow(row pgdb.RefreshToken) RefreshToken {
+	token := RefreshToken{
+		Id:        row.ID.String(),
+		UserId:    row.UserID.String(),
+		FamilyId:  row.FamilyID.String(),
+		ExpiresAt: row.ExpiresAt.Time,
+		UsedAt:    timestamptzToPtr(row.UsedAt),
+	}
+	if row.ReplacedBy.Valid {
+		successor := row.ReplacedBy.String()
+		token.ReplacedBy = &successor
+	}
+	return token
+}

--- a/internal/store/refresh_token_postgres_test.go
+++ b/internal/store/refresh_token_postgres_test.go
@@ -1,0 +1,248 @@
+// Integration tests for the refresh-token ledger. The single-use claim is
+// enforced by SQL (a conditional UPDATE ... RETURNING), which the in-memory
+// fake in internal/services cannot exercise: it is exactly the property that
+// decides whether two concurrent presentations of one token both succeed.
+// Same harness and skip rules as user_postgres_test.go.
+package store_test
+
+import (
+	"context"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"expo-open-ota/internal/database"
+	"expo-open-ota/internal/database/postgres"
+	"expo-open-ota/internal/database/postgres/pgdb"
+	"expo-open-ota/internal/store"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func setupRefreshTokenStore(t *testing.T) (*store.PostgresRefreshTokenStore, *store.PostgresUserStore, *pgxpool.Pool) {
+	t.Helper()
+	dbURL := os.Getenv("TEST_DATABASE_URL")
+	if dbURL == "" {
+		if os.Getenv("CI") != "" {
+			t.Fatal("TEST_DATABASE_URL must be set in CI: these tests cover SQL that the in-memory fakes cannot reach")
+		}
+		t.Skip("TEST_DATABASE_URL not set. Start a Postgres and set it to run the ledger tests")
+	}
+	t.Setenv("ADMIN_EMAIL", "seed-admin@example.com")
+	t.Setenv("ADMIN_PASSWORD", "Sup3rSecret!")
+	postgres.RunDBMigrations(dbURL)
+
+	pool, err := pgxpool.New(context.Background(), dbURL)
+	require.NoError(t, err)
+	t.Cleanup(pool.Close)
+	engine := &database.Engine{Queries: pgdb.New(pool), DB: pool}
+	return store.NewPostgresRefreshTokenStore(engine), store.NewPostgresUserStore(engine), pool
+}
+
+func insertRefreshToken(t *testing.T, tokenStore *store.PostgresRefreshTokenStore, userId string, familyId string, expiresAt time.Time) string {
+	t.Helper()
+	id := uuid.NewString()
+	require.NoError(t, tokenStore.InsertRefreshToken(context.Background(), store.InsertRefreshTokenParameters{
+		ID:        id,
+		UserID:    userId,
+		FamilyID:  familyId,
+		ExpiresAt: expiresAt,
+	}))
+	return id
+}
+
+func TestRefreshTokenLedgerLifecycle(t *testing.T) {
+	tokenStore, userStore, pool := setupRefreshTokenStore(t)
+	ctx := context.Background()
+	resetUsers(t, pool)
+	user := insertUser(t, userStore, "ledger@example.com", false)
+	familyId := uuid.NewString()
+
+	tokenId := insertRefreshToken(t, tokenStore, user.Id, familyId, time.Now().Add(time.Hour))
+	successorId := uuid.NewString()
+	consumed, err := tokenStore.RotateRefreshToken(ctx, store.RotateRefreshTokenParameters{
+		OldID:     tokenId,
+		NewID:     successorId,
+		ExpiresAt: time.Now().Add(time.Hour),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, familyId, consumed.FamilyId)
+	assert.Equal(t, user.Id, consumed.UserId)
+
+	// The successor landed in the same transaction, in the same family and
+	// under the same account, without the caller having to say so.
+	successor, err := tokenStore.GetRefreshToken(ctx, successorId, refreshGrace)
+	require.NoError(t, err)
+	assert.Equal(t, familyId, successor.FamilyId)
+	assert.Equal(t, user.Id, successor.UserId)
+	assert.Nil(t, successor.UsedAt)
+
+	// Rotated once, never again: the second attempt finds nothing to claim,
+	// while the row itself is still readable and now carries both its rotation
+	// stamp and the successor it points at. That is what tells a replay apart
+	// from an unknown token, and what a replay inside the grace is answered
+	// with.
+	notFoundErr := (*store.ErrResourceNotFound)(nil)
+	_, err = tokenStore.RotateRefreshToken(ctx, store.RotateRefreshTokenParameters{
+		OldID: tokenId, NewID: uuid.NewString(), ExpiresAt: time.Now().Add(time.Hour),
+	})
+	require.ErrorAs(t, err, &notFoundErr)
+	stored, err := tokenStore.GetRefreshToken(ctx, tokenId, refreshGrace)
+	require.NoError(t, err)
+	require.NotNil(t, stored.UsedAt)
+	require.NotNil(t, stored.ReplacedBy)
+	assert.Equal(t, successorId, *stored.ReplacedBy)
+
+	// The grace verdict is computed by the database, not by the caller's clock.
+	assert.True(t, stored.UsedRecently, "a rotation that just happened is inside the grace")
+	stale, err := tokenStore.GetRefreshToken(ctx, tokenId, 0)
+	require.NoError(t, err)
+	assert.False(t, stale.UsedRecently, "a zero grace admits nothing")
+
+	// An expired token is not claimable either, whether or not it was used.
+	expiredId := insertRefreshToken(t, tokenStore, user.Id, familyId, time.Now().Add(-time.Minute))
+	_, err = tokenStore.RotateRefreshToken(ctx, store.RotateRefreshTokenParameters{
+		OldID: expiredId, NewID: uuid.NewString(), ExpiresAt: time.Now().Add(time.Hour),
+	})
+	require.ErrorAs(t, err, &notFoundErr)
+	// And the refused rotation wrote nothing: no orphan successor.
+	_, err = tokenStore.GetRefreshToken(ctx, successorId, refreshGrace)
+	require.NoError(t, err)
+
+	// An id nothing ever issued reads as not-found rather than as an error.
+	_, err = tokenStore.GetRefreshToken(ctx, uuid.NewString(), refreshGrace)
+	require.ErrorAs(t, err, &notFoundErr)
+}
+
+// refreshGrace mirrors the service's replay window closely enough for the
+// store tests; the exact value only matters to the service.
+const refreshGrace = 30 * time.Second
+
+func TestRevokingAFamilyLeavesOtherFamiliesAlone(t *testing.T) {
+	tokenStore, userStore, pool := setupRefreshTokenStore(t)
+	ctx := context.Background()
+	resetUsers(t, pool)
+	user := insertUser(t, userStore, "ledger@example.com", false)
+
+	leaked := uuid.NewString()
+	otherDevice := uuid.NewString()
+	leakedId := insertRefreshToken(t, tokenStore, user.Id, leaked, time.Now().Add(time.Hour))
+	survivingId := insertRefreshToken(t, tokenStore, user.Id, otherDevice, time.Now().Add(time.Hour))
+
+	require.NoError(t, tokenStore.DeleteRefreshTokenFamily(ctx, leaked))
+
+	notFoundErr := (*store.ErrResourceNotFound)(nil)
+	_, err := tokenStore.GetRefreshToken(ctx, leakedId, refreshGrace)
+	require.ErrorAs(t, err, &notFoundErr)
+	_, err = tokenStore.RotateRefreshToken(ctx, store.RotateRefreshTokenParameters{
+		OldID: survivingId, NewID: uuid.NewString(), ExpiresAt: time.Now().Add(time.Hour),
+	})
+	require.NoError(t, err)
+}
+
+func TestPurgeOnlyDropsExpiredTokensOfThatUser(t *testing.T) {
+	tokenStore, userStore, pool := setupRefreshTokenStore(t)
+	ctx := context.Background()
+	resetUsers(t, pool)
+	user := insertUser(t, userStore, "ledger@example.com", false)
+	other := insertUser(t, userStore, "other@example.com", false)
+
+	expiredId := insertRefreshToken(t, tokenStore, user.Id, uuid.NewString(), time.Now().Add(-time.Minute))
+	liveId := insertRefreshToken(t, tokenStore, user.Id, uuid.NewString(), time.Now().Add(time.Hour))
+	otherExpiredId := insertRefreshToken(t, tokenStore, other.Id, uuid.NewString(), time.Now().Add(-time.Minute))
+
+	require.NoError(t, tokenStore.DeleteExpiredRefreshTokens(ctx, user.Id))
+
+	notFoundErr := (*store.ErrResourceNotFound)(nil)
+	_, err := tokenStore.GetRefreshToken(ctx, expiredId, refreshGrace)
+	require.ErrorAs(t, err, &notFoundErr)
+	_, err = tokenStore.GetRefreshToken(ctx, liveId, refreshGrace)
+	require.NoError(t, err)
+	_, err = tokenStore.GetRefreshToken(ctx, otherExpiredId, refreshGrace)
+	require.NoError(t, err, "the purge is scoped to one account")
+}
+
+// Deleting an account takes its refresh chains with it, so a token cannot
+// outlive the row the authentication path looks up.
+func TestDeletingAUserCascadesToItsRefreshTokens(t *testing.T) {
+	tokenStore, userStore, pool := setupRefreshTokenStore(t)
+	ctx := context.Background()
+	resetUsers(t, pool)
+	insertUser(t, userStore, "remaining-admin@example.com", true)
+	user := insertUser(t, userStore, "ledger@example.com", false)
+
+	tokenId := insertRefreshToken(t, tokenStore, user.Id, uuid.NewString(), time.Now().Add(time.Hour))
+	require.NoError(t, userStore.DeleteUserByID(ctx, user.Id))
+
+	notFoundErr := (*store.ErrResourceNotFound)(nil)
+	_, err := tokenStore.GetRefreshToken(ctx, tokenId, refreshGrace)
+	require.ErrorAs(t, err, &notFoundErr)
+}
+
+// Two requests present the same refresh token at the same instant, repeatedly.
+// Exactly one must claim it: if both did, rotation would hand out two live
+// successors and the replay would never be detected.
+func TestConcurrentConsumeClaimsATokenOnce(t *testing.T) {
+	tokenStore, userStore, pool := setupRefreshTokenStore(t)
+	ctx := context.Background()
+	resetUsers(t, pool)
+	user := insertUser(t, userStore, "ledger@example.com", false)
+
+	for range 20 {
+		tokenId := insertRefreshToken(t, tokenStore, user.Id, uuid.NewString(), time.Now().Add(time.Hour))
+
+		var start sync.WaitGroup
+		var done sync.WaitGroup
+		start.Add(1)
+		results := make([]error, 2)
+		for i := range results {
+			done.Add(1)
+			go func() {
+				defer done.Done()
+				start.Wait()
+				_, results[i] = tokenStore.RotateRefreshToken(ctx, store.RotateRefreshTokenParameters{
+					OldID: tokenId, NewID: uuid.NewString(), ExpiresAt: time.Now().Add(time.Hour),
+				})
+			}()
+		}
+		start.Done()
+		done.Wait()
+
+		claimed := 0
+		for _, err := range results {
+			if err == nil {
+				claimed++
+				continue
+			}
+			notFoundErr := (*store.ErrResourceNotFound)(nil)
+			require.ErrorAs(t, err, &notFoundErr)
+		}
+		require.Equal(t, 1, claimed, "exactly one caller may claim a refresh token")
+	}
+}
+
+func TestBumpUserSessionVersion(t *testing.T) {
+	_, userStore, pool := setupRefreshTokenStore(t)
+	ctx := context.Background()
+	resetUsers(t, pool)
+	user := insertUser(t, userStore, "ledger@example.com", false)
+
+	// Read back rather than trusting the insert's return value, which does not
+	// carry the column: every account starts at generation 0, which is what
+	// makes the DEFAULT on the migrated rows match the tokens already signed.
+	fresh, err := userStore.GetUserByID(ctx, user.Id)
+	require.NoError(t, err)
+	require.EqualValues(t, 0, fresh.SessionVersion)
+
+	require.NoError(t, userStore.BumpUserSessionVersion(ctx, user.Id))
+	bumped, err := userStore.GetUserByID(ctx, user.Id)
+	require.NoError(t, err)
+	assert.EqualValues(t, 1, bumped.SessionVersion)
+
+	notFoundErr := (*store.ErrResourceNotFound)(nil)
+	require.ErrorAs(t, userStore.BumpUserSessionVersion(ctx, uuid.NewString()), &notFoundErr)
+}

--- a/internal/store/user_postgres.go
+++ b/internal/store/user_postgres.go
@@ -26,6 +26,12 @@ type User struct {
 	CreatedAt time.Time
 	// Nil until the account's first successful sign-in.
 	LastConnectedAt *time.Time
+	// SessionVersion is the account's security generation. Every dashboard JWT
+	// carries the value it was minted with, and a mismatch means the session
+	// was revoked (the account was disabled, demoted or changed its password
+	// since). Only the lookups that authenticate populate it. GetUsers does
+	// not: a listing has no session to check.
+	SessionVersion int32
 }
 
 type InsertUserParameters struct {
@@ -187,6 +193,20 @@ func (s *PostgresUserStore) UpdateUserEnabled(ctx context.Context, id string, en
 	return nil
 }
 
+// BumpUserSessionVersion revokes every session the account currently holds:
+// each of its live JWTs carries the previous generation and stops validating
+// on its next use, access tokens included.
+func (s *PostgresUserStore) BumpUserSessionVersion(ctx context.Context, id string) error {
+	commandTag, err := s.engine.Queries.BumpUserSessionVersion(ctx, ToPgUUID(id))
+	if err != nil {
+		return fmt.Errorf("failed to bump user session version in database: %w", err)
+	}
+	if commandTag.RowsAffected() == 0 {
+		return &ErrResourceNotFound{Resource: "user", Identifier: id}
+	}
+	return nil
+}
+
 func (s *PostgresUserStore) TouchUserLastConnected(ctx context.Context, id string) error {
 	if err := s.engine.Queries.TouchUserLastConnectedAt(ctx, ToPgUUID(id)); err != nil {
 		return fmt.Errorf("failed to touch user last connection in database: %w", err)
@@ -203,6 +223,7 @@ func userFromRow(row pgdb.User) User {
 		Enabled:         row.Enabled,
 		CreatedAt:       row.CreatedAt.Time,
 		LastConnectedAt: timestamptzToPtr(row.LastConnectedAt),
+		SessionVersion:  row.SessionVersion,
 	}
 }
 

--- a/internal/store/user_postgres_test.go
+++ b/internal/store/user_postgres_test.go
@@ -156,3 +156,55 @@ func TestGuardedQueriesUnderConcurrentRemovals(t *testing.T) {
 		})
 	}
 }
+
+// The session version is bumped inside the same statement as the change that
+// justifies it, with a CASE on the column's previous value. Getting that
+// direction wrong is invisible to the in-memory fakes and would either sign
+// people out for nothing (bumping on a promotion) or leave a demoted admin
+// holding an admin session, so it is pinned here against real SQL.
+func TestSessionVersionMovesOnlyWhenAccessIsLost(t *testing.T) {
+	userStore, pool := setupUserStore(t)
+	ctx := context.Background()
+	resetUsers(t, pool)
+
+	// Stays admin and enabled throughout, so the "at least one admin" guard
+	// never refuses an operation on the account under test.
+	insertUser(t, userStore, "solo-admin@example.com", true)
+	member := insertUser(t, userStore, "member@example.com", false)
+
+	versionOf := func() int32 {
+		t.Helper()
+		user, err := userStore.GetUserByID(ctx, member.Id)
+		require.NoError(t, err)
+		return user.SessionVersion
+	}
+	require.EqualValues(t, 0, versionOf())
+
+	// A new password always ends the sessions minted under the old one.
+	require.NoError(t, userStore.UpdateUserPassword(ctx, member.Id, "new-hash"))
+	require.EqualValues(t, 1, versionOf())
+
+	// Losing access ends them too.
+	require.NoError(t, userStore.UpdateUserEnabled(ctx, member.Id, false))
+	require.EqualValues(t, 2, versionOf())
+
+	// Regaining it does not: approving an account must not sign anybody out,
+	// and there is nothing to revoke.
+	require.NoError(t, userStore.UpdateUserEnabled(ctx, member.Id, true))
+	require.EqualValues(t, 2, versionOf())
+
+	// Neither does gaining the admin flag.
+	require.NoError(t, userStore.UpdateUserIsAdmin(ctx, member.Id, true))
+	require.EqualValues(t, 2, versionOf())
+
+	// Losing it does.
+	require.NoError(t, userStore.UpdateUserIsAdmin(ctx, member.Id, false))
+	require.EqualValues(t, 3, versionOf())
+
+	// And an idempotent write is not a transition: repeating either call on an
+	// account already in that state must leave the version alone, or a
+	// no-op PATCH from the dashboard would sign the account out.
+	require.NoError(t, userStore.UpdateUserIsAdmin(ctx, member.Id, false))
+	require.NoError(t, userStore.UpdateUserEnabled(ctx, member.Id, true))
+	require.EqualValues(t, 3, versionOf())
+}


### PR DESCRIPTION
- Added tests for session revocation scenarios in `session_revocation_test.go`, covering cases such as disabling/enabling users, changing passwords, and deleting accounts.
- Introduced `BumpUserSessionVersion` method in `UserRepository` to handle session revocation when user state changes (e.g., disabled, demoted, password changed).
- Updated `UserService` to call `revokeSessions` when a user's admin status or enabled state changes, ensuring sessions are invalidated appropriately.
- Implemented `PostgresRefreshTokenStore` for managing refresh tokens in PostgreSQL, including methods for inserting, rotating, and deleting refresh tokens.
- Created integration tests for the refresh token ledger in `refresh_token_postgres_test.go`, ensuring proper handling of token rotations and replays.
- Enhanced `User` struct to include `SessionVersion`, allowing for session validation against the current user state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security Enhancements**
  - Sessions are automatically invalidated after password changes, account disabling, admin-status removal, or account deletion.
  - Refresh sessions now rotate securely, detect reuse, and revoke compromised session chains.
  - Concurrent refresh attempts are handled safely without creating duplicate sessions.

- **Account Management**
  - Password changes may provide a replacement session; otherwise, users receive clear guidance to sign in again.
  - Password-change responses now clearly reflect session renewal status.

- **Reliability**
  - Authentication distinguishes invalid sessions from temporary verification-service failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->