### PR TITLE
feat(eoas): allow overriding the update server URL with --serverUrl

### DIFF
--- a/apps/eoas/src/commands/__tests__/republish.test.ts
+++ b/apps/eoas/src/commands/__tests__/republish.test.ts
@@ -29,7 +29,8 @@ vi.mock('../../lib/package', () => ({
 }));
 vi.mock('../../lib/expoConfig', () => ({
   getPrivateExpoConfigAsync: async () => ({}),
-  getExpoConfigUpdateUrl: () => 'https://ota.example.com/manifest',
+  resolveServerUrl: async (_config: unknown, customServerUrl?: string) =>
+    new URL(customServerUrl ?? 'https://ota.example.com/manifest').origin,
   requireExpoAppId: () => 'app-1',
 }));
 vi.mock('../../lib/serverUpdates', async importOriginal => {
@@ -177,5 +178,28 @@ describe('republish command flow', () => {
 
     expect(promptedNames()).toEqual(['runtimeVersion', 'update']);
     expect(lastPostUrl().searchParams.get('updateId')).toBe('100');
+  });
+
+  it('targets the origin passed as --serverUrl instead of the config one', async () => {
+    vi.mocked(fetchUpdates).mockResolvedValue([
+      serverUpdate({ updateId: '100', platform: 'ios', publishGroup: undefined }),
+    ]);
+    answerPrompts({
+      runtimeVersion: '1.0.0',
+      update: (question: any) => question.choices[0].value,
+    });
+
+    await Republish.run(
+      ['--branch', 'main', '--serverUrl', 'https://publish.example.com/some/path'],
+      eoasRoot
+    );
+
+    expect(lastPostUrl().origin).toBe('https://publish.example.com');
+    expect(vi.mocked(fetchRuntimeVersions).mock.calls[0][0]).toMatchObject({
+      baseUrl: 'https://publish.example.com',
+    });
+    expect(vi.mocked(fetchUpdates).mock.calls[0][0]).toMatchObject({
+      baseUrl: 'https://publish.example.com',
+    });
   });
 });

--- a/apps/eoas/src/commands/publish.ts
+++ b/apps/eoas/src/commands/publish.ts
@@ -61,6 +61,11 @@ export default class Publish extends Command {
       description: 'Name of the branch to point to',
       required: true,
     }),
