### PR TITLE
feat: Implement catalog and lab navigation with react-navigation

### DIFF
--- a/apps/example-app/README.md
+++ b/apps/example-app/README.md
@@ -2,6 +2,43 @@
 
 This is an [Expo](https://expo.dev) project created with [`create-expo-app`](https://www.npmjs.com/package/create-expo-app).
 
+## Telemetry and navigation
+
+The app reports to `expo-observe`, which sends OTLP metrics and logs to the
+`endpointUrl` declared under `extra.eas.observe` in `app.json`. Point that at
+your own server to watch the payloads arrive.
+
+`expo-observe` records per-screen metrics (`cold_ttr`, `warm_ttr` and `tti`)
+only when a navigation integration is enabled, and it ships one integration per
+framework. They cannot both run at once, because the React Navigation one needs
+to own the navigation container that expo-router renders itself. So the app
+carries two navigation trees over the same screens and you pick one when you
+build the bundle:
+
+```bash
+yarn start                     # expo-router tree, routes live in app/
+yarn start:react-navigation    # @react-navigation tree, defined in navigation/
+```
+
+The same prefix works on any other script, for instance
+`yarn release_staging:react-navigation` to publish an update running the React
+Navigation tree. `EXPO_PUBLIC_NAV` is inlined by Metro, so the choice is made
+when the bundle is built and cannot change at runtime. `metro.config.js`
+resolves the entry of the unused tree to nothing so that a bundle only ever
+contains one of them, which is also what keeps Metro from rejecting a graph that
+holds both expo-router and React Navigation. The React Navigation mode still
+needs `EXPO_ROUTER_DISABLE_RN_NAVIGATION_CHECK=1`, which its scripts already
+set, because expo-router stays resolvable through `expo-observe` itself.
+
+Whichever tree is running, `Observe.configure()` happens in `observe.config.ts`
+at module scope, before anything mounts. It also turns on `dispatchInDebug`,
+without which a debug build would discard everything instead of sending it.
+
+The Lab tab is where the interesting payloads come from. It opens a screen that
+stays busy for two seconds so `tti` lands well above `ttr`, sends log events at
+several severities, throws during render so the error boundary reports it, and
+throws asynchronously so the global handler picks it up.
+
 ## Get started
 
 1. Install dependencies

--- a/apps/example-app/app/(tabs)/_layout.tsx
+++ b/apps/example-app/app/(tabs)/_layout.tsx
@@ -1,0 +1,36 @@
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { Tabs } from 'expo-router/js-tabs';
+
+export default function TabsLayout() {
+  return (
+    <Tabs screenOptions={{ headerShown: false }}>
+      <Tabs.Screen
+        name="index"
+        options={{
+          title: 'Updates',
+          tabBarIcon: ({ color, size }) => (
+            <Ionicons name="cloud-download-outline" color={color} size={size} />
+          ),
+        }}
+      />
+      <Tabs.Screen
+        name="catalog"
+        options={{
+          title: 'Catalog',
+          tabBarIcon: ({ color, size }) => (
+            <Ionicons name="list-outline" color={color} size={size} />
+          ),
+        }}
+      />
+      <Tabs.Screen
+        name="lab"
+        options={{
+          title: 'Lab',
+          tabBarIcon: ({ color, size }) => (
+            <Ionicons name="flask-outline" color={color} size={size} />
+          ),
+        }}
+      />
+    </Tabs>
+  );
+}

--- a/apps/example-app/app/(tabs)/catalog/[id].tsx
+++ b/apps/example-app/app/(tabs)/catalog/[id].tsx
@@ -1,0 +1,8 @@
+import { useLocalSearchParams } from 'expo-router';
+
+import { ItemScreen } from '@/screens/ItemScreen';
+
+export default function ItemRoute() {
+  const params = useLocalSearchParams<{ id: string }>();
+  return <ItemScreen id={params.id} params={params} />;
+}

--- a/apps/example-app/app/(tabs)/catalog/_layout.tsx
+++ b/apps/example-app/app/(tabs)/catalog/_layout.tsx
@@ -1,0 +1,10 @@
+import { Stack } from 'expo-router';
+
+export default function CatalogLayout() {
+  return (
+    <Stack>
+      <Stack.Screen name="index" options={{ title: 'Catalog' }} />
+      <Stack.Screen name="[id]" options={{ title: 'Item' }} />
+    </Stack>
+  );
+}

--- a/apps/example-app/app/(tabs)/catalog/index.tsx
+++ b/apps/example-app/app/(tabs)/catalog/index.tsx
@@ -1,0 +1,12 @@
+import { useRouter } from 'expo-router';
+
+import { CatalogScreen } from '@/screens/CatalogScreen';
+
+export default function CatalogRoute() {
+  const router = useRouter();
+  return (
+    <CatalogScreen
+      onOpenItem={(id) => router.push(`/catalog/${id}?from=list`)}
+    />
+  );
+}

--- a/apps/example-app/app/(tabs)/index.tsx
+++ b/apps/example-app/app/(tabs)/index.tsx
@@ -1,0 +1,3 @@
+import { UpdatesScreen } from '@/screens/UpdatesScreen';
+
+export default UpdatesScreen;

--- a/apps/example-app/app/(tabs)/lab/_layout.tsx
+++ b/apps/example-app/app/(tabs)/lab/_layout.tsx
@@ -1,0 +1,10 @@
+import { Stack } from 'expo-router';
+
+export default function LabLayout() {
+  return (
+    <Stack>
+      <Stack.Screen name="index" options={{ title: 'Lab' }} />
+      <Stack.Screen name="slow" options={{ title: 'Slow screen' }} />
+    </Stack>
+  );
+}

--- a/apps/example-app/app/(tabs)/lab/index.tsx
+++ b/apps/example-app/app/(tabs)/lab/index.tsx
@@ -1,0 +1,13 @@
+import { useRouter } from 'expo-router';
+
+import { LabScreen } from '@/screens/LabScreen';
+
+export default function LabRoute() {
+  const router = useRouter();
+  return (
+    <LabScreen
+      onOpenSlow={() => router.push('/lab/slow')}
+      onOpenModal={() => router.push('/modal')}
+    />
+  );
+}

--- a/apps/example-app/app/(tabs)/lab/slow.tsx
+++ b/apps/example-app/app/(tabs)/lab/slow.tsx
@@ -1,0 +1,3 @@
+import { SlowScreen } from '@/screens/SlowScreen';
+
+export default SlowScreen;

--- a/apps/example-app/app/_layout.tsx
+++ b/apps/example-app/app/_layout.tsx
@@ -1,4 +1,4 @@
-import { Observe, ObserveRoot, useObserve } from 'expo-observe';
+import { Observe, ObserveRoot } from 'expo-observe';
 import { DarkTheme, DefaultTheme, ThemeProvider } from 'expo-router/react-navigation';
 import { useFonts } from 'expo-font';
 import { Stack } from 'expo-router';
@@ -18,7 +18,6 @@ function RootLayout() {
   const [loaded] = useFonts({
     SpaceMono: require('../assets/fonts/SpaceMono-Regular.ttf'),
   });
-  const { markInteractive } = useObserve();
 
   useEffect(() => {
     // Once per JS session, not once per render.
@@ -29,19 +28,25 @@ function RootLayout() {
   useEffect(() => {
     if (loaded) {
       SplashScreen.hideAsync();
-      markInteractive()
     }
-  }, [loaded, markInteractive]);
+  }, [loaded]);
 
   if (!loaded) {
     return null;
   }
 
+  // markInteractive is deliberately not called here: the root layout is not a
+  // screen, so the router integration would have no route to attribute the
+  // metric to. Each screen calls it once it is actually usable.
   return (
     <ErrorBoundary>
       <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
         <Stack>
-          <Stack.Screen name="index" options={{ headerShown: false }} />
+          <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+          <Stack.Screen
+            name="modal"
+            options={{ presentation: 'modal', title: 'Modal' }}
+          />
           <Stack.Screen name="+not-found" />
         </Stack>
         <StatusBar style="auto" />

--- a/apps/example-app/app/modal.tsx
+++ b/apps/example-app/app/modal.tsx
@@ -1,0 +1,8 @@
+import { useRouter } from 'expo-router';
+
+import { ModalScreen } from '@/screens/ModalScreen';
+
+export default function ModalRoute() {
+  const router = useRouter();
+  return <ModalScreen onClose={() => router.back()} />;
+}

--- a/apps/example-app/index.js
+++ b/apps/example-app/index.js
@@ -6,4 +6,12 @@
 if (global.HermesInternal) {
   // throw new Error('BOOT CRASH TEST');
 }
-require('expo-router/entry');
+// Must run before any navigation provider mounts: the expo-observe
+// integrations latch their enabled state when their provider first renders.
+require('./observe.config');
+// Both trees ship in the bundle; EXPO_PUBLIC_NAV picks which one boots.
+if (require('./navigation/mode').NAV_MODE === 'react-navigation') {
+  require('./navigation/entry');
+} else {
+  require('expo-router/entry');
+}

--- a/apps/example-app/metro.config.js
+++ b/apps/example-app/metro.config.js
@@ -1,0 +1,21 @@
+const { getDefaultConfig } = require('expo/metro-config')
+
+const config = getDefaultConfig(__dirname)
+
+// index.js requires one of the two navigation trees (see navigation/mode.ts),
+// but Metro walks both branches of that `if` and would pull expo-router and
+// @react-navigation into the same graph — which SDK 56 refuses. Resolve the
+// entry of the tree this build isn't using to nothing, so only one ships.
+const unusedEntry =
+  process.env.EXPO_PUBLIC_NAV === 'react-navigation'
+    ? 'expo-router/entry'
+    : './navigation/entry'
+
+config.resolver.resolveRequest = (context, moduleName, platform) => {
+  if (moduleName === unusedEntry) {
+    return { type: 'empty' }
+  }
+  return context.resolveRequest(context, moduleName, platform)
+}
+
+module.exports = config

--- a/apps/example-app/navigation/ReactNavigationApp.tsx
+++ b/apps/example-app/navigation/ReactNavigationApp.tsx
@@ -1,0 +1,207 @@
+import Ionicons from '@expo/vector-icons/Ionicons'
+import { createBottomTabNavigator } from '@react-navigation/bottom-tabs'
+import {
+  DarkTheme,
+  DefaultTheme,
+  type NavigatorScreenParams,
+} from '@react-navigation/native'
+import {
+  createNativeStackNavigator,
+  type NativeStackScreenProps,
+} from '@react-navigation/native-stack'
+import { useFonts } from 'expo-font'
+import { Observe, ObserveRoot } from 'expo-observe'
+import { ObserveNavigationContainer } from 'expo-observe/integrations/react-navigation'
+import * as SplashScreen from 'expo-splash-screen'
+import { StatusBar } from 'expo-status-bar'
+import { useEffect } from 'react'
+import 'react-native-reanimated'
+
+import ErrorBoundary from '@/components/ErrorBounday'
+import { useColorScheme } from '@/hooks/useColorScheme'
+import { CatalogScreen } from '@/screens/CatalogScreen'
+import { ItemScreen } from '@/screens/ItemScreen'
+import { LabScreen } from '@/screens/LabScreen'
+import { ModalScreen } from '@/screens/ModalScreen'
+import { SlowScreen } from '@/screens/SlowScreen'
+import { UpdatesScreen } from '@/screens/UpdatesScreen'
+
+// Mirrors the expo-router tree in app/. Screen names are what the integration
+// joins into the reported pathname (`/Tabs/Catalog/Item`), so they are chosen
+// to read like the router's route patterns.
+export type CatalogStackParamList = {
+  CatalogList: undefined
+  Item: { id: string; from: string }
+}
+
+export type LabStackParamList = {
+  LabHome: undefined
+  Slow: undefined
+}
+
+export type TabsParamList = {
+  Updates: undefined
+  Catalog: NavigatorScreenParams<CatalogStackParamList> | undefined
+  Lab: NavigatorScreenParams<LabStackParamList> | undefined
+}
+
+export type RootStackParamList = {
+  Tabs: NavigatorScreenParams<TabsParamList> | undefined
+  Modal: undefined
+}
+
+SplashScreen.preventAutoHideAsync()
+
+const CatalogStack = createNativeStackNavigator<CatalogStackParamList>()
+const LabStack = createNativeStackNavigator<LabStackParamList>()
+const Tabs = createBottomTabNavigator<TabsParamList>()
+const RootStack = createNativeStackNavigator<RootStackParamList>()
+
+function CatalogNavigator() {
+  return (
+    <CatalogStack.Navigator>
+      <CatalogStack.Screen
+        name="CatalogList"
+        options={{ title: 'Catalog' }}
+        component={CatalogListRoute}
+      />
+      <CatalogStack.Screen
+        name="Item"
+        options={{ title: 'Item' }}
+        component={ItemRoute}
+      />
+    </CatalogStack.Navigator>
+  )
+}
+
+function CatalogListRoute({
+  navigation,
+}: NativeStackScreenProps<CatalogStackParamList, 'CatalogList'>) {
+  return (
+    <CatalogScreen
+      onOpenItem={(id) => navigation.navigate('Item', { id, from: 'list' })}
+    />
+  )
+}
+
+function ItemRoute({
+  route,
+}: NativeStackScreenProps<CatalogStackParamList, 'Item'>) {
+  return <ItemScreen id={route.params.id} params={route.params} />
+}
+
+function LabNavigator() {
+  return (
+    <LabStack.Navigator>
+      <LabStack.Screen
+        name="LabHome"
+        options={{ title: 'Lab' }}
+        component={LabRoute}
+      />
+      <LabStack.Screen
+        name="Slow"
+        options={{ title: 'Slow screen' }}
+        component={SlowScreen}
+      />
+    </LabStack.Navigator>
+  )
+}
+
+function LabRoute({
+  navigation,
+}: NativeStackScreenProps<LabStackParamList, 'LabHome'>) {
+  return (
+    <LabScreen
+      onOpenSlow={() => navigation.navigate('Slow')}
+      // The modal lives on the root stack, one level above the tabs.
+      onOpenModal={() => navigation.getParent()?.getParent()?.navigate('Modal')}
+    />
+  )
+}
+
+function TabsNavigator() {
+  return (
+    <Tabs.Navigator screenOptions={{ headerShown: false }}>
+      <Tabs.Screen
+        name="Updates"
+        component={UpdatesScreen}
+        options={{
+          tabBarIcon: ({ color, size }) => (
+            <Ionicons name="cloud-download-outline" color={color} size={size} />
+          ),
+        }}
+      />
+      <Tabs.Screen
+        name="Catalog"
+        component={CatalogNavigator}
+        options={{
+          tabBarIcon: ({ color, size }) => (
+            <Ionicons name="list-outline" color={color} size={size} />
+          ),
+        }}
+      />
+      <Tabs.Screen
+        name="Lab"
+        component={LabNavigator}
+        options={{
+          tabBarIcon: ({ color, size }) => (
+            <Ionicons name="flask-outline" color={color} size={size} />
+          ),
+        }}
+      />
+    </Tabs.Navigator>
+  )
+}
+
+function ModalRoute({
+  navigation,
+}: NativeStackScreenProps<RootStackParamList, 'Modal'>) {
+  return <ModalScreen onClose={() => navigation.goBack()} />
+}
+
+function App() {
+  const colorScheme = useColorScheme()
+  const [loaded] = useFonts({
+    SpaceMono: require('../assets/fonts/SpaceMono-Regular.ttf'),
+  })
+
+  useEffect(() => {
+    // Once per JS session, not once per render.
+    Observe.logEvent('app_started')
+    Observe.dispatchEvents()
+  }, [])
+
+  useEffect(() => {
+    if (loaded) {
+      SplashScreen.hideAsync()
+    }
+  }, [loaded])
+
+  if (!loaded) {
+    return null
+  }
+
+  return (
+    <ErrorBoundary>
+      <ObserveNavigationContainer
+        theme={colorScheme === 'dark' ? DarkTheme : DefaultTheme}
+      >
+        <RootStack.Navigator>
+          <RootStack.Screen
+            name="Tabs"
+            component={TabsNavigator}
+            options={{ headerShown: false }}
+          />
+          <RootStack.Screen
+            name="Modal"
+            component={ModalRoute}
+            options={{ presentation: 'modal', title: 'Modal' }}
+          />
+        </RootStack.Navigator>
+        <StatusBar style="auto" />
+      </ObserveNavigationContainer>
+    </ErrorBoundary>
+  )
+}
+
+export const ReactNavigationApp = ObserveRoot.wrap(App)

--- a/apps/example-app/navigation/entry.tsx
+++ b/apps/example-app/navigation/entry.tsx
@@ -1,0 +1,5 @@
+import { registerRootComponent } from 'expo'
+
+import { ReactNavigationApp } from './ReactNavigationApp'
+
+registerRootComponent(ReactNavigationApp)

--- a/apps/example-app/navigation/mode.ts
+++ b/apps/example-app/navigation/mode.ts
@@ -1,0 +1,15 @@
+export type NavMode = 'expo-router' | 'react-navigation'
+
+/**
+ * Which navigation tree the app boots into. expo-observe ships one integration
+ * per framework and they are mutually exclusive: the react-navigation one needs
+ * to own the NavigationContainer, which expo-router renders itself. So the app
+ * carries both trees and picks one here.
+ *
+ * `EXPO_PUBLIC_*` is inlined by Metro, so this is decided when the bundle is
+ * built (`expo start`, `eoas publish`), not at runtime.
+ */
+export const NAV_MODE: NavMode =
+  process.env.EXPO_PUBLIC_NAV === 'react-navigation'
+    ? 'react-navigation'
+    : 'expo-router'

--- a/apps/example-app/observe.config.ts
+++ b/apps/example-app/observe.config.ts
@@ -1,0 +1,20 @@
+import { Observe } from 'expo-observe'
+
+import { NAV_MODE } from './navigation/mode'
+
+/**
+ * Runs at module scope, before any component mounts. The navigation
+ * integrations read `isInitialized()` when their provider mounts and throw if
+ * the value changes afterwards, so `configure` cannot be called from a hook or
+ * an effect.
+ */
+Observe.configure({
+  environment: __DEV__ ? 'development' : 'production',
+  // Debug builds mark their metrics as sent without dispatching them. This app
+  // exists to be watched against a local server, so opt in.
+  dispatchInDebug: true,
+  integrations:
+    NAV_MODE === 'react-navigation'
+      ? { 'react-navigation': true }
+      : { 'expo-router': true },
+})

--- a/apps/example-app/package.json
+++ b/apps/example-app/package.json
@@ -5,6 +5,7 @@
   "version": "1.0.0",
   "scripts": {
     "start": "DISABLE_CODE_SIGNING=true expo start --dev-client",
+    "start:react-navigation": "EXPO_PUBLIC_NAV=react-navigation EXPO_ROUTER_DISABLE_RN_NAVIGATION_CHECK=1 yarn start",
     "reset-project": "node ./scripts/reset-project.js",
     "android": "DISABLE_CODE_SIGNING=true expo run:android",
     "ios": "DISABLE_CODE_SIGNING=true expo run:ios",
@@ -12,7 +13,9 @@
     "test": "jest --watchAll",
     "lint": "expo lint",
     "release_production": "RELEASE_CHANNEL=production ../eoas/bin/dev.js publish --nonInteractive --branch production --disableRepositoryCheck",
+    "release_production:react-navigation": "RELEASE_CHANNEL=production EXPO_ROUTER_DISABLE_RN_NAVIGATION_CHECK=1 ../eoas/bin/dev.js publish --nonInteractive --branch production --disableRepositoryCheck",
     "release_staging": "RELEASE_CHANNEL=staging ../eoas/bin/dev.js publish --nonInteractive --branch staging --disableRepositoryCheck",
+    "release_staging:react-navigation": "EXPO_PUBLIC_NAV=react-navigation EXPO_ROUTER_DISABLE_RN_NAVIGATION_CHECK=1 yarn release_staging",
     "create_production_rollback": "RELEASE_CHANNEL=production ../eoas/bin/dev.js rollback --branch production",
     "create_staging_rollback": "RELEASE_CHANNEL=staging ../eoas/bin/dev.js rollback --branch staging",
     "prebuild_production": "RELEASE_CHANNEL=production expo prebuild",
@@ -24,6 +27,9 @@
   "dependencies": {
     "@expo/vector-icons": "^15.0.2",
     "@react-native-picker/picker": "2.11.4",
+    "@react-navigation/bottom-tabs": "^7.18.14",
+    "@react-navigation/native": "^7.3.14",
+    "@react-navigation/native-stack": "^7.18.6",
     "expo": "^56.0.0",
     "expo-blur": "~56.0.4",
     "expo-clipboard": "~56.0.4",
@@ -59,12 +65,12 @@
     "@types/react": "~19.2.14",
     "@types/react-test-renderer": "^19.1.0",
     "eslint": "^9.0.0",
+    "eslint-config-expo": "~56.0.4",
     "jest": "^29.2.1",
     "jest-expo": "~56.0.5",
     "prettier": "^2.5.1",
     "react-test-renderer": "19.2.3",
-    "typescript": "~6.0.3",
-    "eslint-config-expo": "~56.0.4"
+    "typescript": "~6.0.3"
   },
   "private": true,
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"

--- a/apps/example-app/screens/CatalogScreen.tsx
+++ b/apps/example-app/screens/CatalogScreen.tsx
@@ -1,0 +1,58 @@
+import { useEffect } from 'react'
+import { FlatList, SafeAreaView, StyleSheet, TouchableOpacity } from 'react-native'
+import { useObserve } from 'expo-observe'
+
+import { ThemedText } from '@/components/ThemedText'
+import { CATALOG_ITEMS } from './catalog'
+
+export function CatalogScreen({
+  onOpenItem,
+}: {
+  onOpenItem: (id: string) => void
+}) {
+  const { markInteractive } = useObserve()
+
+  useEffect(() => {
+    markInteractive()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <FlatList
+        data={CATALOG_ITEMS}
+        keyExtractor={(item) => item.id}
+        contentContainerStyle={styles.list}
+        renderItem={({ item }) => (
+          <TouchableOpacity
+            style={styles.row}
+            onPress={() => onOpenItem(item.id)}
+          >
+            <ThemedText type="defaultSemiBold">{item.title}</ThemedText>
+            <ThemedText style={styles.subtitle}>{item.subtitle}</ThemedText>
+          </TouchableOpacity>
+        )}
+      />
+    </SafeAreaView>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#fff',
+  },
+  list: {
+    padding: 16,
+    gap: 8,
+  },
+  row: {
+    padding: 16,
+    borderRadius: 8,
+    backgroundColor: '#f3f4f6',
+  },
+  subtitle: {
+    color: '#6b7280',
+    fontSize: 14,
+  },
+})

--- a/apps/example-app/screens/ItemScreen.tsx
+++ b/apps/example-app/screens/ItemScreen.tsx
@@ -1,0 +1,55 @@
+import { useEffect } from 'react'
+import { SafeAreaView, ScrollView, StyleSheet } from 'react-native'
+import { useObserve } from 'expo-observe'
+
+import { ThemedText } from '@/components/ThemedText'
+import { findCatalogItem } from './catalog'
+
+export function ItemScreen({
+  id,
+  params,
+}: {
+  id: string
+  /** Raw params as the navigation framework saw them, echoed so they can be
+   * compared with the `routeParams` attribute that lands on the server. */
+  params: Record<string, unknown>
+}) {
+  const { markInteractive } = useObserve()
+  const item = findCatalogItem(id)
+
+  useEffect(() => {
+    markInteractive()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <ScrollView contentContainerStyle={styles.content}>
+        <ThemedText type="title">{item?.title ?? `Item ${id}`}</ThemedText>
+        <ThemedText>{item?.subtitle ?? 'Unknown item'}</ThemedText>
+        <ThemedText type="subtitle">Route params</ThemedText>
+        <ThemedText style={styles.code}>
+          {JSON.stringify(params, null, 2)}
+        </ThemedText>
+      </ScrollView>
+    </SafeAreaView>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#fff',
+  },
+  content: {
+    padding: 16,
+    gap: 12,
+  },
+  code: {
+    fontFamily: 'SpaceMono',
+    fontSize: 13,
+    backgroundColor: '#f3f4f6',
+    padding: 12,
+    borderRadius: 8,
+  },
+})

--- a/apps/example-app/screens/LabScreen.tsx
+++ b/apps/example-app/screens/LabScreen.tsx
@@ -1,0 +1,122 @@
+import { useEffect, useState } from 'react'
+import { SafeAreaView, ScrollView, StyleSheet, TouchableOpacity } from 'react-native'
+import { Observe, useObserve } from 'expo-observe'
+
+import { ThemedText } from '@/components/ThemedText'
+
+function Action({
+  title,
+  description,
+  onPress,
+}: {
+  title: string
+  description: string
+  onPress: () => void
+}) {
+  return (
+    <TouchableOpacity style={styles.action} onPress={onPress}>
+      <ThemedText type="defaultSemiBold">{title}</ThemedText>
+      <ThemedText style={styles.description}>{description}</ThemedText>
+    </TouchableOpacity>
+  )
+}
+
+export function LabScreen({
+  onOpenSlow,
+  onOpenModal,
+}: {
+  onOpenSlow: () => void
+  onOpenModal: () => void
+}) {
+  const { markInteractive } = useObserve()
+  const [crashOnRender, setCrashOnRender] = useState(false)
+
+  useEffect(() => {
+    markInteractive()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  if (crashOnRender) {
+    // Caught by the app's ErrorBoundary, which logs it through Observe.
+    throw new Error('Deliberate render crash from the observe lab')
+  }
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <ScrollView contentContainerStyle={styles.content}>
+        <ThemedText type="title">Observe lab</ThemedText>
+
+        <Action
+          title="Open the slow screen"
+          description="tti lands ~2s after ttr on /lab/slow"
+          onPress={onOpenSlow}
+        />
+        <Action
+          title="Open the modal"
+          description="A route presented on top of the tabs"
+          onPress={onOpenModal}
+        />
+        <Action
+          title="Log an info event"
+          description="Observe.logEvent with custom attributes"
+          onPress={() =>
+            Observe.logEvent('lab_button_pressed', {
+              body: 'Info event from the lab screen',
+              attributes: { source: 'lab', kind: 'info' },
+            })
+          }
+        />
+        <Action
+          title="Log a warning event"
+          description="Same event, severity warn"
+          onPress={() =>
+            Observe.logEvent('lab_button_pressed', {
+              body: 'Warning event from the lab screen',
+              attributes: { source: 'lab', kind: 'warn' },
+              severity: 'warn',
+            })
+          }
+        />
+        <Action
+          title="Throw during render"
+          description="ErrorBoundary catches it and logs an event"
+          onPress={() => setCrashOnRender(true)}
+        />
+        <Action
+          title="Throw asynchronously"
+          description="Uncaught error, captured by the global handler"
+          onPress={() => {
+            setTimeout(() => {
+              throw new Error('Deliberate async crash from the observe lab')
+            }, 0)
+          }}
+        />
+        <Action
+          title="Dispatch now"
+          description="Flush pending metrics and logs to the server"
+          onPress={() => Observe.dispatchEvents()}
+        />
+      </ScrollView>
+    </SafeAreaView>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#fff',
+  },
+  content: {
+    padding: 16,
+    gap: 8,
+  },
+  action: {
+    padding: 16,
+    borderRadius: 8,
+    backgroundColor: '#f3f4f6',
+  },
+  description: {
+    color: '#6b7280',
+    fontSize: 14,
+  },
+})

--- a/apps/example-app/screens/ModalScreen.tsx
+++ b/apps/example-app/screens/ModalScreen.tsx
@@ -1,0 +1,35 @@
+import { useEffect } from 'react'
+import { Button, SafeAreaView, StyleSheet } from 'react-native'
+import { useObserve } from 'expo-observe'
+
+import { ThemedText } from '@/components/ThemedText'
+
+export function ModalScreen({ onClose }: { onClose: () => void }) {
+  const { markInteractive } = useObserve()
+
+  useEffect(() => {
+    markInteractive()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <ThemedText type="title">Modal</ThemedText>
+      <ThemedText>
+        Presented above the tabs, so it reports its own route.
+      </ThemedText>
+      <Button title="Close" onPress={onClose} />
+    </SafeAreaView>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#fff',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 12,
+    padding: 16,
+  },
+})

--- a/apps/example-app/screens/SlowScreen.tsx
+++ b/apps/example-app/screens/SlowScreen.tsx
@@ -1,0 +1,55 @@
+import { useEffect, useState } from 'react'
+import { ActivityIndicator, SafeAreaView, StyleSheet } from 'react-native'
+import { useObserve } from 'expo-observe'
+
+import { ThemedText } from '@/components/ThemedText'
+
+const LOADING_MS = 2000
+
+/**
+ * Renders immediately but only becomes usable two seconds later, so `tti` lands
+ * well above `cold_ttr`/`warm_ttr` for this route. Useful to check the server
+ * really keeps the two metrics apart per route.
+ */
+export function SlowScreen() {
+  const { markInteractive } = useObserve()
+  const [ready, setReady] = useState(false)
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setReady(true)
+      markInteractive({ params: { simulatedLoadMs: LOADING_MS } })
+    }, LOADING_MS)
+    return () => clearTimeout(timer)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  return (
+    <SafeAreaView style={styles.container}>
+      {ready ? (
+        <>
+          <ThemedText type="subtitle">Interactive</ThemedText>
+          <ThemedText>
+            markInteractive() fired {LOADING_MS}ms after the screen was focused.
+          </ThemedText>
+        </>
+      ) : (
+        <>
+          <ActivityIndicator size="large" />
+          <ThemedText>Pretending to load…</ThemedText>
+        </>
+      )}
+    </SafeAreaView>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#fff',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 12,
+    padding: 16,
+  },
+})

--- a/apps/example-app/screens/UpdatesScreen.tsx
+++ b/apps/example-app/screens/UpdatesScreen.tsx
@@ -13,22 +13,13 @@ import { ThemedText } from '@/components/ThemedText'
 import { ThemedView } from '@/components/ThemedView'
 import Constants from 'expo-constants'
 import { useState, useEffect } from 'react'
+import { useObserve } from 'expo-observe'
 import { UpdatesLogViewer } from '@/components/LogViewer'
 
-
-
-export default function HomeScreen() {
+export function UpdatesScreen() {
   const [loading, load] = useState<boolean>(false)
   const [logs, setLogs] = useState<Updates.UpdatesLogEntry[]>([])
-
-
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const randomCrash = () => {
-    // Random throw an error 50% of time
-    if (Math.random() < 0.5) {
-      throw new Error('Random crash!')
-    }
-  }
+  const { markInteractive } = useObserve()
 
   useEffect(() => {
     const fetchLogs = async () => {
@@ -38,12 +29,14 @@ export default function HomeScreen() {
       } catch (error) {
         console.error('Error fetching logs:', error)
       }
+      // The screen only shows anything useful once the update logs are in, so
+      // that is what "interactive" means here.
+      markInteractive()
     }
 
     fetchLogs()
-    // randomCrash()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
-
 
   const checkUpdates = async () => {
     if (__DEV__ || loading || Platform.OS === 'web') {

--- a/apps/example-app/screens/catalog.ts
+++ b/apps/example-app/screens/catalog.ts
@@ -1,0 +1,25 @@
+export type CatalogItem = {
+  id: string
+  title: string
+  subtitle: string
+}
+
+/**
+ * Static list. The point is not the data, it is that opening an item produces a
+ * navigation metric carrying route params, so the server sees a route pattern
+ * (`/catalog/[id]`) distinct from the concrete path.
+ */
+export const CATALOG_ITEMS: CatalogItem[] = [
+  { id: '1', title: 'Manifest', subtitle: 'What the client polls' },
+  { id: '2', title: 'Assets', subtitle: 'Hashed bundle files' },
+  { id: '3', title: 'Branches', subtitle: 'Where updates live' },
+  { id: '4', title: 'Channels', subtitle: 'What builds point at' },
+  { id: '5', title: 'Rollouts', subtitle: 'Partial delivery' },
+  { id: '6', title: 'Rollbacks', subtitle: 'Back to embedded' },
+  { id: '7', title: 'Code signing', subtitle: 'Signed manifests' },
+  { id: '8', title: 'Telemetry', subtitle: 'Metrics and logs' },
+]
+
+export function findCatalogItem(id: string): CatalogItem | undefined {
+  return CATALOG_ITEMS.find((item) => item.id === id)
+}

--- a/apps/example-app/yarn.lock
+++ b/apps/example-app/yarn.lock
@@ -1843,6 +1843,67 @@
     invariant "^2.2.4"
     nullthrows "^1.1.1"
 
+"@react-navigation/bottom-tabs@^7.18.14":
+  version "7.18.14"
+  resolved "https://registry.yarnpkg.com/@react-navigation/bottom-tabs/-/bottom-tabs-7.18.14.tgz#24fb78948fb06ef7a19b4ff0d596c1d6d643bdbf"
+  integrity sha512-A3V9rDSut459TBPtkD7rb0npUUBlJBfMunyRT5nOGKqPguhuXWk1h91NfQMuqyW2DCUvvFZChzsbLbj42rXTdQ==
+  dependencies:
+    "@react-navigation/elements" "^2.9.36"
+    color "^4.2.3"
+    sf-symbols-typescript "^2.1.0"
+
+"@react-navigation/core@^7.21.11":
+  version "7.21.11"
+  resolved "https://registry.yarnpkg.com/@react-navigation/core/-/core-7.21.11.tgz#dfc9c85f297755fe94c69b34b94df0982c4bf45f"
+  integrity sha512-bCW1PsLA/eOXDOukcJFEzlcL3Zpy8DJuDCfkDDwAQlAgoSZ/J9+ZeDRUMmCUi6xbnFgvFEEIMertaLeErOFP0Q==
+  dependencies:
+    "@react-navigation/routers" "^7.6.4"
+    escape-string-regexp "^4.0.0"
+    fast-deep-equal "^3.1.3"
+    nanoid "^3.3.11"
+    query-string "^7.1.3"
+    react-is "^19.1.0"
+    use-latest-callback "^0.2.4"
+    use-sync-external-store "^1.5.0"
+
+"@react-navigation/elements@^2.9.36":
+  version "2.9.36"
+  resolved "https://registry.yarnpkg.com/@react-navigation/elements/-/elements-2.9.36.tgz#b060502ed97768f719b604dc9b652031babded1a"
+  integrity sha512-+10x9s5v2Q7FwAYdSmPMgILtxZyC5e4hWJQu8g5o3u4p8DUToTBmGvys/UvmEr+h9xmm0Go42qw9Ff2ape53kQ==
+  dependencies:
+    color "^4.2.3"
+    use-latest-callback "^0.2.4"
+    use-sync-external-store "^1.5.0"
+
+"@react-navigation/native-stack@^7.18.6":
+  version "7.18.6"
+  resolved "https://registry.yarnpkg.com/@react-navigation/native-stack/-/native-stack-7.18.6.tgz#71ed9d2a28368bd46d8dded050dbffd9d818f090"
+  integrity sha512-KuvvSBddHrbKC4c6yKz+UCFey2xgTuPQHgjf2wJQAvA7JM8jCQa3G1+QzhO6d44nYNKir3y6EounXZvQE/BX6w==
+  dependencies:
+    "@react-navigation/elements" "^2.9.36"
+    color "^4.2.3"
+    sf-symbols-typescript "^2.1.0"
+    warn-once "^0.1.1"
+
+"@react-navigation/native@^7.3.14":
+  version "7.3.14"
+  resolved "https://registry.yarnpkg.com/@react-navigation/native/-/native-7.3.14.tgz#d846d80b7036fad3a1f1a2f37aa69e020eebe145"
+  integrity sha512-hcKTDNBuuAA1/xW6QeKYmMPVhk5W9dKGQpPmn5dQeeePwMpu5OZ14NOgwKH0w9D3tg2jupojTcVL0tsx5DTFXg==
+  dependencies:
+    "@react-navigation/core" "^7.21.11"
+    escape-string-regexp "^4.0.0"
+    fast-deep-equal "^3.1.3"
+    nanoid "^3.3.11"
+    standard-navigation "^0.0.8"
+    use-latest-callback "^0.2.4"
+
+"@react-navigation/routers@^7.6.4":
+  version "7.6.4"
+  resolved "https://registry.yarnpkg.com/@react-navigation/routers/-/routers-7.6.4.tgz#7b0dfa19f9fef0ab1588c9dbfc7f7616fced3ff8"
+  integrity sha512-GI7eJm8/KsZUQaYcXvEExikKurRZRgEsSzyZ7faENfi65yqJBCXjDMwyN1pF6pNW1MoLH1ErDwDivFxY6BzD3w==
+  dependencies:
+    nanoid "^3.3.11"
+
 "@rtsao/scc@^1.1.0":
   version "1.1.0"
   resolved "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz"
@@ -6112,7 +6173,7 @@ multitars@^1.0.0:
   resolved "https://registry.yarnpkg.com/multitars/-/multitars-1.0.0.tgz#50828be6b04328242e1c0f8439fbca4f6569e761"
   integrity sha512-H/J4fMLedtudftaYMOg7ajzLYgT3/rwbWVJbqr/iUgB8DQztn38ys5HOqI1CzSxx8QhXXwOOnnBvd4v3jG5+Mg==
 
-nanoid@^3.3.16, nanoid@^3.3.8:
+nanoid@^3.3.11, nanoid@^3.3.16, nanoid@^3.3.8:
   version "3.3.16"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.16.tgz#a04d8ec4b1f10009d2d533947aefe4293737816c"
   integrity sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==
@@ -7367,6 +7428,11 @@ standard-navigation@^0.0.5:
   resolved "https://registry.yarnpkg.com/standard-navigation/-/standard-navigation-0.0.5.tgz#8ce5fef5a251991f58ed69283bee5cc1d242625e"
   integrity sha512-YAmzwAiiQVocZxO/VGPFiQHcu5pKiz09QIGC0MK6aRMoa3E0QkoTQgcqJr7ZZ3OMiNhu4DkaGElFI5htjOIDbw==
 
+standard-navigation@^0.0.8:
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/standard-navigation/-/standard-navigation-0.0.8.tgz#aef79bef130ec8ba0a9c070d3a728d96d68df8a8"
+  integrity sha512-TyVbo7INUDWtsUWDFn8RR7kwR87U0S4xHfLfbbnyeC581TmmyqQ+eM+nPw8rQTSD8QitRVcYfPaSHr/QJiUy1g==
+
 statuses@2.0.1:
   version "2.0.1"
   resolved "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz"
@@ -7883,6 +7949,11 @@ use-sidecar@^1.1.3:
     detect-node-es "^1.1.0"
     tslib "^2.0.0"
 
+use-sync-external-store@^1.5.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz#b174bfa65cb2b526732d9f2ac0a408027876f32d"
+  integrity sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==
+
 utils-merge@1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz"
@@ -7938,7 +8009,7 @@ walker@^1.0.7, walker@^1.0.8:
   dependencies:
     makeerror "1.0.12"
 
-warn-once@^0.1.0:
+warn-once@^0.1.0, warn-once@^0.1.1:
   version "0.1.1"
   resolved "https://registry.npmjs.org/warn-once/-/warn-once-0.1.1.tgz"
   integrity sha512-VkQZJbO8zVImzYFteBXvBOZEl1qL175WH8VmZcxF2fZAoudNhNDvHi+doCaAEdU2l2vtcIwa2zn0QK5+I1HQ3Q==


### PR DESCRIPTION
- Added catalog and lab tab layouts with respective screens.
- Created ItemScreen and CatalogScreen for displaying items and their details.
- Integrated modal navigation for displaying additional information.
- Implemented slow loading screen to demonstrate performance metrics.
- Added updates screen to check for application updates and display logs.
- Configured expo-observe for tracking navigation metrics and events.
- Updated package dependencies for react-navigation and related libraries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a catalog with item detail pages and navigation.
  * Added an Observe lab for testing metrics, logs, dispatching, and error handling.
  * Added modal and simulated slow-loading screens.
  * Added support for choosing between Expo Router and React Navigation builds.
  * Added tab navigation for Updates, Catalog, and Lab.
* **Documentation**
  * Documented telemetry, navigation setup, build options, and lab capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->