### PR TITLE
Mcp auth

### DIFF
--- a/apps/dashboard/src/App.tsx
+++ b/apps/dashboard/src/App.tsx
@@ -3,6 +3,7 @@ import { Navigate, Route, Routes, useNavigate } from 'react-router';
 import { isAuthenticated } from '@/lib/auth.ts';
 import { lazy, ReactNode, Suspense, useEffect } from 'react';
 import { Login } from '@/pages/Login';
+import { OAuthConsent } from '@/pages/OAuthConsent';
 import { Toaster } from '@/components/ui/toaster.tsx';
 import { Updates } from '@/pages/Updates';
 import { Settings } from '@/pages/Settings';
@@ -25,7 +26,9 @@ import { RouteErrorBoundary } from '@/components/RouteErrorBoundary';
 import { Branches } from '@/pages/Branches';
 import { useSettings } from '@/lib/SettingsContext';
 
-const Observe = lazy(() => import('@/ee/pages/Observe').then(module => ({ default: module.Observe })));
+const Observe = lazy(() =>
+  import('@/ee/pages/Observe').then(module => ({ default: module.Observe }))
+);
 
 function withLayout(children: ReactNode) {
   return <Layout>{children}</Layout>;
@@ -88,6 +91,9 @@ export const App = () => {
       <Toaster />
       <Routes>
         <Route path="/login" element={<Login />} />
+        {/* Standalone like /login: the OAuth bounce lands here for any account,
+            and the page handles the not-signed-in case itself (returnTo). */}
+        <Route path="/oauth/consent" element={<OAuthConsent />} />
         <Route
           path="*"
           element={

--- a/apps/dashboard/src/lib/api.ts
+++ b/apps/dashboard/src/lib/api.ts
@@ -1,4 +1,4 @@
-import { getRefreshToken, getToken, logout, setTokens } from '@/lib/auth.ts';
+import { getRefreshToken, getToken, logout, saveReturnTo, setTokens } from '@/lib/auth.ts';
 
 export type APIProblemPayload = {
   title: string;
@@ -892,6 +892,7 @@ export class ApiClient {
     } catch (error) {
       // A network failure is the same story as a 5xx: unreachable, not revoked.
       console.error('Failed to refresh token:', error);
+      this.endSession(refreshToken);
     }
   }
 
@@ -910,7 +911,13 @@ export class ApiClient {
       return;
     }
     logout();
-    window.location.assign('/login');
+    // Remember where the session died so the next sign-in resumes there; the
+    // stored path is router-relative, so the /dashboard basename is stripped.
+    const currentPath = window.location.pathname.replace(/^\/dashboard/, '');
+    if (currentPath && currentPath !== '/login') {
+      saveReturnTo(currentPath + window.location.search);
+    }
+    window.location.assign('/dashboard/login');
   }
 
   public async login(email: string, password: string) {
@@ -918,6 +925,37 @@ export class ApiClient {
     form.append('email', email);
     form.append('password', password);
     return this.request<{ token: string; refreshToken: string }>(`/auth/login`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: form.toString(),
+    });
+  }
+
+  // The OAuth consent screen echoes back the authorization request it was
+  // opened with, plus the user's decision; the server re-validates everything
+  // and answers with the redirect delivering the code (or the denial).
+  public async submitOAuthConsent(
+    authorizationParams: URLSearchParams,
+    decision: 'approve' | 'deny'
+  ) {
+    const form = new URLSearchParams();
+    for (const name of [
+      'client_id',
+      'redirect_uri',
+      'response_type',
+      'code_challenge',
+      'code_challenge_method',
+      'scope',
+      'state',
+      'resource',
+    ]) {
+      const value = authorizationParams.get(name);
+      if (value) {
+        form.append(name, value);
+      }
+    }
+    form.append('decision', decision);
+    return this.request<{ redirectUrl: string }>(`/api/oauth/consent`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
       body: form.toString(),

--- a/apps/dashboard/src/lib/api.ts
+++ b/apps/dashboard/src/lib/api.ts
@@ -865,35 +865,32 @@ export class ApiClient {
   }
 
   private async performRefresh(refreshToken: string) {
+    let response: Response;
     try {
       const form = new URLSearchParams();
       form.append('refreshToken', refreshToken);
-      const response = await fetch(`${this.baseUrl}/auth/refreshToken`, {
+      response = await fetch(`${this.baseUrl}/auth/refreshToken`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
         body: form.toString(),
       });
+    } catch (error) {
+      // A network failure means unreachable, not revoked: keep the tokens and
+      // let the caller surface the failure. The next call retries.
+      console.error('Failed to refresh token:', error);
+      throw error;
+    }
 
-      if (!response.ok) {
-        // Only the server saying "this credential is no longer valid" ends the
-        // session. A 500 means it could not reach its database and a 429 means
-        // it is throttling — /auth/refreshToken distinguishes them precisely so
-        // that a blip or a shared office IP does not throw away a perfectly
-        // good refresh token. Keep it and let the caller surface the failure.
-        if (response.status !== 401 && response.status !== 403) {
-          throw new Error(`Refresh unavailable (${response.status})`);
-        }
+    if (!response.ok) {
+      if (response.status === 401 || response.status === 403) {
         this.endSession(refreshToken);
         return;
       }
-
-      const data = await response.json();
-      setTokens(data.token, data.refreshToken);
-    } catch (error) {
-      // A network failure is the same story as a 5xx: unreachable, not revoked.
-      console.error('Failed to refresh token:', error);
-      this.endSession(refreshToken);
+      throw new Error(`Refresh unavailable (${response.status})`);
     }
+
+    const data = await response.json();
+    setTokens(data.token, data.refreshToken);
   }
 
   // endSession is what a revocation looks like from the client: the account was

--- a/apps/dashboard/src/lib/auth.ts
+++ b/apps/dashboard/src/lib/auth.ts
@@ -19,3 +19,41 @@ export const logout = () => {
   localStorage.removeItem('token');
   localStorage.removeItem('refreshToken');
 };
+
+const RETURN_TO_KEY = 'returnTo';
+const RETURN_TO_TTL_MS = 10 * 60 * 1000;
+
+// Where the next successful sign-in should land instead of the home page.
+// sessionStorage rather than router state: it must survive the SSO round-trip
+// through the identity provider. Writing is idempotent, so it is render-safe.
+export const saveReturnTo = (path: string) => {
+  sessionStorage.setItem(RETURN_TO_KEY, JSON.stringify({ path, at: Date.now() }));
+};
+
+// peekReturnTo is deliberately read-only so it can be called during render
+// (StrictMode renders twice); the entry is dropped by clearReturnTo once the
+// destination page mounts, or by the TTL for abandoned flows.
+export const peekReturnTo = (): string | null => {
+  const raw = sessionStorage.getItem(RETURN_TO_KEY);
+  if (!raw) {
+    return null;
+  }
+  try {
+    const { path, at } = JSON.parse(raw) as { path?: unknown; at?: unknown };
+    if (typeof path !== 'string' || typeof at !== 'number' || Date.now() - at > RETURN_TO_TTL_MS) {
+      return null;
+    }
+    // Router-internal paths only: anything else could bounce a fresh session
+    // to another origin.
+    if (!path.startsWith('/') || path.startsWith('//')) {
+      return null;
+    }
+    return path;
+  } catch {
+    return null;
+  }
+};
+
+export const clearReturnTo = () => {
+  sessionStorage.removeItem(RETURN_TO_KEY);
+};

--- a/apps/dashboard/src/pages/Login/index.tsx
+++ b/apps/dashboard/src/pages/Login/index.tsx
@@ -7,7 +7,7 @@ import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Form, FormControl, FormField, FormItem, FormMessage } from '@/components/ui/form.tsx';
 import { useCallback, useEffect, useState } from 'react';
-import { isAuthenticated, setTokens } from '@/lib/auth.ts';
+import { isAuthenticated, peekReturnTo, setTokens } from '@/lib/auth.ts';
 import { Navigate, useNavigate } from 'react-router';
 import { api, ApiProblemError } from '@/lib/api.ts';
 import { Alert, AlertDescription } from '@/components/ui/alert';
@@ -76,7 +76,11 @@ export const Login = () => {
     window.history.replaceState(null, '', window.location.pathname + window.location.search);
     if (ssoToken && ssoRefreshToken) {
       setTokens(ssoToken, ssoRefreshToken);
-      navigate('/');
+      // peek, never clear here: setting the tokens re-renders this component,
+      // whose declarative Navigate reads the entry again; clearing first would
+      // hand that render a null and send the user to the home page. The
+      // destination page clears it.
+      navigate(peekReturnTo() ?? '/');
       return;
     }
     setSignInNotice(SSO_ERROR_MESSAGES[errorCode ?? ''] ?? SSO_ERROR_MESSAGES.sso_failed);
@@ -87,7 +91,7 @@ export const Login = () => {
       try {
         const response = await api.login(data.email, data.password);
         setTokens(response.token, response.refreshToken);
-        navigate('/');
+        navigate(peekReturnTo() ?? '/');
       } catch (error) {
         // A 403 means the credentials were right but the account may not use
         // this door: SSO is enforced for it, or it is waiting for approval.
@@ -119,7 +123,8 @@ export const Login = () => {
   // bounce (closured on a stale value) would win the navigation race. It also
   // sends an already-signed-in visitor of /login straight to the dashboard.
   if (isAuthenticated()) {
-    return <Navigate to="/" replace />;
+    // peek, not clear: render-safe, and the destination page clears the entry.
+    return <Navigate to={peekReturnTo() ?? '/'} replace />;
   }
 
   return (

--- a/apps/dashboard/src/pages/OAuthConsent/index.tsx
+++ b/apps/dashboard/src/pages/OAuthConsent/index.tsx
@@ -1,0 +1,141 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Navigate, useLocation, useSearchParams } from 'react-router';
+import { KeyRound, TriangleAlert } from 'lucide-react';
+import { Button } from '@/components/ui/button.tsx';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { api, describeApiError } from '@/lib/api.ts';
+import { clearReturnTo, isAuthenticated, saveReturnTo } from '@/lib/auth.ts';
+
+const REQUIRED_PARAMS = [
+  'client_id',
+  'redirect_uri',
+  'response_type',
+  'code_challenge',
+  'code_challenge_method',
+];
+
+// The OAuth consent screen: an external MCP client asked for access, the
+// authorize endpoint validated the request and bounced it here with the
+// registered client name resolved server-side. Approving posts the request
+// back with the session and follows the redirect that delivers the code.
+export const OAuthConsent = () => {
+  const location = useLocation();
+  const [searchParams] = useSearchParams();
+  const [submitting, setSubmitting] = useState<'approve' | 'deny' | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const loggedIn = isAuthenticated();
+  useEffect(() => {
+    if (loggedIn) {
+      clearReturnTo();
+    }
+  }, [loggedIn]);
+
+  const clientName = searchParams.get('client_name') || 'An application';
+  const redirectHost = useMemo(() => {
+    try {
+      return new URL(searchParams.get('redirect_uri') ?? '').host || null;
+    } catch {
+      return null;
+    }
+  }, [searchParams]);
+
+  if (!loggedIn) {
+    // Idempotent write, safe during render; Login sends the user back here.
+    saveReturnTo(location.pathname + location.search);
+    return <Navigate to="/login" replace />;
+  }
+
+  const invalidRequest = REQUIRED_PARAMS.some(name => !searchParams.get(name));
+
+  const decide = async (decision: 'approve' | 'deny') => {
+    setSubmitting(decision);
+    setError(null);
+    try {
+      const { redirectUrl } = await api.submitOAuthConsent(searchParams, decision);
+      window.location.assign(redirectUrl);
+    } catch (submitError) {
+      setSubmitting(null);
+      const { title, description } = describeApiError(
+        submitError,
+        'Could not record your decision'
+      );
+      setError(description || title);
+    }
+  };
+
+  return (
+    <div className="flex min-h-screen w-full items-center justify-center bg-background px-4">
+      <div className="w-full max-w-sm">
+        <div className="rounded-lg border bg-card p-8 shadow-elevated">
+          <div className="mb-6 flex flex-col items-center gap-3 text-center">
+            <div className="flex h-11 w-11 items-center justify-center rounded-lg border border-primary/30 bg-primary/10 text-primary">
+              <KeyRound className="h-5 w-5" strokeWidth={2} />
+            </div>
+            <div className="space-y-1">
+              <h1 className="font-display text-lg font-semibold tracking-tight text-foreground">
+                Connection request
+              </h1>
+              <p className="text-sm text-muted-foreground">
+                <span className="font-medium text-foreground">{clientName}</span> wants to access
+                your Expo Open OTA account.
+              </p>
+            </div>
+          </div>
+
+          {invalidRequest ? (
+            <Alert variant="destructive">
+              <TriangleAlert className="h-4 w-4" />
+              <AlertDescription>
+                This authorization request is invalid or incomplete. Close this tab and start again
+                from the application that opened it.
+              </AlertDescription>
+            </Alert>
+          ) : (
+            <>
+              <div className="mb-6 rounded-md border bg-background/50 p-4 text-sm text-muted-foreground">
+                <p>
+                  It will act through the MCP server with your account&apos;s own permissions: the
+                  apps and updates you can see and manage, it can too.
+                </p>
+                {redirectHost && (
+                  <p className="mt-2">
+                    You will be sent back to{' '}
+                    <span className="font-mono text-xs text-foreground">{redirectHost}</span>.
+                  </p>
+                )}
+              </div>
+
+              {error && (
+                <Alert variant="destructive" className="mb-5">
+                  <TriangleAlert className="h-4 w-4" />
+                  <AlertDescription>{error}</AlertDescription>
+                </Alert>
+              )}
+
+              <div className="flex gap-3">
+                <Button
+                  variant="outline"
+                  className="flex-1"
+                  disabled={submitting !== null}
+                  onClick={() => decide('deny')}>
+                  {submitting === 'deny' ? 'Denying…' : 'Deny'}
+                </Button>
+                <Button
+                  className="flex-1"
+                  disabled={submitting !== null}
+                  onClick={() => decide('approve')}>
+                  {submitting === 'approve' ? 'Authorizing…' : 'Authorize'}
+                </Button>
+              </div>
+            </>
+          )}
+        </div>
+
+        <p className="mt-6 text-center text-xs text-muted-foreground">
+          Only authorize applications you trust
+        </p>
+      </div>
+    </div>
+  );
+};

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -11,8 +11,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/gorilla/handlers"
-
 	_ "expo-open-ota/internal/bucketmigrations"
 )
 
@@ -70,13 +68,9 @@ func main() {
 	container, cleanup := infrastructure.InitDependencies(context.Background())
 	defer cleanup()
 	router := infrastructure.NewRouter(container)
-	corsOptions := handlers.CORS(
-		handlers.AllowedHeaders([]string{"Authorization", "Content-Type"}),
-		handlers.AllowedMethods([]string{"GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"}),
-		handlers.AllowedOrigins([]string{"*"}),
-		handlers.AllowCredentials(),
-	)
-	ready := http.Handler(corsOptions(router))
+	// No global CORS: each surface declares its own where its routes are
+	// registered (dashboard subrouters, OAuth endpoints, /mcp).
+	ready := http.Handler(router)
 	handler.Store(&ready)
 	log.Println("✅ Server is ready to serve traffic.")
 	select {}

--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,12 @@ require (
 )
 
 require (
+	github.com/google/jsonschema-go v0.4.3 // indirect
+	github.com/segmentio/encoding v0.5.4 // indirect
+	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
+)
+
+require (
 	cloud.google.com/go v0.112.2 // indirect
 	cloud.google.com/go/auth v0.3.0 // indirect
 	cloud.google.com/go/auth/oauth2adapt v0.2.2 // indirect
@@ -76,6 +82,7 @@ require (
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/klauspost/compress v1.18.6 // indirect
 	github.com/mfridman/interpolate v0.0.2 // indirect
+	github.com/modelcontextprotocol/go-sdk v1.7.0
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/oschwald/maxminddb-golang v1.13.0 // indirect
 	github.com/paulmach/orb v0.13.0 // indirect
@@ -100,7 +107,7 @@ require (
 	golang.org/x/net v0.57.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/text v0.40.0 // indirect
-	golang.org/x/time v0.5.0 // indirect
+	golang.org/x/time v0.15.0 // indirect
 	google.golang.org/genproto v0.0.0-20240401170217-c3f982113cda // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260414002931-afd174a4e478 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260414002931-afd174a4e478 // indirect

--- a/go.sum
+++ b/go.sum
@@ -140,6 +140,8 @@ github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.3/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
+github.com/google/jsonschema-go v0.4.3 h1:/DBOLZTfDow7pe2GmaJNhltueGTtDKICi8V8p+DQPd0=
+github.com/google/jsonschema-go v0.4.3/go.mod h1:r5quNTdLOYEz95Ru18zA0ydNbBuYoo9tgaYcxEYhJVE=
 github.com/google/martian/v3 v3.3.3 h1:DIhPTQrbPkgs2yJYdXU/eNACCG5DVQjySNRNlflZ9Fc=
 github.com/google/martian/v3 v3.3.3/go.mod h1:iEPrYcgCF7jA9OtScMFQyAlZZ4YXTKEtJ1E6RWzmBA0=
 github.com/google/s2a-go v0.1.7 h1:60BLSyTrOV4/haCDW4zb1guZItoSq8foHCXrAnjBo/o=
@@ -183,6 +185,8 @@ github.com/maxatome/go-testdeep v1.12.0 h1:Ql7Go8Tg0C1D/uMMX59LAoYK7LffeJQ6X2T04
 github.com/maxatome/go-testdeep v1.12.0/go.mod h1:lPZc/HAcJMP92l7yI6TRz1aZN5URwUBUAfUNvrclaNM=
 github.com/mfridman/interpolate v0.0.2 h1:pnuTK7MQIxxFz1Gr+rjSIx9u7qVjf5VOoM/u6BbAxPY=
 github.com/mfridman/interpolate v0.0.2/go.mod h1:p+7uk6oE07mpE/Ik1b8EckO0O4ZXiGAfshKBWLUM9Xg=
+github.com/modelcontextprotocol/go-sdk v1.7.0 h1:yqjY2dsbKAC0LSuWZVBMrHgiG8ukXv6NRo0JiALay44=
+github.com/modelcontextprotocol/go-sdk v1.7.0/go.mod h1:dL7u98E/zjJTGzEq+j30jQ8K2k1mb6LeAH4inEcSGts=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/ncruces/go-strftime v0.1.9 h1:bY0MQC28UADQmHmaF5dgpLmImcShSi2kHU9XLdhx/f4=
@@ -220,6 +224,8 @@ github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0t
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/segmentio/asm v1.2.1 h1:DTNbBqs57ioxAD4PrArqftgypG4/qNpXoJx8TVXxPR0=
 github.com/segmentio/asm v1.2.1/go.mod h1:BqMnlJP91P8d+4ibuonYZw9mfnzI9HfxselHZr5aAcs=
+github.com/segmentio/encoding v0.5.4 h1:OW1VRern8Nw6ITAtwSZ7Idrl3MXCFwXHPgqESYfvNt0=
+github.com/segmentio/encoding v0.5.4/go.mod h1:HS1ZKa3kSN32ZHVZ7ZLPLXWvOVIiZtyJnO1gPH1sKt0=
 github.com/sethvargo/go-retry v0.3.0 h1:EEt31A35QhrcRZtrYFDTBg91cqZVnFL2navjDrah2SE=
 github.com/sethvargo/go-retry v0.3.0/go.mod h1:mNX17F0C/HguQMyMyJxcnU471gOZGxCLyYaFyAZraas=
 github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=
@@ -236,6 +242,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/xyproto/randomstring v1.0.5 h1:YtlWPoRdgMu3NZtP45drfy1GKoojuR7hmRcnhZqKjWU=
 github.com/xyproto/randomstring v1.0.5/go.mod h1:rgmS5DeNXLivK7YprL0pY+lTuhNQW3iGxZ18UQApw/E=
+github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=
+github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
 github.com/zeebo/xxh3 v1.0.2 h1:xZmwmqxHZA8AI603jOQ0tMqmBr9lPeFwGg6d+xy9DC0=
 github.com/zeebo/xxh3 v1.0.2/go.mod h1:5NWz9Sef7zIDm2JHfFlcQvNekmcEl9ekUZQQKCYaDcA=
 go.opencensus.io v0.24.0 h1:y73uSU6J157QMP2kn2r30vwW1A2W2WFwSCGnAVxeaD0=
@@ -300,6 +308,8 @@ golang.org/x/text v0.40.0 h1:Ub2Z6/xjgF1WrYQz2nuITOEegKFtiIy+rieRJ5lHZKs=
 golang.org/x/text v0.40.0/go.mod h1:hpnzDAfGV753zIKo+wk3u1bVKCGPbrnF7+7LBF/UHVY=
 golang.org/x/time v0.5.0 h1:o7cqy6amK/52YcAKIPlM3a+Fpj35zvRj2TP+e1xFSfk=
 golang.org/x/time v0.5.0/go.mod h1:3BpzKBy/shNhVucY/MWOyx10tF3SFh9QdLuxbVysPQM=
+golang.org/x/time v0.15.0 h1:bbrp8t3bGUeFOx08pvsMYRTCVSMk89u4tKbNOZbp88U=
+golang.org/x/time v0.15.0/go.mod h1:Y4YMaQmXwGQZoFaVFk4YpCt4FLQMYKZe9oeV/f4MSno=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3HoIrodX9oNMXvdceNzlUR8zjMvY=

--- a/internal/database/postgres/migrations/20260730120000_oauth_clients.sql
+++ b/internal/database/postgres/migrations/20260730120000_oauth_clients.sql
@@ -1,0 +1,23 @@
+-- +goose Up
+-- +goose StatementBegin
+
+-- OAuth clients registered through dynamic client registration (RFC 7591),
+-- the unauthenticated endpoint MCP clients use to introduce themselves before
+-- their first authorization. Only public clients exist here: a client proves
+-- nothing at registration and holds no secret afterwards, so a row is not a
+-- credential. What the row pins down is the redirect allowlist: an
+-- authorization code is only ever delivered to a URI this client declared at
+-- registration time.
+CREATE TABLE oauth_clients (
+    id UUID PRIMARY KEY,
+    name TEXT NOT NULL,
+    redirect_uris TEXT[] NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP TABLE IF EXISTS oauth_clients;
+-- +goose StatementEnd

--- a/internal/database/postgres/migrations/20260730130000_oauth_authorization_codes.sql
+++ b/internal/database/postgres/migrations/20260730130000_oauth_authorization_codes.sql
@@ -1,0 +1,31 @@
+-- +goose Up
+-- +goose StatementBegin
+
+-- One row per authorization code in flight: the single-use ticket the consent
+-- screen mints and the token endpoint trades for a session. It freezes the
+-- whole authorization context (client, redirect, PKCE challenge, user), so the
+-- exchange can verify the request coming back is the one the user approved.
+-- Rows live about a minute and are purged inline as new ones are minted.
+CREATE TABLE oauth_authorization_codes (
+    -- The code itself. It travels through the browser, so alone it is not
+    -- enough to redeem: the exchange also demands the PKCE verifier, which
+    -- never left the client.
+    id UUID PRIMARY KEY,
+    client_id UUID NOT NULL REFERENCES oauth_clients(id) ON DELETE CASCADE,
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    redirect_uri TEXT NOT NULL,
+    code_challenge TEXT NOT NULL,
+    scope TEXT NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    expires_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    -- NULL until the code is exchanged; a second exchange finds it stamped
+    -- and is refused.
+    used_at TIMESTAMP WITH TIME ZONE
+);
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP TABLE IF EXISTS oauth_authorization_codes;
+-- +goose StatementEnd

--- a/internal/database/postgres/pgdb/models.go
+++ b/internal/database/postgres/pgdb/models.go
@@ -168,6 +168,18 @@ type IdentityValueStat struct {
 	LastSeenAt  pgtype.Timestamptz `json:"last_seen_at"`
 }
 
+type OauthAuthorizationCode struct {
+	ID            pgtype.UUID        `json:"id"`
+	ClientID      pgtype.UUID        `json:"client_id"`
+	UserID        pgtype.UUID        `json:"user_id"`
+	RedirectUri   string             `json:"redirect_uri"`
+	CodeChallenge string             `json:"code_challenge"`
+	Scope         string             `json:"scope"`
+	CreatedAt     pgtype.Timestamptz `json:"created_at"`
+	ExpiresAt     pgtype.Timestamptz `json:"expires_at"`
+	UsedAt        pgtype.Timestamptz `json:"used_at"`
+}
+
 type OauthClient struct {
 	ID           pgtype.UUID        `json:"id"`
 	Name         string             `json:"name"`

--- a/internal/database/postgres/pgdb/models.go
+++ b/internal/database/postgres/pgdb/models.go
@@ -168,6 +168,13 @@ type IdentityValueStat struct {
 	LastSeenAt  pgtype.Timestamptz `json:"last_seen_at"`
 }
 
+type OauthClient struct {
+	ID           pgtype.UUID        `json:"id"`
+	Name         string             `json:"name"`
+	RedirectUris []string           `json:"redirect_uris"`
+	CreatedAt    pgtype.Timestamptz `json:"created_at"`
+}
+
 type RefreshToken struct {
 	ID         pgtype.UUID        `json:"id"`
 	UserID     pgtype.UUID        `json:"user_id"`

--- a/internal/database/postgres/pgdb/queries.sql.go
+++ b/internal/database/postgres/pgdb/queries.sql.go
@@ -2663,6 +2663,22 @@ func (q *Queries) InsertChannelRollout(ctx context.Context, arg InsertChannelRol
 	return result.RowsAffected(), nil
 }
 
+const insertOAuthClient = `-- name: InsertOAuthClient :exec
+INSERT INTO oauth_clients (id, name, redirect_uris)
+VALUES ($1, $2, $3)
+`
+
+type InsertOAuthClientParams struct {
+	ID           pgtype.UUID `json:"id"`
+	Name         string      `json:"name"`
+	RedirectUris []string    `json:"redirect_uris"`
+}
+
+func (q *Queries) InsertOAuthClient(ctx context.Context, arg InsertOAuthClientParams) error {
+	_, err := q.db.Exec(ctx, insertOAuthClient, arg.ID, arg.Name, arg.RedirectUris)
+	return err
+}
+
 const insertRefreshToken = `-- name: InsertRefreshToken :exec
 INSERT INTO refresh_tokens (id, user_id, family_id, expires_at)
 VALUES ($1, $2, $3, $4)

--- a/internal/database/postgres/pgdb/queries.sql.go
+++ b/internal/database/postgres/pgdb/queries.sql.go
@@ -529,6 +529,15 @@ func (q *Queries) DeleteEnterpriseLicense(ctx context.Context) error {
 	return err
 }
 
+const deleteExpiredOAuthAuthorizationCodes = `-- name: DeleteExpiredOAuthAuthorizationCodes :exec
+DELETE FROM oauth_authorization_codes WHERE expires_at < CURRENT_TIMESTAMP
+`
+
+func (q *Queries) DeleteExpiredOAuthAuthorizationCodes(ctx context.Context) error {
+	_, err := q.db.Exec(ctx, deleteExpiredOAuthAuthorizationCodes)
+	return err
+}
+
 const deleteExpiredRefreshTokensForUser = `-- name: DeleteExpiredRefreshTokensForUser :exec
 DELETE FROM refresh_tokens
 WHERE user_id = $1
@@ -1610,6 +1619,22 @@ func (q *Queries) GetLatestUpdateWithRollout(ctx context.Context, arg GetLatestU
 	return i, err
 }
 
+const getOAuthClient = `-- name: GetOAuthClient :one
+SELECT id, name, redirect_uris, created_at FROM oauth_clients WHERE id = $1
+`
+
+func (q *Queries) GetOAuthClient(ctx context.Context, id pgtype.UUID) (OauthClient, error) {
+	row := q.db.QueryRow(ctx, getOAuthClient, id)
+	var i OauthClient
+	err := row.Scan(
+		&i.ID,
+		&i.Name,
+		&i.RedirectUris,
+		&i.CreatedAt,
+	)
+	return i, err
+}
+
 const getRefreshToken = `-- name: GetRefreshToken :one
 SELECT id, user_id, family_id, created_at, expires_at, used_at, replaced_by,
        (used_at IS NOT NULL AND used_at > CURRENT_TIMESTAMP - $1::interval) AS used_recently
@@ -2661,6 +2686,34 @@ func (q *Queries) InsertChannelRollout(ctx context.Context, arg InsertChannelRol
 		return 0, err
 	}
 	return result.RowsAffected(), nil
+}
+
+const insertOAuthAuthorizationCode = `-- name: InsertOAuthAuthorizationCode :exec
+INSERT INTO oauth_authorization_codes (id, client_id, user_id, redirect_uri, code_challenge, scope, expires_at)
+VALUES ($1, $2, $3, $4, $5, $6, $7)
+`
+
+type InsertOAuthAuthorizationCodeParams struct {
+	ID            pgtype.UUID        `json:"id"`
+	ClientID      pgtype.UUID        `json:"client_id"`
+	UserID        pgtype.UUID        `json:"user_id"`
+	RedirectUri   string             `json:"redirect_uri"`
+	CodeChallenge string             `json:"code_challenge"`
+	Scope         string             `json:"scope"`
+	ExpiresAt     pgtype.Timestamptz `json:"expires_at"`
+}
+
+func (q *Queries) InsertOAuthAuthorizationCode(ctx context.Context, arg InsertOAuthAuthorizationCodeParams) error {
+	_, err := q.db.Exec(ctx, insertOAuthAuthorizationCode,
+		arg.ID,
+		arg.ClientID,
+		arg.UserID,
+		arg.RedirectUri,
+		arg.CodeChallenge,
+		arg.Scope,
+		arg.ExpiresAt,
+	)
+	return err
 }
 
 const insertOAuthClient = `-- name: InsertOAuthClient :exec

--- a/internal/database/postgres/pgdb/queries.sql.go
+++ b/internal/database/postgres/pgdb/queries.sql.go
@@ -164,6 +164,32 @@ func (q *Queries) ClearUpdateRollout(ctx context.Context, arg ClearUpdateRollout
 	return result.RowsAffected(), nil
 }
 
+const consumeOAuthAuthorizationCode = `-- name: ConsumeOAuthAuthorizationCode :one
+UPDATE oauth_authorization_codes
+SET used_at = CURRENT_TIMESTAMP
+WHERE id = $1 AND used_at IS NULL AND expires_at > CURRENT_TIMESTAMP
+RETURNING id, client_id, user_id, redirect_uri, code_challenge, scope, created_at, expires_at, used_at
+`
+
+// Single-use claim, atomic on purpose: two exchanges presenting the same code
+// concurrently must not both succeed. The loser gets no row.
+func (q *Queries) ConsumeOAuthAuthorizationCode(ctx context.Context, id pgtype.UUID) (OauthAuthorizationCode, error) {
+	row := q.db.QueryRow(ctx, consumeOAuthAuthorizationCode, id)
+	var i OauthAuthorizationCode
+	err := row.Scan(
+		&i.ID,
+		&i.ClientID,
+		&i.UserID,
+		&i.RedirectUri,
+		&i.CodeChallenge,
+		&i.Scope,
+		&i.CreatedAt,
+		&i.ExpiresAt,
+		&i.UsedAt,
+	)
+	return i, err
+}
+
 const consumeRefreshToken = `-- name: ConsumeRefreshToken :one
 UPDATE refresh_tokens
 SET used_at = CURRENT_TIMESTAMP, replaced_by = $1

--- a/internal/database/postgres/queries/queries.sql
+++ b/internal/database/postgres/queries/queries.sql
@@ -2271,3 +2271,7 @@ LEFT JOIN LATERAL (
       AND f.update_id = r.update_uuid
       AND f.resolved_at IS NULL
 ) failures ON TRUE;
+
+-- name: InsertOAuthClient :exec
+INSERT INTO oauth_clients (id, name, redirect_uris)
+VALUES ($1, $2, $3);

--- a/internal/database/postgres/queries/queries.sql
+++ b/internal/database/postgres/queries/queries.sql
@@ -2275,3 +2275,13 @@ LEFT JOIN LATERAL (
 -- name: InsertOAuthClient :exec
 INSERT INTO oauth_clients (id, name, redirect_uris)
 VALUES ($1, $2, $3);
+
+-- name: GetOAuthClient :one
+SELECT * FROM oauth_clients WHERE id = $1;
+
+-- name: InsertOAuthAuthorizationCode :exec
+INSERT INTO oauth_authorization_codes (id, client_id, user_id, redirect_uri, code_challenge, scope, expires_at)
+VALUES ($1, $2, $3, $4, $5, $6, $7);
+
+-- name: DeleteExpiredOAuthAuthorizationCodes :exec
+DELETE FROM oauth_authorization_codes WHERE expires_at < CURRENT_TIMESTAMP;

--- a/internal/database/postgres/queries/queries.sql
+++ b/internal/database/postgres/queries/queries.sql
@@ -2285,3 +2285,11 @@ VALUES ($1, $2, $3, $4, $5, $6, $7);
 
 -- name: DeleteExpiredOAuthAuthorizationCodes :exec
 DELETE FROM oauth_authorization_codes WHERE expires_at < CURRENT_TIMESTAMP;
+
+-- name: ConsumeOAuthAuthorizationCode :one
+-- Single-use claim, atomic on purpose: two exchanges presenting the same code
+-- concurrently must not both succeed. The loser gets no row.
+UPDATE oauth_authorization_codes
+SET used_at = CURRENT_TIMESTAMP
+WHERE id = $1 AND used_at IS NULL AND expires_at > CURRENT_TIMESTAMP
+RETURNING *;

--- a/internal/mcp/handler.go
+++ b/internal/mcp/handler.go
@@ -1,0 +1,17 @@
+package mcp
+
+import (
+	"net/http"
+)
+
+type MCPHandler struct {
+	service *MCPService
+}
+
+func NewMCPHandler(service *MCPService) *MCPHandler {
+	return &MCPHandler{service: service}
+}
+
+func (h *MCPHandler) GlobalHandler(w http.ResponseWriter, r *http.Request) {
+	h.service.streamable.ServeHTTP(w, r)
+}

--- a/internal/mcp/service.go
+++ b/internal/mcp/service.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"expo-open-ota/internal/version"
 	"net/http"
+	"time"
 
 	mcpprot "github.com/modelcontextprotocol/go-sdk/mcp"
 )
@@ -21,7 +22,17 @@ func NewMCPService() *MCPService {
 
 	streamable := mcpprot.NewStreamableHTTPHandler(
 		func(*http.Request) *mcpprot.Server { return server },
-		nil,
+		&mcpprot.StreamableHTTPOptions{
+			// The SDK's DNS-rebinding guard 403s any loopback connection
+			// carrying a public Host header, which is exactly a reverse proxy
+			// forwarding to 127.0.0.1. It exists for unauthenticated local
+			// servers; /mcp requires a Bearer before this handler runs.
+			DisableLocalhostProtection: true,
+			// MCP clients rarely DELETE their session; without a timeout,
+			// sessions of vanished clients accumulate for the process
+			// lifetime. An idle client past this simply re-initializes.
+			SessionTimeout: 30 * time.Minute,
+		},
 	)
 	return &MCPService{server: server, streamable: streamable}
 }

--- a/internal/mcp/service.go
+++ b/internal/mcp/service.go
@@ -1,0 +1,27 @@
+package mcp
+
+import (
+	"expo-open-ota/internal/version"
+	"net/http"
+
+	mcpprot "github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+type MCPService struct {
+	server     *mcpprot.Server
+	streamable *mcpprot.StreamableHTTPHandler
+}
+
+func NewMCPService() *MCPService {
+	server := mcpprot.NewServer(&mcpprot.Implementation{
+		Name:    "Expo-Open-Ota",
+		Version: version.Version,
+		Title:   "Expo Open OTA",
+	}, nil)
+
+	streamable := mcpprot.NewStreamableHTTPHandler(
+		func(*http.Request) *mcpprot.Server { return server },
+		nil,
+	)
+	return &MCPService{server: server, streamable: streamable}
+}

--- a/internal/middleware/cors_middleware.go
+++ b/internal/middleware/cors_middleware.go
@@ -1,0 +1,54 @@
+package middleware
+
+import (
+	"expo-open-ota/config"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/gorilla/mux"
+)
+
+// NewDashboardCORSMiddleware serves the only browser that legitimately calls
+// the dashboard surfaces (/api, /auth) cross-origin: the SPA on a localhost
+// dev server. In production the SPA is served by this server under /dashboard,
+// same origin, and no other website gets to read these responses from a
+// visitor's browser. Preflights are answered here, before authentication,
+// because they carry no Authorization header; the subrouter needs a catch-all
+// OPTIONS route for them to match.
+func NewDashboardCORSMiddleware() mux.MiddlewareFunc {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			origin := r.Header.Get("Origin")
+			if origin != "" && isDashboardOrigin(origin) {
+				w.Header().Add("Vary", "Origin")
+				w.Header().Set("Access-Control-Allow-Origin", origin)
+				w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, PATCH, DELETE, OPTIONS")
+				w.Header().Set("Access-Control-Allow-Headers", "Authorization, Content-Type, Use-Cli-Auth")
+			}
+			if r.Method == http.MethodOptions {
+				w.WriteHeader(http.StatusNoContent)
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// isDashboardOrigin accepts the deployment's own origin and local dev servers
+// (vite serves the SPA from localhost on an arbitrary port).
+func isDashboardOrigin(origin string) bool {
+	parsed, err := url.Parse(origin)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return false
+	}
+	hostname := parsed.Hostname()
+	if hostname == "localhost" || hostname == "127.0.0.1" || hostname == "::1" {
+		return true
+	}
+	base, err := url.Parse(strings.TrimRight(config.GetEnv("BASE_URL"), "/"))
+	if err != nil {
+		return false
+	}
+	return parsed.Scheme == base.Scheme && parsed.Host == base.Host
+}

--- a/internal/middleware/cors_middleware_test.go
+++ b/internal/middleware/cors_middleware_test.go
@@ -1,0 +1,69 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gorilla/mux"
+)
+
+func dashboardCORSRouter(t *testing.T) *mux.Router {
+	t.Helper()
+	t.Setenv("BASE_URL", "https://ota.example.com")
+	router := mux.NewRouter()
+	sub := router.PathPrefix("/api").Subrouter()
+	sub.Use(NewDashboardCORSMiddleware())
+	sub.PathPrefix("/").HandlerFunc(func(http.ResponseWriter, *http.Request) {}).Methods(http.MethodOptions)
+	sub.HandleFunc("/me", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}).Methods(http.MethodGet)
+	return router
+}
+
+func TestDashboardCORSAllowedOrigins(t *testing.T) {
+	router := dashboardCORSRouter(t)
+	for _, origin := range []string{"https://ota.example.com", "http://localhost:5173", "http://127.0.0.1:4000"} {
+		res := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodOptions, "/api/me", nil)
+		req.Header.Set("Origin", origin)
+		router.ServeHTTP(res, req)
+
+		if res.Code != http.StatusNoContent {
+			t.Fatalf("%s: expected 204 on preflight, got %d", origin, res.Code)
+		}
+		if res.Header().Get("Access-Control-Allow-Origin") != origin {
+			t.Errorf("%s: expected the origin echoed back, got %q", origin, res.Header().Get("Access-Control-Allow-Origin"))
+		}
+	}
+}
+
+func TestDashboardCORSForeignOriginRefused(t *testing.T) {
+	router := dashboardCORSRouter(t)
+	res := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/me", nil)
+	req.Header.Set("Origin", "https://evil.example.com")
+	router.ServeHTTP(res, req)
+
+	if res.Header().Get("Access-Control-Allow-Origin") != "" {
+		t.Error("a foreign origin must get no CORS headers")
+	}
+	// The request itself still runs; CORS only governs what the calling page
+	// may read, authentication is the auth middleware's job.
+	if res.Code != http.StatusOK {
+		t.Fatalf("expected the request to reach the handler, got %d", res.Code)
+	}
+}
+
+func TestDashboardCORSNoOrigin(t *testing.T) {
+	router := dashboardCORSRouter(t)
+	res := httptest.NewRecorder()
+	router.ServeHTTP(res, httptest.NewRequest(http.MethodGet, "/api/me", nil))
+
+	if res.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", res.Code)
+	}
+	if res.Header().Get("Access-Control-Allow-Origin") != "" {
+		t.Error("no Origin, no CORS headers")
+	}
+}

--- a/internal/middleware/logging_middleware.go
+++ b/internal/middleware/logging_middleware.go
@@ -66,3 +66,13 @@ func (r *statusRecorder) WriteHeader(code int) {
 	r.statusCode = code
 	r.ResponseWriter.WriteHeader(code)
 }
+
+func (r *statusRecorder) Flush() {
+	if flusher, ok := r.ResponseWriter.(http.Flusher); ok {
+		flusher.Flush()
+	}
+}
+
+func (r *statusRecorder) Unwrap() http.ResponseWriter {
+	return r.ResponseWriter
+}

--- a/internal/middleware/oauth_middleware.go
+++ b/internal/middleware/oauth_middleware.go
@@ -1,0 +1,50 @@
+package middleware
+
+import (
+	"errors"
+	"expo-open-ota/internal/helpers"
+	"expo-open-ota/internal/oauth"
+	"expo-open-ota/internal/services"
+	"fmt"
+	"net/http"
+
+	"github.com/gorilla/mux"
+)
+
+// NewOAuthMiddleware guards the MCP endpoint behind an OAuth access token.
+// Every refusal carries the WWW-Authenticate header pointing at the resource
+// metadata; that header is how a client that has never seen this server
+// discovers where to authenticate, so the 401 is part of the protocol, not
+// just an error.
+func NewOAuthMiddleware(oauthService *oauth.OAuthService) mux.MiddlewareFunc {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			bearerToken, err := helpers.GetBearerToken(r)
+			if err != nil {
+				renderUnauthorized(w, "")
+				return
+			}
+			principal, err := oauthService.AuthenticateMCPToken(r.Context(), bearerToken)
+			if err != nil {
+				// A database outage must not read as a dead token, the client
+				// would throw away a valid credential and restart the flow.
+				if errors.Is(err, services.ErrAuthUnavailable) {
+					http.Error(w, "Could not verify the account", http.StatusInternalServerError)
+					return
+				}
+				renderUnauthorized(w, "invalid_token")
+				return
+			}
+			next.ServeHTTP(w, r.WithContext(services.WithPrincipal(r.Context(), principal)))
+		})
+	}
+}
+
+func renderUnauthorized(w http.ResponseWriter, errorCode string) {
+	challenge := fmt.Sprintf("Bearer resource_metadata=%q", oauth.ResourceMetadataURL())
+	if errorCode != "" {
+		challenge += fmt.Sprintf(", error=%q", errorCode)
+	}
+	w.Header().Set("WWW-Authenticate", challenge)
+	http.Error(w, "Unauthorized", http.StatusUnauthorized)
+}

--- a/internal/middleware/oauth_middleware.go
+++ b/internal/middleware/oauth_middleware.go
@@ -1,50 +1,68 @@
 package middleware
 
 import (
+	"context"
 	"errors"
-	"expo-open-ota/internal/helpers"
 	"expo-open-ota/internal/oauth"
 	"expo-open-ota/internal/services"
-	"fmt"
 	"net/http"
 
 	"github.com/gorilla/mux"
+	"github.com/modelcontextprotocol/go-sdk/auth"
 )
 
+// principalExtraKey carries the resolved principal through the SDK's
+// TokenInfo.Extra, from the verifier to the inner middleware.
+const principalExtraKey = "principal"
+
 // NewOAuthMiddleware guards the MCP endpoint behind an OAuth access token.
-// Every refusal carries the WWW-Authenticate header pointing at the resource
-// metadata; that header is how a client that has never seen this server
-// discovers where to authenticate, so the 401 is part of the protocol, not
-// just an error.
+// It wraps the SDK's RequireBearerToken rather than checking the header
+// itself: that is the only way to plant the TokenInfo the streamable
+// transport pins sessions to (session hijacking prevention), and it also
+// answers refusals with the WWW-Authenticate challenge clients discover the
+// authorization flow through.
 func NewOAuthMiddleware(oauthService *oauth.OAuthService) mux.MiddlewareFunc {
+	verifier := func(ctx context.Context, token string, _ *http.Request) (*auth.TokenInfo, error) {
+		principal, expiresAt, err := oauthService.AuthenticateMCPToken(ctx, token)
+		if err != nil {
+			// A database outage must not read as a dead token (500, not
+			// 401), the client would throw away a valid credential and
+			// restart the flow. Bare errors on both paths: the SDK writes
+			// the error message into the response body.
+			if errors.Is(err, services.ErrAuthUnavailable) {
+				return nil, services.ErrAuthUnavailable
+			}
+			return nil, auth.ErrInvalidToken
+		}
+		return &auth.TokenInfo{
+			UserID:     principal.UserId,
+			Scopes:     []string{oauth.ScopeMCP},
+			Expiration: expiresAt,
+			Extra:      map[string]any{principalExtraKey: principal},
+		}, nil
+	}
+	requireBearer := auth.RequireBearerToken(verifier, &auth.RequireBearerTokenOptions{
+		ResourceMetadataURL: oauth.ResourceMetadataURL(),
+	})
 	return func(next http.Handler) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			bearerToken, err := helpers.GetBearerToken(r)
-			if err != nil {
-				renderUnauthorized(w, "")
-				return
-			}
-			principal, err := oauthService.AuthenticateMCPToken(r.Context(), bearerToken)
-			if err != nil {
-				// A database outage must not read as a dead token, the client
-				// would throw away a valid credential and restart the flow.
-				if errors.Is(err, services.ErrAuthUnavailable) {
-					http.Error(w, "Could not verify the account", http.StatusInternalServerError)
-					return
-				}
-				renderUnauthorized(w, "invalid_token")
-				return
-			}
-			next.ServeHTTP(w, r.WithContext(services.WithPrincipal(r.Context(), principal)))
-		})
+		return requireBearer(principalFromTokenInfo(next))
 	}
 }
 
-func renderUnauthorized(w http.ResponseWriter, errorCode string) {
-	challenge := fmt.Sprintf("Bearer resource_metadata=%q", oauth.ResourceMetadataURL())
-	if errorCode != "" {
-		challenge += fmt.Sprintf(", error=%q", errorCode)
-	}
-	w.Header().Set("WWW-Authenticate", challenge)
-	http.Error(w, "Unauthorized", http.StatusUnauthorized)
+// principalFromTokenInfo copies the principal minted by the verifier into the
+// context key the rest of the codebase reads.
+func principalFromTokenInfo(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		info := auth.TokenInfoFromContext(r.Context())
+		if info == nil {
+			http.Error(w, "Unauthorized", http.StatusUnauthorized)
+			return
+		}
+		principal, _ := info.Extra[principalExtraKey].(*services.DashboardPrincipal)
+		if principal == nil {
+			http.Error(w, "Unauthorized", http.StatusUnauthorized)
+			return
+		}
+		next.ServeHTTP(w, r.WithContext(services.WithPrincipal(r.Context(), principal)))
+	})
 }

--- a/internal/middleware/oauth_middleware_test.go
+++ b/internal/middleware/oauth_middleware_test.go
@@ -32,6 +32,10 @@ func (f *fakeOAuthUserRepo) GetUserByID(_ context.Context, id string) (store.Use
 	return f.user, nil
 }
 
+func (f *fakeOAuthUserRepo) BumpUserSessionVersion(_ context.Context, _ string) error {
+	return nil
+}
+
 // principalCapture records what the middleware put in the context of the
 // request that reached the wrapped handler.
 type principalCapture struct {
@@ -42,7 +46,7 @@ func oauthTestSetup(t *testing.T, repo *fakeOAuthUserRepo) (*oauth.OAuthService,
 	t.Helper()
 	t.Setenv("BASE_URL", "https://ota.example.com")
 	t.Setenv("JWT_SECRET", "test-secret")
-	service := oauth.NewOAuthService(nil, nil, repo)
+	service := oauth.NewOAuthService(nil, nil, nil, repo)
 
 	capture := &principalCapture{}
 	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/middleware/oauth_middleware_test.go
+++ b/internal/middleware/oauth_middleware_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
+	"github.com/modelcontextprotocol/go-sdk/auth"
 )
 
 type fakeOAuthUserRepo struct {
@@ -137,8 +138,8 @@ func TestOAuthMiddlewareRejections(t *testing.T) {
 			if res.Code != http.StatusUnauthorized {
 				t.Fatalf("expected 401, got %d", res.Code)
 			}
-			if challenge := res.Header().Get("WWW-Authenticate"); !strings.Contains(challenge, `error="invalid_token"`) {
-				t.Errorf("expected error=\"invalid_token\" in WWW-Authenticate, got %q", challenge)
+			if challenge := res.Header().Get("WWW-Authenticate"); !strings.Contains(challenge, "resource_metadata") {
+				t.Errorf("the 401 must carry the discovery challenge, got %q", challenge)
 			}
 		})
 	}
@@ -173,5 +174,28 @@ func TestOAuthMiddlewareDatabaseOutage(t *testing.T) {
 	}
 	if res.Header().Get("WWW-Authenticate") != "" {
 		t.Error("a 500 must not carry WWW-Authenticate, the client would restart the flow")
+	}
+	if strings.Contains(res.Body.String(), "connection refused") {
+		t.Error("the response body must not leak the underlying database error")
+	}
+}
+
+func TestOAuthMiddlewareBindsSessionUser(t *testing.T) {
+	repo := &fakeOAuthUserRepo{user: enabledUser()}
+	service, _, _ := oauthTestSetup(t, repo)
+	token, err := service.IssueAccessToken(services.DashboardPrincipal{UserId: "user-1", SessionVersion: 3})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// The streamable transport pins sessions to TokenInfo.UserID; assert the
+	// middleware actually plants it where the SDK reads it.
+	var seenInfo *auth.TokenInfo
+	handler := NewOAuthMiddleware(service)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenInfo = auth.TokenInfoFromContext(r.Context())
+	}))
+	doMCPRequest(handler, token)
+	if seenInfo == nil || seenInfo.UserID != "user-1" {
+		t.Fatalf("TokenInfo.UserID must reach the transport, got %+v", seenInfo)
 	}
 }

--- a/internal/middleware/oauth_middleware_test.go
+++ b/internal/middleware/oauth_middleware_test.go
@@ -42,7 +42,7 @@ func oauthTestSetup(t *testing.T, repo *fakeOAuthUserRepo) (*oauth.OAuthService,
 	t.Helper()
 	t.Setenv("BASE_URL", "https://ota.example.com")
 	t.Setenv("JWT_SECRET", "test-secret")
-	service := oauth.NewOAuthService(nil, repo)
+	service := oauth.NewOAuthService(nil, nil, repo)
 
 	capture := &principalCapture{}
 	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/middleware/oauth_middleware_test.go
+++ b/internal/middleware/oauth_middleware_test.go
@@ -1,0 +1,177 @@
+package middleware
+
+import (
+	"context"
+	"errors"
+	"expo-open-ota/internal/crypto"
+	"expo-open-ota/internal/oauth"
+	"expo-open-ota/internal/services"
+	"expo-open-ota/internal/store"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+type fakeOAuthUserRepo struct {
+	user store.User
+	err  error
+}
+
+func (f *fakeOAuthUserRepo) GetUserByID(_ context.Context, id string) (store.User, error) {
+	if f.err != nil {
+		return store.User{}, f.err
+	}
+	if f.user.Id != id {
+		return store.User{}, &store.ErrResourceNotFound{Resource: "user", Identifier: id}
+	}
+	return f.user, nil
+}
+
+// principalCapture records what the middleware put in the context of the
+// request that reached the wrapped handler.
+type principalCapture struct {
+	principal *services.DashboardPrincipal
+}
+
+func oauthTestSetup(t *testing.T, repo *fakeOAuthUserRepo) (*oauth.OAuthService, http.Handler, *principalCapture) {
+	t.Helper()
+	t.Setenv("BASE_URL", "https://ota.example.com")
+	t.Setenv("JWT_SECRET", "test-secret")
+	service := oauth.NewOAuthService(nil, repo)
+
+	capture := &principalCapture{}
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capture.principal = services.PrincipalFromContext(r.Context())
+		w.WriteHeader(http.StatusOK)
+	})
+	return service, NewOAuthMiddleware(service)(next), capture
+}
+
+func doMCPRequest(handler http.Handler, token string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	res := httptest.NewRecorder()
+	handler.ServeHTTP(res, req)
+	return res
+}
+
+func enabledUser() store.User {
+	return store.User{Id: "user-1", Email: "a@b.c", IsAdmin: false, Enabled: true, SessionVersion: 3}
+}
+
+func TestOAuthMiddlewareMissingToken(t *testing.T) {
+	_, handler, _ := oauthTestSetup(t, &fakeOAuthUserRepo{user: enabledUser()})
+	res := doMCPRequest(handler, "")
+
+	if res.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", res.Code)
+	}
+	challenge := res.Header().Get("WWW-Authenticate")
+	if !strings.Contains(challenge, `resource_metadata="https://ota.example.com/.well-known/oauth-protected-resource/mcp"`) {
+		t.Errorf("WWW-Authenticate must point at the resource metadata, got %q", challenge)
+	}
+}
+
+func TestOAuthMiddlewareValidToken(t *testing.T) {
+	repo := &fakeOAuthUserRepo{user: enabledUser()}
+	service, handler, capture := oauthTestSetup(t, repo)
+	token, err := service.IssueAccessToken(services.DashboardPrincipal{UserId: "user-1", SessionVersion: 3})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	res := doMCPRequest(handler, token)
+	if res.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", res.Code, res.Body.String())
+	}
+	if capture.principal == nil {
+		t.Fatal("no principal in the request context")
+	}
+	// The principal must come from the user row, not from the claims.
+	if capture.principal.Email != "a@b.c" || capture.principal.UserId != "user-1" {
+		t.Errorf("unexpected principal: %+v", capture.principal)
+	}
+}
+
+func TestOAuthMiddlewareRejections(t *testing.T) {
+	repo := &fakeOAuthUserRepo{user: enabledUser()}
+	service, handler, _ := oauthTestSetup(t, repo)
+
+	dashboardToken, _ := crypto.GenerateJWTToken("test-secret", jwt.MapClaims{
+		"sub": "admin-dashboard", "type": "token", "userId": "user-1", "sv": 3,
+		"exp": time.Now().Add(time.Hour).Unix(),
+	})
+	expiredToken, _ := crypto.GenerateJWTToken("test-secret", jwt.MapClaims{
+		"sub": "mcp", "aud": "https://ota.example.com/mcp", "userId": "user-1", "sv": 3,
+		"exp": time.Now().Add(-time.Minute).Unix(),
+	})
+	wrongAudience, _ := crypto.GenerateJWTToken("test-secret", jwt.MapClaims{
+		"sub": "mcp", "aud": "https://other.example.com/mcp", "userId": "user-1", "sv": 3,
+		"exp": time.Now().Add(time.Hour).Unix(),
+	})
+	staleSessionVersion, err := service.IssueAccessToken(services.DashboardPrincipal{UserId: "user-1", SessionVersion: 2})
+	if err != nil {
+		t.Fatal(err)
+	}
+	unknownUser, err := service.IssueAccessToken(services.DashboardPrincipal{UserId: "user-2", SessionVersion: 3})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cases := map[string]string{
+		"dashboard token":       dashboardToken,
+		"expired token":         expiredToken,
+		"wrong audience":        wrongAudience,
+		"stale session version": staleSessionVersion,
+		"unknown user":          unknownUser,
+	}
+	for name, token := range cases {
+		t.Run(name, func(t *testing.T) {
+			res := doMCPRequest(handler, token)
+			if res.Code != http.StatusUnauthorized {
+				t.Fatalf("expected 401, got %d", res.Code)
+			}
+			if challenge := res.Header().Get("WWW-Authenticate"); !strings.Contains(challenge, `error="invalid_token"`) {
+				t.Errorf("expected error=\"invalid_token\" in WWW-Authenticate, got %q", challenge)
+			}
+		})
+	}
+}
+
+func TestOAuthMiddlewareDisabledUser(t *testing.T) {
+	user := enabledUser()
+	user.Enabled = false
+	repo := &fakeOAuthUserRepo{user: user}
+	service, handler, _ := oauthTestSetup(t, repo)
+	token, err := service.IssueAccessToken(services.DashboardPrincipal{UserId: "user-1", SessionVersion: 3})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if res := doMCPRequest(handler, token); res.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", res.Code)
+	}
+}
+
+func TestOAuthMiddlewareDatabaseOutage(t *testing.T) {
+	repo := &fakeOAuthUserRepo{err: errors.New("connection refused")}
+	service, handler, _ := oauthTestSetup(t, repo)
+	token, err := service.IssueAccessToken(services.DashboardPrincipal{UserId: "user-1", SessionVersion: 3})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	res := doMCPRequest(handler, token)
+	if res.Code != http.StatusInternalServerError {
+		t.Fatalf("an outage must be a 500, not a dead token: got %d", res.Code)
+	}
+	if res.Header().Get("WWW-Authenticate") != "" {
+		t.Error("a 500 must not carry WWW-Authenticate, the client would restart the flow")
+	}
+}

--- a/internal/oauth/authorize.go
+++ b/internal/oauth/authorize.go
@@ -71,6 +71,26 @@ func (s *OAuthService) ValidateAuthorizationRequest(ctx context.Context, req Aut
 	return client, nil
 }
 
+// DenyAuthorization answers a refused consent: no code, but the client waiting
+// on its redirect_uri still gets told, with the same validation as an
+// approval so a forged request cannot turn the denial into an open redirect.
+func (s *OAuthService) DenyAuthorization(ctx context.Context, req AuthorizationRequest) (string, error) {
+	if _, err := s.ValidateAuthorizationRequest(ctx, req); err != nil {
+		return "", err
+	}
+	redirect, err := url.Parse(req.RedirectURI)
+	if err != nil {
+		return "", err
+	}
+	query := redirect.Query()
+	query.Set("error", "access_denied")
+	if req.State != "" {
+		query.Set("state", req.State)
+	}
+	redirect.RawQuery = query.Encode()
+	return redirect.String(), nil
+}
+
 // CreateAuthorizationCode turns an approved consent into a single-use code and
 // returns the full redirect URL delivering it to the client.
 func (s *OAuthService) CreateAuthorizationCode(ctx context.Context, userId string, req AuthorizationRequest) (string, error) {

--- a/internal/oauth/authorize.go
+++ b/internal/oauth/authorize.go
@@ -1,0 +1,109 @@
+package oauth
+
+import (
+	"context"
+	"errors"
+	"expo-open-ota/internal/services"
+	"expo-open-ota/internal/store"
+	"fmt"
+	"net/url"
+	"slices"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// authorizationCodeTTL only covers the redirect from the consent click to the
+// token exchange; login happens before the code is minted.
+const authorizationCodeTTL = time.Minute
+
+// ErrInvalidAuthorizationRequest rejects an authorization request; its message
+// is safe to show to the user.
+var ErrInvalidAuthorizationRequest = errors.New("invalid authorization request")
+
+// AuthorizationRequest is the query an OAuth client sends to the authorize
+// endpoint, echoed through the consent screen and back.
+type AuthorizationRequest struct {
+	ClientID            string
+	RedirectURI         string
+	ResponseType        string
+	CodeChallenge       string
+	CodeChallengeMethod string
+	Scope               string
+	State               string
+	Resource            string
+}
+
+// ValidateAuthorizationRequest checks a request against the registered client
+// and this server's capabilities, and returns the client for display. Nothing
+// is ever redirected to a URI this validation has not approved.
+func (s *OAuthService) ValidateAuthorizationRequest(ctx context.Context, req AuthorizationRequest) (Client, error) {
+	if _, err := uuid.Parse(req.ClientID); err != nil {
+		return Client{}, fmt.Errorf("%w: unknown client_id", ErrInvalidAuthorizationRequest)
+	}
+	stored, err := s.clientRepo.GetOAuthClient(ctx, req.ClientID)
+	if err != nil {
+		if notFoundErr := (*store.ErrResourceNotFound)(nil); errors.As(err, &notFoundErr) {
+			return Client{}, fmt.Errorf("%w: unknown client_id", ErrInvalidAuthorizationRequest)
+		}
+		return Client{}, fmt.Errorf("%w: %v", services.ErrAuthUnavailable, err)
+	}
+	client := Client{ID: stored.Id, Name: stored.Name, RedirectURIs: stored.RedirectURIs}
+	if !slices.Contains(client.RedirectURIs, req.RedirectURI) {
+		return Client{}, fmt.Errorf("%w: redirect_uri is not registered for this client", ErrInvalidAuthorizationRequest)
+	}
+	if req.ResponseType != "code" {
+		return Client{}, fmt.Errorf("%w: only response_type \"code\" is supported", ErrInvalidAuthorizationRequest)
+	}
+	if req.CodeChallengeMethod != "S256" {
+		return Client{}, fmt.Errorf("%w: only code_challenge_method \"S256\" is supported (PKCE is required)", ErrInvalidAuthorizationRequest)
+	}
+	// 43-128 chars per RFC 7636; anything else is not a S256 challenge.
+	if length := len(req.CodeChallenge); length < 43 || length > 128 {
+		return Client{}, fmt.Errorf("%w: code_challenge is malformed", ErrInvalidAuthorizationRequest)
+	}
+	if req.Scope != "" && req.Scope != ScopeMCP {
+		return Client{}, fmt.Errorf("%w: unsupported scope %q", ErrInvalidAuthorizationRequest, req.Scope)
+	}
+	if req.Resource != "" && req.Resource != ResourceURL() {
+		return Client{}, fmt.Errorf("%w: unknown resource %q", ErrInvalidAuthorizationRequest, req.Resource)
+	}
+	return client, nil
+}
+
+// CreateAuthorizationCode turns an approved consent into a single-use code and
+// returns the full redirect URL delivering it to the client.
+func (s *OAuthService) CreateAuthorizationCode(ctx context.Context, userId string, req AuthorizationRequest) (string, error) {
+	if _, err := s.ValidateAuthorizationRequest(ctx, req); err != nil {
+		return "", err
+	}
+	code := uuid.New().String()
+	if err := s.codeRepo.DeleteExpiredOAuthAuthorizationCodes(ctx); err != nil {
+		return "", err
+	}
+	if err := s.codeRepo.InsertOAuthAuthorizationCode(ctx, store.InsertOAuthAuthorizationCodeParameters{
+		ID:            code,
+		ClientID:      req.ClientID,
+		UserID:        userId,
+		RedirectURI:   req.RedirectURI,
+		CodeChallenge: req.CodeChallenge,
+		Scope:         ScopeMCP,
+		ExpiresAt:     time.Now().Add(authorizationCodeTTL),
+	}); err != nil {
+		return "", err
+	}
+
+	// The URI parses: it survived registration validation and the exact-match
+	// check above.
+	redirect, err := url.Parse(req.RedirectURI)
+	if err != nil {
+		return "", err
+	}
+	query := redirect.Query()
+	query.Set("code", code)
+	if req.State != "" {
+		query.Set("state", req.State)
+	}
+	redirect.RawQuery = query.Encode()
+	return redirect.String(), nil
+}

--- a/internal/oauth/authorize.go
+++ b/internal/oauth/authorize.go
@@ -6,6 +6,7 @@ import (
 	"expo-open-ota/internal/services"
 	"expo-open-ota/internal/store"
 	"fmt"
+	"log"
 	"net/url"
 	"slices"
 	"time"
@@ -99,7 +100,9 @@ func (s *OAuthService) CreateAuthorizationCode(ctx context.Context, userId strin
 	}
 	code := uuid.New().String()
 	if err := s.codeRepo.DeleteExpiredOAuthAuthorizationCodes(ctx); err != nil {
-		return "", err
+		// Best-effort housekeeping: an unrelated sweep failure must not block
+		// this user's consent.
+		log.Printf("failed to sweep expired oauth authorization codes: %v", err)
 	}
 	if err := s.codeRepo.InsertOAuthAuthorizationCode(ctx, store.InsertOAuthAuthorizationCodeParameters{
 		ID:            code,

--- a/internal/oauth/authorize_test.go
+++ b/internal/oauth/authorize_test.go
@@ -1,0 +1,151 @@
+package oauth
+
+import (
+	"context"
+	"expo-open-ota/internal/services"
+	"expo-open-ota/internal/store"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// A well-formed S256 challenge is 43 chars of base64url.
+const testChallenge = "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"
+
+func seedClient(t *testing.T, repo *fakeClientRepo, redirectURIs ...string) string {
+	t.Helper()
+	id := uuid.New().String()
+	repo.inserted = append(repo.inserted, store.InsertOAuthClientParameters{
+		ID:           id,
+		Name:         "Claude Code",
+		RedirectURIs: redirectURIs,
+	})
+	return id
+}
+
+func validAuthorizeQuery(clientID string) url.Values {
+	q := url.Values{}
+	q.Set("client_id", clientID)
+	q.Set("redirect_uri", "http://127.0.0.1:53422/callback")
+	q.Set("response_type", "code")
+	q.Set("code_challenge", testChallenge)
+	q.Set("code_challenge_method", "S256")
+	q.Set("state", "xyz")
+	q.Set("resource", "https://ota.example.com/mcp")
+	return q
+}
+
+func TestAuthorizeRedirectsToConsent(t *testing.T) {
+	handler, clientRepo, _ := newTestHandlerWithCodes(t)
+	clientID := seedClient(t, clientRepo, "http://127.0.0.1:53422/callback")
+
+	res := httptest.NewRecorder()
+	handler.AuthorizeHandler(res, httptest.NewRequest(http.MethodGet, "/oauth/authorize?"+validAuthorizeQuery(clientID).Encode(), nil))
+
+	if res.Code != http.StatusFound {
+		t.Fatalf("expected 302, got %d: %s", res.Code, res.Body.String())
+	}
+	location, err := url.Parse(res.Header().Get("Location"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(location.String(), "https://ota.example.com/dashboard/oauth/consent?") {
+		t.Fatalf("expected a consent bounce, got %s", location)
+	}
+	forwarded := location.Query()
+	if forwarded.Get("client_name") != "Claude Code" {
+		t.Error("the consent screen needs the server-resolved client_name")
+	}
+	if forwarded.Get("state") != "xyz" || forwarded.Get("code_challenge") != testChallenge {
+		t.Error("state and code_challenge must survive the bounce")
+	}
+}
+
+func TestAuthorizeRejections(t *testing.T) {
+	handler, clientRepo, _ := newTestHandlerWithCodes(t)
+	clientID := seedClient(t, clientRepo, "http://127.0.0.1:53422/callback")
+
+	mutations := map[string]func(url.Values){
+		"unknown client":         func(q url.Values) { q.Set("client_id", uuid.New().String()) },
+		"malformed client id":    func(q url.Values) { q.Set("client_id", "not-a-uuid") },
+		"unregistered redirect":  func(q url.Values) { q.Set("redirect_uri", "https://evil.example.com/cb") },
+		"wrong response_type":    func(q url.Values) { q.Set("response_type", "token") },
+		"missing code_challenge": func(q url.Values) { q.Del("code_challenge") },
+		"plain challenge method": func(q url.Values) { q.Set("code_challenge_method", "plain") },
+		"unsupported scope":      func(q url.Values) { q.Set("scope", "admin") },
+		"foreign resource":       func(q url.Values) { q.Set("resource", "https://other.example.com/mcp") },
+	}
+	for name, mutate := range mutations {
+		t.Run(name, func(t *testing.T) {
+			q := validAuthorizeQuery(clientID)
+			mutate(q)
+			res := httptest.NewRecorder()
+			handler.AuthorizeHandler(res, httptest.NewRequest(http.MethodGet, "/oauth/authorize?"+q.Encode(), nil))
+
+			if res.Code != http.StatusBadRequest {
+				t.Fatalf("expected 400, got %d", res.Code)
+			}
+			if location := res.Header().Get("Location"); location != "" {
+				t.Fatalf("an invalid request must never redirect, got Location %q", location)
+			}
+		})
+	}
+}
+
+func TestConsentMintsCode(t *testing.T) {
+	handler, clientRepo, codeRepo := newTestHandlerWithCodes(t)
+	clientID := seedClient(t, clientRepo, "http://127.0.0.1:53422/callback")
+
+	form := validAuthorizeQuery(clientID)
+	req := httptest.NewRequest(http.MethodPost, "/api/oauth/consent", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req = req.WithContext(services.WithPrincipal(context.Background(), &services.DashboardPrincipal{UserId: "user-1"}))
+	res := httptest.NewRecorder()
+	handler.ConsentHandler(res, req)
+
+	if res.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", res.Code, res.Body.String())
+	}
+	body := decodeJSON(t, res)
+	redirectURL, err := url.Parse(body["redirectUrl"].(string))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if redirectURL.Host != "127.0.0.1:53422" || redirectURL.Path != "/callback" {
+		t.Fatalf("the code must be delivered to the registered redirect_uri, got %s", redirectURL)
+	}
+	code := redirectURL.Query().Get("code")
+	if code == "" || redirectURL.Query().Get("state") != "xyz" {
+		t.Fatalf("expected code and state in the redirect, got %s", redirectURL)
+	}
+	if len(codeRepo.inserted) != 1 {
+		t.Fatalf("expected 1 stored code, got %d", len(codeRepo.inserted))
+	}
+	stored := codeRepo.inserted[0]
+	if stored.ID != code || stored.UserID != "user-1" || stored.ClientID != clientID || stored.CodeChallenge != testChallenge {
+		t.Errorf("stored code does not freeze the consent context: %+v", stored)
+	}
+	if remaining := time.Until(stored.ExpiresAt); remaining <= 0 || remaining > 2*time.Minute {
+		t.Errorf("unexpected code TTL: %v", remaining)
+	}
+}
+
+func TestConsentWithoutPrincipal(t *testing.T) {
+	handler, clientRepo, _ := newTestHandlerWithCodes(t)
+	clientID := seedClient(t, clientRepo, "http://127.0.0.1:53422/callback")
+
+	form := validAuthorizeQuery(clientID)
+	req := httptest.NewRequest(http.MethodPost, "/api/oauth/consent", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	res := httptest.NewRecorder()
+	handler.ConsentHandler(res, req)
+
+	if res.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", res.Code)
+	}
+}

--- a/internal/oauth/authorize_test.go
+++ b/internal/oauth/authorize_test.go
@@ -102,6 +102,7 @@ func TestConsentMintsCode(t *testing.T) {
 	clientID := seedClient(t, clientRepo, "http://127.0.0.1:53422/callback")
 
 	form := validAuthorizeQuery(clientID)
+	form.Set("decision", "approve")
 	req := httptest.NewRequest(http.MethodPost, "/api/oauth/consent", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req = req.WithContext(services.WithPrincipal(context.Background(), &services.DashboardPrincipal{UserId: "user-1"}))
@@ -135,11 +136,41 @@ func TestConsentMintsCode(t *testing.T) {
 	}
 }
 
+func TestConsentDeny(t *testing.T) {
+	handler, clientRepo, codeRepo := newTestHandlerWithCodes(t)
+	clientID := seedClient(t, clientRepo, "http://127.0.0.1:53422/callback")
+
+	form := validAuthorizeQuery(clientID)
+	form.Set("decision", "deny")
+	req := httptest.NewRequest(http.MethodPost, "/api/oauth/consent", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req = req.WithContext(services.WithPrincipal(context.Background(), &services.DashboardPrincipal{UserId: "user-1"}))
+	res := httptest.NewRecorder()
+	handler.ConsentHandler(res, req)
+
+	if res.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", res.Code, res.Body.String())
+	}
+	body := decodeJSON(t, res)
+	redirectURL, err := url.Parse(body["redirectUrl"].(string))
+	if err != nil {
+		t.Fatal(err)
+	}
+	query := redirectURL.Query()
+	if query.Get("error") != "access_denied" || query.Get("state") != "xyz" || query.Get("code") != "" {
+		t.Fatalf("a denial must deliver error=access_denied and no code, got %s", redirectURL)
+	}
+	if len(codeRepo.inserted) != 0 {
+		t.Error("a denial must not mint a code")
+	}
+}
+
 func TestConsentWithoutPrincipal(t *testing.T) {
 	handler, clientRepo, _ := newTestHandlerWithCodes(t)
 	clientID := seedClient(t, clientRepo, "http://127.0.0.1:53422/callback")
 
 	form := validAuthorizeQuery(clientID)
+	form.Set("decision", "approve")
 	req := httptest.NewRequest(http.MethodPost, "/api/oauth/consent", strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	res := httptest.NewRecorder()

--- a/internal/oauth/handler.go
+++ b/internal/oauth/handler.go
@@ -222,7 +222,7 @@ func (h *OAuthHandler) TokenHandler(w http.ResponseWriter, r *http.Request) {
 	// Tokens in the body: no cache anywhere.
 	w.Header().Set("Cache-Control", "no-store")
 	clientIP := helpers.ClientIP(r)
-	if decision := h.limiter.CheckRefresh(clientIP); !decision.Allowed {
+	if decision := h.limiter.CheckOAuthToken(clientIP); !decision.Allowed {
 		handlers.RenderThrottled(w, decision.RetryAfter)
 		return
 	}
@@ -250,7 +250,7 @@ func (h *OAuthHandler) TokenHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	if err != nil {
 		if errors.Is(err, ErrInvalidGrant) {
-			h.limiter.RecordRefreshFailure(clientIP)
+			h.limiter.RecordOAuthTokenFailure(clientIP)
 			renderTokenError(w, "invalid_grant", "the grant is invalid, expired, or was already used")
 			return
 		}

--- a/internal/oauth/handler.go
+++ b/internal/oauth/handler.go
@@ -50,10 +50,9 @@ func WithCORS(next http.HandlerFunc) http.HandlerFunc {
 // resource. Registered both path-inserted (/.well-known/...(/mcp) and at the
 // root, because non-conforming clients probe either.
 func (h *OAuthHandler) ProtectedResourceMetadataHandler(w http.ResponseWriter, r *http.Request) {
-	base := baseURL()
 	handlers.RenderJSON(w, http.StatusOK, map[string]interface{}{
-		"resource":                 base + "/mcp",
-		"authorization_servers":    []string{base},
+		"resource":                 ResourceURL(),
+		"authorization_servers":    []string{baseURL()},
 		"scopes_supported":         []string{ScopeMCP},
 		"bearer_methods_supported": []string{"header"},
 	})

--- a/internal/oauth/handler.go
+++ b/internal/oauth/handler.go
@@ -206,6 +206,64 @@ func (h *OAuthHandler) ConsentHandler(w http.ResponseWriter, r *http.Request) {
 	handlers.RenderJSON(w, http.StatusOK, map[string]string{"redirectUrl": redirectURL})
 }
 
+// TokenHandler implements the token endpoint for the authorization_code and
+// refresh_token grants (RFC 6749 request and error shapes).
+func (h *OAuthHandler) TokenHandler(w http.ResponseWriter, r *http.Request) {
+	// Tokens in the body: no cache anywhere.
+	w.Header().Set("Cache-Control", "no-store")
+	clientIP := helpers.ClientIP(r)
+	if decision := h.limiter.CheckRefresh(clientIP); !decision.Allowed {
+		handlers.RenderThrottled(w, decision.RetryAfter)
+		return
+	}
+	if err := r.ParseForm(); err != nil {
+		renderTokenError(w, "invalid_request", "request body is not a valid form")
+		return
+	}
+
+	var response *TokenResponse
+	var err error
+	switch r.PostForm.Get("grant_type") {
+	case "authorization_code":
+		response, err = h.service.ExchangeAuthorizationCode(r.Context(), ExchangeAuthorizationCodeRequest{
+			Code:         r.PostForm.Get("code"),
+			ClientID:     r.PostForm.Get("client_id"),
+			RedirectURI:  r.PostForm.Get("redirect_uri"),
+			CodeVerifier: r.PostForm.Get("code_verifier"),
+			Resource:     r.PostForm.Get("resource"),
+		})
+	case "refresh_token":
+		response, err = h.service.RefreshAccessToken(r.Context(), r.PostForm.Get("refresh_token"))
+	default:
+		renderTokenError(w, "unsupported_grant_type", "supported grant types are authorization_code and refresh_token")
+		return
+	}
+	if err != nil {
+		if errors.Is(err, ErrInvalidGrant) {
+			h.limiter.RecordRefreshFailure(clientIP)
+			renderTokenError(w, "invalid_grant", "the grant is invalid, expired, or was already used")
+			return
+		}
+		handlers.RenderError(w, http.StatusInternalServerError, "Could not process the token request, try again later")
+		return
+	}
+	handlers.RenderJSON(w, http.StatusOK, map[string]interface{}{
+		"access_token":  response.AccessToken,
+		"token_type":    "Bearer",
+		"expires_in":    response.ExpiresIn,
+		"refresh_token": response.RefreshToken,
+		"scope":         response.Scope,
+	})
+}
+
+// renderTokenError uses the RFC 6749 error shape, which token clients parse.
+func renderTokenError(w http.ResponseWriter, code string, description string) {
+	handlers.RenderJSON(w, http.StatusBadRequest, map[string]string{
+		"error":             code,
+		"error_description": description,
+	})
+}
+
 // renderRegistrationError uses the RFC 7591 error shape, which registering
 // clients parse, instead of this server's own error envelope.
 func renderRegistrationError(w http.ResponseWriter, description string) {

--- a/internal/oauth/handler.go
+++ b/internal/oauth/handler.go
@@ -194,7 +194,17 @@ func (h *OAuthHandler) ConsentHandler(w http.ResponseWriter, r *http.Request) {
 		handlers.RenderError(w, http.StatusBadRequest, "invalid form body")
 		return
 	}
-	redirectURL, err := h.service.CreateAuthorizationCode(r.Context(), principal.UserId, authorizationRequestFromValues(r.PostForm))
+	var redirectURL string
+	var err error
+	switch r.PostForm.Get("decision") {
+	case "approve":
+		redirectURL, err = h.service.CreateAuthorizationCode(r.Context(), principal.UserId, authorizationRequestFromValues(r.PostForm))
+	case "deny":
+		redirectURL, err = h.service.DenyAuthorization(r.Context(), authorizationRequestFromValues(r.PostForm))
+	default:
+		handlers.RenderError(w, http.StatusBadRequest, "decision must be approve or deny")
+		return
+	}
 	if err != nil {
 		if errors.Is(err, ErrInvalidAuthorizationRequest) {
 			handlers.RenderError(w, http.StatusBadRequest, err.Error())

--- a/internal/oauth/handler.go
+++ b/internal/oauth/handler.go
@@ -7,10 +7,16 @@ import (
 	"expo-open-ota/internal/handlers"
 	"expo-open-ota/internal/helpers"
 	"expo-open-ota/internal/ratelimit"
+	"expo-open-ota/internal/services"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 )
+
+// consentPath is the dashboard route the authorize endpoint bounces to; the
+// SPA holds the session (localStorage), so only it can ask who is consenting.
+const consentPath = "/dashboard/oauth/consent"
 
 // The single coarse scope this server issues; finer scopes wait until the MCP
 // server exposes tools worth splitting over.
@@ -124,6 +130,80 @@ func (h *OAuthHandler) RegisterHandler(w http.ResponseWriter, r *http.Request) {
 		"response_types":             []string{"code"},
 		"client_id_issued_at":        time.Now().Unix(),
 	})
+}
+
+func authorizationRequestFromValues(values url.Values) AuthorizationRequest {
+	return AuthorizationRequest{
+		ClientID:            values.Get("client_id"),
+		RedirectURI:         values.Get("redirect_uri"),
+		ResponseType:        values.Get("response_type"),
+		CodeChallenge:       values.Get("code_challenge"),
+		CodeChallengeMethod: values.Get("code_challenge_method"),
+		Scope:               values.Get("scope"),
+		State:               values.Get("state"),
+		Resource:            values.Get("resource"),
+	}
+}
+
+// AuthorizeHandler validates an authorization request and bounces it to the
+// consent screen. Invalid requests are answered in place, never redirected:
+// the redirect_uri cannot be trusted before it is validated.
+func (h *OAuthHandler) AuthorizeHandler(w http.ResponseWriter, r *http.Request) {
+	req := authorizationRequestFromValues(r.URL.Query())
+	client, err := h.service.ValidateAuthorizationRequest(r.Context(), req)
+	if err != nil {
+		if errors.Is(err, ErrInvalidAuthorizationRequest) {
+			handlers.RenderError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		handlers.RenderError(w, http.StatusInternalServerError, "Could not validate the authorization request, try again later")
+		return
+	}
+
+	consent := url.Values{}
+	consent.Set("client_id", req.ClientID)
+	// The registered name, resolved server-side for the consent screen; a
+	// name in the query could be forged.
+	consent.Set("client_name", client.Name)
+	consent.Set("redirect_uri", req.RedirectURI)
+	consent.Set("response_type", req.ResponseType)
+	consent.Set("code_challenge", req.CodeChallenge)
+	consent.Set("code_challenge_method", req.CodeChallengeMethod)
+	if req.Scope != "" {
+		consent.Set("scope", req.Scope)
+	}
+	if req.State != "" {
+		consent.Set("state", req.State)
+	}
+	if req.Resource != "" {
+		consent.Set("resource", req.Resource)
+	}
+	http.Redirect(w, r, baseURL()+consentPath+"?"+consent.Encode(), http.StatusFound)
+}
+
+// ConsentHandler turns an approved consent into an authorization code. It sits
+// behind the dashboard auth middleware; the caller is the consent screen
+// acting with the user's own session.
+func (h *OAuthHandler) ConsentHandler(w http.ResponseWriter, r *http.Request) {
+	principal := services.PrincipalFromContext(r.Context())
+	if principal == nil {
+		handlers.RenderError(w, http.StatusUnauthorized, "This action requires a dashboard session")
+		return
+	}
+	if err := r.ParseForm(); err != nil {
+		handlers.RenderError(w, http.StatusBadRequest, "invalid form body")
+		return
+	}
+	redirectURL, err := h.service.CreateAuthorizationCode(r.Context(), principal.UserId, authorizationRequestFromValues(r.PostForm))
+	if err != nil {
+		if errors.Is(err, ErrInvalidAuthorizationRequest) {
+			handlers.RenderError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		handlers.RenderError(w, http.StatusInternalServerError, "Could not record the consent, try again later")
+		return
+	}
+	handlers.RenderJSON(w, http.StatusOK, map[string]string{"redirectUrl": redirectURL})
 }
 
 // renderRegistrationError uses the RFC 7591 error shape, which registering

--- a/internal/oauth/handler.go
+++ b/internal/oauth/handler.go
@@ -1,0 +1,137 @@
+package oauth
+
+import (
+	"encoding/json"
+	"errors"
+	"expo-open-ota/config"
+	"expo-open-ota/internal/handlers"
+	"expo-open-ota/internal/helpers"
+	"expo-open-ota/internal/ratelimit"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// The single coarse scope this server issues; finer scopes wait until the MCP
+// server exposes tools worth splitting over.
+const ScopeMCP = "mcp"
+
+type OAuthHandler struct {
+	service *OAuthService
+	limiter *ratelimit.Limiter
+}
+
+func NewOAuthHandler(service *OAuthService, limiter *ratelimit.Limiter) *OAuthHandler {
+	return &OAuthHandler{service: service, limiter: limiter}
+}
+
+func baseURL() string {
+	return strings.TrimRight(config.GetEnv("BASE_URL"), "/")
+}
+
+// WithCORS opens an endpoint to cross-origin callers. The OAuth surface is
+// meant to be reached from other origins (claude.ai and its kind fetch the
+// metadata and token endpoints from their own pages), and nothing on it relies
+// on cookies, so a wildcard grants nothing a curl could not already do.
+func WithCORS(next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization, mcp-protocol-version")
+		if r.Method == http.MethodOptions {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		next(w, r)
+	}
+}
+
+// ProtectedResourceMetadataHandler serves RFC 9728 metadata for the MCP
+// resource. Registered both path-inserted (/.well-known/...(/mcp) and at the
+// root, because non-conforming clients probe either.
+func (h *OAuthHandler) ProtectedResourceMetadataHandler(w http.ResponseWriter, r *http.Request) {
+	base := baseURL()
+	handlers.RenderJSON(w, http.StatusOK, map[string]interface{}{
+		"resource":                 base + "/mcp",
+		"authorization_servers":    []string{base},
+		"scopes_supported":         []string{ScopeMCP},
+		"bearer_methods_supported": []string{"header"},
+	})
+}
+
+// AuthorizationServerMetadataHandler serves RFC 8414 metadata. The issuer is
+// the bare BASE_URL, deliberately without a path: path-bearing issuers trigger
+// the well-known path-insertion rules clients disagree on.
+func (h *OAuthHandler) AuthorizationServerMetadataHandler(w http.ResponseWriter, r *http.Request) {
+	base := baseURL()
+	handlers.RenderJSON(w, http.StatusOK, map[string]interface{}{
+		"issuer":                                base,
+		"authorization_endpoint":                base + "/oauth/authorize",
+		"token_endpoint":                        base + "/oauth/token",
+		"registration_endpoint":                 base + "/oauth/register",
+		"response_types_supported":              []string{"code"},
+		"grant_types_supported":                 []string{"authorization_code", "refresh_token"},
+		"code_challenge_methods_supported":      []string{"S256"},
+		"token_endpoint_auth_methods_supported": []string{"none"},
+		"scopes_supported":                      []string{ScopeMCP},
+	})
+}
+
+// registerRequest is the RFC 7591 metadata this server acts on; other fields
+// are accepted and ignored.
+type registerRequest struct {
+	ClientName              string   `json:"client_name"`
+	RedirectURIs            []string `json:"redirect_uris"`
+	TokenEndpointAuthMethod string   `json:"token_endpoint_auth_method"`
+}
+
+// RegisterHandler implements dynamic client registration (RFC 7591).
+func (h *OAuthHandler) RegisterHandler(w http.ResponseWriter, r *http.Request) {
+	clientIP := helpers.ClientIP(r)
+	if decision := h.limiter.CheckOAuthRegister(clientIP); !decision.Allowed {
+		handlers.RenderThrottled(w, decision.RetryAfter)
+		return
+	}
+
+	var req registerRequest
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 16*1024)).Decode(&req); err != nil {
+		renderRegistrationError(w, "request body is not valid JSON")
+		return
+	}
+	// Public clients only: there is no secret to hand out, so a client asking
+	// to authenticate with one registered something this server cannot honor.
+	if req.TokenEndpointAuthMethod != "" && req.TokenEndpointAuthMethod != "none" {
+		renderRegistrationError(w, "only token_endpoint_auth_method \"none\" is supported")
+		return
+	}
+
+	client, err := h.service.RegisterClient(r.Context(), req.ClientName, req.RedirectURIs)
+	if err != nil {
+		if errors.Is(err, ErrInvalidClientMetadata) {
+			renderRegistrationError(w, err.Error())
+			return
+		}
+		handlers.RenderError(w, http.StatusInternalServerError, "Could not register the client, try again later")
+		return
+	}
+	h.limiter.RecordOAuthRegister(clientIP)
+
+	handlers.RenderJSON(w, http.StatusCreated, map[string]interface{}{
+		"client_id":                  client.ID,
+		"client_name":                client.Name,
+		"redirect_uris":              client.RedirectURIs,
+		"token_endpoint_auth_method": "none",
+		"grant_types":                []string{"authorization_code", "refresh_token"},
+		"response_types":             []string{"code"},
+		"client_id_issued_at":        time.Now().Unix(),
+	})
+}
+
+// renderRegistrationError uses the RFC 7591 error shape, which registering
+// clients parse, instead of this server's own error envelope.
+func renderRegistrationError(w http.ResponseWriter, description string) {
+	handlers.RenderJSON(w, http.StatusBadRequest, map[string]string{
+		"error":             "invalid_client_metadata",
+		"error_description": description,
+	})
+}

--- a/internal/oauth/handler_test.go
+++ b/internal/oauth/handler_test.go
@@ -19,13 +19,42 @@ func (f *fakeClientRepo) InsertOAuthClient(_ context.Context, params store.Inser
 	return nil
 }
 
+func (f *fakeClientRepo) GetOAuthClient(_ context.Context, id string) (store.OAuthClient, error) {
+	for _, params := range f.inserted {
+		if params.ID == id {
+			return store.OAuthClient{Id: params.ID, Name: params.Name, RedirectURIs: params.RedirectURIs}, nil
+		}
+	}
+	return store.OAuthClient{}, &store.ErrResourceNotFound{Resource: "oauth client", Identifier: id}
+}
+
+type fakeCodeRepo struct {
+	inserted []store.InsertOAuthAuthorizationCodeParameters
+}
+
+func (f *fakeCodeRepo) InsertOAuthAuthorizationCode(_ context.Context, params store.InsertOAuthAuthorizationCodeParameters) error {
+	f.inserted = append(f.inserted, params)
+	return nil
+}
+
+func (f *fakeCodeRepo) DeleteExpiredOAuthAuthorizationCodes(_ context.Context) error {
+	return nil
+}
+
 func newTestHandler(t *testing.T) (*OAuthHandler, *fakeClientRepo) {
 	t.Helper()
+	handler, clientRepo, _ := newTestHandlerWithCodes(t)
+	return handler, clientRepo
+}
+
+func newTestHandlerWithCodes(t *testing.T) (*OAuthHandler, *fakeClientRepo, *fakeCodeRepo) {
+	t.Helper()
 	t.Setenv("BASE_URL", "https://ota.example.com")
-	repo := &fakeClientRepo{}
+	clientRepo := &fakeClientRepo{}
+	codeRepo := &fakeCodeRepo{}
 	// A nil limiter allows everything; rate limiting has its own tests, and
 	// token verification (the userRepo) has its own in internal/middleware.
-	return NewOAuthHandler(NewOAuthService(repo, nil), nil), repo
+	return NewOAuthHandler(NewOAuthService(clientRepo, codeRepo, nil), nil), clientRepo, codeRepo
 }
 
 func decodeJSON(t *testing.T, res *httptest.ResponseRecorder) map[string]interface{} {

--- a/internal/oauth/handler_test.go
+++ b/internal/oauth/handler_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 )
 
 type fakeClientRepo struct {
@@ -30,11 +31,37 @@ func (f *fakeClientRepo) GetOAuthClient(_ context.Context, id string) (store.OAu
 
 type fakeCodeRepo struct {
 	inserted []store.InsertOAuthAuthorizationCodeParameters
+	consumed map[string]bool
 }
 
 func (f *fakeCodeRepo) InsertOAuthAuthorizationCode(_ context.Context, params store.InsertOAuthAuthorizationCodeParameters) error {
 	f.inserted = append(f.inserted, params)
 	return nil
+}
+
+func (f *fakeCodeRepo) ConsumeOAuthAuthorizationCode(_ context.Context, id string) (store.OAuthAuthorizationCode, error) {
+	for i, params := range f.inserted {
+		if params.ID != id {
+			continue
+		}
+		if f.consumed[id] || time.Now().After(params.ExpiresAt) {
+			break
+		}
+		if f.consumed == nil {
+			f.consumed = map[string]bool{}
+		}
+		f.consumed[id] = true
+		return store.OAuthAuthorizationCode{
+			ID:            params.ID,
+			ClientID:      params.ClientID,
+			UserID:        params.UserID,
+			RedirectURI:   params.RedirectURI,
+			CodeChallenge: params.CodeChallenge,
+			Scope:         params.Scope,
+			ExpiresAt:     f.inserted[i].ExpiresAt,
+		}, nil
+	}
+	return store.OAuthAuthorizationCode{}, &store.ErrResourceNotFound{Resource: "oauth authorization code", Identifier: id}
 }
 
 func (f *fakeCodeRepo) DeleteExpiredOAuthAuthorizationCodes(_ context.Context) error {
@@ -54,7 +81,7 @@ func newTestHandlerWithCodes(t *testing.T) (*OAuthHandler, *fakeClientRepo, *fak
 	codeRepo := &fakeCodeRepo{}
 	// A nil limiter allows everything; rate limiting has its own tests, and
 	// token verification (the userRepo) has its own in internal/middleware.
-	return NewOAuthHandler(NewOAuthService(clientRepo, codeRepo, nil), nil), clientRepo, codeRepo
+	return NewOAuthHandler(NewOAuthService(clientRepo, codeRepo, nil, nil), nil), clientRepo, codeRepo
 }
 
 func decodeJSON(t *testing.T, res *httptest.ResponseRecorder) map[string]interface{} {

--- a/internal/oauth/handler_test.go
+++ b/internal/oauth/handler_test.go
@@ -23,8 +23,9 @@ func newTestHandler(t *testing.T) (*OAuthHandler, *fakeClientRepo) {
 	t.Helper()
 	t.Setenv("BASE_URL", "https://ota.example.com")
 	repo := &fakeClientRepo{}
-	// A nil limiter allows everything; rate limiting has its own tests.
-	return NewOAuthHandler(NewOAuthService(repo), nil), repo
+	// A nil limiter allows everything; rate limiting has its own tests, and
+	// token verification (the userRepo) has its own in internal/middleware.
+	return NewOAuthHandler(NewOAuthService(repo, nil), nil), repo
 }
 
 func decodeJSON(t *testing.T, res *httptest.ResponseRecorder) map[string]interface{} {

--- a/internal/oauth/handler_test.go
+++ b/internal/oauth/handler_test.go
@@ -1,0 +1,179 @@
+package oauth
+
+import (
+	"context"
+	"encoding/json"
+	"expo-open-ota/internal/store"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+type fakeClientRepo struct {
+	inserted []store.InsertOAuthClientParameters
+}
+
+func (f *fakeClientRepo) InsertOAuthClient(_ context.Context, params store.InsertOAuthClientParameters) error {
+	f.inserted = append(f.inserted, params)
+	return nil
+}
+
+func newTestHandler(t *testing.T) (*OAuthHandler, *fakeClientRepo) {
+	t.Helper()
+	t.Setenv("BASE_URL", "https://ota.example.com")
+	repo := &fakeClientRepo{}
+	// A nil limiter allows everything; rate limiting has its own tests.
+	return NewOAuthHandler(NewOAuthService(repo), nil), repo
+}
+
+func decodeJSON(t *testing.T, res *httptest.ResponseRecorder) map[string]interface{} {
+	t.Helper()
+	var body map[string]interface{}
+	if err := json.Unmarshal(res.Body.Bytes(), &body); err != nil {
+		t.Fatalf("response is not JSON: %v", err)
+	}
+	return body
+}
+
+func TestProtectedResourceMetadata(t *testing.T) {
+	handler, _ := newTestHandler(t)
+	res := httptest.NewRecorder()
+	handler.ProtectedResourceMetadataHandler(res, httptest.NewRequest(http.MethodGet, "/.well-known/oauth-protected-resource/mcp", nil))
+
+	if res.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", res.Code)
+	}
+	body := decodeJSON(t, res)
+	if body["resource"] != "https://ota.example.com/mcp" {
+		t.Errorf("wrong resource: %v", body["resource"])
+	}
+	servers, _ := body["authorization_servers"].([]interface{})
+	if len(servers) != 1 || servers[0] != "https://ota.example.com" {
+		t.Errorf("wrong authorization_servers: %v", body["authorization_servers"])
+	}
+}
+
+func TestAuthorizationServerMetadata(t *testing.T) {
+	handler, _ := newTestHandler(t)
+	res := httptest.NewRecorder()
+	handler.AuthorizationServerMetadataHandler(res, httptest.NewRequest(http.MethodGet, "/.well-known/oauth-authorization-server", nil))
+
+	if res.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", res.Code)
+	}
+	body := decodeJSON(t, res)
+	expectations := map[string]string{
+		"issuer":                 "https://ota.example.com",
+		"authorization_endpoint": "https://ota.example.com/oauth/authorize",
+		"token_endpoint":         "https://ota.example.com/oauth/token",
+		"registration_endpoint":  "https://ota.example.com/oauth/register",
+	}
+	for field, expected := range expectations {
+		if body[field] != expected {
+			t.Errorf("%s: expected %q, got %v", field, expected, body[field])
+		}
+	}
+	methods, _ := body["code_challenge_methods_supported"].([]interface{})
+	if len(methods) != 1 || methods[0] != "S256" {
+		t.Errorf("wrong code_challenge_methods_supported: %v", body["code_challenge_methods_supported"])
+	}
+}
+
+func TestWithCORSPreflight(t *testing.T) {
+	called := false
+	wrapped := WithCORS(func(w http.ResponseWriter, r *http.Request) { called = true })
+
+	res := httptest.NewRecorder()
+	wrapped(res, httptest.NewRequest(http.MethodOptions, "/oauth/register", nil))
+	if called {
+		t.Error("preflight must not reach the handler")
+	}
+	if res.Code != http.StatusNoContent {
+		t.Errorf("expected 204 on preflight, got %d", res.Code)
+	}
+	if res.Header().Get("Access-Control-Allow-Origin") != "*" {
+		t.Error("missing Access-Control-Allow-Origin")
+	}
+}
+
+func registerBody(t *testing.T, payload map[string]interface{}) *strings.Reader {
+	t.Helper()
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return strings.NewReader(string(raw))
+}
+
+func TestRegisterClient(t *testing.T) {
+	handler, repo := newTestHandler(t)
+	res := httptest.NewRecorder()
+	handler.RegisterHandler(res, httptest.NewRequest(http.MethodPost, "/oauth/register", registerBody(t, map[string]interface{}{
+		"client_name":   "Claude Code",
+		"redirect_uris": []string{"http://127.0.0.1:53422/callback", "https://claude.ai/api/callback"},
+	})))
+
+	if res.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", res.Code, res.Body.String())
+	}
+	body := decodeJSON(t, res)
+	if body["client_id"] == "" || body["client_id"] == nil {
+		t.Error("missing client_id")
+	}
+	if body["token_endpoint_auth_method"] != "none" {
+		t.Errorf("wrong token_endpoint_auth_method: %v", body["token_endpoint_auth_method"])
+	}
+	if len(repo.inserted) != 1 {
+		t.Fatalf("expected 1 stored client, got %d", len(repo.inserted))
+	}
+	if repo.inserted[0].ID != body["client_id"] {
+		t.Error("stored client id differs from the returned client_id")
+	}
+}
+
+func TestRegisterClientRejections(t *testing.T) {
+	cases := []struct {
+		name    string
+		payload map[string]interface{}
+	}{
+		{"no redirect_uris", map[string]interface{}{"client_name": "x"}},
+		{"http on a public host", map[string]interface{}{"redirect_uris": []string{"http://evil.example.com/callback"}}},
+		{"relative uri", map[string]interface{}{"redirect_uris": []string{"/callback"}}},
+		{"fragment in uri", map[string]interface{}{"redirect_uris": []string{"https://a.example.com/cb#frag"}}},
+		{"confidential auth method", map[string]interface{}{
+			"redirect_uris":              []string{"https://a.example.com/cb"},
+			"token_endpoint_auth_method": "client_secret_basic",
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			handler, repo := newTestHandler(t)
+			res := httptest.NewRecorder()
+			handler.RegisterHandler(res, httptest.NewRequest(http.MethodPost, "/oauth/register", registerBody(t, tc.payload)))
+
+			if res.Code != http.StatusBadRequest {
+				t.Fatalf("expected 400, got %d: %s", res.Code, res.Body.String())
+			}
+			if body := decodeJSON(t, res); body["error"] != "invalid_client_metadata" {
+				t.Errorf("expected RFC 7591 error shape, got: %s", res.Body.String())
+			}
+			if len(repo.inserted) != 0 {
+				t.Error("a rejected registration must not store a client")
+			}
+		})
+	}
+}
+
+func TestRegisterClientLoopbackHTTPAllowed(t *testing.T) {
+	handler, _ := newTestHandler(t)
+	for _, uri := range []string{"http://localhost:8080/cb", "http://127.0.0.1:1234/cb", "http://[::1]:9/cb"} {
+		res := httptest.NewRecorder()
+		handler.RegisterHandler(res, httptest.NewRequest(http.MethodPost, "/oauth/register", registerBody(t, map[string]interface{}{
+			"redirect_uris": []string{uri},
+		})))
+		if res.Code != http.StatusCreated {
+			t.Errorf("%s: expected 201, got %d: %s", uri, res.Code, res.Body.String())
+		}
+	}
+}

--- a/internal/oauth/service.go
+++ b/internal/oauth/service.go
@@ -1,0 +1,104 @@
+package oauth
+
+import (
+	"context"
+	"errors"
+	"expo-open-ota/internal/store"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/google/uuid"
+)
+
+const (
+	maxRedirectURIs    = 10
+	maxRedirectURILen  = 512
+	maxClientNameLen   = 256
+	fallbackClientName = "MCP client"
+)
+
+// ErrInvalidClientMetadata rejects a registration; its message is safe to
+// return to the client as the RFC 7591 error_description.
+var ErrInvalidClientMetadata = errors.New("invalid client metadata")
+
+type ClientRepository interface {
+	InsertOAuthClient(ctx context.Context, params store.InsertOAuthClientParameters) error
+}
+
+// Client is a registered OAuth client: a public client (no secret) pinned to
+// the redirect URIs it declared at registration.
+type Client struct {
+	ID           string
+	Name         string
+	RedirectURIs []string
+}
+
+type OAuthService struct {
+	clientRepo ClientRepository
+}
+
+func NewOAuthService(clientRepo ClientRepository) *OAuthService {
+	return &OAuthService{clientRepo: clientRepo}
+}
+
+// RegisterClient validates the requested metadata and stores a new client.
+// Errors wrapping ErrInvalidClientMetadata are the caller's fault; anything
+// else is the database.
+func (s *OAuthService) RegisterClient(ctx context.Context, name string, redirectURIs []string) (Client, error) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		name = fallbackClientName
+	}
+	if len(name) > maxClientNameLen {
+		return Client{}, fmt.Errorf("%w: client_name exceeds %d characters", ErrInvalidClientMetadata, maxClientNameLen)
+	}
+	if len(redirectURIs) == 0 {
+		return Client{}, fmt.Errorf("%w: redirect_uris is required", ErrInvalidClientMetadata)
+	}
+	if len(redirectURIs) > maxRedirectURIs {
+		return Client{}, fmt.Errorf("%w: at most %d redirect_uris are allowed", ErrInvalidClientMetadata, maxRedirectURIs)
+	}
+	for _, raw := range redirectURIs {
+		if err := validateRedirectURI(raw); err != nil {
+			return Client{}, err
+		}
+	}
+
+	client := Client{
+		ID:           uuid.New().String(),
+		Name:         name,
+		RedirectURIs: redirectURIs,
+	}
+	if err := s.clientRepo.InsertOAuthClient(ctx, store.InsertOAuthClientParameters{
+		ID:           client.ID,
+		Name:         client.Name,
+		RedirectURIs: client.RedirectURIs,
+	}); err != nil {
+		return Client{}, err
+	}
+	return client, nil
+}
+
+// validateRedirectURI accepts https URIs, custom app schemes, and plain http
+// only towards a loopback host, per the OAuth 2.1 rules for public clients.
+func validateRedirectURI(raw string) error {
+	if raw == "" || len(raw) > maxRedirectURILen {
+		return fmt.Errorf("%w: redirect_uri is empty or exceeds %d characters", ErrInvalidClientMetadata, maxRedirectURILen)
+	}
+	u, err := url.Parse(raw)
+	if err != nil || !u.IsAbs() {
+		return fmt.Errorf("%w: redirect_uri %q is not an absolute URI", ErrInvalidClientMetadata, raw)
+	}
+	if u.Fragment != "" {
+		return fmt.Errorf("%w: redirect_uri %q must not contain a fragment", ErrInvalidClientMetadata, raw)
+	}
+	if u.Scheme == "http" && !isLoopbackHost(u.Hostname()) {
+		return fmt.Errorf("%w: redirect_uri %q uses http on a non-loopback host", ErrInvalidClientMetadata, raw)
+	}
+	return nil
+}
+
+func isLoopbackHost(host string) bool {
+	return host == "localhost" || host == "127.0.0.1" || host == "::1"
+}

--- a/internal/oauth/service.go
+++ b/internal/oauth/service.go
@@ -25,6 +25,13 @@ var ErrInvalidClientMetadata = errors.New("invalid client metadata")
 
 type ClientRepository interface {
 	InsertOAuthClient(ctx context.Context, params store.InsertOAuthClientParameters) error
+	GetOAuthClient(ctx context.Context, id string) (store.OAuthClient, error)
+}
+
+// CodeRepository is the authorization-code ledger.
+type CodeRepository interface {
+	InsertOAuthAuthorizationCode(ctx context.Context, params store.InsertOAuthAuthorizationCodeParameters) error
+	DeleteExpiredOAuthAuthorizationCodes(ctx context.Context) error
 }
 
 // UserRepository is the slice of the users table token verification needs.
@@ -42,13 +49,15 @@ type Client struct {
 
 type OAuthService struct {
 	clientRepo ClientRepository
+	codeRepo   CodeRepository
 	userRepo   UserRepository
 	secret     string
 }
 
-func NewOAuthService(clientRepo ClientRepository, userRepo UserRepository) *OAuthService {
+func NewOAuthService(clientRepo ClientRepository, codeRepo CodeRepository, userRepo UserRepository) *OAuthService {
 	return &OAuthService{
 		clientRepo: clientRepo,
+		codeRepo:   codeRepo,
 		userRepo:   userRepo,
 		secret:     config.GetEnv("JWT_SECRET"),
 	}

--- a/internal/oauth/service.go
+++ b/internal/oauth/service.go
@@ -3,6 +3,7 @@ package oauth
 import (
 	"context"
 	"errors"
+	"expo-open-ota/config"
 	"expo-open-ota/internal/store"
 	"fmt"
 	"net/url"
@@ -26,6 +27,11 @@ type ClientRepository interface {
 	InsertOAuthClient(ctx context.Context, params store.InsertOAuthClientParameters) error
 }
 
+// UserRepository is the slice of the users table token verification needs.
+type UserRepository interface {
+	GetUserByID(ctx context.Context, id string) (store.User, error)
+}
+
 // Client is a registered OAuth client: a public client (no secret) pinned to
 // the redirect URIs it declared at registration.
 type Client struct {
@@ -36,10 +42,16 @@ type Client struct {
 
 type OAuthService struct {
 	clientRepo ClientRepository
+	userRepo   UserRepository
+	secret     string
 }
 
-func NewOAuthService(clientRepo ClientRepository) *OAuthService {
-	return &OAuthService{clientRepo: clientRepo}
+func NewOAuthService(clientRepo ClientRepository, userRepo UserRepository) *OAuthService {
+	return &OAuthService{
+		clientRepo: clientRepo,
+		userRepo:   userRepo,
+		secret:     config.GetEnv("JWT_SECRET"),
+	}
 }
 
 // RegisterClient validates the requested metadata and stores a new client.

--- a/internal/oauth/service.go
+++ b/internal/oauth/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"expo-open-ota/config"
+	"expo-open-ota/internal/services"
 	"expo-open-ota/internal/store"
 	"fmt"
 	"net/url"
@@ -31,12 +32,16 @@ type ClientRepository interface {
 // CodeRepository is the authorization-code ledger.
 type CodeRepository interface {
 	InsertOAuthAuthorizationCode(ctx context.Context, params store.InsertOAuthAuthorizationCodeParameters) error
+	ConsumeOAuthAuthorizationCode(ctx context.Context, id string) (store.OAuthAuthorizationCode, error)
 	DeleteExpiredOAuthAuthorizationCodes(ctx context.Context) error
 }
 
-// UserRepository is the slice of the users table token verification needs.
+// UserRepository is the slice of the users table the token flows need.
 type UserRepository interface {
 	GetUserByID(ctx context.Context, id string) (store.User, error)
+	// BumpUserSessionVersion is the replay response: it retires every session
+	// of the account, dashboard included.
+	BumpUserSessionVersion(ctx context.Context, id string) error
 }
 
 // Client is a registered OAuth client: a public client (no secret) pinned to
@@ -48,18 +53,20 @@ type Client struct {
 }
 
 type OAuthService struct {
-	clientRepo ClientRepository
-	codeRepo   CodeRepository
-	userRepo   UserRepository
-	secret     string
+	clientRepo  ClientRepository
+	codeRepo    CodeRepository
+	refreshRepo services.RefreshTokenRepository
+	userRepo    UserRepository
+	secret      string
 }
 
-func NewOAuthService(clientRepo ClientRepository, codeRepo CodeRepository, userRepo UserRepository) *OAuthService {
+func NewOAuthService(clientRepo ClientRepository, codeRepo CodeRepository, refreshRepo services.RefreshTokenRepository, userRepo UserRepository) *OAuthService {
 	return &OAuthService{
-		clientRepo: clientRepo,
-		codeRepo:   codeRepo,
-		userRepo:   userRepo,
-		secret:     config.GetEnv("JWT_SECRET"),
+		clientRepo:  clientRepo,
+		codeRepo:    codeRepo,
+		refreshRepo: refreshRepo,
+		userRepo:    userRepo,
+		secret:      config.GetEnv("JWT_SECRET"),
 	}
 }
 

--- a/internal/oauth/token.go
+++ b/internal/oauth/token.go
@@ -51,38 +51,42 @@ func (s *OAuthService) IssueAccessToken(principal services.DashboardPrincipal) (
 // AuthenticateMCPToken validates an access token and re-reads the account
 // behind it, mirroring what AuthenticateSession does for dashboard JWTs: the
 // signature proves the token was valid when minted, the user row says whether
-// it still is.
-func (s *OAuthService) AuthenticateMCPToken(ctx context.Context, tokenString string) (*services.DashboardPrincipal, error) {
+// it still is. The returned time is the token's expiration.
+func (s *OAuthService) AuthenticateMCPToken(ctx context.Context, tokenString string) (*services.DashboardPrincipal, time.Time, error) {
 	claims := jwt.MapClaims{}
 	if _, err := crypto.DecodeAndExtractJWTToken(s.secret, tokenString, &claims); err != nil {
-		return nil, err
+		return nil, time.Time{}, err
 	}
 	if claims["sub"] != mcpSubject {
-		return nil, errors.New("invalid token subject")
+		return nil, time.Time{}, errors.New("invalid token subject")
 	}
 	if audience, _ := claims.GetAudience(); len(audience) != 1 || audience[0] != ResourceURL() {
-		return nil, errors.New("invalid token audience")
+		return nil, time.Time{}, errors.New("invalid token audience")
+	}
+	expiresAt, err := claims.GetExpirationTime()
+	if err != nil || expiresAt == nil {
+		return nil, time.Time{}, errors.New("invalid token expiration")
 	}
 	userId, _ := claims["userId"].(string)
 	if userId == "" {
-		return nil, services.ErrSessionRevoked
+		return nil, time.Time{}, services.ErrSessionRevoked
 	}
 	sessionVersion, _ := claims["sv"].(float64)
 
 	user, err := s.userRepo.GetUserByID(ctx, userId)
 	if err != nil {
 		if notFoundErr := (*store.ErrResourceNotFound)(nil); errors.As(err, &notFoundErr) {
-			return nil, services.ErrSessionRevoked
+			return nil, time.Time{}, services.ErrSessionRevoked
 		}
-		return nil, fmt.Errorf("%w: %v", services.ErrAuthUnavailable, err)
+		return nil, time.Time{}, fmt.Errorf("%w: %v", services.ErrAuthUnavailable, err)
 	}
 	if !user.Enabled || user.SessionVersion != int32(sessionVersion) {
-		return nil, services.ErrSessionRevoked
+		return nil, time.Time{}, services.ErrSessionRevoked
 	}
 	return &services.DashboardPrincipal{
 		UserId:         user.Id,
 		Email:          user.Email,
 		IsAdmin:        user.IsAdmin,
 		SessionVersion: user.SessionVersion,
-	}, nil
+	}, expiresAt.Time, nil
 }

--- a/internal/oauth/token.go
+++ b/internal/oauth/token.go
@@ -1,0 +1,88 @@
+package oauth
+
+import (
+	"context"
+	"errors"
+	"expo-open-ota/internal/crypto"
+	"expo-open-ota/internal/services"
+	"expo-open-ota/internal/store"
+	"fmt"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// mcpSubject is what separates an MCP access token from every other JWT this
+// server signs with the same secret; the dashboard tokens carry their own sub
+// and each side's validation refuses the other's.
+const mcpSubject = "mcp"
+
+const accessTokenTTL = time.Hour
+
+// ResourceURL is the RFC 8707 identifier of the MCP server, carried as the
+// aud claim of every access token and required back at verification.
+func ResourceURL() string {
+	return baseURL() + "/mcp"
+}
+
+// ResourceMetadataURL is where a 401 sends clients to discover how to
+// authenticate (RFC 9728).
+func ResourceMetadataURL() string {
+	return baseURL() + "/.well-known/oauth-protected-resource/mcp"
+}
+
+// IssueAccessToken mints the Bearer token the token endpoint hands out.
+func (s *OAuthService) IssueAccessToken(principal services.DashboardPrincipal) (string, error) {
+	token, err := crypto.GenerateJWTToken(s.secret, jwt.MapClaims{
+		"sub":    mcpSubject,
+		"aud":    ResourceURL(),
+		"exp":    time.Now().Add(accessTokenTTL).Unix(),
+		"iat":    time.Now().Unix(),
+		"userId": principal.UserId,
+		"sv":     principal.SessionVersion,
+		"scope":  ScopeMCP,
+	})
+	if err != nil {
+		return "", fmt.Errorf("error while generating the mcp access token: %w", err)
+	}
+	return token, nil
+}
+
+// AuthenticateMCPToken validates an access token and re-reads the account
+// behind it, mirroring what AuthenticateSession does for dashboard JWTs: the
+// signature proves the token was valid when minted, the user row says whether
+// it still is.
+func (s *OAuthService) AuthenticateMCPToken(ctx context.Context, tokenString string) (*services.DashboardPrincipal, error) {
+	claims := jwt.MapClaims{}
+	if _, err := crypto.DecodeAndExtractJWTToken(s.secret, tokenString, &claims); err != nil {
+		return nil, err
+	}
+	if claims["sub"] != mcpSubject {
+		return nil, errors.New("invalid token subject")
+	}
+	if audience, _ := claims.GetAudience(); len(audience) != 1 || audience[0] != ResourceURL() {
+		return nil, errors.New("invalid token audience")
+	}
+	userId, _ := claims["userId"].(string)
+	if userId == "" {
+		return nil, services.ErrSessionRevoked
+	}
+	sessionVersion, _ := claims["sv"].(float64)
+
+	user, err := s.userRepo.GetUserByID(ctx, userId)
+	if err != nil {
+		if notFoundErr := (*store.ErrResourceNotFound)(nil); errors.As(err, &notFoundErr) {
+			return nil, services.ErrSessionRevoked
+		}
+		return nil, fmt.Errorf("%w: %v", services.ErrAuthUnavailable, err)
+	}
+	if !user.Enabled || user.SessionVersion != int32(sessionVersion) {
+		return nil, services.ErrSessionRevoked
+	}
+	return &services.DashboardPrincipal{
+		UserId:         user.Id,
+		Email:          user.Email,
+		IsAdmin:        user.IsAdmin,
+		SessionVersion: user.SessionVersion,
+	}, nil
+}

--- a/internal/oauth/token.go
+++ b/internal/oauth/token.go
@@ -2,14 +2,19 @@ package oauth
 
 import (
 	"context"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/base64"
 	"errors"
 	"expo-open-ota/internal/crypto"
 	"expo-open-ota/internal/services"
 	"expo-open-ota/internal/store"
 	"fmt"
+	"log"
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
+	"github.com/google/uuid"
 )
 
 // mcpSubject is what separates an MCP access token from every other JWT this
@@ -17,7 +22,18 @@ import (
 // and each side's validation refuses the other's.
 const mcpSubject = "mcp"
 
-const accessTokenTTL = time.Hour
+const (
+	accessTokenTTL  = time.Hour
+	refreshTokenTTL = 7 * 24 * time.Hour
+	// refreshReplayGrace covers a client racing itself; same semantics as the
+	// dashboard ledger.
+	refreshReplayGrace = 30 * time.Second
+)
+
+// ErrInvalidGrant covers every way a code or refresh token can be refused;
+// the token endpoint answers all of them with the RFC 6749 invalid_grant so
+// a probe learns nothing about which check failed.
+var ErrInvalidGrant = errors.New("invalid grant")
 
 // ResourceURL is the RFC 8707 identifier of the MCP server, carried as the
 // aud claim of every access token and required back at verification.
@@ -46,6 +62,203 @@ func (s *OAuthService) IssueAccessToken(principal services.DashboardPrincipal) (
 		return "", fmt.Errorf("error while generating the mcp access token: %w", err)
 	}
 	return token, nil
+}
+
+// TokenResponse is what the token endpoint returns for both grants.
+type TokenResponse struct {
+	AccessToken  string
+	RefreshToken string
+	ExpiresIn    int64
+	Scope        string
+}
+
+// ExchangeAuthorizationCodeRequest is the authorization_code grant as sent by
+// the client.
+type ExchangeAuthorizationCodeRequest struct {
+	Code         string
+	ClientID     string
+	RedirectURI  string
+	CodeVerifier string
+	Resource     string
+}
+
+// ExchangeAuthorizationCode trades a consented code for a token pair. The code
+// is consumed before anything is verified: a failed exchange must burn it, or
+// its PKCE challenge could be brute-forced by retrying.
+func (s *OAuthService) ExchangeAuthorizationCode(ctx context.Context, req ExchangeAuthorizationCodeRequest) (*TokenResponse, error) {
+	if _, err := uuid.Parse(req.Code); err != nil {
+		return nil, ErrInvalidGrant
+	}
+	if length := len(req.CodeVerifier); length < 43 || length > 128 {
+		return nil, ErrInvalidGrant
+	}
+	code, err := s.codeRepo.ConsumeOAuthAuthorizationCode(ctx, req.Code)
+	if err != nil {
+		if notFoundErr := (*store.ErrResourceNotFound)(nil); errors.As(err, &notFoundErr) {
+			return nil, ErrInvalidGrant
+		}
+		return nil, fmt.Errorf("%w: %v", services.ErrAuthUnavailable, err)
+	}
+	// The exchange must replay exactly what the user consented to.
+	if code.ClientID != req.ClientID || code.RedirectURI != req.RedirectURI {
+		return nil, ErrInvalidGrant
+	}
+	if req.Resource != "" && req.Resource != ResourceURL() {
+		return nil, ErrInvalidGrant
+	}
+	digest := sha256.Sum256([]byte(req.CodeVerifier))
+	challenge := base64.RawURLEncoding.EncodeToString(digest[:])
+	if subtle.ConstantTimeCompare([]byte(challenge), []byte(code.CodeChallenge)) != 1 {
+		return nil, ErrInvalidGrant
+	}
+
+	principal, err := s.principalForUser(ctx, code.UserID)
+	if err != nil {
+		return nil, err
+	}
+	tokenId := uuid.New().String()
+	expiresAt := time.Now().Add(refreshTokenTTL)
+	if err := s.refreshRepo.InsertRefreshToken(ctx, store.InsertRefreshTokenParameters{
+		ID:        tokenId,
+		UserID:    principal.UserId,
+		FamilyID:  uuid.New().String(),
+		ExpiresAt: expiresAt,
+	}); err != nil {
+		return nil, fmt.Errorf("%w: %v", services.ErrAuthUnavailable, err)
+	}
+	if purgeErr := s.refreshRepo.DeleteExpiredRefreshTokens(ctx, principal.UserId); purgeErr != nil {
+		log.Printf("failed to purge expired refresh tokens for user %s: %v", principal.UserId, purgeErr)
+	}
+	return s.issueTokenPair(*principal, tokenId, expiresAt)
+}
+
+// RefreshAccessToken trades a refresh token for a new pair and spends the old
+// one; rotation, replay grace and replay revocation mirror the dashboard's
+// RefreshSession over the same ledger.
+func (s *OAuthService) RefreshAccessToken(ctx context.Context, tokenString string) (*TokenResponse, error) {
+	claims := jwt.MapClaims{}
+	if _, err := crypto.DecodeAndExtractJWTToken(s.secret, tokenString, &claims); err != nil {
+		return nil, ErrInvalidGrant
+	}
+	if claims["sub"] != mcpSubject || claims["type"] != "refreshToken" {
+		return nil, ErrInvalidGrant
+	}
+	userId, _ := claims["userId"].(string)
+	if userId == "" {
+		return nil, ErrInvalidGrant
+	}
+	principal, err := s.principalForUser(ctx, userId)
+	if err != nil {
+		return nil, err
+	}
+	if sessionVersion, _ := claims["sv"].(float64); principal.SessionVersion != int32(sessionVersion) {
+		return nil, ErrInvalidGrant
+	}
+	spentId, _ := claims["jti"].(string)
+	if spentId == "" {
+		return nil, ErrInvalidGrant
+	}
+
+	successorId := uuid.New().String()
+	expiresAt := time.Now().Add(refreshTokenTTL)
+	_, err = s.refreshRepo.RotateRefreshToken(ctx, store.RotateRefreshTokenParameters{
+		OldID:     spentId,
+		NewID:     successorId,
+		ExpiresAt: expiresAt,
+	})
+	if err == nil {
+		if purgeErr := s.refreshRepo.DeleteExpiredRefreshTokens(ctx, principal.UserId); purgeErr != nil {
+			log.Printf("failed to purge expired refresh tokens for user %s: %v", principal.UserId, purgeErr)
+		}
+		return s.issueTokenPair(*principal, successorId, expiresAt)
+	}
+	notFoundErr := (*store.ErrResourceNotFound)(nil)
+	if !errors.As(err, &notFoundErr) {
+		return nil, fmt.Errorf("%w: %v", services.ErrAuthUnavailable, err)
+	}
+
+	// The rotation refused the token; find out why from its row.
+	spent, err := s.refreshRepo.GetRefreshToken(ctx, spentId, refreshReplayGrace)
+	if err != nil {
+		if errors.As(err, &notFoundErr) {
+			return nil, ErrInvalidGrant
+		}
+		return nil, fmt.Errorf("%w: %v", services.ErrAuthUnavailable, err)
+	}
+	if spent.UsedAt == nil {
+		return nil, ErrInvalidGrant
+	}
+	if spent.UsedRecently && spent.ReplacedBy != nil {
+		// Same client racing itself within refreshReplayGrace: hand back the
+		// successor already written instead of minting a second one.
+		successor, err := s.refreshRepo.GetRefreshToken(ctx, *spent.ReplacedBy, refreshReplayGrace)
+		if err != nil {
+			if errors.As(err, &notFoundErr) {
+				return nil, ErrInvalidGrant
+			}
+			return nil, fmt.Errorf("%w: %v", services.ErrAuthUnavailable, err)
+		}
+		if successor.UsedAt != nil {
+			return nil, ErrInvalidGrant
+		}
+		return s.issueTokenPair(*principal, successor.Id, successor.ExpiresAt)
+	}
+
+	// Spent long ago and presented again: a stolen credential. Bump the
+	// account's generation to kill every session, not just this family.
+	if err := s.refreshRepo.DeleteRefreshTokenFamily(ctx, spent.FamilyId); err != nil {
+		log.Printf("failed to revoke oauth refresh token family %s after a replay: %v", spent.FamilyId, err)
+	}
+	if err := s.userRepo.BumpUserSessionVersion(ctx, principal.UserId); err != nil {
+		log.Printf("failed to revoke the sessions of user %s after a replay: %v", principal.UserId, err)
+	}
+	log.Printf("🚨 [OAUTH] refresh token replay for user %s: family %s revoked, every session of the account invalidated", spent.UserId, spent.FamilyId)
+	return nil, ErrInvalidGrant
+}
+
+// principalForUser re-reads the account; every grant dies with it.
+func (s *OAuthService) principalForUser(ctx context.Context, userId string) (*services.DashboardPrincipal, error) {
+	user, err := s.userRepo.GetUserByID(ctx, userId)
+	if err != nil {
+		if notFoundErr := (*store.ErrResourceNotFound)(nil); errors.As(err, &notFoundErr) {
+			return nil, ErrInvalidGrant
+		}
+		return nil, fmt.Errorf("%w: %v", services.ErrAuthUnavailable, err)
+	}
+	if !user.Enabled {
+		return nil, ErrInvalidGrant
+	}
+	return &services.DashboardPrincipal{
+		UserId:         user.Id,
+		Email:          user.Email,
+		IsAdmin:        user.IsAdmin,
+		SessionVersion: user.SessionVersion,
+	}, nil
+}
+
+func (s *OAuthService) issueTokenPair(principal services.DashboardPrincipal, tokenId string, expiresAt time.Time) (*TokenResponse, error) {
+	accessToken, err := s.IssueAccessToken(principal)
+	if err != nil {
+		return nil, err
+	}
+	refreshToken, err := crypto.GenerateJWTToken(s.secret, jwt.MapClaims{
+		"sub":    mcpSubject,
+		"type":   "refreshToken",
+		"exp":    expiresAt.Unix(),
+		"iat":    time.Now().Unix(),
+		"userId": principal.UserId,
+		"sv":     principal.SessionVersion,
+		"jti":    tokenId,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("error while generating the mcp refresh token: %w", err)
+	}
+	return &TokenResponse{
+		AccessToken:  accessToken,
+		RefreshToken: refreshToken,
+		ExpiresIn:    int64(accessTokenTTL.Seconds()),
+		Scope:        ScopeMCP,
+	}, nil
 }
 
 // AuthenticateMCPToken validates an access token and re-reads the account

--- a/internal/oauth/token_test.go
+++ b/internal/oauth/token_test.go
@@ -1,0 +1,257 @@
+package oauth
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"expo-open-ota/internal/crypto"
+	"expo-open-ota/internal/store"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+const testVerifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+
+type fakeTokenUserRepo struct {
+	users  map[string]store.User
+	bumped []string
+}
+
+func (f *fakeTokenUserRepo) GetUserByID(_ context.Context, id string) (store.User, error) {
+	user, ok := f.users[id]
+	if !ok {
+		return store.User{}, &store.ErrResourceNotFound{Resource: "user", Identifier: id}
+	}
+	return user, nil
+}
+
+func (f *fakeTokenUserRepo) BumpUserSessionVersion(_ context.Context, id string) error {
+	f.bumped = append(f.bumped, id)
+	user := f.users[id]
+	user.SessionVersion++
+	f.users[id] = user
+	return nil
+}
+
+// fakeRefreshLedger mirrors the semantics of PostgresRefreshTokenStore.
+type fakeRefreshLedger struct {
+	rows map[string]*store.RefreshToken
+}
+
+func newFakeRefreshLedger() *fakeRefreshLedger {
+	return &fakeRefreshLedger{rows: map[string]*store.RefreshToken{}}
+}
+
+func (f *fakeRefreshLedger) InsertRefreshToken(_ context.Context, params store.InsertRefreshTokenParameters) error {
+	f.rows[params.ID] = &store.RefreshToken{
+		Id:        params.ID,
+		UserId:    params.UserID,
+		FamilyId:  params.FamilyID,
+		ExpiresAt: params.ExpiresAt,
+	}
+	return nil
+}
+
+func (f *fakeRefreshLedger) RotateRefreshToken(_ context.Context, params store.RotateRefreshTokenParameters) (store.RefreshToken, error) {
+	row, ok := f.rows[params.OldID]
+	if !ok || row.UsedAt != nil || time.Now().After(row.ExpiresAt) {
+		return store.RefreshToken{}, &store.ErrResourceNotFound{Resource: "refresh token", Identifier: params.OldID}
+	}
+	now := time.Now()
+	row.UsedAt = &now
+	successor := params.NewID
+	row.ReplacedBy = &successor
+	f.rows[successor] = &store.RefreshToken{
+		Id:        successor,
+		UserId:    row.UserId,
+		FamilyId:  row.FamilyId,
+		ExpiresAt: params.ExpiresAt,
+	}
+	return *row, nil
+}
+
+func (f *fakeRefreshLedger) GetRefreshToken(_ context.Context, id string, replayGrace time.Duration) (store.RefreshToken, error) {
+	row, ok := f.rows[id]
+	if !ok {
+		return store.RefreshToken{}, &store.ErrResourceNotFound{Resource: "refresh token", Identifier: id}
+	}
+	result := *row
+	result.UsedRecently = row.UsedAt != nil && time.Since(*row.UsedAt) < replayGrace
+	return result, nil
+}
+
+func (f *fakeRefreshLedger) DeleteRefreshTokenFamily(_ context.Context, familyId string) error {
+	for id, row := range f.rows {
+		if row.FamilyId == familyId {
+			delete(f.rows, id)
+		}
+	}
+	return nil
+}
+
+func (f *fakeRefreshLedger) DeleteExpiredRefreshTokens(_ context.Context, _ string) error {
+	return nil
+}
+
+// tokenTestSetup returns a service wired with all fakes plus a freshly
+// consented code ready to exchange.
+func tokenTestSetup(t *testing.T) (*OAuthService, *fakeTokenUserRepo, *fakeRefreshLedger, ExchangeAuthorizationCodeRequest) {
+	t.Helper()
+	t.Setenv("BASE_URL", "https://ota.example.com")
+	t.Setenv("JWT_SECRET", "test-secret")
+	clientRepo := &fakeClientRepo{}
+	codeRepo := &fakeCodeRepo{}
+	userRepo := &fakeTokenUserRepo{users: map[string]store.User{
+		"user-1": {Id: "user-1", Email: "a@b.c", Enabled: true, SessionVersion: 3},
+	}}
+	ledger := newFakeRefreshLedger()
+	service := NewOAuthService(clientRepo, codeRepo, ledger, userRepo)
+
+	clientID := seedClient(t, clientRepo, "http://127.0.0.1:53422/callback")
+	digest := sha256.Sum256([]byte(testVerifier))
+	challenge := base64.RawURLEncoding.EncodeToString(digest[:])
+	redirectURL, err := service.CreateAuthorizationCode(context.Background(), "user-1", AuthorizationRequest{
+		ClientID:            clientID,
+		RedirectURI:         "http://127.0.0.1:53422/callback",
+		ResponseType:        "code",
+		CodeChallenge:       challenge,
+		CodeChallengeMethod: "S256",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	code := codeRepo.inserted[len(codeRepo.inserted)-1].ID
+	_ = redirectURL
+
+	return service, userRepo, ledger, ExchangeAuthorizationCodeRequest{
+		Code:         code,
+		ClientID:     clientID,
+		RedirectURI:  "http://127.0.0.1:53422/callback",
+		CodeVerifier: testVerifier,
+	}
+}
+
+func TestExchangeAuthorizationCode(t *testing.T) {
+	service, _, ledger, req := tokenTestSetup(t)
+
+	response, err := service.ExchangeAuthorizationCode(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	principal, _, err := service.AuthenticateMCPToken(context.Background(), response.AccessToken)
+	if err != nil {
+		t.Fatalf("the minted access token must verify: %v", err)
+	}
+	if principal.UserId != "user-1" {
+		t.Errorf("access token minted for the wrong user: %+v", principal)
+	}
+	if response.RefreshToken == "" || len(ledger.rows) != 1 {
+		t.Error("the exchange must open a refresh chain")
+	}
+
+	// The code is spent: a second exchange must fail.
+	if _, err := service.ExchangeAuthorizationCode(context.Background(), req); err != ErrInvalidGrant {
+		t.Fatalf("a code must be single-use, got %v", err)
+	}
+}
+
+func TestExchangeRejections(t *testing.T) {
+	mutations := map[string]func(*ExchangeAuthorizationCodeRequest){
+		"wrong verifier": func(r *ExchangeAuthorizationCodeRequest) {
+			r.CodeVerifier = "wrong-wrong-wrong-wrong-wrong-wrong-wrong-wrong"
+		},
+		"wrong client":       func(r *ExchangeAuthorizationCodeRequest) { r.ClientID = "other-client" },
+		"wrong redirect_uri": func(r *ExchangeAuthorizationCodeRequest) { r.RedirectURI = "http://127.0.0.1:9/cb" },
+		"foreign resource":   func(r *ExchangeAuthorizationCodeRequest) { r.Resource = "https://other.example.com/mcp" },
+		"unknown code":       func(r *ExchangeAuthorizationCodeRequest) { r.Code = "11111111-1111-1111-1111-111111111111" },
+	}
+	for name, mutate := range mutations {
+		t.Run(name, func(t *testing.T) {
+			service, _, _, req := tokenTestSetup(t)
+			mutate(&req)
+			if _, err := service.ExchangeAuthorizationCode(context.Background(), req); err != ErrInvalidGrant {
+				t.Fatalf("expected ErrInvalidGrant, got %v", err)
+			}
+		})
+	}
+}
+
+func TestRefreshRotation(t *testing.T) {
+	service, _, _, req := tokenTestSetup(t)
+	first, err := service.ExchangeAuthorizationCode(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	second, err := service.RefreshAccessToken(context.Background(), first.RefreshToken)
+	if err != nil {
+		t.Fatalf("a fresh refresh token must rotate: %v", err)
+	}
+	if _, _, err := service.AuthenticateMCPToken(context.Background(), second.AccessToken); err != nil {
+		t.Fatalf("the refreshed access token must verify: %v", err)
+	}
+	if second.RefreshToken == first.RefreshToken {
+		t.Fatal("rotation must issue a new refresh token")
+	}
+}
+
+func TestRefreshReplayRevokesEverything(t *testing.T) {
+	service, userRepo, ledger, req := tokenTestSetup(t)
+	first, err := service.ExchangeAuthorizationCode(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := service.RefreshAccessToken(context.Background(), first.RefreshToken); err != nil {
+		t.Fatal(err)
+	}
+
+	// Backdate the spend beyond the replay grace: the re-presentation is now
+	// a theft signal, not a race.
+	for _, row := range ledger.rows {
+		if row.UsedAt != nil {
+			spent := time.Now().Add(-2 * refreshReplayGrace)
+			row.UsedAt = &spent
+		}
+	}
+	if _, err := service.RefreshAccessToken(context.Background(), first.RefreshToken); err != ErrInvalidGrant {
+		t.Fatalf("expected ErrInvalidGrant on replay, got %v", err)
+	}
+	if len(userRepo.bumped) != 1 || userRepo.bumped[0] != "user-1" {
+		t.Error("a replay must bump the account's session version")
+	}
+	if len(ledger.rows) != 0 {
+		t.Error("a replay must revoke the whole family")
+	}
+}
+
+func TestRefreshRejectsDashboardToken(t *testing.T) {
+	service, _, ledger, req := tokenTestSetup(t)
+	if _, err := service.ExchangeAuthorizationCode(context.Background(), req); err != nil {
+		t.Fatal(err)
+	}
+	// Same ledger, other audience: a dashboard refresh JWT naming a live MCP
+	// row must be refused before the ledger is ever consulted.
+	var mcpRowId string
+	for id := range ledger.rows {
+		mcpRowId = id
+	}
+	dashboardToken, err := crypto.GenerateJWTToken("test-secret", jwt.MapClaims{
+		"sub":    "admin-dashboard",
+		"type":   "refreshToken",
+		"exp":    time.Now().Add(time.Hour).Unix(),
+		"userId": "user-1",
+		"sv":     3,
+		"jti":    mcpRowId,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := service.RefreshAccessToken(context.Background(), dashboardToken); err != ErrInvalidGrant {
+		t.Fatalf("expected ErrInvalidGrant, got %v", err)
+	}
+	if ledger.rows[mcpRowId].UsedAt != nil {
+		t.Fatal("the cross-audience attempt must not have touched the row")
+	}
+}

--- a/internal/ratelimit/ratelimit.go
+++ b/internal/ratelimit/ratelimit.go
@@ -36,6 +36,7 @@ const (
 	scopePasswordChange = "password_change"
 	scopeSSOCallbackIP  = "sso_callback_ip"
 	scopeOAuthRegister  = "oauth_register_ip"
+	scopeOAuthTokenIP   = "oauth_token_ip"
 )
 
 // The limits. They are constants and not configuration: an operator is not
@@ -171,6 +172,18 @@ func (l *Limiter) CheckSSOCallback(ip netip.Addr) Decision {
 
 func (l *Limiter) RecordSSOCallbackFailure(ip netip.Addr) {
 	l.recordIP(scopeSSOCallbackIP, ip, l.ipLimit())
+}
+
+// CheckOAuthToken and RecordOAuthTokenFailure bound guessing at authorization
+// codes and refresh tokens on the OAuth token endpoint. Same threat as the
+// dashboard's refresh scope, but a separate counter on purpose: a looping MCP
+// client must not burn the budget dashboard sessions refresh under.
+func (l *Limiter) CheckOAuthToken(ip netip.Addr) Decision {
+	return l.checkIP(scopeOAuthTokenIP, ip, l.ipLimit())
+}
+
+func (l *Limiter) RecordOAuthTokenFailure(ip netip.Addr) {
+	l.recordIP(scopeOAuthTokenIP, ip, l.ipLimit())
 }
 
 // CheckOAuthRegister and RecordOAuthRegister bound how many OAuth clients one

--- a/internal/ratelimit/ratelimit.go
+++ b/internal/ratelimit/ratelimit.go
@@ -35,6 +35,7 @@ const (
 	scopeRefreshIP      = "refresh_ip"
 	scopePasswordChange = "password_change"
 	scopeSSOCallbackIP  = "sso_callback_ip"
+	scopeOAuthRegister  = "oauth_register_ip"
 )
 
 // The limits. They are constants and not configuration: an operator is not
@@ -170,6 +171,18 @@ func (l *Limiter) CheckSSOCallback(ip netip.Addr) Decision {
 
 func (l *Limiter) RecordSSOCallbackFailure(ip netip.Addr) {
 	l.recordIP(scopeSSOCallbackIP, ip, l.ipLimit())
+}
+
+// CheckOAuthRegister and RecordOAuthRegister bound how many OAuth clients one
+// address may create. Unlike every other scope this counts SUCCESSES: dynamic
+// client registration is unauthenticated by design (RFC 7591), so the thing to
+// bound is rows written, not credentials guessed.
+func (l *Limiter) CheckOAuthRegister(ip netip.Addr) Decision {
+	return l.checkIP(scopeOAuthRegister, ip, l.ipLimit())
+}
+
+func (l *Limiter) RecordOAuthRegister(ip netip.Addr) {
+	l.recordIP(scopeOAuthRegister, ip, l.ipLimit())
 }
 
 func normalizeEmail(email string) string {

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -32,6 +32,7 @@ func NewRouter(container *AppContainer) *mux.Router {
 
 	// No authentication below this point.
 	registerInfraRoutes(r)
+	registerMCPRoutes(r, container)
 	registerPublishRoutes(r, container)
 	registerIngestRoutes(r, container)
 	registerClientRoutes(r, container)

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -49,6 +49,7 @@ func NewRouter(container *AppContainer) *mux.Router {
 	// license, SSO, app creation).
 	adminOnly := middleware.NewAdminMiddleware(container.UserRepo)
 
+	registerOAuthApiRoutes(apiSubrouter, container)
 	registerAccountRoutes(apiSubrouter, container, adminOnly)
 	registerAppRoutes(apiSubrouter, container)
 

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -37,6 +37,7 @@ func NewRouter(container *AppContainer) *mux.Router {
 	registerIngestRoutes(r, container)
 	registerClientRoutes(r, container)
 	registerPreAuthRoutes(r, container)
+	registerOAuthRoutes(r, container)
 	registerDashboardAssets(r)
 
 	// Authentication from here on: the Use-Cli-Auth header picks between a

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -43,6 +43,10 @@ func NewRouter(container *AppContainer) *mux.Router {
 	// Authentication from here on: the Use-Cli-Auth header picks between a
 	// CLI credential and the dashboard session JWT.
 	apiSubrouter := r.PathPrefix("/api").Subrouter()
+	// CORS first: a preflight carries no Authorization header and must be
+	// answered before the auth middleware; the catch-all makes it match.
+	apiSubrouter.Use(middleware.NewDashboardCORSMiddleware())
+	apiSubrouter.PathPrefix("/").HandlerFunc(func(http.ResponseWriter, *http.Request) {}).Methods(http.MethodOptions)
 	apiSubrouter.Use(middleware.NewAuthMiddleware(container.DashboardAuthService, container.CliAuthService))
 
 	// adminOnly guards the global administration surface (users, roles,

--- a/internal/router/routes_auth.go
+++ b/internal/router/routes_auth.go
@@ -1,6 +1,7 @@
 package infrastructure
 
 import (
+	"expo-open-ota/internal/middleware"
 	"net/http"
 
 	"github.com/gorilla/mux"
@@ -11,6 +12,8 @@ import (
 // exchange.
 func registerPreAuthRoutes(r *mux.Router, container *AppContainer) {
 	corsSubrouter := r.PathPrefix("/auth").Subrouter()
+	corsSubrouter.Use(middleware.NewDashboardCORSMiddleware())
+	corsSubrouter.PathPrefix("/").HandlerFunc(func(http.ResponseWriter, *http.Request) {}).Methods(http.MethodOptions)
 	corsSubrouter.HandleFunc("/login", container.AuthHandler.LoginHandler).Methods(http.MethodPost)
 	corsSubrouter.HandleFunc("/refreshToken", container.AuthHandler.RefreshTokenHandler).Methods(http.MethodPost)
 

--- a/internal/router/routes_mcp.go
+++ b/internal/router/routes_mcp.go
@@ -1,6 +1,7 @@
 package infrastructure
 
 import (
+	"expo-open-ota/internal/middleware"
 	"net/http"
 
 	"github.com/gorilla/mux"
@@ -11,5 +12,8 @@ func registerMCPRoutes(r *mux.Router, container *AppContainer) {
 		return
 	}
 	mcpRouter := r.PathPrefix("/mcp").Subrouter()
-	mcpRouter.HandleFunc("", container.MCPHandler.GlobalHandler).Methods(http.MethodPost)
+	mcpRouter.Use(middleware.NewOAuthMiddleware(container.OAuthService))
+	// POST carries the JSON-RPC messages, GET the SSE notification stream,
+	// DELETE the session teardown; all three are the same streamable endpoint.
+	mcpRouter.HandleFunc("", container.MCPHandler.GlobalHandler).Methods(http.MethodPost, http.MethodGet, http.MethodDelete)
 }

--- a/internal/router/routes_mcp.go
+++ b/internal/router/routes_mcp.go
@@ -27,7 +27,7 @@ func mcpCORS(next http.Handler) http.Handler {
 }
 
 func registerMCPRoutes(r *mux.Router, container *AppContainer) {
-	if container.MCPHandler == nil {
+	if container.MCPHandler == nil || container.OAuthService == nil {
 		return
 	}
 	mcpRouter := r.PathPrefix("/mcp").Subrouter()

--- a/internal/router/routes_mcp.go
+++ b/internal/router/routes_mcp.go
@@ -7,13 +7,34 @@ import (
 	"github.com/gorilla/mux"
 )
 
+// mcpCORS opens the MCP endpoint to browser-based clients (MCP Inspector,
+// web agents). It must run BEFORE the auth middleware: a preflight carries no
+// Authorization header, so it has to be answered here, and the headers must
+// also land on 401s or the browser hides the WWW-Authenticate challenge the
+// whole discovery flow starts from.
+func mcpCORS(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS")
+		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization, Mcp-Session-Id, mcp-protocol-version, Last-Event-ID")
+		w.Header().Set("Access-Control-Expose-Headers", "Mcp-Session-Id, WWW-Authenticate")
+		if r.Method == http.MethodOptions {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
 func registerMCPRoutes(r *mux.Router, container *AppContainer) {
 	if container.MCPHandler == nil {
 		return
 	}
 	mcpRouter := r.PathPrefix("/mcp").Subrouter()
+	mcpRouter.Use(mcpCORS)
 	mcpRouter.Use(middleware.NewOAuthMiddleware(container.OAuthService))
 	// POST carries the JSON-RPC messages, GET the SSE notification stream,
 	// DELETE the session teardown; all three are the same streamable endpoint.
-	mcpRouter.HandleFunc("", container.MCPHandler.GlobalHandler).Methods(http.MethodPost, http.MethodGet, http.MethodDelete)
+	mcpRouter.HandleFunc("", container.MCPHandler.GlobalHandler).
+		Methods(http.MethodPost, http.MethodGet, http.MethodDelete, http.MethodOptions)
 }

--- a/internal/router/routes_mcp.go
+++ b/internal/router/routes_mcp.go
@@ -7,6 +7,9 @@ import (
 )
 
 func registerMCPRoutes(r *mux.Router, container *AppContainer) {
+	if container.MCPHandler == nil {
+		return
+	}
 	mcpRouter := r.PathPrefix("/mcp").Subrouter()
 	mcpRouter.HandleFunc("", container.MCPHandler.GlobalHandler).Methods(http.MethodPost)
 }

--- a/internal/router/routes_mcp.go
+++ b/internal/router/routes_mcp.go
@@ -1,0 +1,12 @@
+package infrastructure
+
+import (
+	"net/http"
+
+	"github.com/gorilla/mux"
+)
+
+func registerMCPRoutes(r *mux.Router, container *AppContainer) {
+	mcpRouter := r.PathPrefix("/mcp").Subrouter()
+	mcpRouter.HandleFunc("", container.MCPHandler.GlobalHandler).Methods(http.MethodPost)
+}

--- a/internal/router/routes_mcp_test.go
+++ b/internal/router/routes_mcp_test.go
@@ -1,0 +1,54 @@
+package infrastructure
+
+import (
+	"expo-open-ota/internal/mcp"
+	"expo-open-ota/internal/oauth"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gorilla/mux"
+)
+
+func TestMCPEndpointCORS(t *testing.T) {
+	t.Setenv("BASE_URL", "https://ota.example.com")
+	t.Setenv("JWT_SECRET", "test-secret")
+	container := &AppContainer{
+		MCPHandler:   mcp.NewMCPHandler(mcp.NewMCPService()),
+		OAuthService: oauth.NewOAuthService(nil, nil, nil, nil),
+	}
+	router := mux.NewRouter()
+	registerMCPRoutes(router, container)
+
+	// The preflight carries no Authorization header and must be answered
+	// before authentication.
+	res := httptest.NewRecorder()
+	router.ServeHTTP(res, httptest.NewRequest(http.MethodOptions, "/mcp", nil))
+	if res.Code != http.StatusNoContent {
+		t.Fatalf("expected 204 on preflight, got %d", res.Code)
+	}
+	if res.Header().Get("Access-Control-Allow-Origin") != "*" {
+		t.Error("missing Access-Control-Allow-Origin on preflight")
+	}
+	if allowed := res.Header().Get("Access-Control-Allow-Headers"); !strings.Contains(allowed, "Mcp-Session-Id") {
+		t.Errorf("Mcp-Session-Id must be an allowed request header, got %q", allowed)
+	}
+
+	// The unauthenticated 401 must stay CORS-readable, or a browser client
+	// never sees the WWW-Authenticate challenge that starts the flow.
+	res = httptest.NewRecorder()
+	router.ServeHTTP(res, httptest.NewRequest(http.MethodPost, "/mcp", nil))
+	if res.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 without a token, got %d", res.Code)
+	}
+	if res.Header().Get("Access-Control-Allow-Origin") != "*" {
+		t.Error("the 401 must carry Access-Control-Allow-Origin")
+	}
+	if exposed := res.Header().Get("Access-Control-Expose-Headers"); !strings.Contains(exposed, "WWW-Authenticate") {
+		t.Errorf("WWW-Authenticate must be exposed to browser clients, got %q", exposed)
+	}
+	if res.Header().Get("WWW-Authenticate") == "" {
+		t.Error("missing the WWW-Authenticate challenge itself")
+	}
+}

--- a/internal/router/routes_oauth.go
+++ b/internal/router/routes_oauth.go
@@ -1,0 +1,26 @@
+package infrastructure
+
+import (
+	"expo-open-ota/internal/oauth"
+	"net/http"
+
+	"github.com/gorilla/mux"
+)
+
+// registerOAuthRoutes registers the OAuth 2.1 surface MCP clients authenticate
+// through: the discovery documents and dynamic client registration. Absent in
+// stateless mode, which has nowhere to store clients.
+func registerOAuthRoutes(r *mux.Router, container *AppContainer) {
+	if container.OAuthHandler == nil {
+		return
+	}
+	h := container.OAuthHandler
+
+	// Path-inserted form first (RFC 9728 for a resource at /mcp), root form as
+	// the fallback non-conforming clients probe.
+	r.HandleFunc("/.well-known/oauth-protected-resource/mcp", oauth.WithCORS(h.ProtectedResourceMetadataHandler)).Methods(http.MethodGet, http.MethodOptions)
+	r.HandleFunc("/.well-known/oauth-protected-resource", oauth.WithCORS(h.ProtectedResourceMetadataHandler)).Methods(http.MethodGet, http.MethodOptions)
+	r.HandleFunc("/.well-known/oauth-authorization-server", oauth.WithCORS(h.AuthorizationServerMetadataHandler)).Methods(http.MethodGet, http.MethodOptions)
+
+	r.HandleFunc("/oauth/register", oauth.WithCORS(h.RegisterHandler)).Methods(http.MethodPost, http.MethodOptions)
+}

--- a/internal/router/routes_oauth.go
+++ b/internal/router/routes_oauth.go
@@ -24,6 +24,7 @@ func registerOAuthRoutes(r *mux.Router, container *AppContainer) {
 	r.HandleFunc("/.well-known/oauth-authorization-server", oauth.WithCORS(h.AuthorizationServerMetadataHandler)).Methods(http.MethodGet, http.MethodOptions)
 
 	r.HandleFunc("/oauth/register", oauth.WithCORS(h.RegisterHandler)).Methods(http.MethodPost, http.MethodOptions)
+	r.HandleFunc("/oauth/token", oauth.WithCORS(h.TokenHandler)).Methods(http.MethodPost, http.MethodOptions)
 	// Top-level browser navigation, no CORS involved.
 	r.HandleFunc("/oauth/authorize", h.AuthorizeHandler).Methods(http.MethodGet)
 }

--- a/internal/router/routes_oauth.go
+++ b/internal/router/routes_oauth.go
@@ -1,6 +1,7 @@
 package infrastructure
 
 import (
+	"expo-open-ota/internal/middleware"
 	"expo-open-ota/internal/oauth"
 	"net/http"
 
@@ -23,4 +24,17 @@ func registerOAuthRoutes(r *mux.Router, container *AppContainer) {
 	r.HandleFunc("/.well-known/oauth-authorization-server", oauth.WithCORS(h.AuthorizationServerMetadataHandler)).Methods(http.MethodGet, http.MethodOptions)
 
 	r.HandleFunc("/oauth/register", oauth.WithCORS(h.RegisterHandler)).Methods(http.MethodPost, http.MethodOptions)
+	// Top-level browser navigation, no CORS involved.
+	r.HandleFunc("/oauth/authorize", h.AuthorizeHandler).Methods(http.MethodGet)
+}
+
+// registerOAuthApiRoutes mounts the consent endpoint behind the dashboard
+// session; api is the authenticated /api subrouter.
+func registerOAuthApiRoutes(api *mux.Router, container *AppContainer) {
+	if container.OAuthHandler == nil {
+		return
+	}
+	consentRouter := api.PathPrefix("/oauth").Subrouter()
+	consentRouter.Use(middleware.NewDashboardOnlyMiddleware())
+	consentRouter.HandleFunc("/consent", container.OAuthHandler.ConsentHandler).Methods(http.MethodPost)
 }

--- a/internal/router/wire.go
+++ b/internal/router/wire.go
@@ -48,6 +48,7 @@ type AppContainer struct {
 	RolloutHandler              *dashhandlers.RolloutHandler
 	MCPHandler                  *mcp.MCPHandler
 	OAuthHandler                *oauth.OAuthHandler
+	OAuthService                *oauth.OAuthService
 	SettingsHandler             *dashhandlers.SettingsHandler
 	SSOHandler                  *sso.SSOHandler
 	UpdateHandler               *dashhandlers.UpdateHandler
@@ -247,9 +248,11 @@ func InitDependencies(ctx context.Context) (*AppContainer, func()) {
 	// Shared across handlers; with Redis configured, also across replicas.
 	rateLimiter := ratelimit.New(cache.GetCache())
 
+	var oauthService *oauth.OAuthService
 	var oauthHandler *oauth.OAuthHandler
 	if oauthClientRepo != nil {
-		oauthHandler = oauth.NewOAuthHandler(oauth.NewOAuthService(oauthClientRepo), rateLimiter)
+		oauthService = oauth.NewOAuthService(oauthClientRepo, userRepo)
+		oauthHandler = oauth.NewOAuthHandler(oauthService, rateLimiter)
 	}
 
 	container := &AppContainer{
@@ -284,6 +287,7 @@ func InitDependencies(ctx context.Context) (*AppContainer, func()) {
 		IdentityHandler:             identity.NewIdentityHandler(identityService),
 		MCPHandler:                  mcpHandler,
 		OAuthHandler:                oauthHandler,
+		OAuthService:                oauthService,
 	}
 
 	if checkInRecorder != nil {

--- a/internal/router/wire.go
+++ b/internal/router/wire.go
@@ -20,6 +20,7 @@ import (
 	"expo-open-ota/internal/handlers"
 	dashhandlers "expo-open-ota/internal/handlers/dashboard"
 	"expo-open-ota/internal/mcp"
+	"expo-open-ota/internal/oauth"
 	"expo-open-ota/internal/ratelimit"
 	"expo-open-ota/internal/services"
 	"expo-open-ota/internal/store"
@@ -46,6 +47,7 @@ type AppContainer struct {
 	RollbackHandler             *handlers.RollbackHandler
 	RolloutHandler              *dashhandlers.RolloutHandler
 	MCPHandler                  *mcp.MCPHandler
+	OAuthHandler                *oauth.OAuthHandler
 	SettingsHandler             *dashhandlers.SettingsHandler
 	SSOHandler                  *sso.SSOHandler
 	UpdateHandler               *dashhandlers.UpdateHandler
@@ -81,6 +83,8 @@ func InitDependencies(ctx context.Context) (*AppContainer, func()) {
 	// nil in stateless mode: accounts only exist on the control plane.
 	var userRepo services.UserRepository
 	var refreshTokenRepo services.RefreshTokenRepository
+	var oauthClientRepo oauth.ClientRepository
+	var mcpHandler *mcp.MCPHandler
 	var rolloutRepo services.RolloutRepository
 	var licenseRepo licensing.LicenseRepository
 	var ssoRepo sso.SSORepository
@@ -132,6 +136,8 @@ func InitDependencies(ctx context.Context) (*AppContainer, func()) {
 		appRepo = store.NewPostgresAppStore(dbEngine)
 		userRepo = store.NewPostgresUserStore(dbEngine)
 		refreshTokenRepo = store.NewPostgresRefreshTokenStore(dbEngine)
+		oauthClientRepo = store.NewPostgresOAuthClientStore(dbEngine)
+		mcpHandler = mcp.NewMCPHandler(mcp.NewMCPService())
 		licenseRepo = licensing.NewPostgresLicenseStore(dbEngine)
 		ssoRepo = sso.NewPostgresSSOStore(dbEngine)
 		apiKeyAccessRepo = apikeyrestrictions.NewPostgresApiKeyAccessStore(dbEngine)
@@ -237,11 +243,14 @@ func InitDependencies(ctx context.Context) (*AppContainer, func()) {
 	deploymentService.SetOnAuditEvent(auditService.Record)
 	rolloutService := services.NewRolloutService(rolloutRepo, channelRepo, updateRepo, deploymentService)
 	rolloutService.SetOnAuditEvent(auditService.Record)
-	mcpService := mcp.NewMCPService()
-	mcpHandler := mcp.NewMCPHandler(mcpService)
 
 	// Shared across handlers; with Redis configured, also across replicas.
 	rateLimiter := ratelimit.New(cache.GetCache())
+
+	var oauthHandler *oauth.OAuthHandler
+	if oauthClientRepo != nil {
+		oauthHandler = oauth.NewOAuthHandler(oauth.NewOAuthService(oauthClientRepo), rateLimiter)
+	}
 
 	container := &AppContainer{
 		AuthHandler:                 dashhandlers.NewAuthHandler(dashboardAuthService, rateLimiter),
@@ -274,6 +283,7 @@ func InitDependencies(ctx context.Context) (*AppContainer, func()) {
 		ObserveExplorerHandler:      observe.NewExplorerHandler(explorer, identityService),
 		IdentityHandler:             identity.NewIdentityHandler(identityService),
 		MCPHandler:                  mcpHandler,
+		OAuthHandler:                oauthHandler,
 	}
 
 	if checkInRecorder != nil {

--- a/internal/router/wire.go
+++ b/internal/router/wire.go
@@ -253,7 +253,7 @@ func InitDependencies(ctx context.Context) (*AppContainer, func()) {
 	var oauthService *oauth.OAuthService
 	var oauthHandler *oauth.OAuthHandler
 	if oauthClientRepo != nil {
-		oauthService = oauth.NewOAuthService(oauthClientRepo, oauthCodeRepo, userRepo)
+		oauthService = oauth.NewOAuthService(oauthClientRepo, oauthCodeRepo, refreshTokenRepo, userRepo)
 		oauthHandler = oauth.NewOAuthHandler(oauthService, rateLimiter)
 	}
 

--- a/internal/router/wire.go
+++ b/internal/router/wire.go
@@ -85,6 +85,7 @@ func InitDependencies(ctx context.Context) (*AppContainer, func()) {
 	var userRepo services.UserRepository
 	var refreshTokenRepo services.RefreshTokenRepository
 	var oauthClientRepo oauth.ClientRepository
+	var oauthCodeRepo oauth.CodeRepository
 	var mcpHandler *mcp.MCPHandler
 	var rolloutRepo services.RolloutRepository
 	var licenseRepo licensing.LicenseRepository
@@ -138,6 +139,7 @@ func InitDependencies(ctx context.Context) (*AppContainer, func()) {
 		userRepo = store.NewPostgresUserStore(dbEngine)
 		refreshTokenRepo = store.NewPostgresRefreshTokenStore(dbEngine)
 		oauthClientRepo = store.NewPostgresOAuthClientStore(dbEngine)
+		oauthCodeRepo = store.NewPostgresOAuthCodeStore(dbEngine)
 		mcpHandler = mcp.NewMCPHandler(mcp.NewMCPService())
 		licenseRepo = licensing.NewPostgresLicenseStore(dbEngine)
 		ssoRepo = sso.NewPostgresSSOStore(dbEngine)
@@ -251,7 +253,7 @@ func InitDependencies(ctx context.Context) (*AppContainer, func()) {
 	var oauthService *oauth.OAuthService
 	var oauthHandler *oauth.OAuthHandler
 	if oauthClientRepo != nil {
-		oauthService = oauth.NewOAuthService(oauthClientRepo, userRepo)
+		oauthService = oauth.NewOAuthService(oauthClientRepo, oauthCodeRepo, userRepo)
 		oauthHandler = oauth.NewOAuthHandler(oauthService, rateLimiter)
 	}
 

--- a/internal/router/wire.go
+++ b/internal/router/wire.go
@@ -19,6 +19,7 @@ import (
 	"expo-open-ota/internal/database/postgres/migrations"
 	"expo-open-ota/internal/handlers"
 	dashhandlers "expo-open-ota/internal/handlers/dashboard"
+	"expo-open-ota/internal/mcp"
 	"expo-open-ota/internal/ratelimit"
 	"expo-open-ota/internal/services"
 	"expo-open-ota/internal/store"
@@ -44,6 +45,7 @@ type AppContainer struct {
 	RBACService                 *rbac.RBACService
 	RollbackHandler             *handlers.RollbackHandler
 	RolloutHandler              *dashhandlers.RolloutHandler
+	MCPHandler                  *mcp.MCPHandler
 	SettingsHandler             *dashhandlers.SettingsHandler
 	SSOHandler                  *sso.SSOHandler
 	UpdateHandler               *dashhandlers.UpdateHandler
@@ -235,6 +237,8 @@ func InitDependencies(ctx context.Context) (*AppContainer, func()) {
 	deploymentService.SetOnAuditEvent(auditService.Record)
 	rolloutService := services.NewRolloutService(rolloutRepo, channelRepo, updateRepo, deploymentService)
 	rolloutService.SetOnAuditEvent(auditService.Record)
+	mcpService := mcp.NewMCPService()
+	mcpHandler := mcp.NewMCPHandler(mcpService)
 
 	// Shared across handlers; with Redis configured, also across replicas.
 	rateLimiter := ratelimit.New(cache.GetCache())
@@ -269,6 +273,7 @@ func InitDependencies(ctx context.Context) (*AppContainer, func()) {
 		ObserveHealthHistoryHandler: observe.NewHealthHistoryHandler(healthHistory, stateHistory),
 		ObserveExplorerHandler:      observe.NewExplorerHandler(explorer, identityService),
 		IdentityHandler:             identity.NewIdentityHandler(identityService),
+		MCPHandler:                  mcpHandler,
 	}
 
 	if checkInRecorder != nil {

--- a/internal/store/oauth_client_postgres.go
+++ b/internal/store/oauth_client_postgres.go
@@ -1,0 +1,35 @@
+package store
+
+import (
+	"context"
+	"expo-open-ota/internal/database"
+	"expo-open-ota/internal/database/postgres/pgdb"
+	"fmt"
+)
+
+type InsertOAuthClientParameters struct {
+	ID           string
+	Name         string
+	RedirectURIs []string
+}
+
+type PostgresOAuthClientStore struct {
+	engine *database.Engine
+}
+
+func NewPostgresOAuthClientStore(engine *database.Engine) *PostgresOAuthClientStore {
+	return &PostgresOAuthClientStore{
+		engine: engine,
+	}
+}
+
+func (s *PostgresOAuthClientStore) InsertOAuthClient(ctx context.Context, params InsertOAuthClientParameters) error {
+	if err := s.engine.Queries.InsertOAuthClient(ctx, pgdb.InsertOAuthClientParams{
+		ID:           ToPgUUID(params.ID),
+		Name:         params.Name,
+		RedirectUris: params.RedirectURIs,
+	}); err != nil {
+		return fmt.Errorf("failed to insert oauth client into database: %w", err)
+	}
+	return nil
+}

--- a/internal/store/oauth_client_postgres.go
+++ b/internal/store/oauth_client_postgres.go
@@ -7,6 +7,14 @@ import (
 	"fmt"
 )
 
+// OAuthClient is a dynamically registered OAuth client: a public client
+// pinned to the redirect URIs it declared at registration.
+type OAuthClient struct {
+	Id           string
+	Name         string
+	RedirectURIs []string
+}
+
 type InsertOAuthClientParameters struct {
 	ID           string
 	Name         string
@@ -21,6 +29,21 @@ func NewPostgresOAuthClientStore(engine *database.Engine) *PostgresOAuthClientSt
 	return &PostgresOAuthClientStore{
 		engine: engine,
 	}
+}
+
+func (s *PostgresOAuthClientStore) GetOAuthClient(ctx context.Context, id string) (OAuthClient, error) {
+	row, err := s.engine.Queries.GetOAuthClient(ctx, ToPgUUID(id))
+	if err != nil {
+		if database.IsNoRows(err) {
+			return OAuthClient{}, &ErrResourceNotFound{Resource: "oauth client", Identifier: id}
+		}
+		return OAuthClient{}, fmt.Errorf("failed to retrieve oauth client from database: %w", err)
+	}
+	return OAuthClient{
+		Id:           row.ID.String(),
+		Name:         row.Name,
+		RedirectURIs: row.RedirectUris,
+	}, nil
 }
 
 func (s *PostgresOAuthClientStore) InsertOAuthClient(ctx context.Context, params InsertOAuthClientParameters) error {

--- a/internal/store/oauth_code_postgres.go
+++ b/internal/store/oauth_code_postgres.go
@@ -1,0 +1,55 @@
+package store
+
+import (
+	"context"
+	"expo-open-ota/internal/database"
+	"expo-open-ota/internal/database/postgres/pgdb"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+type InsertOAuthAuthorizationCodeParameters struct {
+	ID            string
+	ClientID      string
+	UserID        string
+	RedirectURI   string
+	CodeChallenge string
+	Scope         string
+	ExpiresAt     time.Time
+}
+
+type PostgresOAuthCodeStore struct {
+	engine *database.Engine
+}
+
+func NewPostgresOAuthCodeStore(engine *database.Engine) *PostgresOAuthCodeStore {
+	return &PostgresOAuthCodeStore{
+		engine: engine,
+	}
+}
+
+func (s *PostgresOAuthCodeStore) InsertOAuthAuthorizationCode(ctx context.Context, params InsertOAuthAuthorizationCodeParameters) error {
+	if err := s.engine.Queries.InsertOAuthAuthorizationCode(ctx, pgdb.InsertOAuthAuthorizationCodeParams{
+		ID:            ToPgUUID(params.ID),
+		ClientID:      ToPgUUID(params.ClientID),
+		UserID:        ToPgUUID(params.UserID),
+		RedirectUri:   params.RedirectURI,
+		CodeChallenge: params.CodeChallenge,
+		Scope:         params.Scope,
+		ExpiresAt:     pgtype.Timestamptz{Time: params.ExpiresAt.UTC(), Valid: true},
+	}); err != nil {
+		return fmt.Errorf("failed to insert oauth authorization code into database: %w", err)
+	}
+	return nil
+}
+
+// DeleteExpiredOAuthAuthorizationCodes purges dead codes; called inline when a
+// new one is minted, which keeps the table bounded without a background job.
+func (s *PostgresOAuthCodeStore) DeleteExpiredOAuthAuthorizationCodes(ctx context.Context) error {
+	if err := s.engine.Queries.DeleteExpiredOAuthAuthorizationCodes(ctx); err != nil {
+		return fmt.Errorf("failed to delete expired oauth authorization codes from database: %w", err)
+	}
+	return nil
+}

--- a/internal/store/oauth_code_postgres.go
+++ b/internal/store/oauth_code_postgres.go
@@ -10,6 +10,18 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
+// OAuthAuthorizationCode is the consent context a consumed code was frozen
+// with; the token exchange verifies the request against it.
+type OAuthAuthorizationCode struct {
+	ID            string
+	ClientID      string
+	UserID        string
+	RedirectURI   string
+	CodeChallenge string
+	Scope         string
+	ExpiresAt     time.Time
+}
+
 type InsertOAuthAuthorizationCodeParameters struct {
 	ID            string
 	ClientID      string
@@ -43,6 +55,28 @@ func (s *PostgresOAuthCodeStore) InsertOAuthAuthorizationCode(ctx context.Contex
 		return fmt.Errorf("failed to insert oauth authorization code into database: %w", err)
 	}
 	return nil
+}
+
+// ConsumeOAuthAuthorizationCode claims a code, atomically and exactly once.
+// ErrResourceNotFound means it was not claimable: unknown, expired, or
+// already exchanged.
+func (s *PostgresOAuthCodeStore) ConsumeOAuthAuthorizationCode(ctx context.Context, id string) (OAuthAuthorizationCode, error) {
+	row, err := s.engine.Queries.ConsumeOAuthAuthorizationCode(ctx, ToPgUUID(id))
+	if err != nil {
+		if database.IsNoRows(err) {
+			return OAuthAuthorizationCode{}, &ErrResourceNotFound{Resource: "oauth authorization code", Identifier: id}
+		}
+		return OAuthAuthorizationCode{}, fmt.Errorf("failed to consume oauth authorization code in database: %w", err)
+	}
+	return OAuthAuthorizationCode{
+		ID:            row.ID.String(),
+		ClientID:      row.ClientID.String(),
+		UserID:        row.UserID.String(),
+		RedirectURI:   row.RedirectUri,
+		CodeChallenge: row.CodeChallenge,
+		Scope:         row.Scope,
+		ExpiresAt:     row.ExpiresAt.Time,
+	}, nil
 }
 
 // DeleteExpiredOAuthAuthorizationCodes purges dead codes; called inline when a


### PR DESCRIPTION
Implement Oauth authentication for MCP Servers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added OAuth 2.1 support for MCP: dynamic client registration, authorization/consent, token issuance (authorization-code exchange + refresh rotation), and protected-resource metadata.
  * Added bearer-token protected MCP endpoints with request principal attachment.
  * Added a dedicated dashboard OAuth consent page and improved post-login return-to navigation.
  * Introduced MCP- and dashboard-specific CORS handling with preflight short-circuiting.
* **Bug Fixes**
  * Authorization codes are single-use; consent denial redirects with `access_denied` and mints no codes; expired codes are cleaned up best-effort.
* **Tests**
  * Expanded OAuth consent/token, refresh rotation/replay, and MCP/CORS coverage.
* **Chores**
  * Updated Go dependencies and switched to per-surface CORS (removed global wrapper).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->