### PR TITLE
fix: enable stateless mode on the MCP streamable handler

### DIFF
--- a/internal/mcp/service.go
+++ b/internal/mcp/service.go
@@ -3,7 +3,6 @@ package mcp
 import (
 	"context"
 	"net/http"
-	"time"
 	"xprem/internal/services"
 	"xprem/internal/version"
 
@@ -22,9 +21,9 @@ func NewMCPService(configurators ...ConfigureServer) *MCPService {
 	// The tool schemas are inferred by reflection and never change, so every
 	// session server shares one cache.
 	schemas := &mcpprot.SchemaCache{}
-	// One server per session, built at initialize: the tool list is per
-	// account, so what a session's tools/list shows is already filtered to
-	// what its principal may use.
+	// One server per request: the tool list is per account, so what a
+	// request's tools/list shows is already filtered to what its principal
+	// may use.
 	newSessionServer := func(req *http.Request) *mcpprot.Server {
 		server := mcpprot.NewServer(&mcpprot.Implementation{
 			Name:    "xprem",
@@ -46,10 +45,10 @@ func NewMCPService(configurators ...ConfigureServer) *MCPService {
 			// forwarding to 127.0.0.1. It exists for unauthenticated local
 			// servers; /mcp requires a Bearer before this handler runs.
 			DisableLocalhostProtection: true,
-			// MCP clients rarely DELETE their session; without a timeout,
-			// sessions of vanished clients accumulate for the process
-			// lifetime. An idle client past this simply re-initializes.
-			SessionTimeout: 30 * time.Minute,
+			// Sessions live in process memory; behind a load balancer with
+			// several replicas, a session created on one replica 404s on the
+			// others. Stateless makes every POST self-contained.
+			Stateless: true,
 		},
 	)
 	return &MCPService{streamable: streamable}

--- a/internal/router/routes_mcp.go
+++ b/internal/router/routes_mcp.go
@@ -33,8 +33,8 @@ func registerMCPRoutes(r *mux.Router, container *AppContainer) {
 	mcpRouter := r.PathPrefix("/mcp").Subrouter()
 	mcpRouter.Use(mcpCORS)
 	mcpRouter.Use(middleware.NewOAuthMiddleware(container.OAuthService))
-	// POST carries the JSON-RPC messages, GET the SSE notification stream,
-	// DELETE the session teardown; all three are the same streamable endpoint.
+	// POST carries the JSON-RPC messages; the handler is stateless, so GET
+	// and DELETE get a spec-compliant 405 from the SDK.
 	mcpRouter.HandleFunc("", container.MCPHandler.GlobalHandler).
 		Methods(http.MethodPost, http.MethodGet, http.MethodDelete, http.MethodOptions)
 }


### PR DESCRIPTION
Without stateless mode, the MCP server does not work correctly in a multi-replica topology.

## Problem

The go-sdk `StreamableHTTPHandler` keeps MCP sessions in process memory. Behind the load balancer, `initialize` lands on one replica which issues the `Mcp-Session-Id`, and the next request is routed to another replica that has never seen that session — the client gets `404 session not found`. In production this shows up on virtually every connection.

## Fix

Enable `Stateless: true` on the handler (aligned with the sessionless direction of the MCP spec, SEP-2567). Every POST is now self-contained: the server is rebuilt per request from the request's principal, so per-account tool filtering keeps working, and the shared `SchemaCache` keeps the per-request cost negligible. `SessionTimeout` is removed since there are no sessions left to expire.

## Why not sticky sessions

Consistent hashing on `Mcp-Session-Id` doesn't route back to the replica that created the session (the id is generated server-side after the hash decision), nginx `sticky learn` is a paid feature, and even perfect stickiness still loses all sessions on every deploy or restart since they live in RAM.

## What is lost

Only the out-of-request server→client channel (GET SSE stream, push notifications, sampling/elicitation, stream resumption). None of our tools use it — they are all pure request/response. In-request progress notifications still work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MCP request handling by making sessions stateless, supporting more reliable operation across load-balanced environments.
  * Clarified HTTP method behavior, including appropriate responses for unsupported GET and DELETE requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->