### PR TITLE
feat: add support for disabling device telemetry

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strconv"
 
 	"github.com/joho/godotenv"
 )
@@ -35,6 +36,22 @@ func IsDBMode() bool {
 // Empty means Observe (identity included) is not enabled.
 func GetClickHouseURL() string {
 	return GetEnv("CLICKHOUSE_URL")
+}
+
+// IsDeviceTelemetryDisabled reports whether the operator turned off every
+// recording made about a device: the manifest check-ins that populate the
+// Postgres registry (device_identity and the update-health tables it feeds),
+// the identity ops and the telemetry rows the Observe SDK dispatches, and the
+// ClickHouse connection those rows would land in. It is the privacy switch a
+// deployment flips when it wants to serve updates and collect nothing about
+// who receives them.
+//
+// It disables COLLECTION, not the schema: the tables stay, and whatever was
+// recorded before the switch stays with them. Deleting it is the operator's
+// call, not a boot side effect.
+func IsDeviceTelemetryDisabled() bool {
+	disabled, _ := strconv.ParseBool(GetEnv("DISABLE_DEVICE_TELEMETRY"))
+	return disabled
 }
 
 func ValidateMasterKey() error {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -179,3 +179,22 @@ func TestTestMode(t *testing2.T) {
 	testMode := IsTestMode()
 	assert.True(t, testMode)
 }
+
+// The switch is off unless the operator says otherwise, and a value that is
+// not a boolean is not a way to turn collection off by accident.
+func TestDeviceTelemetryDisabled(t *testing2.T) {
+	teardown := setup(t)
+	defer teardown()
+	for value, expected := range map[string]bool{
+		"":      false,
+		"false": false,
+		"0":     false,
+		"maybe": false,
+		"true":  true,
+		"1":     true,
+		"TRUE":  true,
+	} {
+		t.Setenv("DISABLE_DEVICE_TELEMETRY", value)
+		assert.Equal(t, expected, IsDeviceTelemetryDisabled(), "DISABLE_DEVICE_TELEMETRY=%q", value)
+	}
+}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -466,6 +466,14 @@ environment:
     required:
       - key: "controlPlane"
         is: "true"
+  # Set to "true" to record nothing about the devices being served: no device
+  # registry, no update-health state, no telemetry ingestion. Updates are
+  # delivered exactly the same; the Observe and Identity dashboards report the
+  # feature as unavailable.
+  - name: "DISABLE_DEVICE_TELEMETRY"
+    value: ""
+    enabled: true
+    required: false
   - name: "JWT_SECRET"
     value: ""
     required: true

--- a/internal/router/wire.go
+++ b/internal/router/wire.go
@@ -102,10 +102,11 @@ func InitDependencies(ctx context.Context) (*AppContainer, func()) {
 	var auditRepo audit.AuditRepository
 	// Device identity (ee/identity) is the Postgres device registry: wired
 	// in every DB-mode deployment (no ClickHouse required), it powers the
-	// identity dashboard and the update-health display. nil only in
-	// stateless mode, where the observe ingestion acknowledge-and-drops and
-	// the dashboard handler answers 400. The service owns the store; the
-	// ingest route and the dashboard handler both go through it.
+	// identity dashboard and the update-health display. nil in stateless
+	// mode and under DISABLE_DEVICE_TELEMETRY, where the observe ingestion
+	// acknowledge-and-drops and the dashboard handler answers 400. The
+	// service owns the store; the ingest route and the dashboard handler
+	// both go through it.
 	var identityService *identity.Service
 	// The ClickHouse side of Observe: telemetry rows and their branch
 	// enrichment. Declared as interfaces and only assigned inside the
@@ -122,7 +123,8 @@ func InitDependencies(ctx context.Context) (*AppContainer, func()) {
 	var stateHistory *observe.StateHistory
 	var explorer *observe.Explorer
 	// Records device check-ins into the universal registry, debounced; nil
-	// only in stateless mode, where polls and ingestion are side-effect free.
+	// in stateless mode and under DISABLE_DEVICE_TELEMETRY, where polls and
+	// ingestion are side-effect free.
 	var checkInRecorder *observe.CheckInRecorder
 
 	cleanup := func() {}
@@ -158,7 +160,6 @@ func InitDependencies(ctx context.Context) (*AppContainer, func()) {
 		migrations.SetEngine(dbEngine)
 		postgres.RunDBMigrations(dbUrl)
 
-		stateHistory = observe.NewStateHistory(dbEngine)
 		authRepo = store.NewPostgresAuthStore(dbEngine)
 		appRepo = store.NewPostgresAppStore(dbEngine)
 		userRepo = store.NewPostgresUserStore(dbEngine)
@@ -176,51 +177,67 @@ func InitDependencies(ctx context.Context) (*AppContainer, func()) {
 		updateRepo = pgUpdateStore
 		rolloutRepo = store.NewPostgresRolloutStore(dbEngine)
 
-		// GeoIP enrichment is optional: without a configured GeoLite2 City
-		// database, devices simply stay unlocated. A configured-but-broken
-		// path fails the boot loudly instead of resolving nothing forever.
-		var geoResolver identity.GeoResolver
-		if mmdbPath := config.GetEnv("GEOIP_MMDB_PATH"); mmdbPath != "" {
-			resolver, err := identity.NewGeoLite2Resolver(mmdbPath)
-			if err != nil {
-				log.Fatalf("🚨 [IDENTITY] %v", err)
-			}
-			geoResolver = resolver
-			addCleanup(resolver.Close)
-		}
-		// The device registry (ee/identity) is Postgres-only and runs in
-		// EVERY DB-mode deployment: it powers the identity dashboard AND the
-		// update-health display (adoption/MAU, launch failures), which must
-		// work with no ClickHouse and no observe SDK.
-		identityService = identity.NewService(identity.NewPostgresIdentityStore(dbEngine), geoResolver)
-		checkInRecorder = observe.NewCheckInRecorder(identityService, cache.GetCache())
-		// nil when ClickHouse is absent: the explorer then reduces to its
-		// Postgres half rather than disappearing.
-		var observeClickHouse *clickhouse.Engine
-
-		// ClickHouse gates ONLY the telemetry pipeline (the metrics/logs
-		// fact tables). A configured-but-broken URL fails the boot loudly
-		// instead of silently disabling a feature the operator asked for.
-		if chUrl := config.GetClickHouseURL(); chUrl != "" {
-			chEngine, err := clickhouse.NewClickHouseEngine(ctx, chUrl)
-			if err != nil {
-				log.Fatalf("🚨 [CLICKHOUSE] %v", err)
-			}
-			addCleanup(chEngine.Close)
-			clickhouse.RunDBMigrations(chUrl, dbUrl)
-			telemetrySink = observe.NewClickHouseTelemetrySink(chEngine)
-			branchResolver = observe.NewBranchResolver(cache.GetCache(), pgUpdateStore.GetUpdateOriginByUUID)
-			healthHistory = observe.NewHealthHistory(dbEngine, chEngine)
-			observeClickHouse = chEngine
-			addCleanup(healthHistory.Start(ctx))
-		} else {
-			// Not a Fatal: deployments without ClickHouse keep booting, the
-			// registry and update health work regardless; only the
-			// metrics/logs ingestion is off.
-			log.Println("⚙️  [OBSERVE] CLICKHOUSE_URL is not set; telemetry ingestion (metrics/logs) stays disabled")
+		// Everything a deployment records ABOUT A DEVICE hangs below: the
+		// Postgres registry and the update-health tables it feeds, then the
+		// ClickHouse telemetry pipeline on top of it. DISABLE_DEVICE_TELEMETRY
+		// leaves the whole subtree unwired, which is what makes "nothing is
+		// recorded" a property of the wiring instead of a check every write
+		// path has to remember. Every consumer already guards these nils: it
+		// is the shape stateless mode has always had.
+		if config.IsDeviceTelemetryDisabled() {
+			log.Println("🔕 [TELEMETRY] DISABLE_DEVICE_TELEMETRY is set; nothing is recorded about a device: manifest check-ins, identity ops and telemetry batches are all dropped, and no ClickHouse connection is opened. The Observe and Identity dashboards report the feature as unavailable, and CLICKHOUSE_URL is ignored.")
+			// Whatever the outbox still holds from before the switch: nothing
+			// drains it now that the projector is off, so it would sit there
+			// forever.
 			addCleanup(observe.StartHealthOutboxDiscarder(ctx, dbEngine))
+		} else {
+			stateHistory = observe.NewStateHistory(dbEngine)
+			// GeoIP enrichment is optional: without a configured GeoLite2 City
+			// database, devices simply stay unlocated. A configured-but-broken
+			// path fails the boot loudly instead of resolving nothing forever.
+			var geoResolver identity.GeoResolver
+			if mmdbPath := config.GetEnv("GEOIP_MMDB_PATH"); mmdbPath != "" {
+				resolver, err := identity.NewGeoLite2Resolver(mmdbPath)
+				if err != nil {
+					log.Fatalf("🚨 [IDENTITY] %v", err)
+				}
+				geoResolver = resolver
+				addCleanup(resolver.Close)
+			}
+			// The device registry (ee/identity) is Postgres-only and runs in
+			// EVERY DB-mode deployment: it powers the identity dashboard AND the
+			// update-health display (adoption/MAU, launch failures), which must
+			// work with no ClickHouse and no observe SDK.
+			identityService = identity.NewService(identity.NewPostgresIdentityStore(dbEngine), geoResolver)
+			checkInRecorder = observe.NewCheckInRecorder(identityService, cache.GetCache())
+			// nil when ClickHouse is absent: the explorer then reduces to its
+			// Postgres half rather than disappearing.
+			var observeClickHouse *clickhouse.Engine
+
+			// ClickHouse gates ONLY the telemetry pipeline (the metrics/logs
+			// fact tables). A configured-but-broken URL fails the boot loudly
+			// instead of silently disabling a feature the operator asked for.
+			if chUrl := config.GetClickHouseURL(); chUrl != "" {
+				chEngine, err := clickhouse.NewClickHouseEngine(ctx, chUrl)
+				if err != nil {
+					log.Fatalf("🚨 [CLICKHOUSE] %v", err)
+				}
+				addCleanup(chEngine.Close)
+				clickhouse.RunDBMigrations(chUrl, dbUrl)
+				telemetrySink = observe.NewClickHouseTelemetrySink(chEngine)
+				branchResolver = observe.NewBranchResolver(cache.GetCache(), pgUpdateStore.GetUpdateOriginByUUID)
+				healthHistory = observe.NewHealthHistory(dbEngine, chEngine)
+				observeClickHouse = chEngine
+				addCleanup(healthHistory.Start(ctx))
+			} else {
+				// Not a Fatal: deployments without ClickHouse keep booting, the
+				// registry and update health work regardless; only the
+				// metrics/logs ingestion is off.
+				log.Println("⚙️  [OBSERVE] CLICKHOUSE_URL is not set; telemetry ingestion (metrics/logs) stays disabled")
+				addCleanup(observe.StartHealthOutboxDiscarder(ctx, dbEngine))
+			}
+			explorer = observe.NewExplorer(dbEngine, observeClickHouse)
 		}
-		explorer = observe.NewExplorer(dbEngine, observeClickHouse)
 	} else {
 		log.Println("⚙️  [STATELESS] Initializing Stateless Mode (Flat-Env Mode)...")
 		if err := config.LoadAppsFromFlatEnv(); err != nil {


### PR DESCRIPTION
This pull request introduces a new privacy feature that allows operators to disable all device telemetry and related data collection with a single environment variable, `DISABLE_DEVICE_TELEMETRY`. When enabled, this switch ensures that no device registry, update-health state, or telemetry data is recorded, while still delivering updates as usual. The implementation centralizes the logic so that no additional checks are needed throughout the codebase; instead, relevant services are simply not wired up when telemetry is disabled. Tests and configuration have been updated to support and verify this feature.

**Device Telemetry Disablement Feature**

* Added `IsDeviceTelemetryDisabled()` in `config/config.go` to check if telemetry is disabled via the `DISABLE_DEVICE_TELEMETRY` environment variable, using robust boolean parsing.
* Updated `helm/values.yaml` to document and expose the `DISABLE_DEVICE_TELEMETRY` environment variable for deployments.
* Added a test (`TestDeviceTelemetryDisabled`) in `config/config_test.go` to verify the correct interpretation of the environment variable.

**Service Wiring and Initialization**

* Modified `internal/router/wire.go` so that device registry, update-health, and telemetry subsystems are not wired up when telemetry is disabled; instead, ingestion is acknowledged and dropped, and dashboards report the feature as unavailable. [[1]](diffhunk://#diff-ca0a5bccf842dec33baabb6ba99321d1c52e8b1921c1fea34edd08444896eb6aL125-R127) [[2]](diffhunk://#diff-ca0a5bccf842dec33baabb6ba99321d1c52e8b1921c1fea34edd08444896eb6aR180-R194) [[3]](diffhunk://#diff-ca0a5bccf842dec33baabb6ba99321d1c52e8b1921c1fea34edd08444896eb6aL161) [[4]](diffhunk://#diff-ca0a5bccf842dec33baabb6ba99321d1c52e8b1921c1fea34edd08444896eb6aR240) [[5]](diffhunk://#diff-ca0a5bccf842dec33baabb6ba99321d1c52e8b1921c1fea34edd08444896eb6aL105-R109)

**Codebase Maintenance**

* Added necessary import of `strconv` in `config/config.go` to support boolean parsing.

This change ensures privacy requirements can be met with a single configuration switch, while maintaining clear and testable behavior throughout the codebase.