### PR TITLE
fix: adjust time range for health history + labels

### DIFF
--- a/apps/dashboard/src/ee/components/UpdateHealthHistory.tsx
+++ b/apps/dashboard/src/ee/components/UpdateHealthHistory.tsx
@@ -69,6 +69,23 @@ const metricOptions: MetricOption[] = [
 // the truth, so resampling both smooths the line and removes the false zeros.
 const RESAMPLE_TARGET_POINTS = 140;
 
+// The history route refuses a window wider than 90 days, and callers pass the
+// update's publication date as 'from': an update older than that asked for a
+// window the API rejects outright, so the chart 404'd rather than showing the
+// last 90 days of it. Rounded up to a day boundary so the value is stable
+// across renders (it is part of the query key) and stays inside the ceiling
+// whatever the server stamps as 'to'.
+const MAX_HISTORY_WINDOW_MS = 90 * 24 * 60 * 60 * 1_000;
+
+const boundedFrom = (from?: string) => {
+  if (!from) return from;
+  const requested = new Date(from).getTime();
+  if (Number.isNaN(requested)) return from;
+  const day = 24 * 60 * 60 * 1_000;
+  const earliest = Math.ceil((Date.now() - MAX_HISTORY_WINDOW_MS) / day) * day;
+  return requested >= earliest ? from : new Date(earliest).toISOString();
+};
+
 const resampleInterval = (points: AggregatedPoint[]): number => {
   if (points.length < 2) return 0;
   const first = new Date(points[0].timestamp).getTime();
@@ -230,9 +247,10 @@ export const UpdateHealthHistory = ({
     () => Array.from(new Set(series.flatMap(item => item.updateUUIDs))),
     [series]
   );
+  const windowFrom = boundedFrom(from);
   const query = useQuery({
-    queryKey: ['update-health-history', selectedAppId, updateUUIDs.join(','), from],
-    queryFn: () => api.getUpdateHealthHistory(updateUUIDs, from),
+    queryKey: ['update-health-history', selectedAppId, updateUUIDs.join(','), windowFrom],
+    queryFn: () => api.getUpdateHealthHistory(updateUUIDs, windowFrom),
     enabled: !!selectedAppId && updateUUIDs.length > 0,
     refetchInterval: live ? 5_000 : false,
   });

--- a/apps/dashboard/src/ee/components/charts/TimeSeriesChart.tsx
+++ b/apps/dashboard/src/ee/components/charts/TimeSeriesChart.tsx
@@ -113,13 +113,24 @@ const formatCompactNumber = (value: number) =>
     maximumFractionDigits: Math.abs(value) >= 1_000 ? 1 : 0,
   }).format(value);
 
+const DAY_MS = 24 * 60 * 60 * 1_000;
+
+// Tiered, because the tick labels sit on one line: "Apr 9, 02:00 PM" is over
+// ninety pixels wide and five of them collide on any chart narrower than a full
+// page. Each tier drops the smallest unit that no longer separates two
+// neighbouring ticks at that span.
 const timeFormatter = (start: number, end: number) => {
-  const spansMultipleDays = end - start >= 24 * 60 * 60 * 1_000;
-  return new Intl.DateTimeFormat(undefined, {
-    ...(spansMultipleDays ? { month: 'short', day: 'numeric' } : {}),
-    hour: '2-digit',
-    minute: '2-digit',
-  });
+  const span = end - start;
+  if (span < DAY_MS) {
+    return new Intl.DateTimeFormat(undefined, { hour: '2-digit', minute: '2-digit' });
+  }
+  if (span < 7 * DAY_MS) {
+    return new Intl.DateTimeFormat(undefined, { month: 'short', day: 'numeric', hour: '2-digit' });
+  }
+  if (span < 365 * DAY_MS) {
+    return new Intl.DateTimeFormat(undefined, { month: 'short', day: 'numeric' });
+  }
+  return new Intl.DateTimeFormat(undefined, { month: 'short', year: 'numeric' });
 };
 
 const timestampFormatter = new Intl.DateTimeFormat(undefined, {
@@ -326,6 +337,13 @@ export const TimeSeriesChart = ({
     bottom: 28,
     left: Math.max(42, Math.ceil(yLabelWidth) + 12),
   };
+  // A tick label is centred on its instant, so one wider than the gap to the
+  // next tick overlaps it. Same 6px monospace character as the y labels, and
+  // the span decides the format, so both have to be read to know how many fit.
+  const xLabelWidth =
+    Math.max(formatTime.format(xDomain[0]).length, formatTime.format(xDomain[1]).length) * 6;
+  const xTickCount = (plotWidth: number) =>
+    Math.max(2, Math.min(5, Math.floor(plotWidth / (xLabelWidth + 20))));
   // Where a timestamp lands in the plot. The x scale is linear over an explicit
   // domain, so the markers can be placed without reaching into visx internals.
   // Two readings of the same point, on purpose: the badge is positioned in
@@ -389,7 +407,7 @@ export const TimeSeriesChart = ({
                 <Grid columns={false} numTicks={3} />
                 <Axis
                   orientation="bottom"
-                  numTicks={width < 420 ? 3 : 5}
+                  numTicks={xTickCount(Math.max(0, width - margin.left - margin.right))}
                   tickFormat={value => formatTime.format(value as Date)}
                   hideTicks
                 />


### PR DESCRIPTION
This pull request improves the robustness and clarity of time series charting and update history in the dashboard. The main changes include enforcing a maximum window for update history queries to prevent API errors, and refining time axis labeling in charts to ensure labels are readable and do not overlap regardless of chart width or data span.

**Update history query improvements:**
* Added a `boundedFrom` function in `UpdateHealthHistory.tsx` to ensure the history query does not exceed the allowed 90-day window, preventing API errors and making the chart display more reliable for older updates. (`apps/dashboard/src/ee/components/UpdateHealthHistory.tsx`)
* Updated the query key and API call to use the bounded `from` date, ensuring consistency and cache correctness. (`apps/dashboard/src/ee/components/UpdateHealthHistory.tsx`)

**Chart axis formatting and layout:**
* Refactored the time axis label formatter in `TimeSeriesChart.tsx` to use tiered formatting based on the data span, improving readability and preventing label collisions on narrow charts. (`apps/dashboard/src/ee/components/charts/TimeSeriesChart.tsx`)
* Dynamically calculated the number of x-axis ticks based on label width and chart width to avoid overlapping labels. (`apps/dashboard/src/ee/components/charts/TimeSeriesChart.tsx`)
* Updated the chart rendering to use the new tick count logic for the x-axis, further ensuring clear, non-overlapping tick labels. (`apps/dashboard/src/ee/components/charts/TimeSeriesChart.tsx`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Limited health history queries to the supported 90-day window, ensuring older dates are handled consistently.
  * Improved time-axis labels for different date ranges by reducing redundant information.
  * Adjusted chart tick density dynamically to improve readability across varying display widths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->