### PR TITLE
feat(cdn): serve S3 assets through presigned URLs

### DIFF
--- a/apps/dashboard/src/lib/api.ts
+++ b/apps/dashboard/src/lib/api.ts
@@ -746,7 +746,7 @@ export type ServerSettings = {
   AWSSM_CLOUDFRONT_PRIVATE_KEY_SECRET_ID: string;
   PRIVATE_CLOUDFRONT_KEY_PATH: string;
   PROMETHEUS_ENABLED: string;
-  CDN_TYPE: '' | 'cloudfront' | 'gcs-direct' | 'azure-direct' | 'generic';
+  CDN_TYPE: '' | 'cloudfront' | 'gcs-direct' | 's3-direct' | 'azure-direct' | 'generic';
   EXPO_ACCOUNT_USERNAME: string;
   SSO_ENABLED: boolean;
   APPS: { id: string; name?: string }[];

--- a/apps/dashboard/src/pages/Settings/index.tsx
+++ b/apps/dashboard/src/pages/Settings/index.tsx
@@ -235,6 +235,18 @@ export const Settings = () => {
               </Row>
             </>
           )}
+          {settings.CDN_TYPE === 's3-direct' && (
+            <>
+              <Row
+                label="Provider"
+                hint="Assets are served through presigned Amazon S3 URLs.">
+                <span className="font-medium">Amazon S3</span>
+              </Row>
+              <Row label="Bucket">
+                <Mono>{settings.S3_BUCKET_NAME}</Mono>
+              </Row>
+            </>
+          )}
           {settings.CDN_TYPE === 'azure-direct' && (
             <>
               <Row

--- a/internal/cdn/cdn.go
+++ b/internal/cdn/cdn.go
@@ -37,6 +37,11 @@ func GetCDN() CDN {
 			cdnInstance = &gcsCDN
 			return
 		}
+		s3CDN := S3DirectCDN{}
+		if (&s3CDN).isCDNAvailable() {
+			cdnInstance = &s3CDN
+			return
+		}
 		azureCDN := AzureBlobDirectCDN{}
 		if (&azureCDN).isCDNAvailable() {
 			cdnInstance = &azureCDN
@@ -51,14 +56,16 @@ func ResetCDNInstance() {
 }
 
 // ResolvedType names the CDN the server actually resolved at boot:
-// "cloudfront", "gcs-direct", "azure-direct", "generic", or "" when assets
-// are served directly.
+// "cloudfront", "gcs-direct", "s3-direct", "azure-direct", "generic", or ""
+// when assets are served directly.
 func ResolvedType() string {
 	switch GetCDN().(type) {
 	case *CloudfrontCDN:
 		return "cloudfront"
 	case *GCSDirectCDN:
 		return "gcs-direct"
+	case *S3DirectCDN:
+		return "s3-direct"
 	case *AzureBlobDirectCDN:
 		return "azure-direct"
 	case *GenericCDN:

--- a/internal/cdn/cdn_test.go
+++ b/internal/cdn/cdn_test.go
@@ -24,6 +24,75 @@ func clearCDNEnv(t *testing2.T) {
 	t.Setenv("AZURE_STORAGE_ACCOUNT_NAME", "")
 	t.Setenv("AZURE_STORAGE_ACCOUNT_KEY", "")
 	t.Setenv("AZURE_BLOB_ENDPOINT", "")
+	t.Setenv("DISABLE_S3_DIRECT_CDN", "")
+	t.Setenv("AWS_BASE_ENDPOINT", "")
+	t.Setenv("AWS_S3_FORCE_PATH_STYLE", "")
+}
+
+// The aws package builds its S3 client once per process, so every s3-direct
+// test must set the exact same AWS env before the first presign.
+func setS3CDNEnv(t *testing2.T) {
+	t.Setenv("STORAGE_MODE", "s3")
+	t.Setenv("S3_BUCKET_NAME", "test-bucket")
+	t.Setenv("AWS_REGION", "us-east-1")
+	t.Setenv("AWS_ACCESS_KEY_ID", "test-access-key")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "test-secret-key")
+}
+
+func TestGetCDNReturnsS3DirectWhenS3Configured(t *testing2.T) {
+	clearCDNEnv(t)
+	setS3CDNEnv(t)
+	ResetCDNInstance()
+	c := GetCDN()
+	if c == nil {
+		t.Fatalf("expected CDN instance, got nil")
+	}
+	if _, ok := c.(*S3DirectCDN); !ok {
+		t.Fatalf("expected *S3DirectCDN, got %T", c)
+	}
+}
+
+func TestGetCDNReturnsGenericWithCDNBaseURLOnS3(t *testing2.T) {
+	clearCDNEnv(t)
+	setS3CDNEnv(t)
+	// s3-direct is always available in s3 mode with credentials, so the
+	// explicitly configured base URL must win.
+	t.Setenv("CDN_BASE_URL", "https://cdn.example.com")
+	ResetCDNInstance()
+	c := GetCDN()
+	if _, ok := c.(*GenericCDN); !ok {
+		t.Fatalf("expected *GenericCDN, got %T", c)
+	}
+}
+
+func TestGetCDNSkipsS3DirectWhenDisabled(t *testing2.T) {
+	clearCDNEnv(t)
+	setS3CDNEnv(t)
+	t.Setenv("DISABLE_S3_DIRECT_CDN", "true")
+	ResetCDNInstance()
+	if c := GetCDN(); c != nil {
+		t.Fatalf("expected no CDN with s3-direct disabled, got %T", c)
+	}
+}
+
+func TestS3DirectComputeRedirectionURL(t *testing2.T) {
+	clearCDNEnv(t)
+	setS3CDNEnv(t)
+	t.Setenv("BUCKET_KEY_PREFIX", "prefix")
+	c := &S3DirectCDN{}
+	got, err := c.ComputeRedirectionURLForAsset("app-1", "production", "1", "1674170951", "bundles/android.js")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	wantPrefix := "https://test-bucket.s3.us-east-1.amazonaws.com/prefix/app-1/production/1/1674170951/bundles/android.js?"
+	if !strings.HasPrefix(got, wantPrefix) {
+		t.Fatalf("expected URL to start with %q, got %q", wantPrefix, got)
+	}
+	for _, param := range []string{"X-Amz-Signature=", "X-Amz-Expires=900", "X-Amz-Credential="} {
+		if !strings.Contains(got, param) {
+			t.Fatalf("expected URL to contain %q, got %q", param, got)
+		}
+	}
 }
 
 func setAzureCDNEnv(t *testing2.T) {

--- a/internal/cdn/s3_direct.go
+++ b/internal/cdn/s3_direct.go
@@ -1,0 +1,56 @@
+package cdn
+
+import (
+	"context"
+	"expo-open-ota/config"
+	"expo-open-ota/internal/bucket"
+	"expo-open-ota/internal/providers/aws"
+	"fmt"
+	"time"
+
+	awssdk "github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+)
+
+// S3DirectCDN redirects asset requests to presigned URLs served directly by
+// S3, the S3 counterpart of GCSDirectCDN: the bucket stays private and S3
+// validates each URL.
+type S3DirectCDN struct{}
+
+func (c *S3DirectCDN) isCDNAvailable() bool {
+	if config.GetEnv("STORAGE_MODE") != "s3" || config.GetEnv("S3_BUCKET_NAME") == "" {
+		return false
+	}
+	// Opt-out for buckets on an endpoint devices cannot reach (a MinIO on a
+	// private network): the server keeps streaming assets itself.
+	if config.GetEnv("DISABLE_S3_DIRECT_CDN") == "true" {
+		return false
+	}
+	return true
+}
+
+func (c *S3DirectCDN) ComputeRedirectionURLForAsset(appId, branch, runtimeVersion, updateId, asset string) (string, error) {
+	// Must match the full object key that the bucket backend writes:
+	// {BUCKET_KEY_PREFIX}{appId}/{branch}/{rv}/{updateId}/{asset}. Dropping
+	// the prefix here points the signed URL at a non-existent object.
+	key := bucket.ResolveKeyPrefix() + fmt.Sprintf("%s/%s/%s/%s/%s", appId, branch, runtimeVersion, updateId, asset)
+	return presignGetObject(key)
+}
+
+func presignGetObject(key string) (string, error) {
+	s3Client, err := aws.GetS3Client()
+	if err != nil {
+		return "", fmt.Errorf("error getting S3 client: %w", err)
+	}
+	presignClient := s3.NewPresignClient(s3Client)
+	presignResult, err := presignClient.PresignGetObject(context.TODO(), &s3.GetObjectInput{
+		Bucket: awssdk.String(config.GetEnv("S3_BUCKET_NAME")),
+		Key:    awssdk.String(key),
+	}, func(opt *s3.PresignOptions) {
+		opt.Expires = 15 * time.Minute
+	})
+	if err != nil {
+		return "", fmt.Errorf("error presigning URL: %w", err)
+	}
+	return presignResult.URL, nil
+}

--- a/internal/handlers/dashboard/settings_handler.go
+++ b/internal/handlers/dashboard/settings_handler.go
@@ -61,9 +61,9 @@ type SettingsEnv struct {
 	PRIVATE_CLOUDFRONT_KEY_PATH            string `json:"PRIVATE_CLOUDFRONT_KEY_PATH"`
 	PROMETHEUS_ENABLED                     string `json:"PROMETHEUS_ENABLED"`
 	// CDN_TYPE is the CDN the server actually resolved at boot ("cloudfront",
-	// "gcs-direct", "azure-direct", "generic" or "" when assets are served
-	// directly), so the dashboard can display the effective setup instead of
-	// making the user re-derive it from raw variables.
+	// "gcs-direct", "s3-direct", "azure-direct", "generic" or "" when assets
+	// are served directly), so the dashboard can display the effective setup
+	// instead of making the user re-derive it from raw variables.
 	CDN_TYPE string `json:"CDN_TYPE"`
 	// EXPO_ACCOUNT_USERNAME is the Expo account behind the configured access
 	// token. Only resolved in stateless mode (single app, single token) and


### PR DESCRIPTION
This pull request adds support for serving assets directly from Amazon S3 using presigned URLs ("s3-direct" CDN type). It introduces the `S3DirectCDN` implementation, updates environment variable handling, extends the dashboard UI to display S3 settings, and adds comprehensive tests for the new CDN type.

**S3 Direct CDN Implementation:**

* Introduced `S3DirectCDN` in `internal/cdn/s3_direct.go`, which generates presigned S3 URLs for asset access, keeping the bucket private and validating each request via S3.
* Updated CDN selection logic in `internal/cdn/cdn.go` to recognize and prioritize `S3DirectCDN` when S3 is configured and not explicitly disabled.
* Modified the CDN type resolution and documentation to include "s3-direct" as a possible value. [[1]](diffhunk://#diff-6d89fd6da2de09bd0137301fd157ecbc9cdcd1b6ac8ea23e0a1cdf19b2ec9220L54-R68) [[2]](diffhunk://#diff-98eeeb03bc467c524d8b6408de6177bed30777a10e09fb01a240952ebd8f9accL64-R66)

**Dashboard and API Updates:**

* Extended the `ServerSettings` type in `apps/dashboard/src/lib/api.ts` to recognize "s3-direct" as a valid CDN type.
* Updated the dashboard settings page to display S3-specific configuration details when "s3-direct" is active.

**Testing Enhancements:**

* Added tests in `internal/cdn/cdn_test.go` to verify S3 CDN selection, environment variable handling, correct fallback to generic CDN, disabling behavior, and presigned URL generation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Amazon S3 as a direct CDN option.
  * Private S3 buckets now serve assets through secure, time-limited download links.
  * Added S3 CDN details to the dashboard’s CDN settings display.
  * Generic CDN configuration continues to take precedence when explicitly configured.

* **Bug Fixes**
  * Added safeguards to disable S3 direct delivery when configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->