+    serverUrl: Flags.string({
+      description:
+        'URL of the self-hosted update server to publish to. Defaults to the origin of updates.url from your Expo config',
+      required: false,
+    }),
     nonInteractive: Flags.boolean({
       description: 'Run command in non-interactive mode',
       default: false,
@@ -96,6 +101,7 @@ export default class Publish extends Command {
   private sanitizeFlags(flags: any): {
     platform: RequestedPlatform;
     branch: string;
+    customServerUrl?: string;
     nonInteractive: boolean;
     disableRepositoryCheck: boolean;
     outputDir: string;
@@ -109,6 +115,7 @@ export default class Publish extends Command {
       disableRepositoryCheck: flags.disableRepositoryCheck,
       platform: flags.platform,
       branch: flags.branch,
+      customServerUrl: flags.serverUrl,
       nonInteractive: flags.nonInteractive,
       outputDir: flags.outputDir,
       packageRunner: resolvePackageRunner(flags.packageRunner, process.cwd()),
@@ -132,6 +139,7 @@ export default class Publish extends Command {
       platform,
       nonInteractive,
       branch,
+      customServerUrl,
       outputDir,
       packageRunner,
       providedDeprecatedChannel,
@@ -161,12 +169,14 @@ export default class Publish extends Command {
       },
       packageRunner,
     });
-    const serverUrl = await resolveServerUrl(config).catch(e => {
+    const serverUrl = await resolveServerUrl(config, customServerUrl).catch(e => {
       Log.error(e.message);
       process.exit(1);
     });
     const appId = requireExpoAppId(config);
-    if (!nonInteractive) {
+    // A URL passed on the command line needs no confirmation, and `eoas init`
+    // would not fix it anyway.
+    if (!nonInteractive && !customServerUrl) {
       const confirmed = await confirmAsync({
         message: `Is this the correct URL of your self-hosted update server? ${serverUrl}`,
         name: 'export',

--- a/apps/eoas/src/commands/republish.ts
+++ b/apps/eoas/src/commands/republish.ts
@@ -2,11 +2,7 @@ import { Env } from '@expo/eas-build-job';
 import { Command, Flags } from '@oclif/core';
 
 import { getAuthHeaders, retrieveCredentials, validateCredentials } from '../lib/auth';
-import {
-  getExpoConfigUpdateUrl,
-  getPrivateExpoConfigAsync,
-  requireExpoAppId,
-} from '../lib/expoConfig';
+import { getPrivateExpoConfigAsync, requireExpoAppId, resolveServerUrl } from '../lib/expoConfig';
 import { fetchWithRetries } from '../lib/fetch';
 import Log from '../lib/log';
 import { ora } from '../lib/ora';
@@ -36,14 +32,21 @@ export default class Publish extends Command {
       default: 'all',
       required: true,
     }),
+    serverUrl: Flags.string({
+      description:
+        'URL of the self-hosted update server to republish on. Defaults to the origin of updates.url from your Expo config',
+      required: false,
+    }),
   };
   private sanitizeFlags(flags: any): {
     branch: string;
     platform: string;
+    customServerUrl?: string;
   } {
     return {
       branch: flags.branch,
       platform: flags.platform,
+      customServerUrl: flags.serverUrl,
     };
   }
   public async run(): Promise<void> {
@@ -55,7 +58,7 @@ export default class Publish extends Command {
       process.exit(1);
     }
     const { flags } = await this.parse(Publish);
-    const { branch, platform } = this.sanitizeFlags(flags);
+    const { branch, platform, customServerUrl } = this.sanitizeFlags(flags);
     if (!branch) {
       Log.error('Branch name is required');
       process.exit(1);
@@ -75,22 +78,11 @@ export default class Publish extends Command {
     const privateConfig = await getPrivateExpoConfigAsync(projectDir, {
       env: process.env as Env,
     });
-    const updateUrl = getExpoConfigUpdateUrl(privateConfig);
-    if (!updateUrl) {
-      Log.error(
-        "Update url is not setup in your config. Please run 'eoas init' to setup the update url"
-      );
+    const baseUrl = await resolveServerUrl(privateConfig, customServerUrl).catch(e => {
+      Log.error(e.message);
       process.exit(1);
-    }
+    });
     const appId = requireExpoAppId(privateConfig);
-    let baseUrl: string;
-    try {
-      const parsedUrl = new URL(updateUrl);
-      baseUrl = parsedUrl.origin;
-    } catch (e) {
-      Log.error('Invalid URL', e);
-      process.exit(1);
-    }
     let runtimeVersions;
     try {
       runtimeVersions = await fetchRuntimeVersions({ baseUrl, appId, branch, credentials });

--- a/apps/eoas/src/commands/rollback.ts
+++ b/apps/eoas/src/commands/rollback.ts
@@ -4,9 +4,9 @@ import { Command, Flags } from '@oclif/core';
 import { getAuthHeaders, retrieveCredentials, validateCredentials } from '../lib/auth';
 import {
   RequestedPlatform,
-  getExpoConfigUpdateUrl,
   getPrivateExpoConfigAsync,
   requireExpoAppId,
+  resolveServerUrl,
 } from '../lib/expoConfig';
 import { fetchWithRetries } from '../lib/fetch';
 import Log from '../lib/log';
@@ -32,6 +32,11 @@ export default class Publish extends Command {
       description: 'Name of the branch to point to',
       required: true,
     }),
+    serverUrl: Flags.string({
+      description:
+        'URL of the self-hosted update server to roll back on. Defaults to the origin of updates.url from your Expo config',
+      required: false,
+    }),
     nonInteractive: Flags.boolean({
       description: 'Run command in non-interactive mode',
       default: false,
@@ -40,11 +45,13 @@ export default class Publish extends Command {
   private sanitizeFlags(flags: any): {
     platform: RequestedPlatform;
     branch: string;
+    customServerUrl?: string;
     nonInteractive: boolean;
   } {
     return {
       platform: flags.platform,
       branch: flags.branch,
+      customServerUrl: flags.serverUrl,
       nonInteractive: flags.nonInteractive,
     };
   }
@@ -57,7 +64,7 @@ export default class Publish extends Command {
       process.exit(1);
     }
     const { flags } = await this.parse(Publish);
-    const { platform, branch, nonInteractive } = this.sanitizeFlags(flags);
+    const { platform, branch, customServerUrl, nonInteractive } = this.sanitizeFlags(flags);
     if (!branch) {
       Log.error('Branch name is required');
       process.exit(1);
@@ -92,22 +99,11 @@ export default class Publish extends Command {
       );
       process.exit(1);
     }
-    const updateUrl = getExpoConfigUpdateUrl(privateConfig);
-    if (!updateUrl) {
-      Log.error(
-        "Update url is not setup in your config. Please run 'eoas init' to setup the update url"
-      );
+    const baseUrl = await resolveServerUrl(privateConfig, customServerUrl).catch(e => {
+      Log.error(e.message);
       process.exit(1);
-    }
+    });
     const appId = requireExpoAppId(privateConfig);
-    let baseUrl: string;
-    try {
-      const parsedUrl = new URL(updateUrl);
-      baseUrl = parsedUrl.origin;
-    } catch (e) {
-      Log.error('Invalid URL', e);
-      process.exit(1);
-    }
     const runtimeSpinner = ora('🔄 Resolving runtime version...').start();
     const runtimeVersions = [
       ...(!platform || platform === RequestedPlatform.All || platform === RequestedPlatform.Ios

--- a/apps/eoas/src/lib/__tests__/expoConfig.test.ts
+++ b/apps/eoas/src/lib/__tests__/expoConfig.test.ts
@@ -3,7 +3,7 @@ import os from 'os';
 import path from 'path';
 import { describe, expect, it } from 'vitest';
 
-import { createOrModifyExpoConfigAsync } from '../expoConfig';
+import { createOrModifyExpoConfigAsync, resolveServerUrl } from '../expoConfig';
 
 const guardedUpdates = {
   url: 'https://ota.example.com/manifest',
@@ -266,5 +266,33 @@ module.exports = makeConfig();
     await expect(
       createOrModifyExpoConfigAsync(projectDir, { updates: guardedUpdates })
     ).rejects.toThrow('Could not find the exported config object');
+  });
+});
+
+describe('resolveServerUrl', () => {
+  const config = { updates: { url: 'https://ota.example.com/manifest' } } as any;
+
+  it('falls back to the origin of the Expo config update url', async () => {
+    await expect(resolveServerUrl(config)).resolves.toBe('https://ota.example.com');
+  });
+
+  it('prefers the custom server url and keeps only its origin', async () => {
+    await expect(resolveServerUrl(config, 'https://publish.example.com/some/path')).resolves.toBe(
+      'https://publish.example.com'
+    );
+  });
+
+  it('resolves without any update url in the config when a custom one is passed', async () => {
+    await expect(resolveServerUrl({} as any, 'https://publish.example.com')).resolves.toBe(
+      'https://publish.example.com'
+    );
+  });
+
+  it('rejects when neither the config nor the flag provides a url', async () => {
+    await expect(resolveServerUrl({} as any)).rejects.toThrow('Update url is not setup');
+  });
+
+  it('rejects an unparseable custom server url', async () => {
+    await expect(resolveServerUrl(config, 'not-a-url')).rejects.toThrow('Invalid --serverUrl');
   });
 });

--- a/apps/eoas/src/lib/expoConfig.ts
+++ b/apps/eoas/src/lib/expoConfig.ts
@@ -372,17 +372,22 @@ function stringifyWithEnv(obj: Record<string, any>): string {
   return json.replace(/"__RAW_EXPR_(\d+)__"/g, (_match, index) => rawExpressions[Number(index)]);
 }
 
-export async function resolveServerUrl(config: ExpoConfig): Promise<string> {
-  const updateUrl = config.updates?.url;
+// customServerUrl wins over the Expo config, so a project serving updates and
+// receiving publishes on two different origins can point the CLI at the second
+// one without touching its config.
+export async function resolveServerUrl(
+  config: ExpoConfig,
+  customServerUrl?: string
+): Promise<string> {
+  const updateUrl = customServerUrl ?? getExpoConfigUpdateUrl(config);
   if (!updateUrl) {
-    throw new Error('No update URL found in the Expo config.');
+    throw new Error(
+      "Update url is not setup in your config. Please run 'eoas init' to setup the update url, or pass --serverUrl"
+    );
   }
-  let baseUrl: string;
   try {
-    const parsedUrl = new URL(updateUrl);
-    baseUrl = parsedUrl.origin;
+    return new URL(updateUrl).origin;
   } catch {
-    throw new Error('Invalid update URL.');
+    throw new Error(customServerUrl ? 'Invalid --serverUrl value.' : 'Invalid update URL.');
   }
-  return baseUrl;
 }


### PR DESCRIPTION
## Context

Some setups serve updates and receive publishes on two different origins. A
common one: the manifest path is whitelisted at the proxy level and publicly
reachable, while every other path is only reachable behind a VPN. Today the CLI
derives the server URL from `updates.url` in the Expo config, so those projects
have no way to point a publish at the internal origin without rewriting their
config in CI.

This adds a `--serverUrl` flag to override that origin.

Supersedes #61 by @greeeg, which implemented this for `publish` on the pre-v3
CLI. The v3 restructuring left that branch conflicting; this reimplements the
same idea on top of `main` and extends it to `republish` and `rollback`, as
asked in the review there.

## What changed

`resolveServerUrl` now takes an optional custom URL that wins over the Expo
config, and only its origin is kept — so `--serverUrl https://publish.internal/x`
and `--serverUrl https://publish.internal` behave identically. When the flag is
passed, `updates.url` is no longer required at all.

The flag is available on the three commands that talk to the server:

```bash
eoas publish   --branch production --serverUrl https://publish.internal
eoas republish --branch production --serverUrl https://publish.internal
eoas rollback  --branch production --serverUrl https://publish.internal
```

`republish` and `rollback` each had their own inline copy of the "read
`updates.url`, parse it, keep the origin" logic. They now go through
`resolveServerUrl` like `publish` does, which is what makes the flag behave the
same way everywhere. Net effect on those two files is fewer lines than before.

Two smaller consequences:

- `publish` no longer asks *"Is this the correct URL of your self-hosted update
  server?"* when the URL came from the flag. Confirming a value that was just
  typed on the command line, with an error pointing at `eoas init` that would
  not fix a wrong flag, was noise.
- The "no update url configured" error is now a single message across the three
  commands, and mentions `--serverUrl` alongside `eoas init`.

## Tests

- Unit tests on `resolveServerUrl`: config fallback, flag precedence, origin
  extraction, no-url-anywhere, unparseable flag value.
- An end-to-end `republish` test asserting `--serverUrl` redirects all three
  server calls (`fetchRuntimeVersions`, `fetchUpdates`, the republish `POST`)
  to the overridden origin.

## Notes for the reviewer

- No behaviour change when the flag is absent: the resolution path is the same
  as before on all three commands.
- The flag is visible in `--help` rather than hidden — it is a supported setup,
  not a debug escape hatch.
- `doctor` keeps its existing `--url` flag. Renaming it would be a breaking
  change for no benefit here.
- The EOAS command reference on GitBook needs the flag added; not in this repo.

Closes #61.

Co-authored-by: Gregoire Mielle <@greeeg>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `--server-url` option to publish, republish, and rollback commands.
  * Supports sending updates through a self-hosted update server.
  * Custom server URLs are normalized to their origin and take precedence over configured settings.
* **Bug Fixes**
  * Improved handling and reporting of missing or invalid server URLs.
  * Publishing with an explicit server URL no longer prompts for interactive confirmation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->