### PR TITLE
Branch surfing

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -67,6 +67,34 @@ jobs:
       - name: Run tests
         run: npm test
 
+  # The picker ships TypeScript sources straight to consumers, so nothing but the
+  # compiler stands between a broken package and every app that installs it.
+  typecheck-control-center:
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: apps/control-center
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Type-check
+        run: npm run typecheck
+
+      - name: Verify the published contents
+        run: npm pack --dry-run
+
   test:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,6 +112,16 @@ jobs:
     permissions:
       contents: read
       id-token: write
+    strategy:
+      # One package must not stop the other from being published, and a partial
+      # release is easier to finish than to unpick.
+      fail-fast: false
+      matrix:
+        include:
+          - package: apps/eoas
+            build: true
+          - package: apps/control-center
+            build: false
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -131,11 +141,23 @@ jobs:
       - name: Publish NPM package
         env:
           REF_NAME: ${{ github.ref_name }}
+          PACKAGE_DIR: ${{ matrix.package }}
+          NEEDS_BUILD: ${{ matrix.build }}
         run: |
-          cd apps/eoas
+          cd "$PACKAGE_DIR"
           VERSION="${REF_NAME#v}"
-          npm ci
-          npm run build
+          # ci only where a lockfile makes it reproducible; the picker package
+          # has none, and ci refuses to run without one.
+          if [ -f package-lock.json ]; then npm ci; else npm install; fi
+          if [ "$NEEDS_BUILD" = "true" ]; then
+            npm run build
+          fi
+          # Ships TypeScript sources, so the compiler is the only thing standing
+          # between a broken package and everyone who installs it.
+          npm run typecheck --if-present
+          # Fails here rather than on the registry if the files list is wrong,
+          # and prints exactly what a consumer would receive.
+          npm pack --dry-run
           npm version "$VERSION" --no-git-tag-version
 
           if echo "$VERSION" | grep -qE '\-(alpha|beta|rc)'; then

--- a/.gitignore
+++ b/.gitignore
@@ -35,7 +35,7 @@ vendor/
 .DS_Store
 
 # Node.js specific files (if the project includes frontend code)
-node_modules/
+node_modules
 
 # Build directories
 bin/

--- a/apps/control-center/README.md
+++ b/apps/control-center/README.md
@@ -1,0 +1,91 @@
+# @xprem/control-center
+
+See which branch this build is running, and switch to another — from the build
+itself.
+
+Built for acceptance testing: one TestFlight or Play build becomes a shell for
+every branch that is compatible with it, so five people can test five branches in
+parallel without five builds.
+
+```tsx
+import { ControlCenter } from '@xprem/control-center';
+
+export default function App() {
+  return (
+    <>
+      <YourApp />
+      <ControlCenter />
+    </>
+  );
+}
+```
+
+That is the whole integration. There is nothing to configure: the panel reads the
+update URL, app id, channel and runtime version from the config the build already
+carries.
+
+## It turns itself on
+
+At launch, once the first frame has painted, the component asks the server one
+question — is branch surfing allowed on this build's channel? On no, it renders
+`null` and registers nothing. On yes, a small blue marker appears on the right
+edge; press it and the panel opens, branches already in hand. One request per
+app session, answered from the server's cache.
+
+Turn branch surfing on for a channel from the xprem dashboard and the panel is
+there at the next launch of every build on that channel — nothing to republish.
+Turn it off and it disappears the same way. A production channel never shows it.
+
+## Footprint
+
+JavaScript only. No native module, no config plugin, no `prebuild`. It ships in
+the JS bundle, which means **it can be delivered over the air to a build that is
+already in testers' hands** — the picker itself is an update.
+
+The only dependencies are `expo-updates` and `expo-constants`, which the app has
+already. The edge marker is the built-in way in; your own trigger works from
+anywhere:
+
+```tsx
+import { openControlCenter } from '@xprem/control-center';
+```
+
+## What a tester sees
+
+The panel opens on the branch currently running — live dot, channel and runtime
+under it — then the branches this build can switch to, drawn as a rail of
+branch dots, newest first. Only branches with an update built for **this** binary's
+runtime version are listed: a branch that changed native code cannot be reached
+without a new build, so offering it would be a dead end.
+
+When a branch crashes on launch, expo-updates falls back on its own and the server
+refuses to serve that branch again. The panel says so, names the branch, and says
+what unblocks it — publishing a fix to that same branch.
+
+## Requirements
+
+- Expo SDK 54 or newer (`setUpdateRequestHeadersOverride`)
+- `xprem-branch` declared in `updates.requestHeaders` at build time
+
+The second one is not optional: expo-updates only accepts a runtime override for
+keys that existed when the app was built. `eoas init` writes it for you.
+
+```ts
+updates: {
+  requestHeaders: {
+    'expo-channel-name': process.env.RELEASE_CHANNEL,
+    'expo-app-id': '...',
+    'xprem-branch': 'default',
+  },
+}
+```
+
+## If a build gets stuck
+
+It cannot be bricked. A branch that fails to launch is rolled back by
+expo-updates itself, onto the bundle embedded in the binary. To get moving again,
+in order of preference:
+
+1. publish a fix to the branch being tested
+2. turn branch surfing off for the channel, which returns every device
+3. reinstall the app, which clears the stored choice

--- a/apps/control-center/README.md
+++ b/apps/control-center/README.md
@@ -65,20 +65,31 @@ what unblocks it — publishing a fix to that same branch.
 ## Requirements
 
 - Expo SDK 54 or newer (`setUpdateRequestHeadersOverride`)
-- `xprem-branch` declared in `updates.requestHeaders` at build time
-
-The second one is not optional: expo-updates only accepts a runtime override for
-keys that existed when the app was built. `eoas init` writes it for you.
+- `expo-app-id`, `expo-channel-name` and `xprem-branch` declared in
+  `updates.requestHeaders` at build time
 
 ```ts
 updates: {
   requestHeaders: {
-    'expo-channel-name': process.env.RELEASE_CHANNEL,
+    'expo-channel-name': 'staging',
     'expo-app-id': '...',
-    'xprem-branch': 'default',
+    'xprem-branch': '',
   },
 }
 ```
+
+Those three are not optional, and the panel refuses to appear without them —
+switching branches replaces the whole header set, and expo-updates only accepts an
+override for keys that existed when the app was built. A build missing one of them
+would drop it from every poll from then on, which the server answers with a 400,
+which means no update can reach the device to undo it. Reinstalling is the only way
+out, so the package checks first and logs which header is missing. `eoas init`
+writes them for you.
+
+Declare `expo-channel-name` as a literal, not `process.env.SOMETHING`. The config is
+evaluated when the JS bundle is exported, so an unset variable silently removes the
+key — and an export run with the wrong value would bake in the wrong channel. Only
+the key matters here: the value sent at runtime is always the build's real channel.
 
 ## If a build gets stuck
 

--- a/apps/control-center/package.json
+++ b/apps/control-center/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@xprem/control-center",
+  "version": "0.1.0",
+  "description": "A branch picker that appears on builds whose channel allows surfing. JS-only, for xprem branch surfing.",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "files": [
+    "/src"
+  ],
+  "scripts": {
+    "typecheck": "tsc --noEmit"
+  },
+  "keywords": [
+    "xprem",
+    "expo",
+    "expo-updates",
+    "branch-surfing",
+    "qa"
+  ],
+  "license": "MIT",
+  "peerDependencies": {
+    "expo-constants": "*",
+    "expo-updates": ">=0.29.0",
+    "react": ">=18",
+    "react-native": ">=0.72"
+  },
+  "devDependencies": {
+    "@types/react": "~19.2.14",
+    "typescript": "~6.0.3"
+  }
+}

--- a/apps/control-center/package.json
+++ b/apps/control-center/package.json
@@ -5,7 +5,8 @@
   "main": "src/index.ts",
   "types": "src/index.ts",
   "files": [
-    "/src"
+    "src",
+    "README.md"
   ],
   "scripts": {
     "typecheck": "tsc --noEmit"
@@ -27,5 +28,10 @@
   "devDependencies": {
     "@types/react": "~19.2.14",
     "typescript": "~6.0.3"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/axelmarciano/xprem.git",
+    "directory": "apps/control-center"
   }
 }

--- a/apps/control-center/src/BranchIcon.tsx
+++ b/apps/control-center/src/BranchIcon.tsx
@@ -1,0 +1,57 @@
+import { View } from 'react-native';
+import { palette } from './theme';
+
+/**
+ * The git-branch glyph, drawn with borders instead of an SVG because this package
+ * ships no native modules. The curve is the bottom-right quadrant of a box whose
+ * corner radius equals its height, which is exactly a quarter circle.
+ *
+ * Geometry is lucide's 24-unit grid, so it lines up with the icon everyone knows.
+ */
+const GRID = 24;
+
+export function BranchIcon({ size = 24, color = palette.ink, weight = 2 }) {
+  const s = size / GRID;
+  const stroke = weight * s;
+  const dot = (cx: number, cy: number) => ({
+    position: 'absolute' as const,
+    left: (cx - 3) * s,
+    top: (cy - 3) * s,
+    width: 6 * s,
+    height: 6 * s,
+    borderRadius: 3 * s,
+    borderWidth: stroke,
+    borderColor: color,
+  });
+
+  return (
+    <View style={{ width: size, height: size }}>
+      <View
+        style={{
+          position: 'absolute',
+          left: (6 - weight / 2) * s,
+          top: 4 * s,
+          width: stroke,
+          height: 16 * s,
+          backgroundColor: color,
+        }}
+      />
+      <View
+        style={{
+          position: 'absolute',
+          left: 6 * s,
+          top: 7 * s,
+          width: 12 * s,
+          height: 6 * s,
+          borderBottomWidth: stroke,
+          borderRightWidth: stroke,
+          borderColor: color,
+          borderBottomRightRadius: 6 * s,
+        }}
+      />
+      <View style={dot(6, 4)} />
+      <View style={dot(6, 20)} />
+      <View style={dot(18, 4)} />
+    </View>
+  );
+}

--- a/apps/control-center/src/ControlCenter.tsx
+++ b/apps/control-center/src/ControlCenter.tsx
@@ -174,7 +174,15 @@ function ControlCenterPanel() {
     setExpanding(true);
     try {
       const result = await listBranches(config, undefined, true);
-      if (result) setPage(result);
+      if (result === null) {
+        // Surfing was switched off between opening the panel and asking for the
+        // rest. Same stand-down as every other read, or the tester is left
+        // holding switches the server will no longer honour.
+        setAllowed(false);
+        setVisible(false);
+        return;
+      }
+      setPage(result);
       // Set even when the wide answer is itself capped: this only means "already
       // asked", so a keystroke cannot start the same fetch again. Whether the
       // list is COMPLETE is a separate question, read off total below.

--- a/apps/control-center/src/ControlCenter.tsx
+++ b/apps/control-center/src/ControlCenter.tsx
@@ -115,9 +115,12 @@ function ControlCenterPanel() {
           setAllowed(true);
           setPage(result);
         })
-        // Silent: at launch there is no panel to show it in, and the next launch
-        // retries. Opening the panel by other means surfaces the error properly.
-        .catch(() => {});
+        .catch((cause: Error) => {
+          // Not silent: the panel is unreachable for the rest of this session
+          // unless the host app calls openControlCenter, and nothing else would
+          // ever say why.
+          console.warn(`[xprem] Could not reach the branch list: ${cause.message}`);
+        });
     });
     return () => {
       cancelled = true;
@@ -126,12 +129,20 @@ function ControlCenterPanel() {
   }, [config]);
 
   useEffect(() => {
-    if (!active) return;
+    // Registered whether or not the probe has answered. Gating it on `active`
+    // made the host app's own trigger a silent no-op for the whole of every
+    // launch, and permanently so whenever the probe failed — which is exactly
+    // when someone reaches for it. Opening early shows the panel's own loading
+    // and error states, which is the point.
     openPanel = open;
     return () => {
-      openPanel = null;
+      // Only if it is still ours: a second instance may have taken over, and
+      // clearing unconditionally would deregister a panel that is still mounted.
+      if (openPanel === open) {
+        openPanel = null;
+      }
     };
-  }, [active, open]);
+  }, [open]);
 
   useEffect(() => {
     if (!visible || !config) return;
@@ -196,8 +207,9 @@ function ControlCenterPanel() {
         if (outcome === 'nothing-to-load') {
           setNote(
             branch
-              ? `${branch} has nothing newer for this build.`
-              : 'This build is already up to date.'
+              ? `Switched to ${branch}. It has nothing newer than what is already ` +
+                `running, so the screen did not change — you will get its next publish.`
+              : 'Back on this build\u2019s own branch. Nothing newer to load.'
           );
         }
       } catch (cause) {

--- a/apps/control-center/src/ControlCenter.tsx
+++ b/apps/control-center/src/ControlCenter.tsx
@@ -1,0 +1,453 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  ActivityIndicator,
+  InteractionManager,
+  Modal,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from 'react-native';
+import { BranchIcon } from './BranchIcon';
+import { readConfig, readLoadedState, SurfConfig } from './config';
+import { BranchPage, listBranches, surfTo } from './surf';
+import { cardShadow, palette, radius, space, type } from './theme';
+import { XpremMark } from './XpremMark';
+
+/** "5 min ago" beats a timestamp for someone deciding what is fresh enough to test. */
+function sinceLabel(iso: string): string {
+  const published = Date.parse(iso);
+  if (Number.isNaN(published)) {
+    return '';
+  }
+  const minutes = Math.max(0, Math.round((Date.now() - published) / 60000));
+  if (minutes < 1) return 'Updated just now';
+  if (minutes < 60) return `Updated ${minutes} min ago`;
+  const hours = Math.round(minutes / 60);
+  if (hours < 24) return `Updated ${hours} hr ago`;
+  const days = Math.round(hours / 24);
+  return days === 1 ? 'Updated yesterday' : `Updated ${days} days ago`;
+}
+
+/**
+ * One probe per JS session. Memoised at module scope rather than in the component:
+ * a useEffect would run again if the tree remounted, and this must be exactly once
+ * per app open. reloadAsync starts a new session, so a surf re-probes naturally.
+ *
+ * Whether a channel allows surfing is a setting that changes whenever an admin
+ * says so, while a manifest is a snapshot frozen when its update was served — so
+ * the answer cannot ride in the manifest, or enabling the feature would only reach
+ * devices that happen to download something afterwards.
+ */
+let sessionProbe: Promise<BranchPage | null> | null = null;
+
+function probeOnce(config: SurfConfig): Promise<BranchPage | null> {
+  sessionProbe ??= listBranches(config).catch(() => null);
+  return sessionProbe;
+}
+
+let openPanel: (() => void) | null = null;
+
+/** Opens the panel from anywhere — the edge handle is the built-in trigger. */
+export function openControlCenter() {
+  openPanel?.();
+}
+
+export function ControlCenter() {
+  const config = useMemo(readConfig, []);
+  const loaded = useMemo(readLoadedState, []);
+  const [visible, setVisible] = useState(false);
+  const [page, setPage] = useState<BranchPage | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [pending, setPending] = useState<string | null>(null);
+  const [note, setNote] = useState<string | null>(null);
+  const [query, setQuery] = useState('');
+  const [expanding, setExpanding] = useState(false);
+  const [expanded, setExpanded] = useState(false);
+
+  const [allowed, setAllowed] = useState(false);
+  const active = config !== null && allowed;
+  const open = useCallback(() => setVisible(true), []);
+  const close = useCallback(() => setVisible(false), []);
+
+  // After first paint: a QA tool must not sit on the critical path of a launch.
+  useEffect(() => {
+    if (!config) return;
+    let cancelled = false;
+    const task = InteractionManager.runAfterInteractions(() => {
+      void probeOnce(config).then(result => {
+        if (cancelled || result === null) return;
+        setAllowed(true);
+        setPage(result);
+      });
+    });
+    return () => {
+      cancelled = true;
+      task.cancel();
+    };
+  }, [config]);
+
+  useEffect(() => {
+    if (!active) return;
+    openPanel = open;
+    return () => {
+      openPanel = null;
+    };
+  }, [active, open]);
+
+  useEffect(() => {
+    if (!visible || !config) return;
+    const controller = new AbortController();
+    setError(null);
+    setNote(null);
+    setQuery('');
+    setExpanding(false);
+    setExpanded(false);
+    listBranches(config, controller.signal)
+      .then(result => {
+        if (result === null) {
+          // Surfing was turned off while this session was running. Stand down
+          // rather than spin: null reads as "loading" everywhere below.
+          setAllowed(false);
+          setVisible(false);
+          return;
+        }
+        setPage(result);
+      })
+      .catch((cause: Error) => {
+        if (cause.name !== 'AbortError') setError(cause.message);
+      });
+    return () => controller.abort();
+  }, [visible, config]);
+
+  const showEverything = useCallback(async () => {
+    if (!config || expanded || expanding) return;
+    setExpanding(true);
+    try {
+      const result = await listBranches(config, undefined, true);
+      if (result) {
+        setPage(result);
+        setExpanded(true);
+      }
+    } catch (cause) {
+      setError((cause as Error).message);
+    } finally {
+      setExpanding(false);
+    }
+  }, [config, expanded, expanding]);
+
+  const search = useCallback(
+    (text: string) => {
+      setQuery(text);
+      // Searching a partial list would answer "no match" for a branch that is
+      // merely further down — a wrong answer, not a short one. So the first
+      // keystroke pulls the rest; showEverything is a no-op once it has.
+      if (text.length > 0) void showEverything();
+    },
+    [showEverything]
+  );
+
+  const switchTo = useCallback(
+    async (branch: string | null) => {
+      if (!config) return;
+      setPending(branch ?? '');
+      setNote(null);
+      try {
+        const outcome = await surfTo(config, branch);
+        if (outcome === 'nothing-to-load') {
+          setNote(
+            branch
+              ? `${branch} has nothing newer for this build.`
+              : 'This build is already up to date.'
+          );
+        }
+      } catch (cause) {
+        setError((cause as Error).message);
+      } finally {
+        setPending(null);
+      }
+    },
+    [config]
+  );
+
+  if (!active || !config) {
+    return null;
+  }
+
+  // What is RUNNING, which after a surf is the surfed branch — not the branch the
+  // channel maps to. Excluded from the list below: there is nothing to switch to.
+  const loadedBranch = loaded.branch;
+  const rows = (page?.branches ?? []).filter(candidate => candidate.name !== loadedBranch);
+  // The server sends a short page of the newest branches. Say how many are left
+  // rather than letting the list pass for the whole truth.
+  const withheld = page ? page.total - page.branches.length : 0;
+  // Keyed on the total, not the page: the page is short by design, so counting
+  // loaded rows would hide the search field exactly when it is most needed.
+  const searchable = (page?.total ?? 0) > 10;
+  const needle = query.trim().toLowerCase();
+  const shown = needle ? rows.filter(r => r.name.toLowerCase().includes(needle)) : rows;
+
+  if (!visible) {
+    // Always present while surfing is allowed: the way in a tester nobody briefed
+    // will actually find. An edge sliver rather than an invisible corner target,
+    // so it never swallows the host app's own controls.
+    return (
+      <Pressable
+        style={styles.handle}
+        onPress={open}
+        hitSlop={{ top: 12, bottom: 12, left: 16, right: 8 }}
+        accessibilityRole="button"
+        accessibilityLabel="Open the branch picker">
+        <View style={styles.handleGrip} />
+      </Pressable>
+    );
+  }
+
+  return (
+    // pageSheet is the native card the dev menu uses: full-height sheet, the app
+    // pushed back behind it, swipe down to dismiss. No custom animation to own.
+    <Modal visible animationType="slide" presentationStyle="pageSheet" onRequestClose={close}>
+      <View style={styles.screen}>
+        <View style={styles.header}>
+          <View style={styles.heroLine}>
+            <BranchIcon size={26} weight={2.2} />
+            <Text style={[type.hero, styles.heroName]} numberOfLines={1}>
+              {loadedBranch ?? 'Embedded build'}
+            </Text>
+            <Pressable
+              style={({ pressed }) => [styles.close, pressed && styles.closePressed]}
+              onPress={close}
+              accessibilityRole="button"
+              accessibilityLabel="Close">
+              <Text style={styles.closeGlyph}>✕</Text>
+            </Pressable>
+          </View>
+
+          <View style={styles.chipLine}>
+            <Text style={type.label}>Running on:</Text>
+            <View style={styles.chip}>
+              <View style={styles.liveDot} />
+              <Text style={type.chip}>Channel: {config.channel}</Text>
+            </View>
+            <View style={[styles.chip, styles.chipNeutral]}>
+              <Text style={[type.chip, styles.chipNeutralInk]}>
+                Runtime {config.runtimeVersion}
+              </Text>
+            </View>
+          </View>
+        </View>
+
+        <ScrollView style={styles.body} contentContainerStyle={styles.bodyContent}>
+          {loaded.refusedBranch && (
+            <View style={styles.warnCard}>
+              <Text style={styles.warnTitle}>{loaded.refusedBranch} was rolled back</Text>
+              <Text style={styles.warnBody}>
+                It crashed on launch, so this build came back here. Publishing a fix to
+                that branch makes it available again.
+              </Text>
+            </View>
+          )}
+
+          <Text style={[type.section, styles.sectionTitle]}>Switch to</Text>
+
+          {searchable && (
+            <TextInput
+              style={styles.search}
+              value={query}
+              onChangeText={search}
+              placeholder="Search branches"
+              placeholderTextColor={palette.muted}
+              autoCapitalize="none"
+              autoCorrect={false}
+              clearButtonMode="while-editing"
+              accessibilityLabel="Search branches"
+            />
+          )}
+
+          {page === null && (
+            <View style={[styles.card, styles.cardCentered]}>
+              <ActivityIndicator color={palette.muted} />
+            </View>
+          )}
+
+          {page !== null && shown.length === 0 && (
+            <View style={[styles.card, styles.cardCentered]}>
+              <Text style={type.meta}>
+                {needle
+                  ? `No branch matches “${query.trim()}”.`
+                  : `Nothing else is published for runtime ${config.runtimeVersion}.`}
+              </Text>
+            </View>
+          )}
+
+          {shown.map(candidate => (
+            <Pressable
+              key={candidate.name}
+              style={({ pressed }) => [styles.card, styles.row, pressed && styles.rowPressed]}
+              disabled={pending !== null}
+              onPress={() => void switchTo(candidate.name)}>
+              <BranchIcon size={22} color={palette.muted} />
+              <View style={styles.rowText}>
+                <Text style={type.rowTitle} numberOfLines={1}>
+                  {candidate.name}
+                </Text>
+                <Text style={type.meta}>{sinceLabel(candidate.lastUpdateAt)}</Text>
+              </View>
+              {pending === candidate.name ? (
+                <ActivityIndicator size="small" color={palette.muted} />
+              ) : (
+                <Text style={styles.chevron}>›</Text>
+              )}
+            </Pressable>
+          ))}
+
+          {withheld > 0 && (
+            <Pressable
+              style={({ pressed }) => [styles.card, styles.seeAll, pressed && styles.rowPressed]}
+              disabled={expanding}
+              onPress={() => void showEverything()}>
+              {expanding ? (
+                <ActivityIndicator size="small" color={palette.muted} />
+              ) : (
+                <Text style={styles.seeAllText}>
+                  Showing the {page?.branches.length} newest · See all {page?.total}
+                </Text>
+              )}
+            </Pressable>
+          )}
+
+          {note && <Text style={[type.meta, styles.footnote]}>{note}</Text>}
+          {error && <Text style={[type.meta, styles.errorText]}>{error}</Text>}
+
+          <Pressable
+            style={({ pressed }) => [styles.pill, pressed && styles.pillPressed]}
+            disabled={pending !== null}
+            onPress={() => void switchTo(null)}>
+            {pending === '' ? (
+              <ActivityIndicator size="small" color={palette.pillInk} />
+            ) : (
+              <Text style={type.pill}>Return to this build&rsquo;s branch</Text>
+            )}
+          </Pressable>
+
+          <View style={styles.brand}>
+            <XpremMark size={16} />
+            <Text style={type.meta}>xprem</Text>
+          </View>
+        </ScrollView>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  handle: {
+    position: 'absolute',
+    right: 0,
+    top: '45%',
+    paddingVertical: space.md,
+    paddingLeft: space.sm,
+    paddingRight: 2,
+  },
+  handleGrip: {
+    width: 4,
+    height: 42,
+    borderTopLeftRadius: 3,
+    borderBottomLeftRadius: 3,
+    backgroundColor: palette.ink,
+    opacity: 0.35,
+  },
+  screen: { flex: 1, backgroundColor: palette.page },
+  header: {
+    backgroundColor: palette.surface,
+    paddingHorizontal: space.lg,
+    paddingTop: space.lg,
+    paddingBottom: space.md,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: palette.border,
+    gap: space.md,
+  },
+  heroLine: { flexDirection: 'row', alignItems: 'center', gap: 10 },
+  heroName: { flex: 1 },
+  close: {
+    width: 32,
+    height: 32,
+    borderRadius: 16,
+    backgroundColor: palette.page,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  closePressed: { backgroundColor: palette.surfacePressed },
+  closeGlyph: { fontSize: 15, color: palette.muted },
+  chipLine: { flexDirection: 'row', alignItems: 'center', flexWrap: 'wrap', gap: space.sm },
+  chip: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    backgroundColor: palette.chipBg,
+    borderRadius: radius.chip,
+    paddingHorizontal: 10,
+    paddingVertical: 5,
+  },
+  chipNeutral: { backgroundColor: palette.page },
+  chipNeutralInk: { color: palette.muted },
+  liveDot: { width: 7, height: 7, borderRadius: 4, backgroundColor: palette.live },
+  body: { flex: 1 },
+  bodyContent: { padding: space.md, paddingBottom: space.xl, gap: space.sm },
+  sectionTitle: { marginTop: space.sm, marginLeft: space.xs },
+  search: {
+    backgroundColor: palette.surface,
+    borderRadius: radius.chip + 2,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: palette.border,
+    minHeight: 42,
+    paddingHorizontal: space.md,
+    fontSize: 16,
+    color: palette.ink,
+  },
+  card: {
+    backgroundColor: palette.surface,
+    borderRadius: radius.card,
+    paddingHorizontal: space.md,
+    paddingVertical: 14,
+    ...cardShadow,
+  },
+  cardCentered: { alignItems: 'center', justifyContent: 'center', minHeight: 64 },
+  row: { flexDirection: 'row', alignItems: 'center', gap: space.sm + 4 },
+  rowPressed: { backgroundColor: palette.surfacePressed },
+  seeAll: { alignItems: 'center', justifyContent: 'center', minHeight: 48 },
+  seeAllText: { fontSize: 15, fontWeight: '600', color: palette.ink },
+  rowText: { flex: 1, gap: 2 },
+  chevron: { fontSize: 22, color: palette.muted, marginTop: -2 },
+  warnCard: {
+    backgroundColor: palette.warnBg,
+    borderRadius: radius.card,
+    padding: space.md,
+    gap: 4,
+  },
+  warnTitle: { fontSize: 16, fontWeight: '600', color: palette.warnInk },
+  warnBody: { fontSize: 14, lineHeight: 20, color: palette.warnInk },
+  footnote: { marginLeft: space.xs },
+  errorText: { marginLeft: space.xs, color: palette.danger },
+  pill: {
+    marginTop: space.md,
+    minHeight: 52,
+    borderRadius: radius.pill,
+    backgroundColor: palette.pill,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  pillPressed: { opacity: 0.85 },
+  brand: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 6,
+    marginTop: space.lg,
+    opacity: 0.5,
+  },
+});
+
+export default ControlCenter;

--- a/apps/control-center/src/ControlCenter.tsx
+++ b/apps/control-center/src/ControlCenter.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Component, ReactNode, useCallback, useEffect, useMemo, useState } from 'react';
 import {
   ActivityIndicator,
   InteractionManager,
@@ -44,7 +44,13 @@ function sinceLabel(iso: string): string {
 let sessionProbe: Promise<BranchPage | null> | null = null;
 
 function probeOnce(config: SurfConfig): Promise<BranchPage | null> {
-  sessionProbe ??= listBranches(config).catch(() => null);
+  // Only an ANSWER is remembered — a list, or the 404 that means surfing is off.
+  // A timeout is not an answer: caching one would disable the picker until the
+  // app is killed, and the tester has no way to know a retry would work.
+  sessionProbe ??= listBranches(config).catch(error => {
+    sessionProbe = null;
+    throw error;
+  });
   return sessionProbe;
 }
 
@@ -55,7 +61,33 @@ export function openControlCenter() {
   openPanel?.();
 }
 
+// A QA tool has no business taking the host app down: whatever throws inside the
+// panel unmounts the panel, never the app around it.
+class ControlCenterBoundary extends Component<{ children: ReactNode }, { failed: boolean }> {
+  state = { failed: false };
+
+  static getDerivedStateFromError() {
+    return { failed: true };
+  }
+
+  componentDidCatch(error: Error) {
+    console.warn(`[xprem] The control center crashed and was unmounted: ${error.message}`);
+  }
+
+  render() {
+    return this.state.failed ? null : this.props.children;
+  }
+}
+
 export function ControlCenter() {
+  return (
+    <ControlCenterBoundary>
+      <ControlCenterPanel />
+    </ControlCenterBoundary>
+  );
+}
+
+function ControlCenterPanel() {
   const config = useMemo(readConfig, []);
   const loaded = useMemo(readLoadedState, []);
   const [visible, setVisible] = useState(false);
@@ -77,11 +109,15 @@ export function ControlCenter() {
     if (!config) return;
     let cancelled = false;
     const task = InteractionManager.runAfterInteractions(() => {
-      void probeOnce(config).then(result => {
-        if (cancelled || result === null) return;
-        setAllowed(true);
-        setPage(result);
-      });
+      probeOnce(config)
+        .then(result => {
+          if (cancelled || result === null) return;
+          setAllowed(true);
+          setPage(result);
+        })
+        // Silent: at launch there is no panel to show it in, and the next launch
+        // retries. Opening the panel by other means surfaces the error properly.
+        .catch(() => {});
     });
     return () => {
       cancelled = true;
@@ -127,10 +163,11 @@ export function ControlCenter() {
     setExpanding(true);
     try {
       const result = await listBranches(config, undefined, true);
-      if (result) {
-        setPage(result);
-        setExpanded(true);
-      }
+      if (result) setPage(result);
+      // Set even when the wide answer is itself capped: this only means "already
+      // asked", so a keystroke cannot start the same fetch again. Whether the
+      // list is COMPLETE is a separate question, read off total below.
+      setExpanded(true);
     } catch (cause) {
       setError((cause as Error).message);
     } finally {
@@ -303,7 +340,7 @@ export function ControlCenter() {
             </Pressable>
           ))}
 
-          {withheld > 0 && (
+          {withheld > 0 && !expanded && (
             <Pressable
               style={({ pressed }) => [styles.card, styles.seeAll, pressed && styles.rowPressed]}
               disabled={expanding}
@@ -316,6 +353,17 @@ export function ControlCenter() {
                 </Text>
               )}
             </Pressable>
+          )}
+
+          {withheld > 0 && expanded && (
+            // The server will not send more than this. Saying so is the whole
+            // point: a search over a list this size must not read as exhaustive.
+            <View style={[styles.card, styles.seeAll]}>
+              <Text style={type.meta}>
+                Showing the {page?.branches.length} newest of {page?.total}. Older
+                branches are not listed.
+              </Text>
+            </View>
           )}
 
           {note && <Text style={[type.meta, styles.footnote]}>{note}</Text>}

--- a/apps/control-center/src/XpremMark.tsx
+++ b/apps/control-center/src/XpremMark.tsx
@@ -1,0 +1,58 @@
+import { StyleSheet, View } from 'react-native';
+
+/**
+ * The xprem mark — the X glyph and its azure dot on the dark tile — rebuilt from
+ * plain Views because the design of this package forbids native modules and
+ * react-native-svg is one. Every shape in the mark is a rounded rect or a
+ * circle, so nothing is lost except the dot's radial gradient, flattened to its
+ * dominant stop; at footer size the difference does not survive the screen.
+ *
+ * Geometry is the SVG's, scaled from its 64-unit viewBox. Colours are baked in,
+ * exactly like the dashboard's mark: the tile must stay identical everywhere.
+ */
+const VIEWBOX = 64;
+// The strokes run (18,22)–(38,46) and (38,22)–(18,46): not a 45° X, slightly
+// taller than wide, and that asymmetry is part of the mark.
+const STROKE = 6.5;
+const STROKE_LENGTH = Math.hypot(38 - 18, 46 - 22) + STROKE; // round caps add a radius each
+const STROKE_ANGLE = (Math.atan2(46 - 22, 38 - 18) * 180) / Math.PI;
+
+export function XpremMark({ size = 16 }: { size?: number }) {
+  const s = size / VIEWBOX;
+  const bar = {
+    position: 'absolute' as const,
+    width: STROKE_LENGTH * s,
+    height: STROKE * s,
+    borderRadius: (STROKE / 2) * s,
+    backgroundColor: '#EEF2FA',
+    left: 28 * s - (STROKE_LENGTH * s) / 2,
+    top: 34 * s - (STROKE * s) / 2,
+  };
+  return (
+    <View
+      style={{
+        width: size,
+        height: size,
+        borderRadius: 14 * s,
+        backgroundColor: '#0A0E16',
+        borderWidth: StyleSheet.hairlineWidth,
+        borderColor: '#232F42',
+      }}
+      accessibilityRole="image"
+      accessibilityLabel="xprem">
+      <View style={[bar, { transform: [{ rotate: `${STROKE_ANGLE}deg` }] }]} />
+      <View style={[bar, { transform: [{ rotate: `${-STROKE_ANGLE}deg` }] }]} />
+      <View
+        style={{
+          position: 'absolute',
+          width: 13 * s,
+          height: 13 * s,
+          borderRadius: 6.5 * s,
+          backgroundColor: '#4E97F2',
+          left: (47 - 6.5) * s,
+          top: (43 - 6.5) * s,
+        }}
+      />
+    </View>
+  );
+}

--- a/apps/control-center/src/config.ts
+++ b/apps/control-center/src/config.ts
@@ -3,7 +3,8 @@ import * as Updates from 'expo-updates';
 
 /** What the update server needs to answer this device, all of it already on hand. */
 export type SurfConfig = {
-  origin: string;
+  /** Where /branch_lists lives: the update URL with its last segment dropped. */
+  baseUrl: string;
   appId: string;
   channel: string;
   runtimeVersion: string;
@@ -93,12 +94,17 @@ export function readConfig(): SurfConfig | null {
     return null;
   }
 
-  let origin: string;
+  let baseUrl: string;
   try {
-    origin = new URL(updates.url).origin;
+    // Sibling of the manifest route, not root of the host: a self-hosted server
+    // at https://host/ota/manifest serves https://host/ota/branch_lists. Using
+    // the origin alone sent every request to the wrong path, and the 404 that
+    // came back was indistinguishable from "this channel does not allow it".
+    const parsed = new URL(updates.url);
+    baseUrl = parsed.origin + parsed.pathname.replace(/\/[^/]*$/, '');
   } catch {
     return null;
   }
 
-  return { origin, appId, channel, runtimeVersion, requestHeaders };
+  return { baseUrl, appId, channel, runtimeVersion, requestHeaders };
 }

--- a/apps/control-center/src/config.ts
+++ b/apps/control-center/src/config.ts
@@ -101,7 +101,10 @@ export function readConfig(): SurfConfig | null {
     // the origin alone sent every request to the wrong path, and the 404 that
     // came back was indistinguishable from "this channel does not allow it".
     const parsed = new URL(updates.url);
-    baseUrl = parsed.origin + parsed.pathname.replace(/\/[^/]*$/, '');
+    // Trailing slashes go first: on ".../manifest/" the segment removal would
+    // otherwise eat the empty part after the slash and leave "manifest" in the
+    // path, sending every request one level too deep.
+    baseUrl = parsed.origin + parsed.pathname.replace(/\/+$/, '').replace(/\/[^/]*$/, '');
   } catch {
     return null;
   }

--- a/apps/control-center/src/config.ts
+++ b/apps/control-center/src/config.ts
@@ -1,0 +1,104 @@
+import Constants from 'expo-constants';
+import * as Updates from 'expo-updates';
+
+/** What the update server needs to answer this device, all of it already on hand. */
+export type SurfConfig = {
+  origin: string;
+  appId: string;
+  channel: string;
+  runtimeVersion: string;
+  /**
+   * The request headers baked at build time. setUpdateRequestHeadersOverride
+   * REPLACES the whole set rather than merging into it, and expo-updates only
+   * accepts keys that were declared at build time — so every override has to be
+   * rebuilt from this, or the poll loses its channel and its app id.
+   */
+  requestHeaders: Record<string, string>;
+};
+
+export const BRANCH_HEADER = 'xprem-branch';
+
+/** State the manifest already carries, so nothing has to be stored on the side. */
+export type LoadedState = {
+  /** The branch actually served. Not necessarily the one that was asked for. */
+  branch: string | null;
+  /** Set when the server refused a branch because its update crashed here. */
+  refusedBranch: string | null;
+};
+
+function extra(): Record<string, unknown> {
+  return ((Updates.manifest as { extra?: Record<string, unknown> } | undefined)?.extra ??
+    {}) as Record<string, unknown>;
+}
+
+export function readLoadedState(): LoadedState {
+  const manifestExtra = extra();
+  return {
+    branch: typeof manifestExtra.branch === 'string' ? manifestExtra.branch : null,
+    refusedBranch:
+      typeof manifestExtra.branchSurfingRefused === 'string' &&
+      manifestExtra.branchSurfingRefused.length > 0
+        ? manifestExtra.branchSurfingRefused
+        : null,
+  };
+}
+
+/**
+ * The keys the override cannot be built without. expo-updates only accepts an
+ * override whose keys were declared at build time, and the override replaces the
+ * whole header set — so a build missing any of these can be sent into a state
+ * where every poll is answered 400 and no update can reach it to fix that.
+ */
+const REQUIRED_BUILD_HEADERS = ['expo-app-id', 'expo-channel-name', BRANCH_HEADER];
+
+function declared(requestHeaders: Record<string, string>, key: string): boolean {
+  return typeof requestHeaders[key] === 'string';
+}
+
+/**
+ * Returns null when this build cannot surf at all: no update config, a runtime too
+ * old for the header override, or a build-time header set the override could not
+ * be rebuilt from. The component renders nothing in that case rather than offering
+ * a switch that would strand the device.
+ */
+export function readConfig(): SurfConfig | null {
+  const updates = Constants.expoConfig?.updates as
+    | { url?: string; requestHeaders?: Record<string, string> }
+    | undefined;
+  if (!updates?.url || typeof Updates.setUpdateRequestHeadersOverride !== 'function') {
+    return null;
+  }
+
+  const requestHeaders = updates.requestHeaders ?? {};
+  // A key whose value came from an unset env var is dropped from the config
+  // entirely, so this checks presence rather than truthiness — the empty string
+  // is a declaration, undefined is not.
+  const missing = REQUIRED_BUILD_HEADERS.filter(key => !declared(requestHeaders, key));
+  if (missing.length > 0) {
+    // Loud, because the symptom is a panel that never appears and the cause is
+    // three lines away in app config.
+    console.warn(
+      `[xprem] Branch surfing is unavailable: ${missing.join(', ')} ${
+        missing.length === 1 ? 'is' : 'are'
+      } missing from updates.requestHeaders. A header can only be overridden at ` +
+        `runtime if it was declared at build time.`
+    );
+    return null;
+  }
+
+  const appId = requestHeaders['expo-app-id'];
+  const channel = Updates.channel;
+  const runtimeVersion = Updates.runtimeVersion;
+  if (!appId || !channel || !runtimeVersion) {
+    return null;
+  }
+
+  let origin: string;
+  try {
+    origin = new URL(updates.url).origin;
+  } catch {
+    return null;
+  }
+
+  return { origin, appId, channel, runtimeVersion, requestHeaders };
+}

--- a/apps/control-center/src/index.ts
+++ b/apps/control-center/src/index.ts
@@ -1,0 +1,2 @@
+export { ControlCenter, openControlCenter } from './ControlCenter';
+export type { SurfableBranch } from './surf';

--- a/apps/control-center/src/surf.ts
+++ b/apps/control-center/src/surf.ts
@@ -1,0 +1,96 @@
+import * as Updates from 'expo-updates';
+import { BRANCH_HEADER, SurfConfig } from './config';
+
+export type SurfableBranch = {
+  name: string;
+  lastUpdateAt: string;
+};
+
+/** A page of branches, plus how many matched in all, so the panel can offer the rest. */
+export type BranchPage = {
+  branches: SurfableBranch[];
+  total: number;
+};
+
+/**
+ * Asks the server which branches this build may be served. Returns null when the
+ * channel does not allow surfing at all — distinct from an empty page, which
+ * means it does but has nothing else built for this runtime version. The panel
+ * hides itself on null and shows an empty state on [].
+ *
+ * The default answer is the newest 50; pass all to ask for the rest, which the
+ * panel only does when a tester taps for it.
+ */
+export async function listBranches(
+  config: SurfConfig,
+  signal?: AbortSignal,
+  all = false
+): Promise<BranchPage | null> {
+  const response = await fetch(`${config.origin}/branch_lists${all ? '?all=1' : ''}`, {
+    method: 'GET',
+    headers: {
+      'expo-app-id': config.appId,
+      'expo-channel-name': config.channel,
+      'expo-runtime-version': config.runtimeVersion,
+    },
+    signal,
+  });
+  if (response.status === 404) {
+    // Surfing off, or the channel does not exist. The server answers the same
+    // either way on purpose, so nothing here can enumerate channels.
+    return null;
+  }
+  if (!response.ok) {
+    throw new Error(`Could not reach the update server (${response.status}).`);
+  }
+  return (await response.json()) as BranchPage;
+}
+
+/**
+ * Rebuilds the WHOLE header set with one value changed: the override replaces
+ * the native set and persists across relaunches.
+ *
+ * The channel and app id are pinned from the running values rather than trusted
+ * from Constants.expoConfig: that copy is evaluated when the JS bundle is
+ * exported, and a config spelled `process.env.RELEASE_CHANNEL` evaluates to
+ * undefined in any bundle exported without the variable. Spreading it then
+ * strips the channel out of every future poll — observed live as /manifest
+ * answering 400 "No channel name provided" until the override is cleared.
+ */
+function applyBranchHeader(config: SurfConfig, branch: string) {
+  const headers: Record<string, string> = {};
+  for (const [key, value] of Object.entries(config.requestHeaders)) {
+    if (typeof value === 'string' && value !== '') {
+      headers[key] = value;
+    }
+  }
+  headers['expo-channel-name'] = config.channel;
+  headers['expo-app-id'] = config.appId;
+  headers[BRANCH_HEADER] = branch;
+  Updates.setUpdateRequestHeadersOverride(headers);
+}
+
+export type SurfOutcome = 'reloading' | 'nothing-to-load';
+
+/**
+ * Points this device at a branch and reloads onto it. Returns without reloading
+ * when the server has nothing new: the caller says so rather than leaving the
+ * tester looking at an unchanged screen.
+ */
+export async function surfTo(config: SurfConfig, branch: string | null): Promise<SurfOutcome> {
+  if (branch) {
+    applyBranchHeader(config, branch);
+  } else {
+    // Returning to the build's own branch is not "override with an empty value",
+    // it is no override at all: null removes it and the native side reverts to
+    // the headers baked at build time — the one state that can never be wrong.
+    Updates.setUpdateRequestHeadersOverride(null);
+  }
+  const { isAvailable } = await Updates.checkForUpdateAsync();
+  if (!isAvailable) {
+    return 'nothing-to-load';
+  }
+  await Updates.fetchUpdateAsync();
+  await Updates.reloadAsync();
+  return 'reloading';
+}

--- a/apps/control-center/src/surf.ts
+++ b/apps/control-center/src/surf.ts
@@ -1,4 +1,5 @@
 import * as Updates from 'expo-updates';
+import { Platform } from 'react-native';
 import { BRANCH_HEADER, SurfConfig } from './config';
 
 export type SurfableBranch = {
@@ -32,6 +33,9 @@ export async function listBranches(
       'expo-app-id': config.appId,
       'expo-channel-name': config.channel,
       'expo-runtime-version': config.runtimeVersion,
+      // The list is per platform, like the manifest: a branch whose only update
+      // is for the other one cannot be served here, so it must not be offered.
+      'expo-platform': Platform.OS,
     },
     signal,
   });
@@ -42,7 +46,13 @@ export async function listBranches(
   if (!response.ok) {
     throw new Error(`Could not reach the update server (${response.status}).`);
   }
-  return (await response.json()) as BranchPage;
+  const page = (await response.json()) as BranchPage;
+  // The build carrying this code outlives the server it was written against, so
+  // a body of another shape hides the panel rather than crashing the host app.
+  if (!page || !Array.isArray(page.branches) || typeof page.total !== 'number') {
+    return null;
+  }
+  return page;
 }
 
 /**

--- a/apps/control-center/src/surf.ts
+++ b/apps/control-center/src/surf.ts
@@ -8,6 +8,9 @@ export type SurfableBranch = {
 };
 
 /** A page of branches, plus how many matched in all, so the panel can offer the rest. */
+/** Set by the server on a 404 it decided, so a proxy's 404 is not mistaken for one. */
+const SURFING_DISABLED_HEADER = 'xprem-branch-surfing';
+
 export type BranchPage = {
   branches: SurfableBranch[];
   total: number;
@@ -27,7 +30,7 @@ export async function listBranches(
   signal?: AbortSignal,
   all = false
 ): Promise<BranchPage | null> {
-  const response = await fetch(`${config.origin}/branch_lists${all ? '?all=1' : ''}`, {
+  const response = await fetch(`${config.baseUrl}/branch_lists${all ? '?all=1' : ''}`, {
     method: 'GET',
     headers: {
       'expo-app-id': config.appId,
@@ -40,7 +43,18 @@ export async function listBranches(
     signal,
   });
   if (response.status === 404) {
-    Updates.setUpdateRequestHeadersOverride(null);
+    // Turning surfing off for a channel has to reach the devices already pinned
+    // to a branch, and this is the only place it can: the panel hides itself on
+    // this answer, so after it does there is no interface left to unpin from.
+    // Left pinned, a device would silently resume surfing the moment surfing was
+    // switched back on, onto a branch nobody chose in that session.
+    //
+    // Gated on the server saying so, not on the status alone: any 404 used to
+    // trigger this, so an old server, a proxy, or a path-based deployment wiped
+    // the tester's branch at every launch with nothing said anywhere.
+    if (response.headers.get(SURFING_DISABLED_HEADER) !== null) {
+      pin(config, null);
+    }
     return null;
   }
   if (!response.ok) {
@@ -66,6 +80,26 @@ export async function listBranches(
  * strips the channel out of every future poll — observed live as /manifest
  * answering 400 "No channel name provided" until the override is cleared.
  */
+/**
+ * What this session last pinned, so a surf that fails partway can put it back.
+ * undefined means "not set by us": the override may still hold something from an
+ * earlier session, which nothing on the client can read back — expo-updates
+ * exposes no getter — so the only honest restore in that case is to clear it.
+ */
+let pinnedBranch: string | null | undefined;
+
+function pin(config: SurfConfig, branch: string | null) {
+  if (branch === null) {
+    // Not "override with an empty value" — no override at all. The native side
+    // reverts to the headers baked at build time, the one state that cannot be
+    // wrong.
+    Updates.setUpdateRequestHeadersOverride(null);
+  } else {
+    applyBranchHeader(config, branch);
+  }
+  pinnedBranch = branch;
+}
+
 function applyBranchHeader(config: SurfConfig, branch: string) {
   const headers: Record<string, string> = {};
   for (const [key, value] of Object.entries(config.requestHeaders)) {
@@ -87,14 +121,22 @@ export type SurfOutcome = 'reloading' | 'nothing-to-load';
  * tester looking at an unchanged screen.
  */
 export async function surfTo(config: SurfConfig, branch: string | null): Promise<SurfOutcome> {
-  if (branch) {
-    applyBranchHeader(config, branch);
-  } else {
-    // Returning to the build's own branch is not "override with an empty value",
-    // it is no override at all: null removes it and the native side reverts to
-    // the headers baked at build time — the one state that can never be wrong.
-    Updates.setUpdateRequestHeadersOverride(null);
+  // The override has to be in place before checkForUpdateAsync, since that is
+  // the request it governs — so a failure after this line leaves the device
+  // pinned to a branch it never loaded, persistently and across relaunches,
+  // while the panel still shows the old one. Whatever happens below, the device
+  // must not be left pointing somewhere the tester was not told about.
+  const previous = pinnedBranch;
+  pin(config, branch);
+  try {
+    return await runSurf(config);
+  } catch (cause) {
+    pin(config, previous ?? null);
+    throw cause;
   }
+}
+
+async function runSurf(_config: SurfConfig): Promise<SurfOutcome> {
   const { isAvailable } = await Updates.checkForUpdateAsync();
   if (!isAvailable) {
     return 'nothing-to-load';

--- a/apps/control-center/src/surf.ts
+++ b/apps/control-center/src/surf.ts
@@ -36,8 +36,7 @@ export async function listBranches(
     signal,
   });
   if (response.status === 404) {
-    // Surfing off, or the channel does not exist. The server answers the same
-    // either way on purpose, so nothing here can enumerate channels.
+    Updates.setUpdateRequestHeadersOverride(null);
     return null;
   }
   if (!response.ok) {

--- a/apps/control-center/src/surf.ts
+++ b/apps/control-center/src/surf.ts
@@ -103,6 +103,11 @@ function pin(config: SurfConfig, branch: string | null) {
 function applyBranchHeader(config: SurfConfig, branch: string) {
   const headers: Record<string, string> = {};
   for (const [key, value] of Object.entries(config.requestHeaders)) {
+    // Empty values are dropped, and that is load-bearing rather than tidy.
+    // expo-updates applies this header set LAST, after the server-defined
+    // headers it has stored, and each entry REPLACES rather than adds — so an
+    // empty xprem-surf-blocked declared in app config would wipe the refusal
+    // verdicts on every poll and let a crashing update be served again.
     if (typeof value === 'string' && value !== '') {
       headers[key] = value;
     }

--- a/apps/control-center/src/theme.ts
+++ b/apps/control-center/src/theme.ts
@@ -1,0 +1,43 @@
+/**
+ * White cards floating on a light page, bold near-black type, one black pill for
+ * the primary action — the register of the Expo dashboard's branch page, which is
+ * where these testers already read about branches.
+ */
+export const palette = {
+  page: '#F6F7F9',
+  surface: '#FFFFFF',
+  surfacePressed: '#EFF1F4',
+  border: 'rgba(17, 24, 39, 0.07)',
+  ink: '#111418',
+  muted: '#6B7280',
+  /** The warm chip the dashboard uses for "Available on". */
+  chipBg: '#FFF1E7',
+  chipInk: '#8A4B1A',
+  pill: '#14171A',
+  pillInk: '#FFFFFF',
+  live: '#22C55E',
+  warnBg: '#FFF6E5',
+  warnInk: '#8A5A08',
+  danger: '#C5221F',
+};
+
+export const type = {
+  hero: { fontSize: 28, fontWeight: '700' as const, color: palette.ink },
+  section: { fontSize: 18, fontWeight: '700' as const, color: palette.ink },
+  rowTitle: { fontSize: 17, fontWeight: '600' as const, color: palette.ink },
+  meta: { fontSize: 14, color: palette.muted },
+  label: { fontSize: 15, color: palette.muted },
+  chip: { fontSize: 14, fontWeight: '500' as const, color: palette.chipInk },
+  pill: { fontSize: 16, fontWeight: '600' as const, color: palette.pillInk },
+};
+
+export const radius = { card: 16, chip: 8, pill: 999 };
+export const space = { xs: 4, sm: 8, md: 16, lg: 24, xl: 32 };
+
+export const cardShadow = {
+  shadowColor: '#0B1220',
+  shadowOpacity: 0.05,
+  shadowRadius: 10,
+  shadowOffset: { width: 0, height: 2 },
+  elevation: 1,
+};

--- a/apps/control-center/tsconfig.json
+++ b/apps/control-center/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ESNext", "DOM"],
+    "jsx": "react-jsx",
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src"]
+}

--- a/apps/dashboard/src/ee/lib/PermissionsContext.tsx
+++ b/apps/dashboard/src/ee/lib/PermissionsContext.tsx
@@ -20,6 +20,7 @@ export type Permission =
   | 'channel:create'
   | 'channel:delete'
   | 'channel:edit-branch'
+  | 'channel:branch-surfing'
   | 'channel-rollout:manage'
   | 'update-rollout:manage'
   | 'update:publish'

--- a/apps/dashboard/src/ee/lib/auditCatalog.ts
+++ b/apps/dashboard/src/ee/lib/auditCatalog.ts
@@ -46,6 +46,7 @@ export const AUDIT_ACTION_GROUPS: AuditActionGroup[] = [
       'channel.created',
       'channel.deleted',
       'channel_branch.mapped',
+      'channel_branch_surfing.updated',
       'branch.created',
       'branch.deleted',
     ],

--- a/apps/dashboard/src/ee/lib/permissionCatalog.ts
+++ b/apps/dashboard/src/ee/lib/permissionCatalog.ts
@@ -76,6 +76,12 @@ export const PERMISSION_GROUPS: PermissionGroup[] = [
         label: 'Change the channel branch',
         description: 'Point a release channel at a different branch.',
       },
+      {
+        value: 'channel:branch-surfing',
+        label: 'Manage branch surfing',
+        description:
+          'Let devices on a channel pick which branch they are served, and set which branches are exposed.',
+      },
     ],
   },
   {

--- a/apps/dashboard/src/lib/api.ts
+++ b/apps/dashboard/src/lib/api.ts
@@ -148,6 +148,15 @@ export type ChannelRecord = {
   rollout?: ChannelRolloutRecord | null;
   branchCurrentUpdate?: BranchUpdateState | null;
   rolloutBranchCurrentUpdate?: BranchUpdateState | null;
+  // Absent in stateless mode, where the setting does not exist.
+  branchSurfing?: BranchSurfingRecord | null;
+};
+
+// Which branches a device polling this channel may ask to be served instead of
+// the mapped one. Pattern is a glob: "*" stands for any run of characters.
+export type BranchSurfingRecord = {
+  enabled: boolean;
+  pattern: string;
 };
 
 export type RuntimeVersionRecord = {
@@ -1298,6 +1307,19 @@ export class ApiClient {
     return this.request<void>(`${this.appScope()}/channels/${encodeURIComponent(channelName)}`, {
       method: 'DELETE',
     });
+  }
+
+  // A full replacement: the pattern is always sent, never inferred, so turning
+  // the switch on cannot silently widen a channel that named a narrower one.
+  public async setChannelBranchSurfing(channelName: string, payload: BranchSurfingRecord) {
+    return this.request<void>(
+      `${this.appScope()}/channels/${encodeURIComponent(channelName)}/branch-surfing`,
+      {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      }
+    );
   }
 
   public async getBranches() {

--- a/apps/dashboard/src/pages/Channels/components/BranchSurfingCard.tsx
+++ b/apps/dashboard/src/pages/Channels/components/BranchSurfingCard.tsx
@@ -20,18 +20,21 @@ export const BranchSurfingCard = ({
 }) => {
   const { toast } = useToast();
   const surfing = channel.branchSurfing;
-  const [pattern, setPattern] = useState(surfing?.pattern ?? ALL_BRANCHES);
+  const [pattern, setPattern] = useState(surfing?.pattern ?? '');
   const [saving, setSaving] = useState(false);
 
   // Reseed when the channel is refetched or the route moves to another channel,
   // so the field never shows a stale channel's pattern.
   useEffect(() => {
-    setPattern(surfing?.pattern ?? ALL_BRANCHES);
+    setPattern(surfing?.pattern ?? '');
   }, [surfing?.pattern, channel.releaseChannelName]);
 
   if (!surfing) return null;
 
   const patternChanged = pattern.trim() !== surfing.pattern;
+  // Nothing can be turned on until the pattern says what it opens: defaulting it
+  // would expose every branch of the app on the first click.
+  const canEnable = pattern.trim().length > 0;
 
   // The endpoint replaces the whole setting, so both fields go on every call:
   // sending only the switch would reset the pattern to its default.
@@ -84,46 +87,48 @@ export const BranchSurfingCard = ({
         {canManage && (
           <Switch
             checked={surfing.enabled}
-            disabled={saving}
+            disabled={saving || (!surfing.enabled && !canEnable)}
             onCheckedChange={next => void save(next, pattern)}
             aria-label={surfing.enabled ? 'Disable branch surfing' : 'Enable branch surfing'}
           />
         )}
       </div>
 
-      {surfing.enabled && (
-        <div className="mt-5 space-y-1.5 border-t pt-5">
-          <Label htmlFor="branch-surfing-pattern">Branches exposed</Label>
-          <div className="flex flex-col gap-2 sm:flex-row">
-            <Input
-              id="branch-surfing-pattern"
-              className="font-mono sm:max-w-xs"
-              value={pattern}
-              disabled={!canManage || saving}
-              onChange={event => setPattern(event.target.value)}
-              placeholder="pr-*"
-            />
-            {canManage && (
-              <Button
-                variant="outline"
-                disabled={saving || !patternChanged}
-                onClick={() => void save(surfing.enabled, pattern)}>
-                {saving ? 'Saving...' : 'Save'}
-              </Button>
-            )}
-          </div>
-          <p className="text-xs text-muted-foreground">
-            <code className="font-mono">*</code> stands for any run of characters:{' '}
-            <code className="font-mono">pr-*</code> exposes every branch starting with{' '}
-            <code className="font-mono">pr-</code>.{' '}
-            {pattern.trim() === ALL_BRANCHES && (
-              <span className="text-amber-600 dark:text-amber-500">
-                Every branch of this app is currently exposed.
-              </span>
-            )}
-          </p>
+      <div className="mt-5 space-y-1.5 border-t pt-5">
+        <Label htmlFor="branch-surfing-pattern">Branches exposed</Label>
+        <div className="flex flex-col gap-2 sm:flex-row">
+          <Input
+            id="branch-surfing-pattern"
+            className="font-mono sm:max-w-xs"
+            value={pattern}
+            disabled={!canManage || saving}
+            onChange={event => setPattern(event.target.value)}
+            placeholder="pr-*"
+          />
+          {canManage && (
+            <Button
+              variant="outline"
+              disabled={saving || !patternChanged}
+              onClick={() => void save(surfing.enabled, pattern)}>
+              {saving ? 'Saving...' : 'Save'}
+            </Button>
+          )}
         </div>
-      )}
+        <p className="text-xs text-muted-foreground">
+          <code className="font-mono">*</code> stands for any run of characters:{' '}
+          <code className="font-mono">pr-*</code> exposes every branch starting with{' '}
+          <code className="font-mono">pr-</code>.{' '}
+          {!canEnable && !surfing.enabled && (
+            <span className="text-foreground">Set it to turn branch surfing on.</span>
+          )}
+          {pattern.trim() === ALL_BRANCHES && (
+            <span className="text-amber-600 dark:text-amber-500">
+              Every branch of this app is exposed, including any created later. Devices
+              read these names from an unauthenticated endpoint.
+            </span>
+          )}
+        </p>
+      </div>
     </section>
   );
 };

--- a/apps/dashboard/src/pages/Channels/components/BranchSurfingCard.tsx
+++ b/apps/dashboard/src/pages/Channels/components/BranchSurfingCard.tsx
@@ -1,0 +1,129 @@
+import { useEffect, useState } from 'react';
+import { Compass } from 'lucide-react';
+import { api, ChannelRecord, describeApiError } from '@/lib/api';
+import { useToast } from '@/hooks/use-toast';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Switch } from '@/components/ui/switch';
+
+const ALL_BRANCHES = '*';
+
+export const BranchSurfingCard = ({
+  channel,
+  canManage,
+  onUpdated,
+}: {
+  channel: ChannelRecord;
+  canManage: boolean;
+  onUpdated: () => Promise<void>;
+}) => {
+  const { toast } = useToast();
+  const surfing = channel.branchSurfing;
+  const [pattern, setPattern] = useState(surfing?.pattern ?? ALL_BRANCHES);
+  const [saving, setSaving] = useState(false);
+
+  // Reseed when the channel is refetched or the route moves to another channel,
+  // so the field never shows a stale channel's pattern.
+  useEffect(() => {
+    setPattern(surfing?.pattern ?? ALL_BRANCHES);
+  }, [surfing?.pattern, channel.releaseChannelName]);
+
+  if (!surfing) return null;
+
+  const patternChanged = pattern.trim() !== surfing.pattern;
+
+  // The endpoint replaces the whole setting, so both fields go on every call:
+  // sending only the switch would reset the pattern to its default.
+  const save = async (enabled: boolean, nextPattern: string) => {
+    const trimmed = nextPattern.trim();
+    if (!trimmed) {
+      toast({
+        title: 'Pattern is empty',
+        description: `Use "${ALL_BRANCHES}" to expose every branch.`,
+        variant: 'destructive',
+      });
+      return;
+    }
+    setSaving(true);
+    try {
+      await api.setChannelBranchSurfing(channel.releaseChannelName, {
+        enabled,
+        pattern: trimmed,
+      });
+      await onUpdated();
+      toast({
+        title: enabled ? 'Branch surfing enabled' : 'Branch surfing disabled',
+        description: enabled
+          ? `Devices on "${channel.releaseChannelName}" can pick branches matching ${trimmed}.`
+          : `Devices on "${channel.releaseChannelName}" are served the mapped branch only.`,
+      });
+    } catch (error) {
+      const message = describeApiError(error, 'Could not update branch surfing');
+      toast({ title: message.title, description: message.description, variant: 'destructive' });
+      setPattern(surfing.pattern);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <section className="rounded-lg border p-5">
+      <div className="flex flex-col justify-between gap-4 sm:flex-row sm:items-start">
+        <div className="min-w-0">
+          <h2 className="flex items-center gap-2 text-sm font-semibold">
+            <Compass className="h-4 w-4 text-muted-foreground" />
+            Branch surfing
+          </h2>
+          <p className="mt-1 text-sm text-muted-foreground">
+            {surfing.enabled
+              ? 'Devices on this channel can ask to be served another branch.'
+              : 'Devices on this channel are always served the branch it maps to.'}
+          </p>
+        </div>
+        {canManage && (
+          <Switch
+            checked={surfing.enabled}
+            disabled={saving}
+            onCheckedChange={next => void save(next, pattern)}
+            aria-label={surfing.enabled ? 'Disable branch surfing' : 'Enable branch surfing'}
+          />
+        )}
+      </div>
+
+      {surfing.enabled && (
+        <div className="mt-5 space-y-1.5 border-t pt-5">
+          <Label htmlFor="branch-surfing-pattern">Branches exposed</Label>
+          <div className="flex flex-col gap-2 sm:flex-row">
+            <Input
+              id="branch-surfing-pattern"
+              className="font-mono sm:max-w-xs"
+              value={pattern}
+              disabled={!canManage || saving}
+              onChange={event => setPattern(event.target.value)}
+              placeholder="pr-*"
+            />
+            {canManage && (
+              <Button
+                variant="outline"
+                disabled={saving || !patternChanged}
+                onClick={() => void save(surfing.enabled, pattern)}>
+                {saving ? 'Saving...' : 'Save'}
+              </Button>
+            )}
+          </div>
+          <p className="text-xs text-muted-foreground">
+            <code className="font-mono">*</code> stands for any run of characters:{' '}
+            <code className="font-mono">pr-*</code> exposes every branch starting with{' '}
+            <code className="font-mono">pr-</code>.{' '}
+            {pattern.trim() === ALL_BRANCHES && (
+              <span className="text-amber-600 dark:text-amber-500">
+                Every branch of this app is currently exposed.
+              </span>
+            )}
+          </p>
+        </div>
+      )}
+    </section>
+  );
+};

--- a/apps/dashboard/src/pages/Channels/index.tsx
+++ b/apps/dashboard/src/pages/Channels/index.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { ArrowLeft, Copy, GitBranch, Plus, Search, Split, Trash2 } from 'lucide-react';
+import { ArrowLeft, Compass, Copy, GitBranch, Plus, Search, Split, Trash2 } from 'lucide-react';
 import { Link, useNavigate, useParams } from 'react-router';
 import { api, ChannelRecord, describeApiError } from '@/lib/api';
 import { useSelectedApp } from '@/lib/SelectedAppContext';
@@ -16,6 +16,7 @@ import { ChannelBranchMapping } from '@/components/ChannelBranchMapping';
 import { SelectBranch } from '@/pages/Channels/components/SelectBranch';
 import { StartRolloutDialog } from '@/pages/Channels/components/StartRolloutDialog';
 import { ManageRolloutDialog } from '@/pages/Channels/components/ManageRolloutDialog';
+import { BranchSurfingCard } from '@/pages/Channels/components/BranchSurfingCard';
 import { RolloutBar } from '@/components/rollout/RolloutBar';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
@@ -129,6 +130,7 @@ export const Channels = () => {
   const canDeleteChannel = useAppPermission('channel:delete', 'admin-only');
   const canEditChannelBranch = useAppPermission('channel:edit-branch', 'admin-only');
   const canManageRollout = useAppPermission('channel-rollout:manage', 'admin-only');
+  const canManageBranchSurfing = useAppPermission('channel:branch-surfing', 'admin-only');
   const [search, setSearch] = useState('');
   const [createOpen, setCreateOpen] = useState(false);
   const [editingMapping, setEditingMapping] = useState(false);
@@ -215,9 +217,30 @@ export const Channels = () => {
       {
         header: 'Channel',
         accessorKey: 'releaseChannelName',
-        cell: ({ row }: { row: { original: ChannelRecord } }) => (
-          <span className="font-medium">{row.original.releaseChannelName}</span>
-        ),
+        cell: ({ row }: { row: { original: ChannelRecord } }) => {
+          const surfing = row.original.branchSurfing;
+          return (
+            <div className="flex items-center gap-2">
+              <span className="font-medium">{row.original.releaseChannelName}</span>
+              {surfing?.enabled && (
+                <Badge
+                  variant="outline"
+                  // Amber on "*" echoes the detail page: the channel exposes
+                  // every branch, which is the setting worth noticing at a
+                  // glance.
+                  className={
+                    surfing.pattern === '*'
+                      ? 'border-amber-400/25 bg-amber-400/10 text-amber-700 dark:text-amber-300'
+                      : 'border-sky-400/25 bg-sky-400/10 text-sky-700 dark:text-sky-300'
+                  }
+                  title={`Devices on this channel can surf to branches matching ${surfing.pattern}`}>
+                  <Compass className="h-3 w-3" />
+                  <span className="font-mono">{surfing.pattern}</span>
+                </Badge>
+              )}
+            </div>
+          );
+        },
       },
       {
         header: 'Status',
@@ -228,7 +251,7 @@ export const Channels = () => {
             className={
               row.original.branchName
                 ? 'border-emerald-400/25 bg-emerald-400/10 text-emerald-700 dark:text-emerald-300'
-                : 'text-muted-foreground'
+                : 'border-red-400/25 bg-red-400/10 text-red-700 dark:text-red-300'
             }>
             {row.original.branchName ? 'Active' : 'Unmapped'}
           </Badge>
@@ -426,6 +449,15 @@ export const Channels = () => {
                   )}
                 </div>
               </section>
+            )}
+            {CONTROL_PLANE_ENABLED && (
+              <BranchSurfingCard
+                channel={selectedChannel}
+                canManage={canManageBranchSurfing}
+                onUpdated={async () => {
+                  await queryClient.invalidateQueries({ queryKey: ['channels', selectedAppId] });
+                }}
+              />
             )}
           </div>
         )}

--- a/apps/eoas/src/commands/init.ts
+++ b/apps/eoas/src/commands/init.ts
@@ -111,9 +111,22 @@ export default class Init extends Command {
         .replace(/\\/g, '\\\\')
         .replace(/'/g, "\\'")}'`,
       enabled: true,
+      // Branch surfing: a build on a channel that allows it can be pointed at
+      // another branch at runtime, and expo-updates only accepts an override for
+      // header keys that already existed at build time — so these have to be
+      // declared here even when the value is empty. Dropping one of them does not
+      // disable the feature, it strips that header from every poll for the rest of
+      // the install; the picker refuses to appear rather than let that happen.
       requestHeaders: {
-        'expo-channel-name': 'process.env.RELEASE_CHANNEL',
+        'expo-channel-name': {
+          __comment: 'Declare as a literal if you surf branches: see xprem-branch below.',
+          value: 'process.env.RELEASE_CHANNEL',
+        },
         'expo-app-id': appId,
+        'xprem-branch': {
+          __comment: 'Branch surfing — the branch to serve; empty means the channel decides.',
+          value: '',
+        },
       },
     };
     const updateConfigSpinner = ora('Updating Expo config').start();

--- a/apps/eoas/src/lib/__tests__/surfingHeaders.test.ts
+++ b/apps/eoas/src/lib/__tests__/surfingHeaders.test.ts
@@ -1,0 +1,70 @@
+import fs from 'fs-extra';
+import os from 'os';
+import path from 'path';
+import { describe, expect, it } from 'vitest';
+
+import { createOrModifyExpoConfigAsync } from '../expoConfig';
+
+// eoas init has to declare these, because expo-updates only accepts a runtime
+// override for header keys that existed at build time. A build missing one can
+// be sent into a state where every poll loses that header for good.
+const updates = {
+  url: 'https://ota.example.com/manifest',
+  requestHeaders: {
+    'expo-channel-name': {
+      __comment: 'Declare as a literal if you surf branches: see xprem-branch below.',
+      value: 'process.env.RELEASE_CHANNEL',
+    },
+    'expo-app-id': 'app-1',
+    'xprem-branch': {
+      __comment: 'Branch surfing — the branch to serve; empty means the channel decides.',
+      value: '',
+    },
+  },
+};
+
+function project(configName: string, contents: string): string {
+  // eslint-disable-next-line node/no-sync
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'eoas-surf-'));
+  // eslint-disable-next-line node/no-sync
+  fs.writeFileSync(path.join(dir, 'package.json'), JSON.stringify({ name: 'app' }));
+  // eslint-disable-next-line node/no-sync
+  fs.writeFileSync(path.join(dir, configName), contents);
+  return dir;
+}
+
+function read(dir: string, fileName: string): string {
+  // eslint-disable-next-line node/no-sync
+  return fs.readFileSync(path.join(dir, fileName), 'utf8');
+}
+
+describe('init writes the branch-surfing headers', () => {
+  it('emits the keys and their comments into app.config.ts', async () => {
+    const dir = project('app.config.ts', 'export default { expo: { name: "app" } };\n');
+
+    await createOrModifyExpoConfigAsync(dir, { updates });
+
+    const written = read(dir, 'app.config.ts');
+    expect(written).toContain('xprem-branch');
+    expect(written).toContain('// Branch surfing — the branch to serve');
+    // The channel is emitted as an expression, not the string "process.env...".
+    expect(written).toContain('process.env.RELEASE_CHANNEL');
+    expect(written).not.toContain("'process.env.RELEASE_CHANNEL'");
+    // The marker itself must never reach the file.
+    expect(written).not.toContain('__comment');
+  });
+
+  // A static app.json is rewritten as app.config.js through JSON.stringify,
+  // which has no room for a comment. What matters there is that the marker is
+  // stripped rather than serialised into the file the user has to live with.
+  it('drops the comment marker on the generated static config', async () => {
+    const dir = project('app.json', JSON.stringify({ expo: { name: 'app' } }, null, 2));
+
+    await createOrModifyExpoConfigAsync(dir, { updates });
+
+    const written = read(dir, 'app.config.js');
+    expect(written).toContain('xprem-branch');
+    expect(written).not.toContain('__comment');
+    expect(written).toContain('process.env.RELEASE_CHANNEL');
+  });
+});

--- a/apps/eoas/src/lib/expoConfig.ts
+++ b/apps/eoas/src/lib/expoConfig.ts
@@ -334,14 +334,14 @@ function updateObjectExpression(
 // unwrapValue drops it there rather than writing the marker into JSON.
 export type CommentedValue = { __comment: string; value: any };
 
+// The key is deliberately underscored: it is a sentinel this module reads and
+// strips, and it must not be mistakable for a real Expo config field.
 function isCommented(value: any): value is CommentedValue {
-  return (
-    typeof value === 'object' &&
-    value !== null &&
-    typeof (value as CommentedValue).__comment === 'string' &&
-    '__value' in value === false &&
-    'value' in value
-  );
+  if (typeof value !== 'object' || value === null || !('value' in value)) {
+    return false;
+  }
+  // eslint-disable-next-line no-underscore-dangle
+  return typeof (value as CommentedValue).__comment === 'string';
 }
 
 /** Strips the comment wrappers, for the JSON path and for reading values back. */
@@ -378,6 +378,7 @@ function createValueNode(j: typeof jscodeshift, value: any): any {
         // Force stringLiteral pour garder les guillemets
         const property = j.objectProperty(j.stringLiteral(key), createValueNode(j, val));
         if (isCommented(val)) {
+          // eslint-disable-next-line no-underscore-dangle -- see isCommented
           property.comments = [j.commentLine(` ${val.__comment}`, true, false)];
         }
         return property;

--- a/apps/eoas/src/lib/expoConfig.ts
+++ b/apps/eoas/src/lib/expoConfig.ts
@@ -329,7 +329,39 @@ function updateObjectExpression(
   });
 }
 
+// A value wrapped like this is emitted with a // comment above it. Only the
+// jscodeshift path can honour it; app.json has nowhere to put a comment, so
+// unwrapValue drops it there rather than writing the marker into JSON.
+export type CommentedValue = { __comment: string; value: any };
+
+function isCommented(value: any): value is CommentedValue {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as CommentedValue).__comment === 'string' &&
+    '__value' in value === false &&
+    'value' in value
+  );
+}
+
+/** Strips the comment wrappers, for the JSON path and for reading values back. */
+export function unwrapValue(value: any): any {
+  if (isCommented(value)) {
+    return unwrapValue(value.value);
+  }
+  if (Array.isArray(value)) {
+    return value.map(unwrapValue);
+  }
+  if (typeof value === 'object' && value !== null) {
+    return Object.fromEntries(Object.entries(value).map(([key, val]) => [key, unwrapValue(val)]));
+  }
+  return value;
+}
+
 function createValueNode(j: typeof jscodeshift, value: any): any {
+  if (isCommented(value)) {
+    return createValueNode(j, value.value);
+  }
   if (typeof value === 'string' && value.startsWith('process.env.')) {
     if (/^process\.env\.\w+$/.test(value)) {
       return j.memberExpression(
@@ -342,9 +374,14 @@ function createValueNode(j: typeof jscodeshift, value: any): any {
 
   if (typeof value === 'object' && value !== null) {
     return j.objectExpression(
-      Object.entries(value).map(
-        ([key, val]) => j.objectProperty(j.stringLiteral(key), createValueNode(j, val)) // Force stringLiteral pour garder les guillemets
-      )
+      Object.entries(value).map(([key, val]) => {
+        // Force stringLiteral pour garder les guillemets
+        const property = j.objectProperty(j.stringLiteral(key), createValueNode(j, val));
+        if (isCommented(val)) {
+          property.comments = [j.commentLine(` ${val.__comment}`, true, false)];
+        }
+        return property;
+      })
     );
   }
 
@@ -362,7 +399,7 @@ function parseExpressionNode(j: typeof jscodeshift, code: string): any {
 function stringifyWithEnv(obj: Record<string, any>): string {
   const rawExpressions: string[] = [];
   const json = JSON.stringify(
-    obj,
+    unwrapValue(obj),
     (_key, value) =>
       typeof value === 'string' && value.startsWith('process.env.')
         ? `__RAW_EXPR_${rawExpressions.push(value) - 1}__`

--- a/apps/example-app/app.config.ts
+++ b/apps/example-app/app.config.ts
@@ -13,7 +13,9 @@ export default ({ config }: ConfigContext): ExpoConfig => {
 
       "requestHeaders": {
         "expo-channel-name": process.env.RELEASE_CHANNEL,
-        "expo-app-id": "d3a60200-4574-4781-9734-c174b511fb55",
+        "expo-app-id": "01434155-7d26-4f77-94b5-01013a80cdfa",
+        "xprem-branch": "",
+        "xprem-surf-blocked": ""
       },
     },
   };

--- a/apps/example-app/app.config.ts
+++ b/apps/example-app/app.config.ts
@@ -14,8 +14,7 @@ export default ({ config }: ConfigContext): ExpoConfig => {
       "requestHeaders": {
         "expo-channel-name": process.env.RELEASE_CHANNEL,
         "expo-app-id": "01434155-7d26-4f77-94b5-01013a80cdfa",
-        "xprem-branch": "",
-        "xprem-surf-blocked": ""
+        "xprem-branch": ""
       },
     },
   };

--- a/apps/example-app/app.json
+++ b/apps/example-app/app.json
@@ -47,9 +47,9 @@
         "origin": false
       },
       "eas": {
-        "projectId": "d3a60200-4574-4781-9734-c174b511fb55",
+        "projectId": "01434155-7d26-4f77-94b5-01013a80cdfa",
         "observe": {
-          "endpointUrl": "https://otatest.ngrok.io/observe/d3a60200-4574-4781-9734-c174b511fb55"
+          "endpointUrl": "https://otatest.ngrok.io/observe/01434155-7d26-4f77-94b5-01013a80cdfa"
         }
       }
     },

--- a/apps/example-app/app/_layout.tsx
+++ b/apps/example-app/app/_layout.tsx
@@ -1,3 +1,4 @@
+import { ControlCenter } from '@xprem/control-center';
 import { Observe, ObserveRoot } from 'expo-observe';
 import { DarkTheme, DefaultTheme, ThemeProvider } from 'expo-router/react-navigation';
 import { useFonts } from 'expo-font';
@@ -50,6 +51,9 @@ function RootLayout() {
           <Stack.Screen name="+not-found" />
         </Stack>
         <StatusBar style="auto" />
+        {/* Renders nothing unless the channel this build polls allows branch
+            surfing, so it is safe to leave mounted in every build. */}
+        <ControlCenter />
       </ThemeProvider>
     </ErrorBoundary>
   );

--- a/apps/example-app/components/ErrorBounday.tsx
+++ b/apps/example-app/components/ErrorBounday.tsx
@@ -25,6 +25,8 @@ class ErrorBoundary extends Component<Props, State> {
     Observe.logEvent('xprem_js_crash', {
       attributes: {
         message: error.message,
+        stack: error.stack || "",
+        name: error.name
       },
     });
     Observe.dispatchEvents();

--- a/apps/example-app/metro.config.js
+++ b/apps/example-app/metro.config.js
@@ -1,6 +1,19 @@
+const path = require('path')
 const { getDefaultConfig } = require('expo/metro-config')
 
 const config = getDefaultConfig(__dirname)
+
+// @xprem/control-center is a sibling reached through a symlink in node_modules,
+// so it resolves by the normal algorithm — including in release bundles. But its
+// OWN imports resolve from where its files live, and there is no node_modules
+// above apps/, so react and expo-updates have to be pointed back here.
+const controlCenterRoot = path.resolve(__dirname, '../control-center')
+config.watchFolders = [...(config.watchFolders ?? []), controlCenterRoot]
+config.resolver.nodeModulesPaths = [
+  ...(config.resolver.nodeModulesPaths ?? []),
+  path.resolve(__dirname, 'node_modules'),
+]
+
 
 // index.js requires one of the two navigation trees (see navigation/mode.ts),
 // but Metro walks both branches of that `if` and would pull expo-router and

--- a/apps/example-app/package.json
+++ b/apps/example-app/package.json
@@ -19,7 +19,8 @@
     "create_production_rollback": "RELEASE_CHANNEL=production ../eoas/bin/dev.js rollback --branch production",
     "create_staging_rollback": "RELEASE_CHANNEL=staging ../eoas/bin/dev.js rollback --branch staging",
     "prebuild_production": "RELEASE_CHANNEL=production expo prebuild",
-    "prebuild_staging": "RELEASE_CHANNEL=staging expo prebuild"
+    "prebuild_staging": "RELEASE_CHANNEL=staging expo prebuild",
+    "postinstall": "mkdir -p node_modules/@xprem && ln -sfn ../../../control-center node_modules/@xprem/control-center"
   },
   "jest": {
     "preset": "jest-expo"

--- a/apps/example-app/tsconfig.json
+++ b/apps/example-app/tsconfig.json
@@ -5,6 +5,9 @@
     "paths": {
       "@/*": [
         "./*"
+      ],
+      "@xprem/control-center": [
+        "../control-center/src/index.ts"
       ]
     }
   },

--- a/apps/updates-debugger/.gitignore
+++ b/apps/updates-debugger/.gitignore
@@ -1,0 +1,6 @@
+node_modules
+dist
+web/dist
+
+# The root .gitignore drops every bin/ directory; this package ships one.
+!bin/

--- a/ee/apikeyrestrictions/acl.go
+++ b/ee/apikeyrestrictions/acl.go
@@ -7,6 +7,7 @@ package apikeyrestrictions
 import (
 	"fmt"
 	"strings"
+	"xprem/internal/branch"
 	"xprem/internal/validation"
 )
 
@@ -111,10 +112,7 @@ func NormalizeBranchRules(rules []BranchRule) ([]BranchRule, error) {
 
 // collapseWildcards rewrites any run of "*" as a single one.
 func collapseWildcards(pattern string) string {
-	for strings.Contains(pattern, "**") {
-		pattern = strings.ReplaceAll(pattern, "**", "*")
-	}
-	return pattern
+	return branch.CollapseWildcards(pattern)
 }
 
 func normalizeActions(pattern string, actions []Action) ([]Action, error) {
@@ -140,28 +138,7 @@ func normalizeActions(pattern string, actions []Action) ([]Action, error) {
 // matchBranchPattern matches name against pattern, "*" standing for any run of
 // characters, including empty.
 func matchBranchPattern(pattern, name string) bool {
-	if !strings.Contains(pattern, "*") {
-		return pattern == name
-	}
-	segments := strings.Split(pattern, "*")
-	prefix, suffix := segments[0], segments[len(segments)-1]
-	if !strings.HasPrefix(name, prefix) || !strings.HasSuffix(name, suffix) {
-		return false
-	}
-	// The anchors must not overlap: "ab*ba" does not match "aba".
-	if len(prefix)+len(suffix) > len(name) {
-		return false
-	}
-	rest := name[len(prefix) : len(name)-len(suffix)]
-	// Inner segments must appear in order; leftmost occurrence is enough.
-	for _, segment := range segments[1 : len(segments)-1] {
-		index := strings.Index(rest, segment)
-		if index < 0 {
-			return false
-		}
-		rest = rest[index+len(segment):]
-	}
-	return true
+	return branch.MatchPattern(pattern, name)
 }
 
 // describeBranchRules renders a rule list for the audit trail.

--- a/ee/observe/checkins.go
+++ b/ee/observe/checkins.go
@@ -17,6 +17,7 @@ import (
 	"xprem/ee/identity"
 	"xprem/internal/cache"
 	"xprem/internal/handlers"
+	"xprem/internal/update"
 
 	"github.com/google/uuid"
 )
@@ -345,36 +346,8 @@ func (r *CheckInRecorder) record(ctx context.Context, checkIn handlers.DeviceChe
 	return r.identity.TouchDevice(ctx, checkIn.AppID, checkIn.EASClientID, currentUpdate, state.device)
 }
 
-const maxFailedUpdateIDsPerCheckIn = 5
 
-// ParseFailedUpdateIDs reads the Expo-Recent-Failed-Update-IDs header, a
-// quoted-UUID list (RFC 8941 style). Invalid entries are dropped and the
-// result is deduplicated and capped.
+// ParseFailedUpdateIDs reads the Expo-Recent-Failed-Update-IDs header.
 func ParseFailedUpdateIDs(raw string) []string {
-	if raw == "" {
-		return nil
-	}
-	ids := make([]string, 0, maxFailedUpdateIDsPerCheckIn)
-	seen := make(map[string]struct{}, maxFailedUpdateIDsPerCheckIn)
-	for _, part := range strings.Split(raw, ",") {
-		part = strings.TrimSpace(part)
-		part = strings.Trim(part, `"`)
-		parsed, err := uuid.Parse(part)
-		if err != nil {
-			continue
-		}
-		id := parsed.String()
-		if _, duplicate := seen[id]; duplicate {
-			continue
-		}
-		seen[id] = struct{}{}
-		ids = append(ids, id)
-		if len(ids) == maxFailedUpdateIDsPerCheckIn {
-			break
-		}
-	}
-	if len(ids) == 0 {
-		return nil
-	}
-	return ids
+	return update.ParseFailedUpdateIDs(raw)
 }

--- a/ee/rbac/permissions.go
+++ b/ee/rbac/permissions.go
@@ -27,6 +27,11 @@ const (
 	PermChannelCreate     Permission = "channel:create"
 	PermChannelDelete     Permission = "channel:delete"
 	PermChannelEditBranch Permission = "channel:edit-branch"
+	// PermChannelBranchSurfing opens or closes a channel to branch surfing and
+	// sets which branches it exposes. Separate from PermChannelEditBranch:
+	// remapping a channel changes what every device gets, while this decides
+	// whether devices may pick a branch themselves.
+	PermChannelBranchSurfing Permission = "channel:branch-surfing"
 	// PermChannelRolloutManage covers the whole lifecycle of a channel
 	// rollout: start, adjust the percentage, promote, or revert.
 	PermChannelRolloutManage Permission = "channel-rollout:manage"
@@ -66,6 +71,7 @@ var AllPermissions = []Permission{
 	PermChannelCreate,
 	PermChannelDelete,
 	PermChannelEditBranch,
+	PermChannelBranchSurfing,
 	PermChannelRolloutManage,
 	PermUpdateRolloutManage,
 	PermUpdatePublish,

--- a/internal/auditlog/auditlog.go
+++ b/internal/auditlog/auditlog.go
@@ -71,9 +71,10 @@ const (
 	ActionAppCreated          Action = "app.created"
 	ActionAppRenamed          Action = "app.renamed"
 	ActionAppDeleted          Action = "app.deleted"
-	ActionChannelCreated      Action = "channel.created"
-	ActionChannelDeleted      Action = "channel.deleted"
-	ActionChannelBranchMapped Action = "channel_branch.mapped"
+	ActionChannelCreated       Action = "channel.created"
+	ActionChannelDeleted       Action = "channel.deleted"
+	ActionChannelBranchMapped  Action = "channel_branch.mapped"
+	ActionBranchSurfingUpdated Action = "channel_branch_surfing.updated"
 	ActionBranchCreated       Action = "branch.created"
 	ActionBranchDeleted       Action = "branch.deleted"
 

--- a/internal/auditlog/auditlog.go
+++ b/internal/auditlog/auditlog.go
@@ -68,15 +68,15 @@ const (
 	ActionSSOConfigDeleted Action = "sso_config.deleted"
 
 	// App management.
-	ActionAppCreated          Action = "app.created"
-	ActionAppRenamed          Action = "app.renamed"
-	ActionAppDeleted          Action = "app.deleted"
+	ActionAppCreated           Action = "app.created"
+	ActionAppRenamed           Action = "app.renamed"
+	ActionAppDeleted           Action = "app.deleted"
 	ActionChannelCreated       Action = "channel.created"
 	ActionChannelDeleted       Action = "channel.deleted"
 	ActionChannelBranchMapped  Action = "channel_branch.mapped"
 	ActionBranchSurfingUpdated Action = "channel_branch_surfing.updated"
-	ActionBranchCreated       Action = "branch.created"
-	ActionBranchDeleted       Action = "branch.deleted"
+	ActionBranchCreated        Action = "branch.created"
+	ActionBranchDeleted        Action = "branch.deleted"
 
 	// Delivery.
 	ActionUpdatePublished       Action = "update.published"

--- a/internal/auditlog/catalog_parity_test.go
+++ b/internal/auditlog/catalog_parity_test.go
@@ -1,0 +1,43 @@
+package auditlog
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const catalogPath = "../../apps/dashboard/src/ee/lib/auditCatalog.ts"
+
+var (
+	goActionPattern = regexp.MustCompile(`Action\w+\s+Action\s*=\s*"([^"]+)"`)
+	tsActionPattern = regexp.MustCompile(`'([a-z_]+\.[a-z_]+)'`)
+)
+
+// An action the dashboard does not list is emitted but cannot be filtered for,
+// so it is invisible to anyone looking for it. Nothing in the type system links
+// the two lists, and they have drifted before.
+func TestEveryAuditActionIsFilterableInTheDashboard(t *testing.T) {
+	catalog, err := os.ReadFile(filepath.Clean(catalogPath))
+	if err != nil {
+		t.Skipf("dashboard sources not available: %v", err)
+	}
+	source, err := os.ReadFile("auditlog.go")
+	if err != nil {
+		t.Fatalf("reading actions: %v", err)
+	}
+
+	listed := map[string]bool{}
+	for _, match := range tsActionPattern.FindAllStringSubmatch(string(catalog), -1) {
+		listed[match[1]] = true
+	}
+
+	emitted := goActionPattern.FindAllStringSubmatch(string(source), -1)
+	assert.NotEmpty(t, emitted, "no actions found — the pattern stopped matching, not the drift")
+	for _, match := range emitted {
+		assert.True(t, listed[match[1]],
+			"%s is emitted by the server but missing from auditCatalog.ts, so it cannot be filtered for", match[1])
+	}
+}

--- a/internal/branch/empty_pattern_test.go
+++ b/internal/branch/empty_pattern_test.go
@@ -9,7 +9,7 @@ import (
 // The stored default for a channel that never opened branch surfing. It must
 // name nothing, or a first careless click exposes the whole app.
 func TestEmptyPatternMatchesNothing(t *testing.T) {
-	for _, name := range []string{"production", "pr-482", "*", "a"} {
+	for _, name := range []string{"production", "pr-482", "*", "a", ""} {
 		assert.False(t, MatchPattern("", name), name)
 	}
 }

--- a/internal/branch/empty_pattern_test.go
+++ b/internal/branch/empty_pattern_test.go
@@ -1,0 +1,15 @@
+package branch
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// The stored default for a channel that never opened branch surfing. It must
+// name nothing, or a first careless click exposes the whole app.
+func TestEmptyPatternMatchesNothing(t *testing.T) {
+	for _, name := range []string{"production", "pr-482", "*", "a"} {
+		assert.False(t, MatchPattern("", name), name)
+	}
+}

--- a/internal/branch/empty_pattern_test.go
+++ b/internal/branch/empty_pattern_test.go
@@ -13,3 +13,10 @@ func TestEmptyPatternMatchesNothing(t *testing.T) {
 		assert.False(t, MatchPattern("", name), name)
 	}
 }
+
+// The empty name too: without the early return, the literal comparison below
+// makes the empty pattern match it, which is the one case where the
+// deny-by-default default would let something through.
+func TestEmptyPatternMatchesTheEmptyNameEither(t *testing.T) {
+	assert.False(t, MatchPattern("", ""))
+}

--- a/internal/branch/pattern.go
+++ b/internal/branch/pattern.go
@@ -1,0 +1,41 @@
+package branch
+
+import "strings"
+
+// MatchPattern reports whether name matches pattern, "*" standing for any run
+// of characters, empty included. Branch names cannot contain "*", so a pattern
+// without one is never ambiguous with a literal name. Callers normalize with
+// CollapseWildcards first.
+func MatchPattern(pattern, name string) bool {
+	if !strings.Contains(pattern, "*") {
+		return pattern == name
+	}
+	segments := strings.Split(pattern, "*")
+	prefix, suffix := segments[0], segments[len(segments)-1]
+	if !strings.HasPrefix(name, prefix) || !strings.HasSuffix(name, suffix) {
+		return false
+	}
+	// The anchors must not overlap: "ab*ba" does not match "aba".
+	if len(prefix)+len(suffix) > len(name) {
+		return false
+	}
+	rest := name[len(prefix) : len(name)-len(suffix)]
+	// Inner segments must appear in order; leftmost occurrence is enough.
+	for _, segment := range segments[1 : len(segments)-1] {
+		index := strings.Index(rest, segment)
+		if index < 0 {
+			return false
+		}
+		rest = rest[index+len(segment):]
+	}
+	return true
+}
+
+// CollapseWildcards rewrites any run of "*" as a single one, so that patterns
+// naming the same set of branches compare equal.
+func CollapseWildcards(pattern string) string {
+	for strings.Contains(pattern, "**") {
+		pattern = strings.ReplaceAll(pattern, "**", "*")
+	}
+	return pattern
+}

--- a/internal/branch/pattern.go
+++ b/internal/branch/pattern.go
@@ -3,10 +3,13 @@ package branch
 import "strings"
 
 // MatchPattern reports whether name matches pattern, "*" standing for any run
-// of characters, empty included. Branch names cannot contain "*", so a pattern
-// without one is never ambiguous with a literal name. Callers normalize with
-// CollapseWildcards first.
+// of characters, empty included. The empty pattern matches no name. Branch
+// names cannot contain "*", so a pattern without one is never ambiguous with a
+// literal name. Callers normalize with CollapseWildcards first.
 func MatchPattern(pattern, name string) bool {
+	if pattern == "" {
+		return false
+	}
 	if !strings.Contains(pattern, "*") {
 		return pattern == name
 	}

--- a/internal/branch/pattern_test.go
+++ b/internal/branch/pattern_test.go
@@ -1,0 +1,48 @@
+package branch
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMatchPattern(t *testing.T) {
+	cases := []struct {
+		pattern string
+		name    string
+		want    bool
+	}{
+		{"production", "production", true},
+		{"production", "Production", false}, // branch names are case sensitive
+		{"production", "production-eu", false},
+		{"*", "anything", true},
+		{"*", "", true},
+		{"pr-*", "pr-482", true},
+		{"pr-*", "pr-", true},
+		{"pr-*", "pr", false},
+		{"pr-*", "release-pr-482", false},
+		{"*-staging", "eu-staging", true},
+		{"*-staging", "staging", false},
+		{"pr-*-eu", "pr-482-eu", true},
+		{"pr-*-eu", "pr-eu", false}, // the two anchors would have to overlap
+		{"ab*ba", "aba", false},
+		{"ab*ba", "abba", true},
+		{"a*b*c", "azzbzzc", true},
+		{"a*b*c", "azzc", false},
+		// A literal "[" is a branch name, not a character class.
+		{"beta[eu]", "beta[eu]", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.pattern+"/"+tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, MatchPattern(tc.pattern, tc.name))
+		})
+	}
+}
+
+func TestCollapseWildcards(t *testing.T) {
+	assert.Equal(t, "*", CollapseWildcards("**"))
+	assert.Equal(t, "*", CollapseWildcards("****"))
+	assert.Equal(t, "pr-*", CollapseWildcards("pr-**"))
+	assert.Equal(t, "pr-*-eu", CollapseWildcards("pr-***-eu"))
+	assert.Equal(t, "production", CollapseWildcards("production"))
+}

--- a/internal/database/postgres/migrations/20260802120000_channel_branch_surfing.sql
+++ b/internal/database/postgres/migrations/20260802120000_channel_branch_surfing.sql
@@ -1,0 +1,24 @@
+-- +goose Up
+-- +goose StatementBegin
+
+-- Branch surfing: a device polling this channel may ask to be served a branch
+-- other than the one the channel maps to. Off unless an admin turns it on, per
+-- channel, so an existing deployment is unaffected by this migration.
+ALTER TABLE channels
+    ADD COLUMN branch_surfing_enabled BOOLEAN NOT NULL DEFAULT FALSE,
+    -- Which branches a device on this channel may reach. Same pattern language
+    -- as api_key_branch_rules.pattern: a branch name, or a name with "*"
+    -- standing for any run of characters ("pr-*", "*-eu", "*"). Sized like
+    -- branches.name so a pattern can always name what exists.
+    ADD COLUMN branch_surfing_pattern VARCHAR(255) NOT NULL DEFAULT '*';
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+
+ALTER TABLE channels
+    DROP COLUMN branch_surfing_enabled,
+    DROP COLUMN branch_surfing_pattern;
+
+-- +goose StatementEnd

--- a/internal/database/postgres/migrations/20260803120000_branch_surfing_pattern_default.sql
+++ b/internal/database/postgres/migrations/20260803120000_branch_surfing_pattern_default.sql
@@ -1,0 +1,29 @@
+-- +goose Up
+-- +goose StatementBegin
+
+-- The pattern is what decides which branch names a device may read, so its
+-- default must not be the permissive end. '' matches no branch (MatchPattern
+-- compares literally when the pattern holds no "*", and branch names are never
+-- empty), and validation.NamePattern refuses to write it back — so it is the
+-- never-configured state and nothing else.
+--
+-- Only channels that never opened branch surfing are touched: a channel that
+-- deliberately holds '*' keeps it.
+ALTER TABLE channels ALTER COLUMN branch_surfing_pattern SET DEFAULT '';
+
+UPDATE channels
+SET branch_surfing_pattern = ''
+WHERE NOT branch_surfing_enabled AND branch_surfing_pattern = '*';
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+
+ALTER TABLE channels ALTER COLUMN branch_surfing_pattern SET DEFAULT '*';
+
+UPDATE channels
+SET branch_surfing_pattern = '*'
+WHERE branch_surfing_pattern = '';
+
+-- +goose StatementEnd

--- a/internal/database/postgres/migrations/20260803120000_branch_surfing_pattern_default.sql
+++ b/internal/database/postgres/migrations/20260803120000_branch_surfing_pattern_default.sql
@@ -20,10 +20,14 @@ WHERE NOT branch_surfing_enabled AND branch_surfing_pattern = '*';
 -- +goose Down
 -- +goose StatementBegin
 
+-- Restores the old default and nothing else. Rewriting '' back to '*' would
+-- hand the widest possible pattern to every channel that simply never opened
+-- branch surfing — including channels created after this migration, which never
+-- held '*' at all — and the dashboard enables the switch as soon as a pattern is
+-- present, so one click would then expose every branch in the app. A rollback
+-- must not be able to widen access. Nothing needs the rewrite: '' matches no
+-- branch under the old code too, so a channel left at '' simply stays unable to
+-- surf, which is where it already was.
 ALTER TABLE channels ALTER COLUMN branch_surfing_pattern SET DEFAULT '*';
-
-UPDATE channels
-SET branch_surfing_pattern = '*'
-WHERE branch_surfing_pattern = '';
 
 -- +goose StatementEnd

--- a/internal/database/postgres/migrations/20260804090000_surfable_branches_index.sql
+++ b/internal/database/postgres/migrations/20260804090000_surfable_branches_index.sql
@@ -1,0 +1,16 @@
+-- +goose NO TRANSACTION
+-- +goose Up
+
+-- Serves GetSurfableBranches, which every build carrying the branch picker runs
+-- once per launch. The existing idx_updates_rv_branch_checked leads on
+-- (runtime_version_id, branch_id) and carries neither platform nor created_at,
+-- so the planner had to heap-fetch every checked update for the runtime version
+-- — both platforms, all branches — and filter before aggregating. Leading with
+-- the two equality predicates and carrying created_at makes it index-only.
+DROP INDEX CONCURRENTLY IF EXISTS idx_updates_rv_platform_branch;
+CREATE INDEX CONCURRENTLY idx_updates_rv_platform_branch
+    ON updates (runtime_version_id, platform, branch_id, created_at DESC)
+    WHERE checked_at IS NOT NULL;
+
+-- +goose Down
+DROP INDEX CONCURRENTLY IF EXISTS idx_updates_rv_platform_branch;

--- a/internal/database/postgres/pgdb/models.go
+++ b/internal/database/postgres/pgdb/models.go
@@ -75,11 +75,13 @@ type Branch struct {
 }
 
 type Channel struct {
-	ID        int64              `json:"id"`
-	AppID     pgtype.UUID        `json:"app_id"`
-	BranchID  *int64             `json:"branch_id"`
-	Name      string             `json:"name"`
-	CreatedAt pgtype.Timestamptz `json:"created_at"`
+	ID                   int64              `json:"id"`
+	AppID                pgtype.UUID        `json:"app_id"`
+	BranchID             *int64             `json:"branch_id"`
+	Name                 string             `json:"name"`
+	CreatedAt            pgtype.Timestamptz `json:"created_at"`
+	BranchSurfingEnabled bool               `json:"branch_surfing_enabled"`
+	BranchSurfingPattern string             `json:"branch_surfing_pattern"`
 }
 
 type ChannelRollout struct {

--- a/internal/database/postgres/pgdb/queries.sql.go
+++ b/internal/database/postgres/pgdb/queries.sql.go
@@ -1177,6 +1177,29 @@ func (q *Queries) GetChannelBranchMapping(ctx context.Context, arg GetChannelBra
 	return i, err
 }
 
+const getChannelBranchSurfing = `-- name: GetChannelBranchSurfing :one
+SELECT branch_surfing_enabled, branch_surfing_pattern
+FROM channels
+WHERE app_id = $1 AND name = $2
+`
+
+type GetChannelBranchSurfingParams struct {
+	AppID pgtype.UUID `json:"app_id"`
+	Name  string      `json:"name"`
+}
+
+type GetChannelBranchSurfingRow struct {
+	BranchSurfingEnabled bool   `json:"branch_surfing_enabled"`
+	BranchSurfingPattern string `json:"branch_surfing_pattern"`
+}
+
+func (q *Queries) GetChannelBranchSurfing(ctx context.Context, arg GetChannelBranchSurfingParams) (GetChannelBranchSurfingRow, error) {
+	row := q.db.QueryRow(ctx, getChannelBranchSurfing, arg.AppID, arg.Name)
+	var i GetChannelBranchSurfingRow
+	err := row.Scan(&i.BranchSurfingEnabled, &i.BranchSurfingPattern)
+	return i, err
+}
+
 const getChannelNamesByBranchName = `-- name: GetChannelNamesByBranchName :many
 SELECT c.name
 FROM channels c
@@ -1318,7 +1341,7 @@ current_updates AS (
         u.created_at DESC,
         u.id DESC
 )
-SELECT channels.id, channels.app_id, channels.branch_id, channels.name, channels.created_at, branches.name as branch_name,
+SELECT channels.id, channels.app_id, channels.branch_id, channels.name, channels.created_at, channels.branch_surfing_enabled, channels.branch_surfing_pattern, branches.name as branch_name,
     cr.id AS rollout_id,
     rb.name AS rollout_branch_name,
     cr.percentage AS rollout_percentage,
@@ -1348,6 +1371,8 @@ type GetChannelsByAppIDRow struct {
 	BranchID                              *int64             `json:"branch_id"`
 	Name                                  string             `json:"name"`
 	CreatedAt                             pgtype.Timestamptz `json:"created_at"`
+	BranchSurfingEnabled                  bool               `json:"branch_surfing_enabled"`
+	BranchSurfingPattern                  string             `json:"branch_surfing_pattern"`
 	BranchName                            *string            `json:"branch_name"`
 	RolloutID                             pgtype.UUID        `json:"rollout_id"`
 	RolloutBranchName                     *string            `json:"rollout_branch_name"`
@@ -1379,6 +1404,8 @@ func (q *Queries) GetChannelsByAppID(ctx context.Context, appID pgtype.UUID) ([]
 			&i.BranchID,
 			&i.Name,
 			&i.CreatedAt,
+			&i.BranchSurfingEnabled,
+			&i.BranchSurfingPattern,
 			&i.BranchName,
 			&i.RolloutID,
 			&i.RolloutBranchName,
@@ -1826,6 +1853,50 @@ func (q *Queries) GetSSOConfig(ctx context.Context) (SsoConfig, error) {
 		&i.ManualUserValidation,
 	)
 	return i, err
+}
+
+const getSurfableBranches = `-- name: GetSurfableBranches :many
+SELECT b.name AS branch_name, MAX(u.created_at)::timestamptz AS last_update_at
+FROM branches b
+JOIN updates u ON u.branch_id = b.id AND u.checked_at IS NOT NULL
+JOIN runtime_versions rv ON rv.id = u.runtime_version_id AND rv.app_id = $1
+WHERE b.app_id = $1 AND rv.version = $2
+GROUP BY b.id, b.name
+ORDER BY MAX(u.created_at) DESC, b.name ASC
+`
+
+type GetSurfableBranchesParams struct {
+	AppID   pgtype.UUID `json:"app_id"`
+	Version string      `json:"version"`
+}
+
+type GetSurfableBranchesRow struct {
+	BranchName   string             `json:"branch_name"`
+	LastUpdateAt pgtype.Timestamptz `json:"last_update_at"`
+}
+
+// Branches a device on this app and runtime version could actually be served.
+// A branch with no published update for that runtime version is unreachable,
+// so listing it would offer a switch that silently does nothing. rv is scoped
+// to the app as well: version strings are unique per app, not globally.
+func (q *Queries) GetSurfableBranches(ctx context.Context, arg GetSurfableBranchesParams) ([]GetSurfableBranchesRow, error) {
+	rows, err := q.db.Query(ctx, getSurfableBranches, arg.AppID, arg.Version)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []GetSurfableBranchesRow
+	for rows.Next() {
+		var i GetSurfableBranchesRow
+		if err := rows.Scan(&i.BranchName, &i.LastUpdateAt); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
 }
 
 const getUpdateByBranchNameAndRuntime = `-- name: GetUpdateByBranchNameAndRuntime :one
@@ -5286,6 +5357,28 @@ type UpdateChannelBranchMappingParams struct {
 // the channel through RepointChannelToRolloutBranch instead, so it is not blocked here.
 func (q *Queries) UpdateChannelBranchMapping(ctx context.Context, arg UpdateChannelBranchMappingParams) (pgconn.CommandTag, error) {
 	return q.db.Exec(ctx, updateChannelBranchMapping, arg.BranchID, arg.AppID, arg.ID)
+}
+
+const updateChannelBranchSurfing = `-- name: UpdateChannelBranchSurfing :execresult
+UPDATE channels
+SET branch_surfing_enabled = $3, branch_surfing_pattern = $4
+WHERE app_id = $1 AND name = $2
+`
+
+type UpdateChannelBranchSurfingParams struct {
+	AppID                pgtype.UUID `json:"app_id"`
+	Name                 string      `json:"name"`
+	BranchSurfingEnabled bool        `json:"branch_surfing_enabled"`
+	BranchSurfingPattern string      `json:"branch_surfing_pattern"`
+}
+
+func (q *Queries) UpdateChannelBranchSurfing(ctx context.Context, arg UpdateChannelBranchSurfingParams) (pgconn.CommandTag, error) {
+	return q.db.Exec(ctx, updateChannelBranchSurfing,
+		arg.AppID,
+		arg.Name,
+		arg.BranchSurfingEnabled,
+		arg.BranchSurfingPattern,
+	)
 }
 
 const updateChannelRolloutPercentage = `-- name: UpdateChannelRolloutPercentage :execrows

--- a/internal/database/postgres/pgdb/queries.sql.go
+++ b/internal/database/postgres/pgdb/queries.sql.go
@@ -1860,14 +1860,15 @@ SELECT b.name AS branch_name, MAX(u.created_at)::timestamptz AS last_update_at
 FROM branches b
 JOIN updates u ON u.branch_id = b.id AND u.checked_at IS NOT NULL
 JOIN runtime_versions rv ON rv.id = u.runtime_version_id AND rv.app_id = $1
-WHERE b.app_id = $1 AND rv.version = $2
+WHERE b.app_id = $1 AND rv.version = $2 AND u.platform = $3::text
 GROUP BY b.id, b.name
 ORDER BY MAX(u.created_at) DESC, b.name ASC
 `
 
 type GetSurfableBranchesParams struct {
-	AppID   pgtype.UUID `json:"app_id"`
-	Version string      `json:"version"`
+	AppID    pgtype.UUID `json:"app_id"`
+	Version  string      `json:"version"`
+	Platform string      `json:"platform"`
 }
 
 type GetSurfableBranchesRow struct {
@@ -1875,12 +1876,14 @@ type GetSurfableBranchesRow struct {
 	LastUpdateAt pgtype.Timestamptz `json:"last_update_at"`
 }
 
-// Branches a device on this app and runtime version could actually be served.
-// A branch with no published update for that runtime version is unreachable,
-// so listing it would offer a switch that silently does nothing. rv is scoped
-// to the app as well: version strings are unique per app, not globally.
+// Branches a device on this app, runtime version and platform could actually be
+// served. A branch with no published update matching all three is unreachable,
+// so listing it would offer a switch that silently does nothing: the manifest
+// route filters on platform too, and would quietly fall back to the channel's
+// branch. rv is scoped to the app as well: version strings are unique per app,
+// not globally.
 func (q *Queries) GetSurfableBranches(ctx context.Context, arg GetSurfableBranchesParams) ([]GetSurfableBranchesRow, error) {
-	rows, err := q.db.Query(ctx, getSurfableBranches, arg.AppID, arg.Version)
+	rows, err := q.db.Query(ctx, getSurfableBranches, arg.AppID, arg.Version, arg.Platform)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/database/postgres/queries/queries.sql
+++ b/internal/database/postgres/queries/queries.sql
@@ -2293,3 +2293,26 @@ UPDATE oauth_authorization_codes
 SET used_at = CURRENT_TIMESTAMP
 WHERE id = $1 AND used_at IS NULL AND expires_at > CURRENT_TIMESTAMP
 RETURNING *;
+
+-- name: GetChannelBranchSurfing :one
+SELECT branch_surfing_enabled, branch_surfing_pattern
+FROM channels
+WHERE app_id = $1 AND name = $2;
+
+-- name: UpdateChannelBranchSurfing :execresult
+UPDATE channels
+SET branch_surfing_enabled = $3, branch_surfing_pattern = $4
+WHERE app_id = $1 AND name = $2;
+
+-- name: GetSurfableBranches :many
+-- Branches a device on this app and runtime version could actually be served.
+-- A branch with no published update for that runtime version is unreachable,
+-- so listing it would offer a switch that silently does nothing. rv is scoped
+-- to the app as well: version strings are unique per app, not globally.
+SELECT b.name AS branch_name, MAX(u.created_at)::timestamptz AS last_update_at
+FROM branches b
+JOIN updates u ON u.branch_id = b.id AND u.checked_at IS NOT NULL
+JOIN runtime_versions rv ON rv.id = u.runtime_version_id AND rv.app_id = $1
+WHERE b.app_id = $1 AND rv.version = $2
+GROUP BY b.id, b.name
+ORDER BY MAX(u.created_at) DESC, b.name ASC;

--- a/internal/database/postgres/queries/queries.sql
+++ b/internal/database/postgres/queries/queries.sql
@@ -2305,14 +2305,16 @@ SET branch_surfing_enabled = $3, branch_surfing_pattern = $4
 WHERE app_id = $1 AND name = $2;
 
 -- name: GetSurfableBranches :many
--- Branches a device on this app and runtime version could actually be served.
--- A branch with no published update for that runtime version is unreachable,
--- so listing it would offer a switch that silently does nothing. rv is scoped
--- to the app as well: version strings are unique per app, not globally.
+-- Branches a device on this app, runtime version and platform could actually be
+-- served. A branch with no published update matching all three is unreachable,
+-- so listing it would offer a switch that silently does nothing: the manifest
+-- route filters on platform too, and would quietly fall back to the channel's
+-- branch. rv is scoped to the app as well: version strings are unique per app,
+-- not globally.
 SELECT b.name AS branch_name, MAX(u.created_at)::timestamptz AS last_update_at
 FROM branches b
 JOIN updates u ON u.branch_id = b.id AND u.checked_at IS NOT NULL
 JOIN runtime_versions rv ON rv.id = u.runtime_version_id AND rv.app_id = $1
-WHERE b.app_id = $1 AND rv.version = $2
+WHERE b.app_id = $1 AND rv.version = $2 AND u.platform = @platform::text
 GROUP BY b.id, b.name
 ORDER BY MAX(u.created_at) DESC, b.name ASC;

--- a/internal/handlers/branch_list_handler.go
+++ b/internal/handlers/branch_list_handler.go
@@ -24,6 +24,12 @@ func NewBranchListHandler(channelService *services.ChannelService) *BranchListHa
 	return &BranchListHandler{channelService: channelService}
 }
 
+const maxRuntimeVersionLen = 128
+
+// SurfingDisabledHeader marks a 404 that came from this endpoint deciding the
+// channel may not surf, rather than from anything else on the way.
+const SurfingDisabledHeader = "xprem-branch-surfing"
+
 func (h *BranchListHandler) HandleBranchList(w http.ResponseWriter, r *http.Request) {
 	requestID := uuid.New().String()
 
@@ -45,7 +51,11 @@ func (h *BranchListHandler) HandleBranchList(w http.ResponseWriter, r *http.Requ
 	if runtimeVersion == "" {
 		runtimeVersion = r.URL.Query().Get("runtimeVersion")
 	}
-	if runtimeVersion == "" {
+	// Bounded because the answer is cached under it, empty answers included: an
+	// unauthenticated caller varying this header would otherwise mint one cache
+	// entry per request, and the local cache has no size ceiling. A version
+	// string longer than this cannot match anything that was ever published.
+	if runtimeVersion == "" || len(runtimeVersion) > maxRuntimeVersionLen {
 		log.Printf("[RequestID: %s] No runtime version provided", requestID)
 		http.Error(w, "No runtime version provided", http.StatusBadRequest)
 		return
@@ -72,6 +82,9 @@ func (h *BranchListHandler) HandleBranchList(w http.ResponseWriter, r *http.Requ
 	if err != nil {
 		status, message := branchListErrorResponse(err)
 		log.Printf("[RequestID: %s] Branch list refused for channel %s: %v", requestID, channelName, err)
+		if status == http.StatusNotFound {
+			w.Header().Set(SurfingDisabledHeader, "off")
+		}
 		http.Error(w, message, status)
 		return
 	}

--- a/internal/handlers/branch_list_handler.go
+++ b/internal/handlers/branch_list_handler.go
@@ -1,0 +1,80 @@
+package handlers
+
+import (
+	"errors"
+	"log"
+	"net/http"
+	"xprem/internal/services"
+	"xprem/internal/store"
+	"xprem/internal/validation"
+
+	"github.com/google/uuid"
+)
+
+// BranchListHandler serves the branches a device may ask to be served instead
+// of the one its channel maps to. Device-facing and unauthenticated like the
+// rest of the client protocol: the app id, the channel and the runtime version
+// are the only claims a device makes, and the channel's branch-surfing setting
+// decides whether it is answered at all.
+type BranchListHandler struct {
+	channelService *services.ChannelService
+}
+
+func NewBranchListHandler(channelService *services.ChannelService) *BranchListHandler {
+	return &BranchListHandler{channelService: channelService}
+}
+
+func (h *BranchListHandler) HandleBranchList(w http.ResponseWriter, r *http.Request) {
+	requestID := uuid.New().String()
+
+	appId := resolveAppID(r)
+	if appId == "" {
+		log.Printf("[RequestID: %s] No app id provided", requestID)
+		http.Error(w, "No app id provided", http.StatusBadRequest)
+		return
+	}
+
+	channelName := r.Header.Get("expo-channel-name")
+	if channelName == "" {
+		log.Printf("[RequestID: %s] No channel name provided", requestID)
+		http.Error(w, "No channel name provided", http.StatusBadRequest)
+		return
+	}
+
+	runtimeVersion := r.Header.Get("expo-runtime-version")
+	if runtimeVersion == "" {
+		runtimeVersion = r.URL.Query().Get("runtimeVersion")
+	}
+	if runtimeVersion == "" {
+		log.Printf("[RequestID: %s] No runtime version provided", requestID)
+		http.Error(w, "No runtime version provided", http.StatusBadRequest)
+		return
+	}
+
+	branches, err := h.channelService.ListSurfableBranches(r.Context(), appId, channelName, runtimeVersion)
+	if err != nil {
+		status, message := branchListErrorResponse(err)
+		log.Printf("[RequestID: %s] Branch list refused for channel %s: %v", requestID, channelName, err)
+		http.Error(w, message, status)
+		return
+	}
+
+	// Same as the manifest response: the answer depends on headers a shared
+	// cache does not key on, so it must never be stored.
+	w.Header().Set("cache-control", "private, max-age=0")
+	RenderJSON(w, http.StatusOK, branches)
+}
+
+func branchListErrorResponse(err error) (int, string) {
+	var svcErr *services.ExpoProtocolError
+	if errors.As(err, &svcErr) {
+		return svcErr.StatusCode, svcErr.Message
+	}
+	if validation.IsValidationError(err) {
+		return http.StatusBadRequest, err.Error()
+	}
+	if errors.Is(err, store.ErrNotSupportedInStatelessMode) {
+		return http.StatusNotFound, "Branch surfing is not enabled for this channel"
+	}
+	return http.StatusInternalServerError, "Internal operational error"
+}

--- a/internal/handlers/branch_list_handler.go
+++ b/internal/handlers/branch_list_handler.go
@@ -51,7 +51,11 @@ func (h *BranchListHandler) HandleBranchList(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	branches, err := h.channelService.ListSurfableBranches(r.Context(), appId, channelName, runtimeVersion)
+	// Devices fetch the first page at every launch; "see all" is a deliberate tap
+	// by one tester, so the wider answer is never on the launch path.
+	all := r.URL.Query().Get("all") == "1"
+
+	branches, err := h.channelService.ListSurfableBranches(r.Context(), appId, channelName, runtimeVersion, all)
 	if err != nil {
 		status, message := branchListErrorResponse(err)
 		log.Printf("[RequestID: %s] Branch list refused for channel %s: %v", requestID, channelName, err)

--- a/internal/handlers/branch_list_handler.go
+++ b/internal/handlers/branch_list_handler.go
@@ -51,11 +51,24 @@ func (h *BranchListHandler) HandleBranchList(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
+	// Same rule as the manifest route, which resolves per platform: a list built
+	// without it would offer branches whose only update is for the other one, and
+	// picking those would quietly land the device back on its channel's branch.
+	platform := r.Header.Get("expo-platform")
+	if platform == "" {
+		platform = r.URL.Query().Get("platform")
+	}
+	if platform != "ios" && platform != "android" {
+		log.Printf("[RequestID: %s] Invalid platform: %s", requestID, platform)
+		http.Error(w, "Invalid platform. Expected \"ios\" or \"android\".", http.StatusBadRequest)
+		return
+	}
+
 	// Devices fetch the first page at every launch; "see all" is a deliberate tap
 	// by one tester, so the wider answer is never on the launch path.
 	all := r.URL.Query().Get("all") == "1"
 
-	branches, err := h.channelService.ListSurfableBranches(r.Context(), appId, channelName, runtimeVersion, all)
+	branches, err := h.channelService.ListSurfableBranches(r.Context(), appId, channelName, runtimeVersion, platform, all)
 	if err != nil {
 		status, message := branchListErrorResponse(err)
 		log.Printf("[RequestID: %s] Branch list refused for channel %s: %v", requestID, channelName, err)

--- a/internal/handlers/branch_list_handler_test.go
+++ b/internal/handlers/branch_list_handler_test.go
@@ -1,0 +1,172 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"xprem/internal/database/postgres/pgdb"
+	"xprem/internal/providers/expo"
+	"xprem/internal/services"
+	"xprem/internal/types"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const surfingTestAppID = "1a2b3c4d-0000-0000-0000-000000000001"
+
+type stubChannelRepo struct {
+	surfing map[string]*types.BranchSurfing
+}
+
+func (r *stubChannelRepo) InsertChannel(_ context.Context, _ string, _ *int64, _ string) (int64, error) {
+	return 0, nil
+}
+func (r *stubChannelRepo) DeleteChannel(_ context.Context, _, _ string) error { return nil }
+func (r *stubChannelRepo) GetChannelNameByBranchName(_ context.Context, _, _ string) ([]string, error) {
+	return nil, nil
+}
+func (r *stubChannelRepo) GetChannels(_ context.Context, _ string) ([]types.ChannelMapping, error) {
+	return nil, nil
+}
+func (r *stubChannelRepo) GetChannelBranchMapping(_ context.Context, _, _ string) (*expo.ChannelMapping, error) {
+	return nil, nil
+}
+func (r *stubChannelRepo) GetBranchSurfing(_ context.Context, _, channelName string) (*types.BranchSurfing, error) {
+	return r.surfing[channelName], nil
+}
+func (r *stubChannelRepo) SetBranchSurfing(_ context.Context, _, _ string, _ types.BranchSurfing) error {
+	return nil
+}
+
+type stubBranchRepo struct {
+	surfable map[string][]types.SurfableBranch
+}
+
+func (r *stubBranchRepo) InsertBranch(_ context.Context, _ pgdb.InsertBranchParams) (int64, error) {
+	return 0, nil
+}
+func (r *stubBranchRepo) UpsertBranchAndRuntimeVersion(_ context.Context, _, _, _ string) error {
+	return nil
+}
+func (r *stubBranchRepo) GetUpdatedMetadataByBranchName(_ context.Context, _, _ string) ([]pgdb.GetUpdatesMetadataByBranchNameRow, error) {
+	return nil, nil
+}
+func (r *stubBranchRepo) DeleteBranchByName(_ context.Context, _, _ string) error { return nil }
+func (r *stubBranchRepo) GetBranches(_ context.Context, _ string) ([]types.BranchMapping, error) {
+	return nil, nil
+}
+func (r *stubBranchRepo) GetSurfableBranches(_ context.Context, _, runtimeVersion string) ([]types.SurfableBranch, error) {
+	return r.surfable[runtimeVersion], nil
+}
+func (r *stubBranchRepo) GetRuntimeVersionsWithUpdateStats(_ context.Context, _, _ string) ([]types.RuntimeVersionWithStats, error) {
+	return nil, nil
+}
+func (r *stubBranchRepo) UpdateChannelBranchMapping(_ context.Context, _, _, _ string) error {
+	return nil
+}
+func (r *stubBranchRepo) CreateRuntimeVersion(_ context.Context, _, _ string) (int64, error) {
+	return 0, nil
+}
+func (r *stubBranchRepo) GetBranchByName(_ context.Context, _, _ string) (int64, error) {
+	return 0, nil
+}
+
+func surfingHandler() *BranchListHandler {
+	channelRepo := &stubChannelRepo{surfing: map[string]*types.BranchSurfing{
+		"qa":         {Enabled: true, Pattern: "pr-*"},
+		"production": {Enabled: false, Pattern: "*"},
+	}}
+	branchRepo := &stubBranchRepo{surfable: map[string][]types.SurfableBranch{
+		"3.0.0": {
+			{Name: "pr-482", LastUpdateAt: "2026-08-01T10:00:00Z"},
+			{Name: "production", LastUpdateAt: "2026-07-30T10:00:00Z"},
+		},
+	}}
+	return NewBranchListHandler(services.NewChannelService(branchRepo, channelRepo))
+}
+
+func branchListRequest(target string, headers map[string]string) *http.Request {
+	r := httptest.NewRequest(http.MethodGet, target, nil)
+	for key, value := range headers {
+		r.Header.Set(key, value)
+	}
+	return r
+}
+
+func TestBranchListRejectsMissingHeaders(t *testing.T) {
+	cases := []struct {
+		name    string
+		headers map[string]string
+	}{
+		{"no app id", map[string]string{"expo-channel-name": "qa", "expo-runtime-version": "3.0.0"}},
+		{"no channel", map[string]string{"expo-app-id": surfingTestAppID, "expo-runtime-version": "3.0.0"}},
+		{"no runtime version", map[string]string{"expo-app-id": surfingTestAppID, "expo-channel-name": "qa"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			surfingHandler().HandleBranchList(w, branchListRequest("/branch_lists", tc.headers))
+			assert.Equal(t, http.StatusBadRequest, w.Code)
+		})
+	}
+}
+
+func TestBranchListServesBranchesMatchingThePattern(t *testing.T) {
+	w := httptest.NewRecorder()
+	surfingHandler().HandleBranchList(w, branchListRequest("/branch_lists", map[string]string{
+		"expo-app-id":          surfingTestAppID,
+		"expo-channel-name":    "qa",
+		"expo-runtime-version": "3.0.0",
+	}))
+
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "private, max-age=0", w.Header().Get("cache-control"))
+	var branches []types.SurfableBranch
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&branches))
+	assert.Equal(t, []types.SurfableBranch{{Name: "pr-482", LastUpdateAt: "2026-08-01T10:00:00Z"}}, branches)
+}
+
+func TestBranchListRefusesChannelWithSurfingOff(t *testing.T) {
+	w := httptest.NewRecorder()
+	surfingHandler().HandleBranchList(w, branchListRequest("/branch_lists", map[string]string{
+		"expo-app-id":          surfingTestAppID,
+		"expo-channel-name":    "production",
+		"expo-runtime-version": "3.0.0",
+	}))
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+// The runtime version falls back to the query string, as the manifest route
+// does for clients that cannot set the header.
+func TestBranchListAcceptsRuntimeVersionFromQuery(t *testing.T) {
+	w := httptest.NewRecorder()
+	surfingHandler().HandleBranchList(w, branchListRequest("/branch_lists?runtimeVersion=3.0.0", map[string]string{
+		"expo-app-id":       surfingTestAppID,
+		"expo-channel-name": "qa",
+	}))
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var branches []types.SurfableBranch
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&branches))
+	assert.Len(t, branches, 1)
+}
+
+// An unknown runtime version is an empty list, not an error: the channel allows
+// surfing, there is simply nothing this binary can be served.
+func TestBranchListIsEmptyForUnknownRuntimeVersion(t *testing.T) {
+	w := httptest.NewRecorder()
+	surfingHandler().HandleBranchList(w, branchListRequest("/branch_lists", map[string]string{
+		"expo-app-id":          surfingTestAppID,
+		"expo-channel-name":    "qa",
+		"expo-runtime-version": "9.9.9",
+	}))
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var branches []types.SurfableBranch
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&branches))
+	assert.Empty(t, branches)
+}

--- a/internal/handlers/branch_list_handler_test.go
+++ b/internal/handlers/branch_list_handler_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"xprem/internal/database/postgres/pgdb"
 	"xprem/internal/providers/expo"
@@ -295,4 +296,59 @@ func TestBranchListRejectsAMissingOrUnknownPlatform(t *testing.T) {
 			assert.Equal(t, http.StatusBadRequest, w.Code)
 		})
 	}
+}
+
+// The answer is cached under the runtime version, empty answers included, and
+// the local cache has no size ceiling — so an unbounded header is one cache
+// entry per request for anyone who can reach this route, which is everyone.
+func TestBranchListRejectsAnOversizedRuntimeVersion(t *testing.T) {
+	w := httptest.NewRecorder()
+	surfingHandler(t).HandleBranchList(w, branchListRequest("/branch_lists", map[string]string{
+		"expo-app-id":          surfingTestAppID,
+		"expo-channel-name":    "qa",
+		"expo-runtime-version": strings.Repeat("9", maxRuntimeVersionLen+1),
+		"expo-platform":        "ios",
+	}))
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+// A device already pinned to a branch only learns that surfing was switched off
+// from this header: the panel hides itself on the 404, and after that there is
+// no interface left to unpin from. It must be on BOTH refusals — a header only
+// the disabled channel carried would tell an unauthenticated caller which
+// channel names exist, which the identical bodies exist to prevent.
+func TestTheRefusalTellsAPinnedDeviceToUnpin(t *testing.T) {
+	for name, channelName := range map[string]string{
+		"surfing disabled": "production",
+		"unknown channel":  "ghost",
+	} {
+		t.Run(name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			surfingHandler(t).HandleBranchList(w, branchListRequest("/branch_lists", map[string]string{
+				"expo-app-id":          surfingTestAppID,
+				"expo-channel-name":    channelName,
+				"expo-runtime-version": "3.0.0",
+				"expo-platform":        "ios",
+			}))
+
+			require.Equal(t, http.StatusNotFound, w.Code)
+			assert.Equal(t, "off", w.Header().Get(SurfingDisabledHeader))
+		})
+	}
+}
+
+// The signal must not ride on refusals the client cannot act on: clearing a
+// tester's branch because a header was malformed would be a silent surprise.
+func TestABadRequestCarriesNoUnpinSignal(t *testing.T) {
+	w := httptest.NewRecorder()
+	surfingHandler(t).HandleBranchList(w, branchListRequest("/branch_lists", map[string]string{
+		"expo-app-id":          surfingTestAppID,
+		"expo-channel-name":    "qa",
+		"expo-runtime-version": "3.0.0",
+		"expo-platform":        "blackberry",
+	}))
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Empty(t, w.Header().Get(SurfingDisabledHeader))
 }

--- a/internal/handlers/branch_list_handler_test.go
+++ b/internal/handlers/branch_list_handler_test.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -74,7 +75,34 @@ func (r *stubBranchRepo) GetBranchByName(_ context.Context, _, _ string) (int64,
 	return 0, nil
 }
 
-func surfingHandler() *BranchListHandler {
+// The delivery-path caches are process-wide singletons keyed on the app id, so a
+// test that shares one with its neighbours would read their answers. Surfing also
+// only exists on the control plane, so DB_URL has to look set.
+func surfingHandler(t *testing.T) *BranchListHandler {
+	t.Helper()
+	t.Setenv("DB_URL", "postgres://stub")
+	services.ForgetBranchSurfing(surfingTestAppID, "qa")
+	services.ForgetBranchSurfing(surfingTestAppID, "production")
+	services.ForgetSurfableBranches(surfingTestAppID, "3.0.0")
+	services.ForgetSurfableBranches(surfingTestAppID, "9.9.9")
+	services.ForgetSurfableBranches(surfingTestAppID, "2.0.0")
+	return newSurfingHandler()
+}
+
+// Same isolation, with a branch set the test chooses.
+func surfingHandlerWithBranches(t *testing.T, branches []types.SurfableBranch) *BranchListHandler {
+	t.Helper()
+	t.Setenv("DB_URL", "postgres://stub")
+	services.ForgetBranchSurfing(surfingTestAppID, "qa")
+	services.ForgetSurfableBranches(surfingTestAppID, "3.0.0")
+	channelRepo := &stubChannelRepo{surfing: map[string]*types.BranchSurfing{
+		"qa": {Enabled: true, Pattern: "pr-*"},
+	}}
+	branchRepo := &stubBranchRepo{surfable: map[string][]types.SurfableBranch{"3.0.0": branches}}
+	return NewBranchListHandler(services.NewChannelService(branchRepo, channelRepo))
+}
+
+func newSurfingHandler() *BranchListHandler {
 	channelRepo := &stubChannelRepo{surfing: map[string]*types.BranchSurfing{
 		"qa":         {Enabled: true, Pattern: "pr-*"},
 		"production": {Enabled: false, Pattern: "*"},
@@ -108,7 +136,7 @@ func TestBranchListRejectsMissingHeaders(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			w := httptest.NewRecorder()
-			surfingHandler().HandleBranchList(w, branchListRequest("/branch_lists", tc.headers))
+			surfingHandler(t).HandleBranchList(w, branchListRequest("/branch_lists", tc.headers))
 			assert.Equal(t, http.StatusBadRequest, w.Code)
 		})
 	}
@@ -116,7 +144,7 @@ func TestBranchListRejectsMissingHeaders(t *testing.T) {
 
 func TestBranchListServesBranchesMatchingThePattern(t *testing.T) {
 	w := httptest.NewRecorder()
-	surfingHandler().HandleBranchList(w, branchListRequest("/branch_lists", map[string]string{
+	surfingHandler(t).HandleBranchList(w, branchListRequest("/branch_lists", map[string]string{
 		"expo-app-id":          surfingTestAppID,
 		"expo-channel-name":    "qa",
 		"expo-runtime-version": "3.0.0",
@@ -124,14 +152,15 @@ func TestBranchListServesBranchesMatchingThePattern(t *testing.T) {
 
 	require.Equal(t, http.StatusOK, w.Code)
 	assert.Equal(t, "private, max-age=0", w.Header().Get("cache-control"))
-	var branches []types.SurfableBranch
-	require.NoError(t, json.NewDecoder(w.Body).Decode(&branches))
-	assert.Equal(t, []types.SurfableBranch{{Name: "pr-482", LastUpdateAt: "2026-08-01T10:00:00Z"}}, branches)
+	var list types.SurfableBranchList
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&list))
+	assert.Equal(t, []types.SurfableBranch{{Name: "pr-482", LastUpdateAt: "2026-08-01T10:00:00Z"}}, list.Branches)
+	assert.Equal(t, 1, list.Total)
 }
 
 func TestBranchListRefusesChannelWithSurfingOff(t *testing.T) {
 	w := httptest.NewRecorder()
-	surfingHandler().HandleBranchList(w, branchListRequest("/branch_lists", map[string]string{
+	surfingHandler(t).HandleBranchList(w, branchListRequest("/branch_lists", map[string]string{
 		"expo-app-id":          surfingTestAppID,
 		"expo-channel-name":    "production",
 		"expo-runtime-version": "3.0.0",
@@ -144,29 +173,64 @@ func TestBranchListRefusesChannelWithSurfingOff(t *testing.T) {
 // does for clients that cannot set the header.
 func TestBranchListAcceptsRuntimeVersionFromQuery(t *testing.T) {
 	w := httptest.NewRecorder()
-	surfingHandler().HandleBranchList(w, branchListRequest("/branch_lists?runtimeVersion=3.0.0", map[string]string{
+	surfingHandler(t).HandleBranchList(w, branchListRequest("/branch_lists?runtimeVersion=3.0.0", map[string]string{
 		"expo-app-id":       surfingTestAppID,
 		"expo-channel-name": "qa",
 	}))
 
 	require.Equal(t, http.StatusOK, w.Code)
-	var branches []types.SurfableBranch
-	require.NoError(t, json.NewDecoder(w.Body).Decode(&branches))
-	assert.Len(t, branches, 1)
+	var list types.SurfableBranchList
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&list))
+	assert.Len(t, list.Branches, 1)
 }
 
 // An unknown runtime version is an empty list, not an error: the channel allows
 // surfing, there is simply nothing this binary can be served.
 func TestBranchListIsEmptyForUnknownRuntimeVersion(t *testing.T) {
 	w := httptest.NewRecorder()
-	surfingHandler().HandleBranchList(w, branchListRequest("/branch_lists", map[string]string{
+	surfingHandler(t).HandleBranchList(w, branchListRequest("/branch_lists", map[string]string{
 		"expo-app-id":          surfingTestAppID,
 		"expo-channel-name":    "qa",
 		"expo-runtime-version": "9.9.9",
 	}))
 
 	require.Equal(t, http.StatusOK, w.Code)
-	var branches []types.SurfableBranch
-	require.NoError(t, json.NewDecoder(w.Body).Decode(&branches))
-	assert.Empty(t, branches)
+	var list types.SurfableBranchList
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&list))
+	assert.Empty(t, list.Branches)
+	assert.Equal(t, 0, list.Total)
+}
+
+// all=1 is the only way to get past the first page, so a device that does not
+// ask for it can never be handed the wide answer by accident.
+func TestBranchListPageWidensOnlyWithTheAllFlag(t *testing.T) {
+	branches := make([]types.SurfableBranch, 0, 30)
+	for i := 0; i < 30; i++ {
+		branches = append(branches, types.SurfableBranch{
+			Name:         fmt.Sprintf("pr-%d", i),
+			LastUpdateAt: "2026-08-01T10:00:00Z",
+		})
+	}
+	handler := surfingHandlerWithBranches(t, branches)
+
+	read := func(url string) types.SurfableBranchList {
+		w := httptest.NewRecorder()
+		handler.HandleBranchList(w, branchListRequest(url, map[string]string{
+			"expo-app-id":          surfingTestAppID,
+			"expo-channel-name":    "qa",
+			"expo-runtime-version": "3.0.0",
+		}))
+		require.Equal(t, http.StatusOK, w.Code)
+		var list types.SurfableBranchList
+		require.NoError(t, json.NewDecoder(w.Body).Decode(&list))
+		return list
+	}
+
+	first := read("/branch_lists")
+	assert.Len(t, first.Branches, 10)
+	assert.Equal(t, 30, first.Total)
+
+	everything := read("/branch_lists?all=1")
+	assert.Len(t, everything.Branches, 30)
+	assert.Equal(t, 30, everything.Total)
 }

--- a/internal/handlers/branch_list_handler_test.go
+++ b/internal/handlers/branch_list_handler_test.go
@@ -59,7 +59,7 @@ func (r *stubBranchRepo) DeleteBranchByName(_ context.Context, _, _ string) erro
 func (r *stubBranchRepo) GetBranches(_ context.Context, _ string) ([]types.BranchMapping, error) {
 	return nil, nil
 }
-func (r *stubBranchRepo) GetSurfableBranches(_ context.Context, _, runtimeVersion string) ([]types.SurfableBranch, error) {
+func (r *stubBranchRepo) GetSurfableBranches(_ context.Context, _, runtimeVersion string, _ string) ([]types.SurfableBranch, error) {
 	return r.surfable[runtimeVersion], nil
 }
 func (r *stubBranchRepo) GetRuntimeVersionsWithUpdateStats(_ context.Context, _, _ string) ([]types.RuntimeVersionWithStats, error) {
@@ -83,9 +83,9 @@ func surfingHandler(t *testing.T) *BranchListHandler {
 	t.Setenv("DB_URL", "postgres://stub")
 	services.ForgetBranchSurfing(surfingTestAppID, "qa")
 	services.ForgetBranchSurfing(surfingTestAppID, "production")
-	services.ForgetSurfableBranches(surfingTestAppID, "3.0.0")
-	services.ForgetSurfableBranches(surfingTestAppID, "9.9.9")
-	services.ForgetSurfableBranches(surfingTestAppID, "2.0.0")
+	services.ForgetSurfableBranches(surfingTestAppID, "3.0.0", "ios")
+	services.ForgetSurfableBranches(surfingTestAppID, "9.9.9", "ios")
+	services.ForgetSurfableBranches(surfingTestAppID, "2.0.0", "ios")
 	return newSurfingHandler()
 }
 
@@ -94,7 +94,7 @@ func surfingHandlerWithBranches(t *testing.T, branches []types.SurfableBranch) *
 	t.Helper()
 	t.Setenv("DB_URL", "postgres://stub")
 	services.ForgetBranchSurfing(surfingTestAppID, "qa")
-	services.ForgetSurfableBranches(surfingTestAppID, "3.0.0")
+	services.ForgetSurfableBranches(surfingTestAppID, "3.0.0", "ios")
 	channelRepo := &stubChannelRepo{surfing: map[string]*types.BranchSurfing{
 		"qa": {Enabled: true, Pattern: "pr-*"},
 	}}
@@ -148,6 +148,7 @@ func TestBranchListServesBranchesMatchingThePattern(t *testing.T) {
 		"expo-app-id":          surfingTestAppID,
 		"expo-channel-name":    "qa",
 		"expo-runtime-version": "3.0.0",
+		"expo-platform":        "ios",
 	}))
 
 	require.Equal(t, http.StatusOK, w.Code)
@@ -164,6 +165,7 @@ func TestBranchListRefusesChannelWithSurfingOff(t *testing.T) {
 		"expo-app-id":          surfingTestAppID,
 		"expo-channel-name":    "production",
 		"expo-runtime-version": "3.0.0",
+		"expo-platform":        "ios",
 	}))
 
 	assert.Equal(t, http.StatusNotFound, w.Code)
@@ -176,6 +178,7 @@ func TestBranchListAcceptsRuntimeVersionFromQuery(t *testing.T) {
 	surfingHandler(t).HandleBranchList(w, branchListRequest("/branch_lists?runtimeVersion=3.0.0", map[string]string{
 		"expo-app-id":       surfingTestAppID,
 		"expo-channel-name": "qa",
+		"expo-platform":     "ios",
 	}))
 
 	require.Equal(t, http.StatusOK, w.Code)
@@ -192,6 +195,7 @@ func TestBranchListIsEmptyForUnknownRuntimeVersion(t *testing.T) {
 		"expo-app-id":          surfingTestAppID,
 		"expo-channel-name":    "qa",
 		"expo-runtime-version": "9.9.9",
+		"expo-platform":        "ios",
 	}))
 
 	require.Equal(t, http.StatusOK, w.Code)
@@ -219,6 +223,7 @@ func TestBranchListPageWidensOnlyWithTheAllFlag(t *testing.T) {
 			"expo-app-id":          surfingTestAppID,
 			"expo-channel-name":    "qa",
 			"expo-runtime-version": "3.0.0",
+			"expo-platform":        "ios",
 		}))
 		require.Equal(t, http.StatusOK, w.Code)
 		var list types.SurfableBranchList
@@ -233,4 +238,61 @@ func TestBranchListPageWidensOnlyWithTheAllFlag(t *testing.T) {
 	everything := read("/branch_lists?all=1")
 	assert.Len(t, everything.Branches, 30)
 	assert.Equal(t, 30, everything.Total)
+}
+
+// A branch whose only update is for the other platform cannot be served here:
+// the manifest route filters on platform too, so offering it would hand the
+// tester a switch that silently drops them back on the channel's branch.
+func TestBranchListIsScopedToThePlatform(t *testing.T) {
+	t.Setenv("DB_URL", "postgres://stub")
+	services.ForgetBranchSurfing(surfingTestAppID, "qa")
+	services.ForgetSurfableBranches(surfingTestAppID, "3.0.0", "ios")
+	services.ForgetSurfableBranches(surfingTestAppID, "3.0.0", "android")
+	channelRepo := &stubChannelRepo{surfing: map[string]*types.BranchSurfing{
+		"qa": {Enabled: true, Pattern: "pr-*"},
+	}}
+	branchRepo := &platformBranchRepo{}
+	handler := NewBranchListHandler(services.NewChannelService(branchRepo, channelRepo))
+
+	for _, platform := range []string{"ios", "android"} {
+		w := httptest.NewRecorder()
+		handler.HandleBranchList(w, branchListRequest("/branch_lists", map[string]string{
+			"expo-app-id":          surfingTestAppID,
+			"expo-channel-name":    "qa",
+			"expo-runtime-version": "3.0.0",
+			"expo-platform":        platform,
+		}))
+		require.Equal(t, http.StatusOK, w.Code)
+		var list types.SurfableBranchList
+		require.NoError(t, json.NewDecoder(w.Body).Decode(&list))
+		require.Len(t, list.Branches, 1)
+		assert.Equal(t, "pr-"+platform, list.Branches[0].Name,
+			"%s must not be offered the other platform's branch", platform)
+	}
+}
+
+// Answers a different branch per platform, so a list built without it returns
+// the wrong one rather than merely a longer one.
+type platformBranchRepo struct{ services.BranchRepository }
+
+func (platformBranchRepo) GetSurfableBranches(_ context.Context, _, _ string, platform string) ([]types.SurfableBranch, error) {
+	return []types.SurfableBranch{{Name: "pr-" + platform, LastUpdateAt: "2026-08-01T10:00:00Z"}}, nil
+}
+
+func TestBranchListRejectsAMissingOrUnknownPlatform(t *testing.T) {
+	for name, platform := range map[string]string{"absent": "", "unknown": "blackberry"} {
+		t.Run(name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			headers := map[string]string{
+				"expo-app-id":          surfingTestAppID,
+				"expo-channel-name":    "qa",
+				"expo-runtime-version": "3.0.0",
+			}
+			if platform != "" {
+				headers["expo-platform"] = platform
+			}
+			surfingHandler(t).HandleBranchList(w, branchListRequest("/branch_lists", headers))
+			assert.Equal(t, http.StatusBadRequest, w.Code)
+		})
+	}
 }

--- a/internal/handlers/dashboard/channels_branch_surfing_test.go
+++ b/internal/handlers/dashboard/channels_branch_surfing_test.go
@@ -56,7 +56,7 @@ func (surfingBranchRepo) DeleteBranchByName(_ context.Context, _, _ string) erro
 func (surfingBranchRepo) GetBranches(_ context.Context, _ string) ([]types.BranchMapping, error) {
 	return nil, nil
 }
-func (surfingBranchRepo) GetSurfableBranches(_ context.Context, _, _ string) ([]types.SurfableBranch, error) {
+func (surfingBranchRepo) GetSurfableBranches(_ context.Context, _, _ string, _ string) ([]types.SurfableBranch, error) {
 	return nil, nil
 }
 func (surfingBranchRepo) GetRuntimeVersionsWithUpdateStats(_ context.Context, _, _ string) ([]types.RuntimeVersionWithStats, error) {

--- a/internal/handlers/dashboard/channels_branch_surfing_test.go
+++ b/internal/handlers/dashboard/channels_branch_surfing_test.go
@@ -1,0 +1,116 @@
+package handlers
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"xprem/internal/database/postgres/pgdb"
+	"xprem/internal/providers/expo"
+	"xprem/internal/services"
+	"xprem/internal/types"
+
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type surfingChannelRepo struct {
+	written []types.BranchSurfing
+}
+
+func (r *surfingChannelRepo) InsertChannel(_ context.Context, _ string, _ *int64, _ string) (int64, error) {
+	return 0, nil
+}
+func (r *surfingChannelRepo) DeleteChannel(_ context.Context, _, _ string) error { return nil }
+func (r *surfingChannelRepo) GetChannelNameByBranchName(_ context.Context, _, _ string) ([]string, error) {
+	return nil, nil
+}
+func (r *surfingChannelRepo) GetChannels(_ context.Context, _ string) ([]types.ChannelMapping, error) {
+	return nil, nil
+}
+func (r *surfingChannelRepo) GetChannelBranchMapping(_ context.Context, _, _ string) (*expo.ChannelMapping, error) {
+	return nil, nil
+}
+func (r *surfingChannelRepo) GetBranchSurfing(_ context.Context, _, _ string) (*types.BranchSurfing, error) {
+	return &types.BranchSurfing{}, nil
+}
+func (r *surfingChannelRepo) SetBranchSurfing(_ context.Context, _, _ string, surfing types.BranchSurfing) error {
+	r.written = append(r.written, surfing)
+	return nil
+}
+
+type surfingBranchRepo struct{}
+
+func (surfingBranchRepo) InsertBranch(_ context.Context, _ pgdb.InsertBranchParams) (int64, error) {
+	return 0, nil
+}
+func (surfingBranchRepo) UpsertBranchAndRuntimeVersion(_ context.Context, _, _, _ string) error {
+	return nil
+}
+func (surfingBranchRepo) GetUpdatedMetadataByBranchName(_ context.Context, _, _ string) ([]pgdb.GetUpdatesMetadataByBranchNameRow, error) {
+	return nil, nil
+}
+func (surfingBranchRepo) DeleteBranchByName(_ context.Context, _, _ string) error { return nil }
+func (surfingBranchRepo) GetBranches(_ context.Context, _ string) ([]types.BranchMapping, error) {
+	return nil, nil
+}
+func (surfingBranchRepo) GetSurfableBranches(_ context.Context, _, _ string) ([]types.SurfableBranch, error) {
+	return nil, nil
+}
+func (surfingBranchRepo) GetRuntimeVersionsWithUpdateStats(_ context.Context, _, _ string) ([]types.RuntimeVersionWithStats, error) {
+	return nil, nil
+}
+func (surfingBranchRepo) UpdateChannelBranchMapping(_ context.Context, _, _, _ string) error {
+	return nil
+}
+func (surfingBranchRepo) CreateRuntimeVersion(_ context.Context, _, _ string) (int64, error) {
+	return 0, nil
+}
+func (surfingBranchRepo) GetBranchByName(_ context.Context, _, _ string) (int64, error) {
+	return 0, nil
+}
+
+func setBranchSurfing(t *testing.T, body string) (*httptest.ResponseRecorder, *surfingChannelRepo) {
+	t.Helper()
+	channelRepo := &surfingChannelRepo{}
+	handler := NewChannelHandler(services.NewChannelService(surfingBranchRepo{}, channelRepo))
+
+	r := httptest.NewRequest(http.MethodPut, "/channels/qa/branch-surfing", strings.NewReader(body))
+	r = mux.SetURLVars(r, map[string]string{"APP_ID": "app-1", "CHANNEL": "qa"})
+	w := httptest.NewRecorder()
+	handler.SetBranchSurfingHandler(w, r)
+	return w, channelRepo
+}
+
+func TestSetBranchSurfingStoresPattern(t *testing.T) {
+	w, channelRepo := setBranchSurfing(t, `{"enabled":true,"pattern":"pr-*"}`)
+
+	require.Equal(t, http.StatusNoContent, w.Code)
+	require.Len(t, channelRepo.written, 1)
+	assert.Equal(t, types.BranchSurfing{Enabled: true, Pattern: "pr-*"}, channelRepo.written[0])
+}
+
+// A PUT replaces the whole setting, so an omitted pattern is refused rather
+// than filled in: defaulting it would silently widen a narrower channel.
+func TestSetBranchSurfingRefusesMissingPattern(t *testing.T) {
+	w, channelRepo := setBranchSurfing(t, `{"enabled":true}`)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Empty(t, channelRepo.written)
+}
+
+func TestSetBranchSurfingRejectsMalformedPattern(t *testing.T) {
+	w, channelRepo := setBranchSurfing(t, `{"enabled":true,"pattern":"pr/../prod"}`)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Empty(t, channelRepo.written)
+}
+
+func TestSetBranchSurfingRejectsInvalidBody(t *testing.T) {
+	w, channelRepo := setBranchSurfing(t, `not json`)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Empty(t, channelRepo.written)
+}

--- a/internal/handlers/dashboard/channels_handler.go
+++ b/internal/handlers/dashboard/channels_handler.go
@@ -10,6 +10,7 @@ import (
 	"xprem/internal/handlers"
 	"xprem/internal/services"
 	"xprem/internal/store"
+	"xprem/internal/types"
 	"xprem/internal/validation"
 
 	"github.com/gorilla/mux"
@@ -92,6 +93,53 @@ func (h *ChannelHandler) DeleteChannelHandler(w http.ResponseWriter, r *http.Req
 	}
 	w.WriteHeader(http.StatusNoContent)
 
+}
+
+func (h *ChannelHandler) SetBranchSurfingHandler(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	appId := vars["APP_ID"]
+	channelName := vars["CHANNEL"]
+	if channelName == "" {
+		handlers.RenderError(w, http.StatusBadRequest, "Channel name is empty")
+		return
+	}
+	var requestBody struct {
+		Enabled bool   `json:"enabled"`
+		Pattern string `json:"pattern"`
+	}
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 4<<10)).Decode(&requestBody); err != nil {
+		handlers.RenderError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	// Required, never defaulted: a PUT replaces the whole setting, so filling a
+	// missing pattern in would silently widen a channel that named a narrower
+	// one. Exposing every branch has to be spelled "*".
+	if requestBody.Pattern == "" {
+		handlers.RenderError(w, http.StatusBadRequest, "Pattern is empty; use \"*\" to expose every branch")
+		return
+	}
+	err := h.channelService.SetBranchSurfing(r.Context(), appId, channelName, types.BranchSurfing{
+		Enabled: requestBody.Enabled,
+		Pattern: requestBody.Pattern,
+	})
+	if err != nil {
+		var valErr *validation.Error
+		if errors.As(err, &valErr) {
+			handlers.RenderError(w, http.StatusBadRequest, valErr.Error())
+			return
+		}
+		if notFoundErr := (*store.ErrResourceNotFound)(nil); errors.As(err, &notFoundErr) {
+			handlers.RenderError(w, http.StatusNotFound, notFoundErr.Error())
+			return
+		}
+		if errors.Is(err, store.ErrNotSupportedInStatelessMode) {
+			handlers.RenderError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		handlers.RenderError(w, http.StatusInternalServerError, "An internal error occurred while updating branch surfing.")
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
 }
 
 func (h *ChannelHandler) GetChannelsHandler(w http.ResponseWriter, r *http.Request) {

--- a/internal/handlers/manifest_handler.go
+++ b/internal/handlers/manifest_handler.go
@@ -160,6 +160,7 @@ func (h *ExpoProtocolHandler) HandleManifest(w http.ResponseWriter, r *http.Requ
 		Platform:              platform,
 		RuntimeVersion:        runtimeVersion,
 		ProtocolVersion:       protocolVersion,
+		XpremBranch:           r.Header.Get("xprem-branch"),
 		ClientID:              r.Header.Get("EAS-Client-ID"),
 		CurrentUpdateID:       r.Header.Get("expo-current-update-id"),
 		ExpoFatalError:        r.Header.Get("expo-fatal-error"),

--- a/internal/handlers/manifest_handler.go
+++ b/internal/handlers/manifest_handler.go
@@ -112,6 +112,24 @@ func (h *ExpoProtocolHandler) reportRejectedCrash(r *http.Request, appId string,
 // manifestParams reads a manifest poll into its parameters. Kept apart from the
 // handler so the header-to-field mapping is reachable without an HTTP round trip:
 // every field below is a wire contract, and a dropped one fails silently.
+// maxRequestedBranchLen bounds the branch a device may ask for. A name longer
+// than one that could ever exist is not a branch, and this header is the only
+// client-supplied value on the manifest path that reaches the query layer and
+// the logs; its two siblings are both bounded before use.
+const maxRequestedBranchLen = 128
+
+// requestedBranch reads the surf header, dropping a value too long to name a
+// branch. Dropped rather than rejected: an over-long header makes the request a
+// plain poll, where refusing it would take an update away from a device whose
+// only fault is a header nobody asked it to send.
+func requestedBranch(r *http.Request) string {
+	branchName := r.Header.Get("xprem-branch")
+	if len(branchName) > maxRequestedBranchLen {
+		return ""
+	}
+	return branchName
+}
+
 func manifestParams(r *http.Request, requestID string) (services.ManifestRequestParams, error) {
 	appId := resolveAppID(r)
 	if appId == "" {
@@ -151,7 +169,7 @@ func manifestParams(r *http.Request, requestID string) (services.ManifestRequest
 		Platform:              platform,
 		RuntimeVersion:        runtimeVersion,
 		ProtocolVersion:       protocolVersion,
-		XpremBranch:           r.Header.Get("xprem-branch"),
+		XpremBranch:           requestedBranch(r),
 		SurfBlockTokens:       r.Header.Get(services.SurfBlockedHeader),
 		ClientID:              r.Header.Get("EAS-Client-ID"),
 		CurrentUpdateID:       r.Header.Get("expo-current-update-id"),

--- a/internal/handlers/manifest_handler.go
+++ b/internal/handlers/manifest_handler.go
@@ -109,28 +109,23 @@ func (h *ExpoProtocolHandler) reportRejectedCrash(r *http.Request, appId string,
 	})
 }
 
-func (h *ExpoProtocolHandler) HandleManifest(w http.ResponseWriter, r *http.Request) {
-	requestID := uuid.New().String()
-
+// manifestParams reads a manifest poll into its parameters. Kept apart from the
+// handler so the header-to-field mapping is reachable without an HTTP round trip:
+// every field below is a wire contract, and a dropped one fails silently.
+func manifestParams(r *http.Request, requestID string) (services.ManifestRequestParams, error) {
 	appId := resolveAppID(r)
 	if appId == "" {
-		log.Printf("[RequestID: %s] No app id provided", requestID)
-		http.Error(w, "No app id provided", http.StatusBadRequest)
-		return
+		return services.ManifestRequestParams{}, errors.New("No app id provided")
 	}
 
 	channelName := r.Header.Get("expo-channel-name")
 	if channelName == "" {
-		log.Printf("[RequestID: %s] No channel name provided", requestID)
-		http.Error(w, "No channel name provided", http.StatusBadRequest)
-		return
+		return services.ManifestRequestParams{}, errors.New("No channel name provided")
 	}
 
 	protocolVersion, err := strconv.ParseInt(r.Header.Get("expo-protocol-version"), 10, 64)
 	if err != nil {
-		log.Printf("[RequestID: %s] Invalid protocol version: %v", requestID, err)
-		http.Error(w, "Invalid protocol version", http.StatusBadRequest)
-		return
+		return services.ManifestRequestParams{}, errors.New("Invalid protocol version")
 	}
 
 	platform := r.Header.Get("expo-platform")
@@ -138,9 +133,7 @@ func (h *ExpoProtocolHandler) HandleManifest(w http.ResponseWriter, r *http.Requ
 		platform = r.URL.Query().Get("platform")
 	}
 	if platform != "ios" && platform != "android" {
-		log.Printf("[RequestID: %s] Invalid platform: %s", requestID, platform)
-		http.Error(w, "Invalid platform", http.StatusBadRequest)
-		return
+		return services.ManifestRequestParams{}, errors.New("Invalid platform")
 	}
 
 	runtimeVersion := r.Header.Get("expo-runtime-version")
@@ -148,12 +141,10 @@ func (h *ExpoProtocolHandler) HandleManifest(w http.ResponseWriter, r *http.Requ
 		runtimeVersion = r.URL.Query().Get("runtimeVersion")
 	}
 	if runtimeVersion == "" {
-		log.Printf("[RequestID: %s] No runtime version provided", requestID)
-		http.Error(w, "No runtime version provided", http.StatusBadRequest)
-		return
+		return services.ManifestRequestParams{}, errors.New("No runtime version provided")
 	}
 
-	params := services.ManifestRequestParams{
+	return services.ManifestRequestParams{
 		RequestID:             requestID,
 		AppID:                 appId,
 		ChannelName:           channelName,
@@ -161,11 +152,41 @@ func (h *ExpoProtocolHandler) HandleManifest(w http.ResponseWriter, r *http.Requ
 		RuntimeVersion:        runtimeVersion,
 		ProtocolVersion:       protocolVersion,
 		XpremBranch:           r.Header.Get("xprem-branch"),
+		SurfBlockTokens:       r.Header.Get(services.SurfBlockedHeader),
 		ClientID:              r.Header.Get("EAS-Client-ID"),
 		CurrentUpdateID:       r.Header.Get("expo-current-update-id"),
 		ExpoFatalError:        r.Header.Get("expo-fatal-error"),
 		RecentFailedUpdateIDs: r.Header.Get("Expo-Recent-Failed-Update-Ids"),
+	}, nil
+}
+
+func serverDefinedHeaders(params services.ManifestRequestParams, result services.ManifestResult) *services.HeaderDictionary {
+	dictionary := services.NewHeaderDictionary()
+	if result.BlockedSurf != nil {
+		services.SetSurfBlocked(dictionary, params.SurfBlockTokens, result.BlockedSurf.Token)
 	}
+	return dictionary
+}
+
+func writeServerDefinedHeaders(w http.ResponseWriter, dictionary *services.HeaderDictionary) {
+	if encoded := dictionary.Encode(); encoded != "" {
+		w.Header().Set(services.ServerDefinedHeadersHeader, encoded)
+	}
+}
+
+func (h *ExpoProtocolHandler) HandleManifest(w http.ResponseWriter, r *http.Request) {
+	requestID := uuid.New().String()
+
+	params, err := manifestParams(r, requestID)
+	if err != nil {
+		log.Printf("[RequestID: %s] %v", requestID, err)
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	appId := params.AppID
+	platform := params.Platform
+	runtimeVersion := params.RuntimeVersion
+	protocolVersion := params.ProtocolVersion
 
 	result, err := h.protocolService.ResolveManifestBundle(r.Context(), params)
 	if err != nil {
@@ -211,6 +232,14 @@ func (h *ExpoProtocolHandler) HandleManifest(w http.ResponseWriter, r *http.Requ
 		})
 	}
 
+	// Set before any response is written so it also rides a noUpdateAvailable,
+	// which is what a device already holding the mapped branch gets.
+	writeServerDefinedHeaders(w, serverDefinedHeaders(params, result))
+	refusedBranch := ""
+	if result.BlockedSurf != nil {
+		refusedBranch = result.BlockedSurf.BranchName
+	}
+
 	if result.Update == nil {
 		log.Printf("[RequestID: %s] No update found for runtimeVersion: %s in branch: %s", requestID, runtimeVersion, result.BranchName)
 		h.protocolService.PutNoUpdateAvailableInResponse(w, r, appId, runtimeVersion, protocolVersion, requestID)
@@ -219,7 +248,7 @@ func (h *ExpoProtocolHandler) HandleManifest(w http.ResponseWriter, r *http.Requ
 
 	updateType := result.UpdateType
 	if updateType == types.NormalUpdate {
-		h.protocolService.PutUpdateInResponse(w, r, appId, *result.Update, platform, protocolVersion, requestID)
+		h.protocolService.PutUpdateInResponse(w, r, appId, *result.Update, platform, protocolVersion, requestID, refusedBranch)
 	} else {
 		h.protocolService.PutRollbackInResponse(w, r, appId, *result.Update, platform, protocolVersion, requestID)
 	}

--- a/internal/handlers/manifest_params_test.go
+++ b/internal/handlers/manifest_params_test.go
@@ -131,14 +131,15 @@ func TestManifestParamsRejects(t *testing.T) {
 // The device-facing half of the refusal: without this header the device keeps
 // asking for the branch that crashed on it, on every poll, forever.
 func TestServerDefinedHeadersCarriesTheVerdict(t *testing.T) {
-	params := services.ManifestRequestParams{SurfBlockTokens: "pr-1@100"}
-	result := services.ManifestResult{BlockedSurf: &services.BlockedSurf{BranchName: "pr-2", Token: "pr-2@200"}}
+	// Tokens are opaque on the wire; the encoding is pinned in the services package.
+	params := services.ManifestRequestParams{SurfBlockTokens: "cHItMQAxMDA"}
+	result := services.ManifestResult{BlockedSurf: &services.BlockedSurf{BranchName: "pr-2", Token: "cHItMgAyMDA"}}
 
 	w := httptest.NewRecorder()
 	writeServerDefinedHeaders(w, serverDefinedHeaders(params, result))
 
 	// The verdict the device already held survives the new one.
-	assert.Equal(t, `xprem-surf-blocked="pr-2@200,pr-1@100"`, w.Header().Get("expo-server-defined-headers"))
+	assert.Equal(t, `xprem-surf-blocked="cHItMgAyMDA,cHItMQAxMDA"`, w.Header().Get("expo-server-defined-headers"))
 }
 
 // No refusal means no header at all: an empty dictionary would replace whatever

--- a/internal/handlers/manifest_params_test.go
+++ b/internal/handlers/manifest_params_test.go
@@ -103,7 +103,10 @@ func TestManifestParamsFallsBackToTheQueryString(t *testing.T) {
 }
 
 func TestManifestParamsRejects(t *testing.T) {
+	// The legacy fallback would resolve an app id without the header.
+	t.Setenv("SKIP_LEGACY_APP_ID_FALLBACK", "true")
 	cases := map[string]func(*http.Request){
+		"no app id":           func(r *http.Request) { r.Header.Del("expo-app-id") },
 		"no channel":          func(r *http.Request) { r.Header.Del("expo-channel-name") },
 		"no protocol version": func(r *http.Request) { r.Header.Del("expo-protocol-version") },
 		"bad protocol version": func(r *http.Request) {

--- a/internal/handlers/manifest_params_test.go
+++ b/internal/handlers/manifest_params_test.go
@@ -1,0 +1,150 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"xprem/internal/services"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const paramsTestAppID = "d3a60200-4574-4781-9734-c174b511fb55"
+
+func validManifestRequest(target string) *http.Request {
+	r := httptest.NewRequest(http.MethodGet, target, nil)
+	r.Header.Set("expo-app-id", paramsTestAppID)
+	r.Header.Set("expo-channel-name", "qa")
+	r.Header.Set("expo-protocol-version", "1")
+	r.Header.Set("expo-platform", "ios")
+	r.Header.Set("expo-runtime-version", "3.0.0")
+	return r
+}
+
+// Every header the manifest path consumes, asserted in one place. A field
+// dropped from the params struct is invisible to the service tests, which build
+// their params by hand.
+func TestManifestParamsReadsEveryHeader(t *testing.T) {
+	r := validManifestRequest("/manifest")
+	r.Header.Set("xprem-branch", "pr-482")
+	r.Header.Set("xprem-surf-blocked", "pr-482@200")
+	r.Header.Set("EAS-Client-ID", "device-1")
+	r.Header.Set("expo-current-update-id", "11111111-1111-4111-8111-111111111111")
+	r.Header.Set("expo-fatal-error", "boom")
+	r.Header.Set("Expo-Recent-Failed-Update-Ids", `"22222222-2222-4222-8222-222222222222"`)
+
+	params, err := manifestParams(r, "req-1")
+
+	require.NoError(t, err)
+	assert.Equal(t, "req-1", params.RequestID)
+	assert.Equal(t, paramsTestAppID, params.AppID)
+	assert.Equal(t, "qa", params.ChannelName)
+	assert.Equal(t, "ios", params.Platform)
+	assert.Equal(t, "3.0.0", params.RuntimeVersion)
+	assert.Equal(t, int64(1), params.ProtocolVersion)
+	assert.Equal(t, "pr-482", params.XpremBranch)
+	assert.Equal(t, "pr-482@200", params.SurfBlockTokens)
+	assert.Equal(t, "device-1", params.ClientID)
+	assert.Equal(t, "11111111-1111-4111-8111-111111111111", params.CurrentUpdateID)
+	assert.Equal(t, "boom", params.ExpoFatalError)
+	assert.Equal(t, `"22222222-2222-4222-8222-222222222222"`, params.RecentFailedUpdateIDs)
+}
+
+// The two surf headers are the ones with no other test able to see them: the
+// service tests set the fields directly, so only this one covers the wire.
+func TestManifestParamsReadsTheSurfHeaders(t *testing.T) {
+	cases := map[string]struct {
+		header string
+		read   func(p services.ManifestRequestParams) string
+	}{
+		"xprem-branch":       {"xprem-branch", func(p services.ManifestRequestParams) string { return p.XpremBranch }},
+		"xprem-surf-blocked": {"xprem-surf-blocked", func(p services.ManifestRequestParams) string { return p.SurfBlockTokens }},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			r := validManifestRequest("/manifest")
+			r.Header.Set(tc.header, "sentinel")
+
+			params, err := manifestParams(r, "req-1")
+
+			require.NoError(t, err)
+			assert.Equal(t, "sentinel", tc.read(params))
+		})
+	}
+}
+
+// Absent optional headers are empty, never a stale value from another field.
+func TestManifestParamsLeavesAbsentHeadersEmpty(t *testing.T) {
+	params, err := manifestParams(validManifestRequest("/manifest"), "req-1")
+
+	require.NoError(t, err)
+	assert.Empty(t, params.XpremBranch)
+	assert.Empty(t, params.SurfBlockTokens)
+	assert.Empty(t, params.ClientID)
+	assert.Empty(t, params.CurrentUpdateID)
+	assert.Empty(t, params.ExpoFatalError)
+	assert.Empty(t, params.RecentFailedUpdateIDs)
+}
+
+// Platform and runtime version fall back to the query string for clients that
+// cannot set the headers.
+func TestManifestParamsFallsBackToTheQueryString(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "/manifest?platform=android&runtimeVersion=2.0.0", nil)
+	r.Header.Set("expo-app-id", paramsTestAppID)
+	r.Header.Set("expo-channel-name", "qa")
+	r.Header.Set("expo-protocol-version", "1")
+
+	params, err := manifestParams(r, "req-1")
+
+	require.NoError(t, err)
+	assert.Equal(t, "android", params.Platform)
+	assert.Equal(t, "2.0.0", params.RuntimeVersion)
+}
+
+func TestManifestParamsRejects(t *testing.T) {
+	cases := map[string]func(*http.Request){
+		"no channel":          func(r *http.Request) { r.Header.Del("expo-channel-name") },
+		"no protocol version": func(r *http.Request) { r.Header.Del("expo-protocol-version") },
+		"bad protocol version": func(r *http.Request) {
+			r.Header.Set("expo-protocol-version", "not-a-number")
+		},
+		"unknown platform":   func(r *http.Request) { r.Header.Set("expo-platform", "blackberry") },
+		"no platform":        func(r *http.Request) { r.Header.Del("expo-platform") },
+		"no runtime version": func(r *http.Request) { r.Header.Del("expo-runtime-version") },
+	}
+	for name, breakIt := range cases {
+		t.Run(name, func(t *testing.T) {
+			r := validManifestRequest("/manifest")
+			breakIt(r)
+
+			_, err := manifestParams(r, "req-1")
+
+			assert.Error(t, err)
+		})
+	}
+}
+
+// The device-facing half of the refusal: without this header the device keeps
+// asking for the branch that crashed on it, on every poll, forever.
+func TestServerDefinedHeadersCarriesTheVerdict(t *testing.T) {
+	params := services.ManifestRequestParams{SurfBlockTokens: "pr-1@100"}
+	result := services.ManifestResult{BlockedSurf: &services.BlockedSurf{BranchName: "pr-2", Token: "pr-2@200"}}
+
+	w := httptest.NewRecorder()
+	writeServerDefinedHeaders(w, serverDefinedHeaders(params, result))
+
+	// The verdict the device already held survives the new one.
+	assert.Equal(t, `xprem-surf-blocked="pr-2@200,pr-1@100"`, w.Header().Get("expo-server-defined-headers"))
+}
+
+// No refusal means no header at all: an empty dictionary would replace whatever
+// the device already carries.
+func TestServerDefinedHeadersIsSilentWithoutARefusal(t *testing.T) {
+	params := services.ManifestRequestParams{SurfBlockTokens: "pr-1@100"}
+
+	w := httptest.NewRecorder()
+	writeServerDefinedHeaders(w, serverDefinedHeaders(params, services.ManifestResult{}))
+
+	assert.Empty(t, w.Header().Get("expo-server-defined-headers"))
+}

--- a/internal/handlers/manifest_params_test.go
+++ b/internal/handlers/manifest_params_test.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"xprem/internal/services"
 
@@ -151,4 +152,16 @@ func TestServerDefinedHeadersIsSilentWithoutARefusal(t *testing.T) {
 	writeServerDefinedHeaders(w, serverDefinedHeaders(params, services.ManifestResult{}))
 
 	assert.Empty(t, w.Header().Get("expo-server-defined-headers"))
+}
+
+// The surf header is client-supplied and reaches the query layer and the logs.
+// Its two siblings are both bounded before use; this one was not.
+func TestRequestedBranchIsBounded(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "/manifest", nil)
+
+	r.Header.Set("xprem-branch", strings.Repeat("b", maxRequestedBranchLen))
+	assert.Len(t, requestedBranch(r), maxRequestedBranchLen, "a name of the maximum length is still a name")
+
+	r.Header.Set("xprem-branch", strings.Repeat("b", maxRequestedBranchLen+1))
+	assert.Empty(t, requestedBranch(r), "one byte over must read as no surf, not as a branch")
 }

--- a/internal/router/routes_app.go
+++ b/internal/router/routes_app.go
@@ -50,6 +50,8 @@ func registerAppRoutes(
 		NeedsPermission(rbac.PermChannelCreate, rbac.FallbackAdminOnly))
 	app.route(http.MethodDelete, "/channels/{CHANNEL}", container.ChannelHandler.DeleteChannelHandler,
 		NeedsPermission(rbac.PermChannelDelete, rbac.FallbackAdminOnly))
+	app.route(http.MethodPut, "/channels/{CHANNEL}/branch-surfing", container.ChannelHandler.SetBranchSurfingHandler,
+		NeedsPermission(rbac.PermChannelBranchSurfing, rbac.FallbackAdminOnly))
 	app.route(http.MethodPost, "/branch/{BRANCH_ID}/updateChannelBranchMapping", container.BranchHandler.UpdateChannelBranchMappingHandler,
 		NeedsPermission(rbac.PermChannelEditBranch, rbac.FallbackAdminOnly))
 

--- a/internal/router/routes_client.go
+++ b/internal/router/routes_client.go
@@ -10,7 +10,11 @@ import (
 // /manifest to learn which update it should run, then fetches what that
 // manifest points at from /assets. No authentication; the app id is the only
 // claim a device makes.
+//
+// /branch_lists is not part of the expo-updates protocol: it is what a device
+// on a branch-surfing channel reads to know which branches it may ask for.
 func registerClientRoutes(r *mux.Router, container *AppContainer) {
 	r.HandleFunc("/manifest", container.ExpoProtocolHandler.HandleManifest).Methods(http.MethodGet)
 	r.HandleFunc("/assets", container.ExpoProtocolHandler.HandleAssets).Methods(http.MethodGet)
+	r.HandleFunc("/branch_lists", container.BranchListHandler.HandleBranchList).Methods(http.MethodGet)
 }

--- a/internal/router/wire.go
+++ b/internal/router/wire.go
@@ -42,6 +42,7 @@ type AppContainer struct {
 	AppHandler                  *dashhandlers.AppHandler
 	AppRepo                     services.AppRepository
 	BranchHandler               *dashhandlers.BranchHandler
+	BranchListHandler           *handlers.BranchListHandler
 	ChannelHandler              *dashhandlers.ChannelHandler
 	ExpoProtocolHandler         *handlers.ExpoProtocolHandler
 	LicenseHandler              *licensing.LicenseHandler
@@ -296,6 +297,7 @@ func InitDependencies(ctx context.Context) (*AppContainer, func()) {
 		AppHandler:                  dashhandlers.NewAppHandler(appService, visibleApps),
 		AppRepo:                     appRepo,
 		BranchHandler:               dashhandlers.NewBranchHandler(branchService),
+		BranchListHandler:           handlers.NewBranchListHandler(channelService),
 		ChannelHandler:              dashhandlers.NewChannelHandler(channelService),
 		ExpoProtocolHandler:         handlers.NewExpoProtocolHandler(expoProtocolService),
 		LicenseHandler:              licensing.NewLicenseHandler(licenseService),

--- a/internal/services/asset_branch_guard_test.go
+++ b/internal/services/asset_branch_guard_test.go
@@ -1,0 +1,65 @@
+package services
+
+import (
+	"context"
+	"testing"
+	"xprem/internal/cache"
+	"xprem/internal/providers/expo"
+	"xprem/internal/types"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const guardAppID = "asset-branch-guard-test"
+
+// A nil setting means the channel does not exist, so its key is absent rather
+// than present and nil.
+func guardService(t *testing.T, surfing *types.BranchSurfing) *ExpoProtocolService {
+	t.Helper()
+	t.Setenv("DB_URL", "postgres://stub")
+	cache.GetCache().Delete(channelBranchSurfingCacheKey(guardAppID, "qa"))
+	settings := map[string]*types.BranchSurfing{}
+	if surfing != nil {
+		settings["qa"] = surfing
+	}
+	return NewExpoProtocolService(fakeAppRepo{}, &fakeChannelRepo{surfing: settings}, nil, nil, nil)
+}
+
+func TestAssetBranchGuardMirrorsTheManifest(t *testing.T) {
+	mapped := &expo.ChannelMapping{Id: "1", BranchName: "staging"}
+	withRollout := &expo.ChannelMapping{
+		Id: "1", BranchName: "staging",
+		Rollout: &expo.ChannelRolloutInfo{ID: "r1", BranchName: "canary", Percentage: 50},
+	}
+
+	cases := []struct {
+		name    string
+		surfing *types.BranchSurfing
+		mapping *expo.ChannelMapping
+		branch  string
+		want    bool
+	}{
+		{"mapped branch", &types.BranchSurfing{}, mapped, "staging", true},
+		{"rollout branch", &types.BranchSurfing{}, withRollout, "canary", true},
+		{"other branch, surfing off", &types.BranchSurfing{}, mapped, "pr-482", false},
+		{"surfed branch matching the pattern", &types.BranchSurfing{Enabled: true, Pattern: "pr-*"}, mapped, "pr-482", true},
+		{"branch outside the pattern", &types.BranchSurfing{Enabled: true, Pattern: "pr-*"}, mapped, "secret", false},
+		{"wildcard exposes everything", &types.BranchSurfing{Enabled: true, Pattern: "*"}, mapped, "secret", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			service := guardService(t, tc.surfing)
+			allowed := service.isAssetBranchAllowed(context.Background(), guardAppID, "qa", tc.branch, tc.mapping)
+			assert.Equal(t, tc.want, allowed)
+		})
+	}
+}
+
+// An unknown channel grants nothing, so a crafted URL naming one cannot read a
+// branch it has no claim to.
+func TestAssetBranchGuardDeniesOnUnknownChannel(t *testing.T) {
+	service := guardService(t, nil)
+	mapped := &expo.ChannelMapping{Id: "1", BranchName: "staging"}
+
+	assert.False(t, service.isAssetBranchAllowed(context.Background(), guardAppID, "qa", "pr-482", mapped))
+}

--- a/internal/services/branch_rules.go
+++ b/internal/services/branch_rules.go
@@ -62,14 +62,18 @@ func ResolveBranchCandidates(ctx context.Context, rules []BranchRule, req *Branc
 // the mapped branch is not a surf, so it falls through and keeps the rollout.
 type branchSurfRule struct{}
 
+// HonoursSurf reports whether the chain will serve the branch the device asked for.
+// Anything downstream that needs to know "is this poll actually surfing" must ask
+// here rather than re-test the header, or it treats declined requests as surfs.
+func HonoursSurf(req *BranchResolutionRequest) bool {
+	return req.RequestedBranch != "" &&
+		req.Surfing.Enabled &&
+		req.RequestedBranch != req.Mapping.BranchName &&
+		branch.MatchPattern(req.Surfing.Pattern, req.RequestedBranch)
+}
+
 func (r *branchSurfRule) Evaluate(ctx context.Context, req *BranchResolutionRequest) ([]string, bool, error) {
-	if req.RequestedBranch == "" || !req.Surfing.Enabled {
-		return nil, false, nil
-	}
-	if req.RequestedBranch == req.Mapping.BranchName {
-		return nil, false, nil
-	}
-	if !branch.MatchPattern(req.Surfing.Pattern, req.RequestedBranch) {
+	if !HonoursSurf(req) {
 		return nil, false, nil
 	}
 	// The mapped branch stays a candidate: a surfed branch with no update for the

--- a/internal/services/branch_rules.go
+++ b/internal/services/branch_rules.go
@@ -2,8 +2,10 @@ package services
 
 import (
 	"context"
+	"xprem/internal/branch"
 	"xprem/internal/providers/expo"
 	"xprem/internal/rollout"
+	"xprem/internal/types"
 )
 
 // BranchResolutionRequest carries everything a rule needs to decide which branches a
@@ -16,6 +18,10 @@ type BranchResolutionRequest struct {
 	Platform       string
 	RuntimeVersion string
 	Mapping        *expo.ChannelMapping
+	// RequestedBranch is the xprem-branch header, empty when the device asks for
+	// nothing in particular. Surfing is the channel's setting for it.
+	RequestedBranch string
+	Surfing         types.BranchSurfing
 }
 
 // BranchRule is one step of the ordered channel-resolution chain evaluated at
@@ -28,10 +34,11 @@ type BranchRule interface {
 	Evaluate(ctx context.Context, req *BranchResolutionRequest) (candidates []string, matched bool, err error)
 }
 
-// DefaultBranchRules is the MIT rule chain: the channel-rollout percentage split when
-// one is active, then the plain mapped branch.
+// DefaultBranchRules is the MIT rule chain: the branch the device asked for when the
+// channel allows it, then the channel-rollout percentage split when one is active,
+// then the plain mapped branch.
 func DefaultBranchRules() []BranchRule {
-	return []BranchRule{&channelRolloutPercentRule{}, &defaultBranchRule{}}
+	return []BranchRule{&branchSurfRule{}, &channelRolloutPercentRule{}, &defaultBranchRule{}}
 }
 
 // ResolveBranchCandidates evaluates the rules in order and returns the first match's
@@ -48,6 +55,26 @@ func ResolveBranchCandidates(ctx context.Context, rules []BranchRule, req *Branc
 		}
 	}
 	return []string{req.Mapping.BranchName}, nil
+}
+
+// branchSurfRule serves the branch the device asked for. Ahead of the rollout rule: a
+// surf is an explicit choice and does not go back through the bucket draw. Asking for
+// the mapped branch is not a surf, so it falls through and keeps the rollout.
+type branchSurfRule struct{}
+
+func (r *branchSurfRule) Evaluate(ctx context.Context, req *BranchResolutionRequest) ([]string, bool, error) {
+	if req.RequestedBranch == "" || !req.Surfing.Enabled {
+		return nil, false, nil
+	}
+	if req.RequestedBranch == req.Mapping.BranchName {
+		return nil, false, nil
+	}
+	if !branch.MatchPattern(req.Surfing.Pattern, req.RequestedBranch) {
+		return nil, false, nil
+	}
+	// The mapped branch stays a candidate: a surfed branch with no update for the
+	// device's runtime version falls back instead of stranding it.
+	return []string{req.RequestedBranch, req.Mapping.BranchName}, true, nil
 }
 
 // channelRolloutPercentRule implements the channel rollout split: devices bucketed

--- a/internal/services/branch_service.go
+++ b/internal/services/branch_service.go
@@ -33,7 +33,7 @@ type BranchRepository interface {
 	GetUpdatedMetadataByBranchName(ctx context.Context, appId string, branchName string) ([]pgdb.GetUpdatesMetadataByBranchNameRow, error)
 	DeleteBranchByName(ctx context.Context, appId string, branchName string) error
 	GetBranches(ctx context.Context, appId string) ([]types.BranchMapping, error)
-	GetSurfableBranches(ctx context.Context, appId string, runtimeVersion string) ([]types.SurfableBranch, error)
+	GetSurfableBranches(ctx context.Context, appId string, runtimeVersion string, platform string) ([]types.SurfableBranch, error)
 	GetRuntimeVersionsWithUpdateStats(ctx context.Context, appId string, branchName string) ([]types.RuntimeVersionWithStats, error)
 	UpdateChannelBranchMapping(ctx context.Context, appId string, channelId string, branchId string) error
 	CreateRuntimeVersion(ctx context.Context, appId string, version string) (int64, error)

--- a/internal/services/branch_service.go
+++ b/internal/services/branch_service.go
@@ -33,6 +33,7 @@ type BranchRepository interface {
 	GetUpdatedMetadataByBranchName(ctx context.Context, appId string, branchName string) ([]pgdb.GetUpdatesMetadataByBranchNameRow, error)
 	DeleteBranchByName(ctx context.Context, appId string, branchName string) error
 	GetBranches(ctx context.Context, appId string) ([]types.BranchMapping, error)
+	GetSurfableBranches(ctx context.Context, appId string, runtimeVersion string) ([]types.SurfableBranch, error)
 	GetRuntimeVersionsWithUpdateStats(ctx context.Context, appId string, branchName string) ([]types.RuntimeVersionWithStats, error)
 	UpdateChannelBranchMapping(ctx context.Context, appId string, channelId string, branchId string) error
 	CreateRuntimeVersion(ctx context.Context, appId string, version string) (int64, error)

--- a/internal/services/branch_surf_block.go
+++ b/internal/services/branch_surf_block.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"context"
+	"encoding/base64"
 	"strings"
 	update2 "xprem/internal/update"
 )
@@ -20,8 +21,16 @@ const (
 
 // surfBlockToken names the exact update that crashed, not just its branch: a fix
 // published to the same branch gets a new update id and is therefore served.
+//
+// Opaque on purpose. The token travels in a comma-separated RFC 8941 string, and
+// a branch name is neither comma-free nor ASCII-only — "pr,ios" is a legal branch
+// that would be read back as two tokens, and a branch with an accent cannot be
+// carried by a structured string at all. Either would silently drop a verdict and
+// let a crashing update be served again. Encoding the pair sidesteps both: the
+// result is base64url, so it can only ever be one token. Nothing decodes it — the
+// token is compared, never read.
 func surfBlockToken(branchName string, updateId string) string {
-	return branchName + "@" + updateId
+	return base64.RawURLEncoding.EncodeToString([]byte(branchName + "\x00" + updateId))
 }
 
 // surfBlockSet holds the surfBlockToken of every update this device must not be
@@ -38,9 +47,9 @@ func (b surfBlockSet) contains(branchName string, updateId string) bool {
 
 // collectSurfBlocks gathers what this device must not be surfed onto, from its
 // two sources. The verdicts it echoes back are already tokens; the crashes it
-// reports are UUIDs, which only the store can resolve to a branch and an update.
-// An id that resolves to nothing tells us nothing, so it is skipped rather than
-// failing the poll.
+// reports are manifest UUIDs, a different identifier from the update id, which
+// only the store can resolve. An id that resolves to nothing tells us nothing, so
+// it is skipped rather than failing the poll.
 //
 // Only called for a device whose surf was honoured AND that reported something,
 // so these lookups stay off the steady-state path.
@@ -64,13 +73,16 @@ func (s *ExpoProtocolService) collectSurfBlocks(ctx context.Context, appId strin
 // the oldest fall off, and their branches become surfable again.
 const maxSurfBlockTokens = 5
 
-// maxSurfBlockTokensRaw bounds the echoed header before it is split. Five tokens
-// of a max-length branch name fit well under it; Go accepts request headers up to
-// 1 MiB, and this value is entirely client-supplied.
+// maxSurfBlockTokensRaw bounds the echoed header before it is split. Five ids fit
+// well under it; Go accepts request headers up to 1 MiB, and this value is
+// entirely client-supplied.
 const maxSurfBlockTokensRaw = 2048
 
 // parseSurfBlockTokens reads the verdicts a device echoes back, bounded on the
-// input AND on the count. Nothing downstream limits either.
+// input AND on the count. Nothing downstream limits either. Anything that is not
+// base64url is dropped: the value is client-supplied, only a token the server
+// itself minted can ever match, and retaining other bytes would be echoed back
+// into a structured string that cannot carry them.
 func parseSurfBlockTokens(raw string) []string {
 	if len(raw) > maxSurfBlockTokensRaw {
 		raw = raw[:maxSurfBlockTokensRaw]
@@ -80,7 +92,7 @@ func parseSurfBlockTokens(raw string) []string {
 		if token = strings.TrimSpace(token); token == "" {
 			continue
 		}
-		if !isPrintableASCII(token) {
+		if !isBase64URL(token) {
 			continue
 		}
 		tokens = append(tokens, token)
@@ -91,27 +103,24 @@ func parseSurfBlockTokens(raw string) []string {
 	return tokens
 }
 
-// isPrintableASCII reports whether every byte is in 0x20-0x7E, the only bytes
-// an RFC 8941 string can carry; a retained token outside that range would be
-// echoed back and break the whole dictionary on the device.
-func isPrintableASCII(s string) bool {
-	for i := 0; i < len(s); i++ {
-		if s[i] < 0x20 || s[i] > 0x7e {
-			return false
-		}
-	}
-	return true
-}
-
 // SetSurfBlocked contributes the verdict to the dictionary the response carries,
 // keeping the ones the device already holds: expo-updates replaces its whole
 // stored copy, so dropping the previous tokens would unblock the branches they
 // name. It writes into the caller's dictionary rather than returning a header, so
 // other members can share it.
+//
+// Tokens are taken one at a time while the joined value still fits the member
+// bound, oldest dropped first. Assembling the whole list and cutting it to length
+// would leave a half token that can never match anything, and would take the
+// newest verdict — the one this response is about — with it.
 func SetSurfBlocked(dictionary *HeaderDictionary, carriedTokens string, token string) {
+	if len(token) > maxHeaderDictionaryValue {
+		return
+	}
 	tokens := make([]string, 0, maxSurfBlockTokens)
 	seen := map[string]struct{}{token: {}}
 	tokens = append(tokens, token)
+	size := len(token)
 	for _, carriedToken := range parseSurfBlockTokens(carriedTokens) {
 		if len(tokens) == maxSurfBlockTokens {
 			break
@@ -119,14 +128,32 @@ func SetSurfBlocked(dictionary *HeaderDictionary, carriedTokens string, token st
 		if _, duplicate := seen[carriedToken]; duplicate {
 			continue
 		}
+		if size+1+len(carriedToken) > maxHeaderDictionaryValue {
+			break
+		}
 		seen[carriedToken] = struct{}{}
 		tokens = append(tokens, carriedToken)
+		size += 1 + len(carriedToken)
 	}
 	dictionary.Set(SurfBlockedHeader, strings.Join(tokens, ","))
 }
 
+// isBase64URL reports whether every byte is in the base64url alphabet, which is
+// what surfBlockToken produces and a subset of what an RFC 8941 string can carry.
+func isBase64URL(s string) bool {
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '-' || c == '_' {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
 // BlockedSurf is what a refused poll reports back so the response can carry the
-// verdict and tell the app which branch it lost.
+// verdict and tell the app which branch it lost. Token names the refused update;
+// BranchName is only for the message shown to the tester.
 type BlockedSurf struct {
 	BranchName string
 	Token      string

--- a/internal/services/branch_surf_block.go
+++ b/internal/services/branch_surf_block.go
@@ -129,7 +129,10 @@ func SetSurfBlocked(dictionary *HeaderDictionary, carriedTokens string, token st
 			continue
 		}
 		if size+1+len(carriedToken) > maxHeaderDictionaryValue {
-			break
+			// Skipped, not stopped: this header is client-supplied, so one
+			// oversized entry would otherwise discard every legitimate verdict
+			// behind it — and those are what keep a crashing update refused.
+			continue
 		}
 		seen[carriedToken] = struct{}{}
 		tokens = append(tokens, carriedToken)

--- a/internal/services/branch_surf_block.go
+++ b/internal/services/branch_surf_block.go
@@ -1,0 +1,114 @@
+package services
+
+import (
+	"context"
+	"strings"
+	update2 "xprem/internal/update"
+)
+
+// SurfBlockedHeader is the dictionary member holding the refusals, which the
+// device echoes back as its own request header on every poll. That replay is what
+// makes a refusal outlive the client's own crash report, which expires after a
+// couple of healthy updates.
+//
+// ServerDefinedHeadersHeader carries the whole dictionary, not just this member:
+// it is written once per response, from one place.
+const (
+	SurfBlockedHeader          = "xprem-surf-blocked"
+	ServerDefinedHeadersHeader = "expo-server-defined-headers"
+)
+
+// surfBlockToken names the exact update that crashed, not just its branch: a fix
+// published to the same branch gets a new update id and is therefore served.
+func surfBlockToken(branchName string, updateId string) string {
+	return branchName + "@" + updateId
+}
+
+// refusedUpdates is the set of updates a device must not be served on the branch
+// it asked for: the ones it reported as failed to launch, plus the verdict it is
+// already carrying.
+type refusedUpdates map[string]struct{}
+
+func (r refusedUpdates) contains(branchName string, updateId string) bool {
+	if len(r) == 0 {
+		return false
+	}
+	_, refused := r[surfBlockToken(branchName, updateId)]
+	return refused
+}
+
+// collectRefusedUpdates resolves the device's failed update UUIDs to the updates
+// they name. Only called for a device that is asking for a branch AND reporting
+// something, so the lookups stay off the steady-state path.
+func (s *ExpoProtocolService) collectRefusedUpdates(ctx context.Context, appId string, surfBlockTokens string, failedUpdateIDsRaw string) refusedUpdates {
+	refused := refusedUpdates{}
+	for _, token := range parseSurfBlockTokens(surfBlockTokens) {
+		refused[token] = struct{}{}
+	}
+	for _, failedID := range update2.ParseFailedUpdateIDs(failedUpdateIDsRaw) {
+		failedUpdate, err := s.updateRepo.GetUpdateByUUID(ctx, appId, failedID)
+		if err != nil || failedUpdate == nil {
+			continue
+		}
+		refused[surfBlockToken(failedUpdate.Branch, failedUpdate.UpdateId)] = struct{}{}
+	}
+	return refused
+}
+
+// maxSurfBlockTokens bounds how many verdicts a device carries. The client
+// replays them on every poll, so the list cannot be allowed to grow for ever;
+// the oldest fall off, and their branches become surfable again.
+const maxSurfBlockTokens = 5
+
+// maxSurfBlockTokensRaw bounds the echoed header before it is split. Five tokens
+// of a max-length branch name fit well under it; Go accepts request headers up to
+// 1 MiB, and this value is entirely client-supplied.
+const maxSurfBlockTokensRaw = 2048
+
+// parseSurfBlockTokens reads the verdicts a device echoes back, bounded on the
+// input AND on the count. Nothing downstream limits either.
+func parseSurfBlockTokens(raw string) []string {
+	if len(raw) > maxSurfBlockTokensRaw {
+		raw = raw[:maxSurfBlockTokensRaw]
+	}
+	tokens := make([]string, 0, maxSurfBlockTokens)
+	for _, token := range strings.Split(raw, ",") {
+		if token = strings.TrimSpace(token); token == "" {
+			continue
+		}
+		tokens = append(tokens, token)
+		if len(tokens) == maxSurfBlockTokens {
+			break
+		}
+	}
+	return tokens
+}
+
+// SetSurfBlocked contributes the verdict to the dictionary the response carries,
+// keeping the ones the device already holds: expo-updates replaces its whole
+// stored copy, so dropping the previous tokens would unblock the branches they
+// name. It writes into the caller's dictionary rather than returning a header, so
+// other members can share it.
+func SetSurfBlocked(dictionary *HeaderDictionary, carriedTokens string, token string) {
+	tokens := make([]string, 0, maxSurfBlockTokens)
+	seen := map[string]struct{}{token: {}}
+	tokens = append(tokens, token)
+	for _, carriedToken := range parseSurfBlockTokens(carriedTokens) {
+		if len(tokens) == maxSurfBlockTokens {
+			break
+		}
+		if _, duplicate := seen[carriedToken]; duplicate {
+			continue
+		}
+		seen[carriedToken] = struct{}{}
+		tokens = append(tokens, carriedToken)
+	}
+	dictionary.Set(SurfBlockedHeader, strings.Join(tokens, ","))
+}
+
+// BlockedSurf is what a refused poll reports back so the response can carry the
+// verdict and tell the app which branch it lost.
+type BlockedSurf struct {
+	BranchName string
+	Token      string
+}

--- a/internal/services/branch_surf_block.go
+++ b/internal/services/branch_surf_block.go
@@ -80,12 +80,27 @@ func parseSurfBlockTokens(raw string) []string {
 		if token = strings.TrimSpace(token); token == "" {
 			continue
 		}
+		if !isPrintableASCII(token) {
+			continue
+		}
 		tokens = append(tokens, token)
 		if len(tokens) == maxSurfBlockTokens {
 			break
 		}
 	}
 	return tokens
+}
+
+// isPrintableASCII reports whether every byte is in 0x20-0x7E, the only bytes
+// an RFC 8941 string can carry; a retained token outside that range would be
+// echoed back and break the whole dictionary on the device.
+func isPrintableASCII(s string) bool {
+	for i := 0; i < len(s); i++ {
+		if s[i] < 0x20 || s[i] > 0x7e {
+			return false
+		}
+	}
+	return true
 }
 
 // SetSurfBlocked contributes the verdict to the dictionary the response carries,

--- a/internal/services/branch_surf_block.go
+++ b/internal/services/branch_surf_block.go
@@ -24,35 +24,39 @@ func surfBlockToken(branchName string, updateId string) string {
 	return branchName + "@" + updateId
 }
 
-// refusedUpdates is the set of updates a device must not be served on the branch
-// it asked for: the ones it reported as failed to launch, plus the verdict it is
-// already carrying.
-type refusedUpdates map[string]struct{}
+// surfBlockSet holds the surfBlockToken of every update this device must not be
+// served on the branch it asked for.
+type surfBlockSet map[string]struct{}
 
-func (r refusedUpdates) contains(branchName string, updateId string) bool {
-	if len(r) == 0 {
+func (b surfBlockSet) contains(branchName string, updateId string) bool {
+	if len(b) == 0 {
 		return false
 	}
-	_, refused := r[surfBlockToken(branchName, updateId)]
-	return refused
+	_, blocked := b[surfBlockToken(branchName, updateId)]
+	return blocked
 }
 
-// collectRefusedUpdates resolves the device's failed update UUIDs to the updates
-// they name. Only called for a device that is asking for a branch AND reporting
-// something, so the lookups stay off the steady-state path.
-func (s *ExpoProtocolService) collectRefusedUpdates(ctx context.Context, appId string, surfBlockTokens string, failedUpdateIDsRaw string) refusedUpdates {
-	refused := refusedUpdates{}
+// collectSurfBlocks gathers what this device must not be surfed onto, from its
+// two sources. The verdicts it echoes back are already tokens; the crashes it
+// reports are UUIDs, which only the store can resolve to a branch and an update.
+// An id that resolves to nothing tells us nothing, so it is skipped rather than
+// failing the poll.
+//
+// Only called for a device whose surf was honoured AND that reported something,
+// so these lookups stay off the steady-state path.
+func (s *ExpoProtocolService) collectSurfBlocks(ctx context.Context, appId string, surfBlockTokens string, failedUpdateIDsRaw string) surfBlockSet {
+	blocks := surfBlockSet{}
 	for _, token := range parseSurfBlockTokens(surfBlockTokens) {
-		refused[token] = struct{}{}
+		blocks[token] = struct{}{}
 	}
 	for _, failedID := range update2.ParseFailedUpdateIDs(failedUpdateIDsRaw) {
 		failedUpdate, err := s.updateRepo.GetUpdateByUUID(ctx, appId, failedID)
 		if err != nil || failedUpdate == nil {
 			continue
 		}
-		refused[surfBlockToken(failedUpdate.Branch, failedUpdate.UpdateId)] = struct{}{}
+		blocks[surfBlockToken(failedUpdate.Branch, failedUpdate.UpdateId)] = struct{}{}
 	}
-	return refused
+	return blocks
 }
 
 // maxSurfBlockTokens bounds how many verdicts a device carries. The client

--- a/internal/services/branch_surf_block_test.go
+++ b/internal/services/branch_surf_block_test.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"context"
+	"encoding/json"
 	"strings"
 	"testing"
 	"xprem/internal/providers/expo"
@@ -264,4 +265,17 @@ func TestParseSurfBlockTokensIsBounded(t *testing.T) {
 			[]string{"pr-1@100", "pr-2@200"},
 			parseSurfBlockTokens(" pr-1@100 , pr-2@200 "))
 	})
+}
+
+// Whether a channel allows surfing must never ride the manifest again. A manifest
+// is frozen when its update is served; the setting changes whenever an admin says
+// so, so a device already up to date would never learn it was turned on. The
+// client asks /branch_lists.
+func TestTheManifestNeverCarriesTheChannelSetting(t *testing.T) {
+	extra := types.ExtraManifestData{}
+	encoded, err := json.Marshal(extra)
+
+	require.NoError(t, err)
+	assert.NotContains(t, string(encoded), "branchSurfing\"",
+		"a channel-lifetime setting has no place in an update-lifetime document")
 }

--- a/internal/services/branch_surf_block_test.go
+++ b/internal/services/branch_surf_block_test.go
@@ -2,7 +2,7 @@ package services
 
 import (
 	"context"
-	"encoding/json"
+	"reflect"
 	"strings"
 	"testing"
 	"xprem/internal/providers/expo"
@@ -172,9 +172,12 @@ func TestHostileBranchNamesProduceSafeTokens(t *testing.T) {
 			"a token the server minted must survive being echoed back")
 	}
 
-	// The distinctness that matters: two branches whose tokens could collide once
-	// concatenated must not, or one crash would block the other's update.
-	assert.NotEqual(t, surfBlockToken("pr", "1@2"), surfBlockToken("pr@1", "2"))
+	// The distinctness that matters: two (branch, update) pairs that concatenate
+	// to the same bytes must still yield different tokens, or one branch's crash
+	// would block another branch's update. This pair collides under the realistic
+	// regression — dropping the separator — where "pr"+"1@2" and "pr@1"+"2" do
+	// not, which is why the earlier version of this assertion proved nothing.
+	assert.NotEqual(t, surfBlockToken("pr", "12"), surfBlockToken("pr1", "2"))
 }
 
 // The verdict is one member among others: a dictionary already carrying something
@@ -296,12 +299,19 @@ func TestParseSurfBlockTokensIsBounded(t *testing.T) {
 // so, so a device already up to date would never learn it was turned on. The
 // client asks /branch_lists.
 func TestTheManifestNeverCarriesTheChannelSetting(t *testing.T) {
-	extra := types.ExtraManifestData{}
-	encoded, err := json.Marshal(extra)
-
-	require.NoError(t, err)
-	assert.NotContains(t, string(encoded), "branchSurfing\"",
-		"a channel-lifetime setting has no place in an update-lifetime document")
+	// Over the field tags, not over an encoding of the zero value: the shape
+	// anyone would actually add is a pointer with omitempty, and that emits
+	// nothing when unset — so marshalling an empty struct and grepping the bytes
+	// passes no matter what the struct declares.
+	extra := reflect.TypeOf(types.ExtraManifestData{})
+	for i := 0; i < extra.NumField(); i++ {
+		field := extra.Field(i)
+		name, _, _ := strings.Cut(field.Tag.Get("json"), ",")
+		assert.NotEqual(t, "branchSurfing", name,
+			"a channel-lifetime setting has no place in an update-lifetime document: %s", field.Name)
+		assert.NotContains(t, strings.ToLower(field.Name), "surfingenabled",
+			"same, under another name: %s", field.Name)
+	}
 }
 
 // Long branch names make five tokens overflow the member bound. Cutting the

--- a/internal/services/branch_surf_block_test.go
+++ b/internal/services/branch_surf_block_test.go
@@ -265,6 +265,15 @@ func TestParseSurfBlockTokensIsBounded(t *testing.T) {
 			[]string{"pr-1@100", "pr-2@200"},
 			parseSurfBlockTokens(" pr-1@100 , pr-2@200 "))
 	})
+
+	// Retained tokens are echoed back inside an RFC 8941 string, which can only
+	// carry printable ASCII; one stray byte would cost the device the whole
+	// dictionary. This also covers the input cap cutting a multi-byte rune.
+	t.Run("drops tokens an RFC 8941 string cannot carry", func(t *testing.T) {
+		assert.Equal(t,
+			[]string{"pr-1@100"},
+			parseSurfBlockTokens("pr-1@100,pr\x002@2,pr-é@3"))
+	})
 }
 
 // Whether a channel allows surfing must never ride the manifest again. A manifest

--- a/internal/services/branch_surf_block_test.go
+++ b/internal/services/branch_surf_block_test.go
@@ -1,0 +1,267 @@
+package services
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"xprem/internal/providers/expo"
+	"xprem/internal/types"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const crashedUUID = "9f1c1d2e-0000-4000-8000-000000000001"
+
+func newBlockHarness(t *testing.T) *rolloutTestHarness {
+	t.Helper()
+	t.Setenv("DB_URL", "postgres://stub")
+	h := newRolloutTestHarness(t)
+	h.channelRepo.mappings["qa"] = &expo.ChannelMapping{Id: "1", BranchName: "staging"}
+	h.channelRepo.surfing = map[string]*types.BranchSurfing{"qa": {Enabled: true, Pattern: "pr-*"}}
+	h.seed(seedRow{branch: "staging", rtv: "1", platform: "ios", id: 100, checked: true})
+	return h
+}
+
+func blockParams(h *rolloutTestHarness) ManifestRequestParams {
+	return ManifestRequestParams{
+		RequestID:       "test",
+		AppID:           h.appId,
+		ChannelName:     "qa",
+		Platform:        "ios",
+		RuntimeVersion:  "1",
+		ProtocolVersion: 1,
+		ClientID:        "device-1",
+		XpremBranch:     "pr-482",
+	}
+}
+
+// The device reports the update it would be served as having failed to launch,
+// so the surf is refused and it lands back on the channel's branch.
+func TestSurfIsRefusedWhenTheServedUpdateCrashed(t *testing.T) {
+	h := newBlockHarness(t)
+	h.seed(seedRow{branch: "pr-482", rtv: "1", platform: "ios", id: 200, checked: true, uuid: crashedUUID})
+
+	params := blockParams(h)
+	params.RecentFailedUpdateIDs = `"` + crashedUUID + `"`
+	result, err := h.protocolService.ResolveManifestBundle(context.Background(), params)
+
+	require.NoError(t, err)
+	assert.Equal(t, "staging", result.BranchName)
+	require.NotNil(t, result.Update, "the fallback must actually be served, not just named")
+	assert.Equal(t, "100", result.Update.UpdateId)
+	require.NotNil(t, result.BlockedSurf)
+	assert.Equal(t, "pr-482", result.BlockedSurf.BranchName)
+	assert.Equal(t, "pr-482@200", result.BlockedSurf.Token)
+}
+
+// A refusal can never empty the candidate list. HonoursSurf requires the asked-for
+// branch to DIFFER from the mapped one, and only the asked-for branch can be
+// refused, so the mapped branch is structurally unrefusable. Loosen that condition
+// and a device ends up served nothing.
+func TestTheMappedBranchIsNeverRefused(t *testing.T) {
+	h := newBlockHarness(t)
+	h.seed(seedRow{branch: "pr-482", rtv: "1", platform: "ios", id: 200, checked: true, uuid: crashedUUID})
+	stagingUUID := uuid.NewString()
+	h.updateRepo.setUUID(h.appId, "staging", "100", stagingUUID)
+
+	// Both branches reported as crashed, and both named in the carried verdicts.
+	params := blockParams(h)
+	params.RecentFailedUpdateIDs = `"` + crashedUUID + `","` + stagingUUID + `"`
+	params.SurfBlockTokens = "pr-482@200,staging@100"
+	result, err := h.protocolService.ResolveManifestBundle(context.Background(), params)
+
+	require.NoError(t, err)
+	assert.Equal(t, "staging", result.BranchName)
+	require.NotNil(t, result.Update, "a device must never be left with no update at all")
+	assert.Equal(t, "100", result.Update.UpdateId)
+}
+
+// A fix published to the same branch has a different update id, so the refusal
+// does not survive it. Refusing per branch instead of per update would strand
+// the device on the embedded bundle for good.
+func TestSurfIsAllowedAgainOnceTheBranchIsFixed(t *testing.T) {
+	h := newBlockHarness(t)
+	h.seed(seedRow{branch: "pr-482", rtv: "1", platform: "ios", id: 200, checked: true, uuid: crashedUUID})
+	h.seed(seedRow{branch: "pr-482", rtv: "1", platform: "ios", id: 300, checked: true, uuid: uuid.NewString()})
+
+	params := blockParams(h)
+	params.RecentFailedUpdateIDs = `"` + crashedUUID + `"`
+	params.SurfBlockTokens = "pr-482@200"
+	result, err := h.protocolService.ResolveManifestBundle(context.Background(), params)
+
+	require.NoError(t, err)
+	assert.Equal(t, "pr-482", result.BranchName)
+	assert.Nil(t, result.BlockedSurf)
+}
+
+// The echoed verdict outlives the crash report, which expo-updates drops after a
+// couple of healthy updates.
+func TestSurfStaysRefusedFromTheEchoedVerdictAlone(t *testing.T) {
+	h := newBlockHarness(t)
+	h.seed(seedRow{branch: "pr-482", rtv: "1", platform: "ios", id: 200, checked: true, uuid: crashedUUID})
+
+	params := blockParams(h)
+	params.SurfBlockTokens = "pr-482@200"
+	result, err := h.protocolService.ResolveManifestBundle(context.Background(), params)
+
+	require.NoError(t, err)
+	assert.Equal(t, "staging", result.BranchName)
+	require.NotNil(t, result.BlockedSurf)
+}
+
+// A failed update on another branch says nothing about the one being asked for.
+func TestSurfSurvivesAFailureOnAnotherBranch(t *testing.T) {
+	h := newBlockHarness(t)
+	h.seed(seedRow{branch: "pr-482", rtv: "1", platform: "ios", id: 200, checked: true, uuid: uuid.NewString()})
+	h.seed(seedRow{branch: "pr-999", rtv: "1", platform: "ios", id: 400, checked: true, uuid: crashedUUID})
+
+	params := blockParams(h)
+	params.RecentFailedUpdateIDs = `"` + crashedUUID + `"`
+	result, err := h.protocolService.ResolveManifestBundle(context.Background(), params)
+
+	require.NoError(t, err)
+	assert.Equal(t, "pr-482", result.BranchName)
+	assert.Nil(t, result.BlockedSurf)
+}
+
+// surfBlockedOnly renders a dictionary carrying nothing but the surf verdict,
+// which is what a response looks like today.
+func surfBlockedOnly(carriedTokens string, token string) string {
+	dictionary := NewHeaderDictionary()
+	SetSurfBlocked(dictionary, carriedTokens, token)
+	return dictionary.Encode()
+}
+
+func TestSetSurfBlockedRendersAStructuredDictionary(t *testing.T) {
+	assert.Equal(t, `xprem-surf-blocked="pr-482@200"`, surfBlockedOnly("", "pr-482@200"))
+}
+
+// The response replaces the client's whole stored dictionary, so a second verdict
+// has to carry the first or it unblocks the branch it names.
+func TestSetSurfBlockedKeepsTheVerdictsAlreadyCarried(t *testing.T) {
+	assert.Equal(t,
+		`xprem-surf-blocked="pr-2@200,pr-1@100"`,
+		surfBlockedOnly("pr-1@100", "pr-2@200"))
+}
+
+func TestSetSurfBlockedDropsDuplicatesAndCaps(t *testing.T) {
+	assert.Equal(t,
+		`xprem-surf-blocked="pr-1@100"`,
+		surfBlockedOnly("pr-1@100", "pr-1@100"))
+
+	carried := "a@1,b@2,c@3,d@4,e@5,f@6"
+	assert.Equal(t,
+		`xprem-surf-blocked="new@9,a@1,b@2,c@3,d@4"`,
+		surfBlockedOnly(carried, "new@9"))
+}
+
+// A branch name may contain a quote; unescaped it would break the dictionary the
+// client parses, silently losing every verdict.
+func TestSetSurfBlockedEscapesQuotes(t *testing.T) {
+	assert.Equal(t,
+		`xprem-surf-blocked="pr-\"x@200"`,
+		surfBlockedOnly("", `pr-"x@200`))
+}
+
+// The verdict is one member among others: a dictionary already carrying something
+// must keep it.
+func TestSetSurfBlockedSharesTheDictionary(t *testing.T) {
+	dictionary := NewHeaderDictionary()
+	dictionary.Set("xprem-other", "value")
+
+	SetSurfBlocked(dictionary, "", "pr-482@200")
+
+	assert.Equal(t, `xprem-other="value", xprem-surf-blocked="pr-482@200"`, dictionary.Encode())
+}
+
+// A poll the surf rule declined is a plain poll. Refusing one would take a device
+// off the branch its own channel maps to, on a channel where nothing was enabled.
+func TestRefusalNeverAppliesToADeclinedSurf(t *testing.T) {
+	t.Run("surfing disabled on the channel", func(t *testing.T) {
+		h := newBlockHarness(t)
+		h.channelRepo.surfing = map[string]*types.BranchSurfing{"qa": {Enabled: false, Pattern: "*"}}
+		h.seed(seedRow{branch: "pr-482", rtv: "1", platform: "ios", id: 200, checked: true, uuid: crashedUUID})
+
+		params := blockParams(h)
+		params.RecentFailedUpdateIDs = `"` + crashedUUID + `"`
+		params.SurfBlockTokens = "pr-482@200"
+		result, err := h.protocolService.ResolveManifestBundle(context.Background(), params)
+
+		require.NoError(t, err)
+		assert.Equal(t, "staging", result.BranchName)
+		assert.Nil(t, result.BlockedSurf, "a channel with surfing off must not produce a verdict")
+	})
+
+	t.Run("branch outside the pattern", func(t *testing.T) {
+		h := newBlockHarness(t)
+		h.seed(seedRow{branch: "hotfix", rtv: "1", platform: "ios", id: 200, checked: true, uuid: crashedUUID})
+
+		params := blockParams(h)
+		params.XpremBranch = "hotfix"
+		params.RecentFailedUpdateIDs = `"` + crashedUUID + `"`
+		result, err := h.protocolService.ResolveManifestBundle(context.Background(), params)
+
+		require.NoError(t, err)
+		assert.Equal(t, "staging", result.BranchName)
+		assert.Nil(t, result.BlockedSurf)
+	})
+
+	// The mapped branch is a legitimate value: ListSurfableBranches offers it under
+	// the default pattern. Asking for it is not a surf, so a crash on it must not
+	// cost the device its own channel branch.
+	t.Run("asking for the mapped branch", func(t *testing.T) {
+		h := newBlockHarness(t)
+		stagingUUID := uuid.NewString()
+		h.updateRepo.setUUID(h.appId, "staging", "100", stagingUUID)
+
+		params := blockParams(h)
+		params.XpremBranch = "staging"
+		params.RecentFailedUpdateIDs = `"` + stagingUUID + `"`
+		result, err := h.protocolService.ResolveManifestBundle(context.Background(), params)
+
+		require.NoError(t, err)
+		assert.Equal(t, "staging", result.BranchName)
+		require.NotNil(t, result.Update, "the device must still be served its channel's branch")
+		assert.Nil(t, result.BlockedSurf)
+	})
+}
+
+// A device on a channel with surfing off costs no repository read, whatever it
+// puts in the two surf headers.
+func TestDeclinedSurfCostsNoLookup(t *testing.T) {
+	h := newBlockHarness(t)
+	h.channelRepo.surfing = map[string]*types.BranchSurfing{"qa": {Enabled: false, Pattern: "*"}}
+	before := h.updateRepo.uuidLookups()
+
+	params := blockParams(h)
+	params.RecentFailedUpdateIDs = `"` + uuid.NewString() + `","` + uuid.NewString() + `"`
+	params.SurfBlockTokens = "a@1,b@2,c@3"
+	_, err := h.protocolService.ResolveManifestBundle(context.Background(), params)
+
+	require.NoError(t, err)
+	assert.Equal(t, before, h.updateRepo.uuidLookups(), "no update lookup may run for a declined surf")
+}
+
+// The header is entirely client-supplied and Go accepts up to 1 MiB of it, so
+// both the input and the count are bounded before anything is retained.
+func TestParseSurfBlockTokensIsBounded(t *testing.T) {
+	t.Run("caps the number of tokens", func(t *testing.T) {
+		raw := strings.Repeat("pr-1@1,", 40000)
+		assert.Len(t, parseSurfBlockTokens(raw), maxSurfBlockTokens)
+	})
+
+	// The count cap alone never trips on filler, so only the input cap can stop
+	// this: a token placed past the boundary must not be reached.
+	t.Run("caps the input before splitting it", func(t *testing.T) {
+		raw := strings.Repeat(",", maxSurfBlockTokensRaw) + "pr-late@1"
+		assert.Empty(t, parseSurfBlockTokens(raw))
+	})
+
+	t.Run("keeps a legitimate value whole", func(t *testing.T) {
+		assert.Equal(t,
+			[]string{"pr-1@100", "pr-2@200"},
+			parseSurfBlockTokens(" pr-1@100 , pr-2@200 "))
+	})
+}

--- a/internal/services/branch_surf_block_test.go
+++ b/internal/services/branch_surf_block_test.go
@@ -54,7 +54,7 @@ func TestSurfIsRefusedWhenTheServedUpdateCrashed(t *testing.T) {
 	assert.Equal(t, "100", result.Update.UpdateId)
 	require.NotNil(t, result.BlockedSurf)
 	assert.Equal(t, "pr-482", result.BlockedSurf.BranchName)
-	assert.Equal(t, "pr-482@200", result.BlockedSurf.Token)
+	assert.Equal(t, "cHItNDgyADIwMA", result.BlockedSurf.Token)
 }
 
 // A refusal can never empty the candidate list. HonoursSurf requires the asked-for
@@ -70,7 +70,7 @@ func TestTheMappedBranchIsNeverRefused(t *testing.T) {
 	// Both branches reported as crashed, and both named in the carried verdicts.
 	params := blockParams(h)
 	params.RecentFailedUpdateIDs = `"` + crashedUUID + `","` + stagingUUID + `"`
-	params.SurfBlockTokens = "pr-482@200,staging@100"
+	params.SurfBlockTokens = "cHItNDgyADIwMA,c3RhZ2luZwAxMDA"
 	result, err := h.protocolService.ResolveManifestBundle(context.Background(), params)
 
 	require.NoError(t, err)
@@ -89,7 +89,7 @@ func TestSurfIsAllowedAgainOnceTheBranchIsFixed(t *testing.T) {
 
 	params := blockParams(h)
 	params.RecentFailedUpdateIDs = `"` + crashedUUID + `"`
-	params.SurfBlockTokens = "pr-482@200"
+	params.SurfBlockTokens = "cHItNDgyADIwMA"
 	result, err := h.protocolService.ResolveManifestBundle(context.Background(), params)
 
 	require.NoError(t, err)
@@ -104,7 +104,7 @@ func TestSurfStaysRefusedFromTheEchoedVerdictAlone(t *testing.T) {
 	h.seed(seedRow{branch: "pr-482", rtv: "1", platform: "ios", id: 200, checked: true, uuid: crashedUUID})
 
 	params := blockParams(h)
-	params.SurfBlockTokens = "pr-482@200"
+	params.SurfBlockTokens = "cHItNDgyADIwMA"
 	result, err := h.protocolService.ResolveManifestBundle(context.Background(), params)
 
 	require.NoError(t, err)
@@ -136,34 +136,45 @@ func surfBlockedOnly(carriedTokens string, token string) string {
 }
 
 func TestSetSurfBlockedRendersAStructuredDictionary(t *testing.T) {
-	assert.Equal(t, `xprem-surf-blocked="pr-482@200"`, surfBlockedOnly("", "pr-482@200"))
+	assert.Equal(t, `xprem-surf-blocked="cHItNDgyADIwMA"`, surfBlockedOnly("", "cHItNDgyADIwMA"))
 }
 
 // The response replaces the client's whole stored dictionary, so a second verdict
 // has to carry the first or it unblocks the branch it names.
 func TestSetSurfBlockedKeepsTheVerdictsAlreadyCarried(t *testing.T) {
 	assert.Equal(t,
-		`xprem-surf-blocked="pr-2@200,pr-1@100"`,
-		surfBlockedOnly("pr-1@100", "pr-2@200"))
+		`xprem-surf-blocked="cHItMgAyMDA,cHItMQAxMDA"`,
+		surfBlockedOnly("cHItMQAxMDA", "cHItMgAyMDA"))
 }
 
 func TestSetSurfBlockedDropsDuplicatesAndCaps(t *testing.T) {
 	assert.Equal(t,
-		`xprem-surf-blocked="pr-1@100"`,
-		surfBlockedOnly("pr-1@100", "pr-1@100"))
+		`xprem-surf-blocked="cHItMQAxMDA"`,
+		surfBlockedOnly("cHItMQAxMDA", "cHItMQAxMDA"))
 
-	carried := "a@1,b@2,c@3,d@4,e@5,f@6"
+	carried := "YQAx,YgAy,YwAz,ZAA0,ZQA1,ZgA2"
 	assert.Equal(t,
-		`xprem-surf-blocked="new@9,a@1,b@2,c@3,d@4"`,
-		surfBlockedOnly(carried, "new@9"))
+		`xprem-surf-blocked="bmV3ADk,YQAx,YgAy,YwAz,ZAA0"`,
+		surfBlockedOnly(carried, "bmV3ADk"))
 }
 
-// A branch name may contain a quote; unescaped it would break the dictionary the
-// client parses, silently losing every verdict.
-func TestSetSurfBlockedEscapesQuotes(t *testing.T) {
-	assert.Equal(t,
-		`xprem-surf-blocked="pr-\"x@200"`,
-		surfBlockedOnly("", `pr-"x@200`))
+// The characters a branch name may legally contain are exactly the ones that
+// would wreck the header carrying it: a comma splits one verdict into two, a
+// quote ends the string early, and a non-ASCII byte cannot be in an RFC 8941
+// string at all. The token is encoded, so none of them ever reach the wire.
+func TestHostileBranchNamesProduceSafeTokens(t *testing.T) {
+	for _, branchName := range []string{"pr,ios", `pr-"x`, "pr-é", " pr-1 ", "pr\x00x"} {
+		token := surfBlockToken(branchName, "200")
+		assert.True(t, isBase64URL(token), "token for %q must be safe to put on the wire", branchName)
+		assert.Equal(t,
+			[]string{token},
+			parseSurfBlockTokens(token),
+			"a token the server minted must survive being echoed back")
+	}
+
+	// The distinctness that matters: two branches whose tokens could collide once
+	// concatenated must not, or one crash would block the other's update.
+	assert.NotEqual(t, surfBlockToken("pr", "1@2"), surfBlockToken("pr@1", "2"))
 }
 
 // The verdict is one member among others: a dictionary already carrying something
@@ -172,9 +183,9 @@ func TestSetSurfBlockedSharesTheDictionary(t *testing.T) {
 	dictionary := NewHeaderDictionary()
 	dictionary.Set("xprem-other", "value")
 
-	SetSurfBlocked(dictionary, "", "pr-482@200")
+	SetSurfBlocked(dictionary, "", "cHItNDgyADIwMA")
 
-	assert.Equal(t, `xprem-other="value", xprem-surf-blocked="pr-482@200"`, dictionary.Encode())
+	assert.Equal(t, `xprem-other="value", xprem-surf-blocked="cHItNDgyADIwMA"`, dictionary.Encode())
 }
 
 // A poll the surf rule declined is a plain poll. Refusing one would take a device
@@ -187,7 +198,7 @@ func TestRefusalNeverAppliesToADeclinedSurf(t *testing.T) {
 
 		params := blockParams(h)
 		params.RecentFailedUpdateIDs = `"` + crashedUUID + `"`
-		params.SurfBlockTokens = "pr-482@200"
+		params.SurfBlockTokens = "cHItNDgyADIwMA"
 		result, err := h.protocolService.ResolveManifestBundle(context.Background(), params)
 
 		require.NoError(t, err)
@@ -238,7 +249,7 @@ func TestDeclinedSurfCostsNoLookup(t *testing.T) {
 
 	params := blockParams(h)
 	params.RecentFailedUpdateIDs = `"` + uuid.NewString() + `","` + uuid.NewString() + `"`
-	params.SurfBlockTokens = "a@1,b@2,c@3"
+	params.SurfBlockTokens = "YQAx,YgAy,YwAz"
 	_, err := h.protocolService.ResolveManifestBundle(context.Background(), params)
 
 	require.NoError(t, err)
@@ -248,31 +259,35 @@ func TestDeclinedSurfCostsNoLookup(t *testing.T) {
 // The header is entirely client-supplied and Go accepts up to 1 MiB of it, so
 // both the input and the count are bounded before anything is retained.
 func TestParseSurfBlockTokensIsBounded(t *testing.T) {
+	// The filler is a VALID token: filler the filter would drop makes this pass
+	// without the cap ever being reached.
 	t.Run("caps the number of tokens", func(t *testing.T) {
-		raw := strings.Repeat("pr-1@1,", 40000)
+		raw := strings.Repeat(surfBlockToken("pr-1", "1")+",", 40000)
 		assert.Len(t, parseSurfBlockTokens(raw), maxSurfBlockTokens)
 	})
 
-	// The count cap alone never trips on filler, so only the input cap can stop
-	// this: a token placed past the boundary must not be reached.
+	// The count cap alone never trips on separators, so only the input cap can
+	// stop this: a valid token placed past the boundary must not be reached.
 	t.Run("caps the input before splitting it", func(t *testing.T) {
-		raw := strings.Repeat(",", maxSurfBlockTokensRaw) + "pr-late@1"
+		raw := strings.Repeat(",", maxSurfBlockTokensRaw) + surfBlockToken("pr-late", "1")
 		assert.Empty(t, parseSurfBlockTokens(raw))
 	})
 
 	t.Run("keeps a legitimate value whole", func(t *testing.T) {
+		first, second := surfBlockToken("pr-1", "100"), surfBlockToken("pr-2", "200")
 		assert.Equal(t,
-			[]string{"pr-1@100", "pr-2@200"},
-			parseSurfBlockTokens(" pr-1@100 , pr-2@200 "))
+			[]string{first, second},
+			parseSurfBlockTokens(" "+first+" , "+second+" "))
 	})
 
 	// Retained tokens are echoed back inside an RFC 8941 string, which can only
 	// carry printable ASCII; one stray byte would cost the device the whole
 	// dictionary. This also covers the input cap cutting a multi-byte rune.
-	t.Run("drops tokens an RFC 8941 string cannot carry", func(t *testing.T) {
+	t.Run("drops anything the server did not mint", func(t *testing.T) {
+		valid := surfBlockToken("pr-1", "100")
 		assert.Equal(t,
-			[]string{"pr-1@100"},
-			parseSurfBlockTokens("pr-1@100,pr\x002@2,pr-é@3"))
+			[]string{valid},
+			parseSurfBlockTokens(valid+",pr-482@200,pr-é,\"quoted\""))
 	})
 }
 
@@ -287,4 +302,30 @@ func TestTheManifestNeverCarriesTheChannelSetting(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotContains(t, string(encoded), "branchSurfing\"",
 		"a channel-lifetime setting has no place in an update-lifetime document")
+}
+
+// Long branch names make five tokens overflow the member bound. Cutting the
+// joined value would keep a half token that can never match, and would take the
+// newest verdict with it — the one the response exists to deliver.
+func TestVerdictsAreDroppedWholeWhenTheyDoNotFit(t *testing.T) {
+	longBranch := strings.Repeat("b", 128)
+	fresh := surfBlockToken(longBranch+"-new", "900")
+	carried := make([]string, 0, maxSurfBlockTokens)
+	for i := 0; i < maxSurfBlockTokens; i++ {
+		carried = append(carried, surfBlockToken(longBranch+string(rune('a'+i)), "100"))
+	}
+
+	dictionary := NewHeaderDictionary()
+	SetSurfBlocked(dictionary, strings.Join(carried, ","), fresh)
+	encoded := dictionary.Encode()
+
+	require.NotEmpty(t, encoded, "the newest verdict must survive; losing it re-serves the crash")
+	value := strings.TrimSuffix(strings.TrimPrefix(encoded, SurfBlockedHeader+`="`), `"`)
+	assert.LessOrEqual(t, len(value), maxHeaderDictionaryValue)
+	kept := strings.Split(value, ",")
+	assert.Equal(t, fresh, kept[0], "the fresh verdict is kept first")
+	for _, token := range kept {
+		assert.True(t, isBase64URL(token), "no token may be left half-written")
+		assert.Contains(t, append(carried, fresh), token, "a kept token must be whole")
+	}
 }

--- a/internal/services/branch_surf_resolution_test.go
+++ b/internal/services/branch_surf_resolution_test.go
@@ -1,0 +1,103 @@
+package services
+
+import (
+	"context"
+	"testing"
+	"xprem/internal/providers/expo"
+	"xprem/internal/types"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// These cover the wiring the unit tests cannot see: ManifestRequestParams.XpremBranch
+// reaching the rule chain and changing which branch is served. Drop any link of that
+// chain and only these fail.
+func newSurfHarness(t *testing.T, surfing *types.BranchSurfing, rollout *expo.ChannelRolloutInfo) *rolloutTestHarness {
+	t.Helper()
+	t.Setenv("DB_URL", "postgres://stub")
+	h := newRolloutTestHarness(t)
+	h.channelRepo.mappings["qa"] = &expo.ChannelMapping{Id: "1", BranchName: "staging", Rollout: rollout}
+	h.channelRepo.surfing = map[string]*types.BranchSurfing{"qa": surfing}
+	h.seed(seedRow{branch: "staging", rtv: "1", platform: "ios", id: 100, checked: true})
+	return h
+}
+
+func surfParams(h *rolloutTestHarness, requested string) ManifestRequestParams {
+	return ManifestRequestParams{
+		RequestID:       "test",
+		AppID:           h.appId,
+		ChannelName:     "qa",
+		Platform:        "ios",
+		RuntimeVersion:  "1",
+		ProtocolVersion: 1,
+		ClientID:        "device-1",
+		XpremBranch:     requested,
+	}
+}
+
+func TestResolveManifestBundleServesTheSurfedBranch(t *testing.T) {
+	h := newSurfHarness(t, &types.BranchSurfing{Enabled: true, Pattern: "pr-*"}, nil)
+	h.seed(seedRow{branch: "pr-482", rtv: "1", platform: "ios", id: 200, checked: true})
+
+	result, err := h.protocolService.ResolveManifestBundle(context.Background(), surfParams(h, "pr-482"))
+
+	require.NoError(t, err)
+	require.NotNil(t, result.Update)
+	assert.Equal(t, "pr-482", result.BranchName)
+	assert.Equal(t, "pr-482", result.Update.Branch)
+}
+
+func TestResolveManifestBundleIgnoresTheHeaderWhenSurfingIsOff(t *testing.T) {
+	h := newSurfHarness(t, &types.BranchSurfing{Enabled: false, Pattern: "*"}, nil)
+	h.seed(seedRow{branch: "pr-482", rtv: "1", platform: "ios", id: 200, checked: true})
+
+	result, err := h.protocolService.ResolveManifestBundle(context.Background(), surfParams(h, "pr-482"))
+
+	require.NoError(t, err)
+	assert.Equal(t, "staging", result.BranchName)
+}
+
+func TestResolveManifestBundleIgnoresABranchOutsideThePattern(t *testing.T) {
+	h := newSurfHarness(t, &types.BranchSurfing{Enabled: true, Pattern: "pr-*"}, nil)
+	h.seed(seedRow{branch: "secret", rtv: "1", platform: "ios", id: 200, checked: true})
+
+	result, err := h.protocolService.ResolveManifestBundle(context.Background(), surfParams(h, "secret"))
+
+	require.NoError(t, err)
+	assert.Equal(t, "staging", result.BranchName)
+}
+
+// The mapped branch trails the surfed one as a candidate, so a branch with nothing for
+// the device's runtime version leaves it no worse off than before it surfed.
+func TestResolveManifestBundleFallsBackWhenTheSurfedBranchHasNothing(t *testing.T) {
+	h := newSurfHarness(t, &types.BranchSurfing{Enabled: true, Pattern: "pr-*"}, nil)
+	h.seed(seedRow{branch: "pr-482", rtv: "99", platform: "ios", id: 200, checked: true})
+
+	result, err := h.protocolService.ResolveManifestBundle(context.Background(), surfParams(h, "pr-482"))
+
+	require.NoError(t, err)
+	require.NotNil(t, result.Update)
+	assert.Equal(t, "staging", result.BranchName)
+}
+
+// End to end this time, not just the rule: an explicit surf is not re-drawn against
+// the channel rollout, even for a device the rollout would have moved.
+func TestResolveManifestBundleSurfOutranksAnActiveRollout(t *testing.T) {
+	const salt = "surf-vs-rollout-salt"
+	h := newSurfHarness(t,
+		&types.BranchSurfing{Enabled: true, Pattern: "pr-*"},
+		&expo.ChannelRolloutInfo{ID: salt, BranchName: "canary", Percentage: 100},
+	)
+	h.seed(seedRow{branch: "canary", rtv: "1", platform: "ios", id: 200, checked: true})
+	h.seed(seedRow{branch: "pr-482", rtv: "1", platform: "ios", id: 300, checked: true})
+
+	surfed, err := h.protocolService.ResolveManifestBundle(context.Background(), surfParams(h, "pr-482"))
+	require.NoError(t, err)
+	assert.Equal(t, "pr-482", surfed.BranchName)
+
+	// Same channel, same device, no header: the rollout applies as usual.
+	plain, err := h.protocolService.ResolveManifestBundle(context.Background(), surfParams(h, ""))
+	require.NoError(t, err)
+	assert.Equal(t, "canary", plain.BranchName)
+}

--- a/internal/services/branch_surf_resolution_test.go
+++ b/internal/services/branch_surf_resolution_test.go
@@ -68,8 +68,10 @@ func TestResolveManifestBundleIgnoresABranchOutsideThePattern(t *testing.T) {
 	assert.Equal(t, "staging", result.BranchName)
 }
 
-// The mapped branch trails the surfed one as a candidate, so a branch with nothing for
-// the device's runtime version leaves it no worse off than before it surfed.
+// The mapped branch trails the surfed one, so a branch with nothing for the device's
+// runtime version falls back to it rather than stranding the device. Deliberately the
+// mapped branch and not whatever the rest of the chain would have picked: a device
+// asking for a branch has no business being drawn into a rollout it did not ask for.
 func TestResolveManifestBundleFallsBackWhenTheSurfedBranchHasNothing(t *testing.T) {
 	h := newSurfHarness(t, &types.BranchSurfing{Enabled: true, Pattern: "pr-*"}, nil)
 	h.seed(seedRow{branch: "pr-482", rtv: "99", platform: "ios", id: 200, checked: true})

--- a/internal/services/branch_surf_rule_test.go
+++ b/internal/services/branch_surf_rule_test.go
@@ -85,3 +85,25 @@ func TestBranchSurfRuleIsInertWithoutARequestedBranch(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, []string{"canary", "staging"}, candidates)
 }
+
+// Deliberate, and pinned here so it reads as a decision rather than an oversight.
+//
+// A channel mid-rollout has two branches: the one it maps to, and the rollout
+// target. Asking for the MAPPED branch is not a surf — it falls through and the
+// device stays subject to the percentage draw. Asking for the ROLLOUT TARGET is
+// a surf, and it is honoured: the device pins onto that branch without being
+// drawn. That is the point of the feature — the rollout target is a branch under
+// test, and a tester must be able to reach it on demand.
+//
+// The cost, accepted: such a device counts in that update's health without
+// having been selected into the rollout. Reverse this and the rule below must
+// exclude Rollout.BranchName, and ListSurfableBranches must stop listing it.
+func TestSurfingOntoTheRolloutTargetIsHonoured(t *testing.T) {
+	rollout := &expo.ChannelRolloutInfo{BranchName: "canary", Percentage: 5}
+	on := types.BranchSurfing{Enabled: true, Pattern: "*"}
+
+	assert.True(t, HonoursSurf(surfRequest("canary", on, rollout)),
+		"the rollout target is reachable on demand")
+	assert.False(t, HonoursSurf(surfRequest("staging", on, rollout)),
+		"the mapped branch is not a surf, so the percentage draw still decides")
+}

--- a/internal/services/branch_surf_rule_test.go
+++ b/internal/services/branch_surf_rule_test.go
@@ -1,0 +1,87 @@
+package services
+
+import (
+	"context"
+	"testing"
+	"xprem/internal/providers/expo"
+	"xprem/internal/types"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func surfRequest(requested string, surfing types.BranchSurfing, rollout *expo.ChannelRolloutInfo) *BranchResolutionRequest {
+	return &BranchResolutionRequest{
+		AppID:           "app-1",
+		ChannelName:     "qa",
+		ClientID:        "device-1",
+		Platform:        "ios",
+		RuntimeVersion:  "3.0.0",
+		Mapping:         &expo.ChannelMapping{Id: "1", BranchName: "staging", Rollout: rollout},
+		RequestedBranch: requested,
+		Surfing:         surfing,
+	}
+}
+
+func TestBranchSurfRuleServesTheRequestedBranch(t *testing.T) {
+	candidates, matched, err := (&branchSurfRule{}).Evaluate(
+		context.Background(),
+		surfRequest("pr-482", types.BranchSurfing{Enabled: true, Pattern: "pr-*"}, nil),
+	)
+
+	require.NoError(t, err)
+	require.True(t, matched)
+	// The mapped branch trails as the runtime-version fallback.
+	assert.Equal(t, []string{"pr-482", "staging"}, candidates)
+}
+
+func TestBranchSurfRuleDeclines(t *testing.T) {
+	on := types.BranchSurfing{Enabled: true, Pattern: "pr-*"}
+	cases := map[string]*BranchResolutionRequest{
+		"no branch requested":  surfRequest("", on, nil),
+		"surfing off":          surfRequest("pr-482", types.BranchSurfing{Enabled: false, Pattern: "*"}, nil),
+		"pattern mismatch":     surfRequest("hotfix-1", on, nil),
+		"already mapped":       surfRequest("staging", types.BranchSurfing{Enabled: true, Pattern: "*"}, nil),
+		"empty pattern denies": surfRequest("pr-482", types.BranchSurfing{Enabled: true, Pattern: ""}, nil),
+	}
+	for name, req := range cases {
+		t.Run(name, func(t *testing.T) {
+			_, matched, err := (&branchSurfRule{}).Evaluate(context.Background(), req)
+			require.NoError(t, err)
+			assert.False(t, matched)
+		})
+	}
+}
+
+// Asking for the branch the channel already maps to is not a surf, so the chain
+// carries on to the rollout rule instead of pinning the device out of its bucket.
+func TestBranchSurfRuleKeepsTheRolloutWhenAskedForTheMappedBranch(t *testing.T) {
+	rollout := &expo.ChannelRolloutInfo{ID: "r1", BranchName: "canary", Percentage: 100}
+	req := surfRequest("staging", types.BranchSurfing{Enabled: true, Pattern: "*"}, rollout)
+
+	candidates, err := ResolveBranchCandidates(context.Background(), DefaultBranchRules(), req)
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"canary", "staging"}, candidates)
+}
+
+// A surf wins over an active rollout: it is an explicit choice, not a draw.
+func TestBranchSurfRuleOutranksTheRollout(t *testing.T) {
+	rollout := &expo.ChannelRolloutInfo{ID: "r1", BranchName: "canary", Percentage: 100}
+	req := surfRequest("pr-482", types.BranchSurfing{Enabled: true, Pattern: "pr-*"}, rollout)
+
+	candidates, err := ResolveBranchCandidates(context.Background(), DefaultBranchRules(), req)
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"pr-482", "staging"}, candidates)
+}
+
+func TestBranchSurfRuleIsInertWithoutARequestedBranch(t *testing.T) {
+	rollout := &expo.ChannelRolloutInfo{ID: "r1", BranchName: "canary", Percentage: 100}
+	req := surfRequest("", types.BranchSurfing{}, rollout)
+
+	candidates, err := ResolveBranchCandidates(context.Background(), DefaultBranchRules(), req)
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"canary", "staging"}, candidates)
+}

--- a/internal/services/branch_surfing_cache_test.go
+++ b/internal/services/branch_surfing_cache_test.go
@@ -1,0 +1,91 @@
+package services
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"xprem/internal/cache"
+	"xprem/internal/types"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const surfingCacheAppID = "branch-surfing-cache-test"
+
+func surfingCacheService(t *testing.T, surfing map[string]*types.BranchSurfing, repoErr error) (*ExpoProtocolService, *countingChannelRepo) {
+	t.Helper()
+	t.Setenv("DB_URL", "postgres://stub")
+	repo := &countingChannelRepo{
+		fakeChannelRepo: &fakeChannelRepo{surfing: surfing},
+		surfingErr:      repoErr,
+	}
+	// The cache is a process-wide singleton, so an entry left by another test
+	// would answer before the repository does.
+	for _, channelName := range []string{"qa", "nope"} {
+		cache.GetCache().Delete(channelBranchSurfingCacheKey(surfingCacheAppID, channelName))
+	}
+	return NewExpoProtocolService(fakeAppRepo{}, repo, nil, nil, nil), repo
+}
+
+func TestBranchSurfingEnabledCachesTheRead(t *testing.T) {
+	service, repo := surfingCacheService(t, map[string]*types.BranchSurfing{
+		"qa": {Enabled: true, Pattern: "pr-*"},
+	}, nil)
+
+	assert.True(t, service.branchSurfingEnabled(context.Background(), surfingCacheAppID, "qa"))
+	assert.True(t, service.branchSurfingEnabled(context.Background(), surfingCacheAppID, "qa"))
+
+	assert.Equal(t, 1, repo.surfingReads, "the second poll must be served from the cache")
+}
+
+// A disabled channel is cached too: the manifest path must not read the
+// database on every poll just because the answer is false.
+func TestBranchSurfingDisabledIsCachedAsWell(t *testing.T) {
+	service, repo := surfingCacheService(t, map[string]*types.BranchSurfing{
+		"qa": {Enabled: false, Pattern: "*"},
+	}, nil)
+
+	assert.False(t, service.branchSurfingEnabled(context.Background(), surfingCacheAppID, "qa"))
+	assert.False(t, service.branchSurfingEnabled(context.Background(), surfingCacheAppID, "qa"))
+
+	assert.Equal(t, 1, repo.surfingReads)
+}
+
+func TestBranchSurfingCacheIsInvalidatedOnWrite(t *testing.T) {
+	surfing := map[string]*types.BranchSurfing{"qa": {Enabled: false, Pattern: "*"}}
+	service, repo := surfingCacheService(t, surfing, nil)
+	require.False(t, service.branchSurfingEnabled(context.Background(), surfingCacheAppID, "qa"))
+
+	surfing["qa"] = &types.BranchSurfing{Enabled: true, Pattern: "pr-*"}
+	invalidateBranchSurfingCache(surfingCacheAppID, "qa")
+
+	assert.True(t, service.branchSurfingEnabled(context.Background(), surfingCacheAppID, "qa"))
+	assert.Equal(t, 2, repo.surfingReads)
+}
+
+// The manifest hot path must never fail on this lookup: a broken read answers
+// "not surfable" rather than turning a poll into a 500.
+func TestBranchSurfingErrorAnswersFalse(t *testing.T) {
+	service, _ := surfingCacheService(t, nil, errors.New("database is down"))
+
+	assert.False(t, service.branchSurfingEnabled(context.Background(), surfingCacheAppID, "qa"))
+}
+
+func TestBranchSurfingUnknownChannelAnswersFalse(t *testing.T) {
+	service, _ := surfingCacheService(t, nil, nil)
+
+	assert.False(t, service.branchSurfingEnabled(context.Background(), surfingCacheAppID, "nope"))
+}
+
+// Stateless mode has no channel settings at all, so the lookup is skipped
+// rather than reaching a repository that would refuse it.
+func TestBranchSurfingIsSkippedInStatelessMode(t *testing.T) {
+	service, repo := surfingCacheService(t, map[string]*types.BranchSurfing{
+		"qa": {Enabled: true, Pattern: "*"},
+	}, nil)
+	t.Setenv("DB_URL", "")
+
+	assert.False(t, service.branchSurfingEnabled(context.Background(), surfingCacheAppID, "qa"))
+	assert.Equal(t, 0, repo.surfingReads)
+}

--- a/internal/services/branch_surfing_cache_test.go
+++ b/internal/services/branch_surfing_cache_test.go
@@ -53,8 +53,13 @@ func TestBranchSurfingDisabledIsCachedAsWell(t *testing.T) {
 	assert.False(t, enabledQA)
 	assert.Equal(t, "*", pattern)
 
+	// Read back from the cache this time. Asserting the value and not just the read
+	// count is what stops the cached branch from answering "enabled" for everyone:
+	// it is the access-control gate of the whole feature.
 	enabledQA, pattern = service.branchSurfingEnabled(context.Background(), surfingCacheAppID, "qa")
 
+	assert.False(t, enabledQA, "a disabled channel must stay disabled when served from cache")
+	assert.Equal(t, "*", pattern)
 	assert.Equal(t, 1, repo.surfingReads)
 }
 
@@ -76,11 +81,21 @@ func TestBranchSurfingCacheIsInvalidatedOnWrite(t *testing.T) {
 
 // The manifest hot path must never fail on this lookup: a broken read answers
 // "not surfable" rather than turning a poll into a 500.
+// The channel IS enabled, so only the error can produce a false: seeding nothing
+// would make this pass against the unknown-channel branch instead.
 func TestBranchSurfingErrorAnswersFalse(t *testing.T) {
-	service, _ := surfingCacheService(t, nil, errors.New("database is down"))
+	service, repo := surfingCacheService(t, map[string]*types.BranchSurfing{
+		"qa": {Enabled: true, Pattern: "*"},
+	}, errors.New("database is down"))
 
-	enabledQA, _ := service.branchSurfingEnabled(context.Background(), surfingCacheAppID, "qa")
+	enabledQA, pattern := service.branchSurfingEnabled(context.Background(), surfingCacheAppID, "qa")
+
 	assert.False(t, enabledQA)
+	assert.Empty(t, pattern)
+	// Nothing is cached from a failed read, so the next poll retries rather than
+	// holding the deployment closed for the TTL.
+	_, _ = service.branchSurfingEnabled(context.Background(), surfingCacheAppID, "qa")
+	assert.Equal(t, 2, repo.surfingReads)
 }
 
 func TestBranchSurfingUnknownChannelAnswersFalse(t *testing.T) {

--- a/internal/services/branch_surfing_cache_test.go
+++ b/internal/services/branch_surfing_cache_test.go
@@ -33,9 +33,12 @@ func TestBranchSurfingEnabledCachesTheRead(t *testing.T) {
 		"qa": {Enabled: true, Pattern: "pr-*"},
 	}, nil)
 
-	assert.True(t, service.branchSurfingEnabled(context.Background(), surfingCacheAppID, "qa"))
-	assert.True(t, service.branchSurfingEnabled(context.Background(), surfingCacheAppID, "qa"))
-
+	enabledQA, pattern := service.branchSurfingEnabled(context.Background(), surfingCacheAppID, "qa")
+	assert.True(t, enabledQA)
+	assert.Equal(t, "pr-*", pattern)
+	enabledQA, pattern = service.branchSurfingEnabled(context.Background(), surfingCacheAppID, "qa")
+	assert.True(t, enabledQA)
+	assert.Equal(t, "pr-*", pattern)
 	assert.Equal(t, 1, repo.surfingReads, "the second poll must be served from the cache")
 }
 
@@ -46,8 +49,11 @@ func TestBranchSurfingDisabledIsCachedAsWell(t *testing.T) {
 		"qa": {Enabled: false, Pattern: "*"},
 	}, nil)
 
-	assert.False(t, service.branchSurfingEnabled(context.Background(), surfingCacheAppID, "qa"))
-	assert.False(t, service.branchSurfingEnabled(context.Background(), surfingCacheAppID, "qa"))
+	enabledQA, pattern := service.branchSurfingEnabled(context.Background(), surfingCacheAppID, "qa")
+	assert.False(t, enabledQA)
+	assert.Equal(t, "*", pattern)
+
+	enabledQA, pattern = service.branchSurfingEnabled(context.Background(), surfingCacheAppID, "qa")
 
 	assert.Equal(t, 1, repo.surfingReads)
 }
@@ -55,12 +61,16 @@ func TestBranchSurfingDisabledIsCachedAsWell(t *testing.T) {
 func TestBranchSurfingCacheIsInvalidatedOnWrite(t *testing.T) {
 	surfing := map[string]*types.BranchSurfing{"qa": {Enabled: false, Pattern: "*"}}
 	service, repo := surfingCacheService(t, surfing, nil)
-	require.False(t, service.branchSurfingEnabled(context.Background(), surfingCacheAppID, "qa"))
+	enabledQA, _ := service.branchSurfingEnabled(context.Background(), surfingCacheAppID, "qa")
+	require.False(t, enabledQA)
+	assert.Equal(t, 1, repo.surfingReads)
 
 	surfing["qa"] = &types.BranchSurfing{Enabled: true, Pattern: "pr-*"}
 	invalidateBranchSurfingCache(surfingCacheAppID, "qa")
 
-	assert.True(t, service.branchSurfingEnabled(context.Background(), surfingCacheAppID, "qa"))
+	enabledQA, _ = service.branchSurfingEnabled(context.Background(), surfingCacheAppID, "qa")
+
+	assert.True(t, enabledQA)
 	assert.Equal(t, 2, repo.surfingReads)
 }
 
@@ -69,13 +79,16 @@ func TestBranchSurfingCacheIsInvalidatedOnWrite(t *testing.T) {
 func TestBranchSurfingErrorAnswersFalse(t *testing.T) {
 	service, _ := surfingCacheService(t, nil, errors.New("database is down"))
 
-	assert.False(t, service.branchSurfingEnabled(context.Background(), surfingCacheAppID, "qa"))
+	enabledQA, _ := service.branchSurfingEnabled(context.Background(), surfingCacheAppID, "qa")
+	assert.False(t, enabledQA)
 }
 
 func TestBranchSurfingUnknownChannelAnswersFalse(t *testing.T) {
 	service, _ := surfingCacheService(t, nil, nil)
 
-	assert.False(t, service.branchSurfingEnabled(context.Background(), surfingCacheAppID, "nope"))
+	enabledNope, _ := service.branchSurfingEnabled(context.Background(), surfingCacheAppID, "nope")
+
+	assert.False(t, enabledNope)
 }
 
 // Stateless mode has no channel settings at all, so the lookup is skipped
@@ -85,7 +98,8 @@ func TestBranchSurfingIsSkippedInStatelessMode(t *testing.T) {
 		"qa": {Enabled: true, Pattern: "*"},
 	}, nil)
 	t.Setenv("DB_URL", "")
+	enabledQA, _ := service.branchSurfingEnabled(context.Background(), surfingCacheAppID, "qa")
 
-	assert.False(t, service.branchSurfingEnabled(context.Background(), surfingCacheAppID, "qa"))
+	assert.False(t, enabledQA)
 	assert.Equal(t, 0, repo.surfingReads)
 }

--- a/internal/services/branch_surfing_test.go
+++ b/internal/services/branch_surfing_test.go
@@ -1,0 +1,118 @@
+package services
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"xprem/internal/types"
+	"xprem/internal/validation"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const surfingAppID = "1a2b3c4d-0000-0000-0000-000000000001"
+
+func surfingService(surfing map[string]*types.BranchSurfing, surfable map[string][]types.SurfableBranch) (*ChannelService, *fakeChannelRepo) {
+	channelRepo := &fakeChannelRepo{surfing: surfing}
+	return NewChannelService(fakeBranchRepo{surfable: surfable}, channelRepo), channelRepo
+}
+
+func TestListSurfableBranchesFiltersOnPattern(t *testing.T) {
+	service, _ := surfingService(
+		map[string]*types.BranchSurfing{"qa": {Enabled: true, Pattern: "pr-*"}},
+		map[string][]types.SurfableBranch{"3.0.0": {
+			{Name: "pr-482", LastUpdateAt: "2026-08-01T10:00:00Z"},
+			{Name: "production", LastUpdateAt: "2026-07-30T10:00:00Z"},
+			{Name: "pr-31", LastUpdateAt: "2026-07-29T10:00:00Z"},
+		}},
+	)
+
+	branches, err := service.ListSurfableBranches(context.Background(), surfingAppID, "qa", "3.0.0")
+
+	require.NoError(t, err)
+	assert.Equal(t, []types.SurfableBranch{
+		{Name: "pr-482", LastUpdateAt: "2026-08-01T10:00:00Z"},
+		{Name: "pr-31", LastUpdateAt: "2026-07-29T10:00:00Z"},
+	}, branches)
+}
+
+// The runtime version is what the repository is asked for: a branch holding no
+// update for the device's runtime version is unreachable, so it must never be
+// offered.
+func TestListSurfableBranchesScopesToRuntimeVersion(t *testing.T) {
+	service, _ := surfingService(
+		map[string]*types.BranchSurfing{"qa": {Enabled: true, Pattern: "*"}},
+		map[string][]types.SurfableBranch{
+			"3.0.0": {{Name: "pr-482", LastUpdateAt: "2026-08-01T10:00:00Z"}},
+			"2.0.0": {{Name: "legacy", LastUpdateAt: "2026-01-01T10:00:00Z"}},
+		},
+	)
+
+	branches, err := service.ListSurfableBranches(context.Background(), surfingAppID, "qa", "2.0.0")
+
+	require.NoError(t, err)
+	assert.Equal(t, []types.SurfableBranch{{Name: "legacy", LastUpdateAt: "2026-01-01T10:00:00Z"}}, branches)
+}
+
+func TestListSurfableBranchesRefusesDisabledChannel(t *testing.T) {
+	service, _ := surfingService(
+		map[string]*types.BranchSurfing{"production": {Enabled: false, Pattern: "*"}},
+		map[string][]types.SurfableBranch{"3.0.0": {{Name: "pr-482", LastUpdateAt: "2026-08-01T10:00:00Z"}}},
+	)
+
+	_, err := service.ListSurfableBranches(context.Background(), surfingAppID, "production", "3.0.0")
+
+	var protocolErr *ExpoProtocolError
+	require.ErrorAs(t, err, &protocolErr)
+	assert.Equal(t, http.StatusNotFound, protocolErr.StatusCode)
+}
+
+// An unknown channel answers exactly as a disabled one does, so the endpoint
+// cannot be used to enumerate which channels exist.
+func TestListSurfableBranchesRefusesUnknownChannelIdentically(t *testing.T) {
+	service, _ := surfingService(
+		map[string]*types.BranchSurfing{"production": {Enabled: false, Pattern: "*"}},
+		nil,
+	)
+
+	_, disabledErr := service.ListSurfableBranches(context.Background(), surfingAppID, "production", "3.0.0")
+	_, unknownErr := service.ListSurfableBranches(context.Background(), surfingAppID, "nope", "3.0.0")
+
+	require.Error(t, disabledErr)
+	require.Error(t, unknownErr)
+	assert.Equal(t, disabledErr.Error(), unknownErr.Error())
+}
+
+func TestListSurfableBranchesRejectsInvalidChannelName(t *testing.T) {
+	service, _ := surfingService(nil, nil)
+
+	_, err := service.ListSurfableBranches(context.Background(), surfingAppID, "qa/../prod", "3.0.0")
+
+	require.Error(t, err)
+	assert.True(t, validation.IsValidationError(err), "a malformed name is a validation error, not a 404")
+}
+
+func TestSetBranchSurfingCollapsesWildcards(t *testing.T) {
+	service, channelRepo := surfingService(map[string]*types.BranchSurfing{"qa": {}}, nil)
+
+	err := service.SetBranchSurfing(context.Background(), surfingAppID, "qa", types.BranchSurfing{
+		Enabled: true,
+		Pattern: "pr-**",
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, types.BranchSurfing{Enabled: true, Pattern: "pr-*"}, channelRepo.surfingWrites["qa"])
+}
+
+func TestSetBranchSurfingRejectsInvalidPattern(t *testing.T) {
+	service, channelRepo := surfingService(map[string]*types.BranchSurfing{"qa": {}}, nil)
+
+	err := service.SetBranchSurfing(context.Background(), surfingAppID, "qa", types.BranchSurfing{
+		Enabled: true,
+		Pattern: "",
+	})
+
+	require.Error(t, err)
+	assert.Empty(t, channelRepo.surfingWrites)
+}

--- a/internal/services/branch_surfing_test.go
+++ b/internal/services/branch_surfing_test.go
@@ -24,7 +24,7 @@ func surfingService(t *testing.T, surfing map[string]*types.BranchSurfing, surfa
 		ForgetBranchSurfing(surfingAppID, channelName)
 	}
 	for _, runtimeVersion := range []string{"3.0.0", "2.0.0"} {
-		ForgetSurfableBranches(surfingAppID, runtimeVersion)
+		ForgetSurfableBranches(surfingAppID, runtimeVersion, "ios")
 	}
 	channelRepo := &fakeChannelRepo{surfing: surfing}
 	return NewChannelService(fakeBranchRepo{surfable: surfable}, channelRepo), channelRepo
@@ -41,7 +41,7 @@ func TestListSurfableBranchesFiltersOnPattern(t *testing.T) {
 		}},
 	)
 
-	list, err := service.ListSurfableBranches(context.Background(), surfingAppID, "qa", "3.0.0", false)
+	list, err := service.ListSurfableBranches(context.Background(), surfingAppID, "qa", "3.0.0", "ios", false)
 
 	require.NoError(t, err)
 	assert.Equal(t, []types.SurfableBranch{
@@ -63,7 +63,7 @@ func TestListSurfableBranchesScopesToRuntimeVersion(t *testing.T) {
 		},
 	)
 
-	list, err := service.ListSurfableBranches(context.Background(), surfingAppID, "qa", "2.0.0", false)
+	list, err := service.ListSurfableBranches(context.Background(), surfingAppID, "qa", "2.0.0", "ios", false)
 
 	require.NoError(t, err)
 	assert.Equal(t, []types.SurfableBranch{{Name: "legacy", LastUpdateAt: "2026-01-01T10:00:00Z"}}, list.Branches)
@@ -76,7 +76,7 @@ func TestListSurfableBranchesRefusesDisabledChannel(t *testing.T) {
 		map[string][]types.SurfableBranch{"3.0.0": {{Name: "pr-482", LastUpdateAt: "2026-08-01T10:00:00Z"}}},
 	)
 
-	_, err := service.ListSurfableBranches(context.Background(), surfingAppID, "production", "3.0.0", false)
+	_, err := service.ListSurfableBranches(context.Background(), surfingAppID, "production", "3.0.0", "ios", false)
 
 	var protocolErr *ExpoProtocolError
 	require.ErrorAs(t, err, &protocolErr)
@@ -92,8 +92,8 @@ func TestListSurfableBranchesRefusesUnknownChannelIdentically(t *testing.T) {
 		nil,
 	)
 
-	_, disabledErr := service.ListSurfableBranches(context.Background(), surfingAppID, "production", "3.0.0", false)
-	_, unknownErr := service.ListSurfableBranches(context.Background(), surfingAppID, "nope", "3.0.0", false)
+	_, disabledErr := service.ListSurfableBranches(context.Background(), surfingAppID, "production", "3.0.0", "ios", false)
+	_, unknownErr := service.ListSurfableBranches(context.Background(), surfingAppID, "nope", "3.0.0", "ios", false)
 
 	require.Error(t, disabledErr)
 	require.Error(t, unknownErr)
@@ -103,7 +103,7 @@ func TestListSurfableBranchesRefusesUnknownChannelIdentically(t *testing.T) {
 func TestListSurfableBranchesRejectsInvalidChannelName(t *testing.T) {
 	service, _ := surfingService(t, nil, nil)
 
-	_, err := service.ListSurfableBranches(context.Background(), surfingAppID, "qa/../prod", "3.0.0", false)
+	_, err := service.ListSurfableBranches(context.Background(), surfingAppID, "qa/../prod", "3.0.0", "ios", false)
 
 	require.Error(t, err)
 	assert.True(t, validation.IsValidationError(err), "a malformed name is a validation error, not a 404")
@@ -147,11 +147,11 @@ func TestListSurfableBranchesIsAnsweredFromCache(t *testing.T) {
 	}}
 	t.Setenv("DB_URL", "postgres://stub")
 	ForgetBranchSurfing(surfingAppID, "qa")
-	ForgetSurfableBranches(surfingAppID, "3.0.0")
+	ForgetSurfableBranches(surfingAppID, "3.0.0", "ios")
 	service := NewChannelService(branchRepo, channelRepo)
 
 	for i := 0; i < 5; i++ {
-		_, err := service.ListSurfableBranches(context.Background(), surfingAppID, "qa", "3.0.0", false)
+		_, err := service.ListSurfableBranches(context.Background(), surfingAppID, "qa", "3.0.0", "ios", false)
 		require.NoError(t, err)
 	}
 
@@ -165,7 +165,7 @@ type countingBranchRepo struct {
 	reads    int
 }
 
-func (r *countingBranchRepo) GetSurfableBranches(_ context.Context, _, runtimeVersion string) ([]types.SurfableBranch, error) {
+func (r *countingBranchRepo) GetSurfableBranches(_ context.Context, _, runtimeVersion string, _ string) ([]types.SurfableBranch, error) {
 	r.reads++
 	return r.surfable[runtimeVersion], nil
 }
@@ -187,7 +187,7 @@ func TestListSurfableBranchesCapsAfterTheFilter(t *testing.T) {
 	wide, _ := surfingService(t,
 		map[string]*types.BranchSurfing{"qa": {Enabled: true, Pattern: "*"}},
 		map[string][]types.SurfableBranch{"3.0.0": all})
-	list, err := wide.ListSurfableBranches(context.Background(), surfingAppID, "qa", "3.0.0", false)
+	list, err := wide.ListSurfableBranches(context.Background(), surfingAppID, "qa", "3.0.0", "ios", false)
 	require.NoError(t, err)
 	assert.Len(t, list.Branches, maxSurfableBranches)
 	assert.Equal(t, "pr-0", list.Branches[0].Name, "newest first survives the cap")
@@ -196,7 +196,7 @@ func TestListSurfableBranchesCapsAfterTheFilter(t *testing.T) {
 	narrow, _ := surfingService(t,
 		map[string]*types.BranchSurfing{"qa": {Enabled: true, Pattern: "team-*"}},
 		map[string][]types.SurfableBranch{"3.0.0": all})
-	teamList, err := narrow.ListSurfableBranches(context.Background(), surfingAppID, "qa", "3.0.0", false)
+	teamList, err := narrow.ListSurfableBranches(context.Background(), surfingAppID, "qa", "3.0.0", "ios", false)
 	require.NoError(t, err)
 	// Cap-before-filter would return nothing at all here: the ten newest branches
 	// are all pr-*, so a page taken before the pattern ran would hold no match.
@@ -220,13 +220,31 @@ func TestSeeAllWidensThePageWithoutUnboundingIt(t *testing.T) {
 		map[string]*types.BranchSurfing{"qa": {Enabled: true, Pattern: "pr-*"}},
 		map[string][]types.SurfableBranch{"3.0.0": all})
 
-	page, err := service.ListSurfableBranches(context.Background(), surfingAppID, "qa", "3.0.0", false)
+	page, err := service.ListSurfableBranches(context.Background(), surfingAppID, "qa", "3.0.0", "ios", false)
 	require.NoError(t, err)
 	assert.Len(t, page.Branches, maxSurfableBranches)
 	assert.Equal(t, 600, page.Total, "the count is of every match, so a client can say what it is missing")
 
-	everything, err := service.ListSurfableBranches(context.Background(), surfingAppID, "qa", "3.0.0", true)
+	everything, err := service.ListSurfableBranches(context.Background(), surfingAppID, "qa", "3.0.0", "ios", true)
 	require.NoError(t, err)
 	assert.Len(t, everything.Branches, maxAllSurfableBranches, "see all is wider, not unbounded")
 	assert.Equal(t, 600, everything.Total)
+}
+
+// The setting is cached under the channel NAME. Deleting the channel must drop
+// it, or the channel keeps answering after it is gone — and a channel recreated
+// under the same name starts out holding a permission nobody granted it.
+func TestDeletingAChannelDropsItsSurfingPermission(t *testing.T) {
+	service, channelRepo := surfingService(t,
+		map[string]*types.BranchSurfing{"qa": {Enabled: true, Pattern: "pr-*"}},
+		map[string][]types.SurfableBranch{"3.0.0": {{Name: "pr-1", LastUpdateAt: "2026-08-01T10:00:00Z"}}})
+
+	_, err := service.ListSurfableBranches(context.Background(), surfingAppID, "qa", "3.0.0", "ios", false)
+	require.NoError(t, err, "the setting is now cached")
+
+	require.NoError(t, service.DeleteChannel(context.Background(), "qa", surfingAppID))
+	channelRepo.surfing = map[string]*types.BranchSurfing{}
+
+	_, err = service.ListSurfableBranches(context.Background(), surfingAppID, "qa", "3.0.0", "ios", false)
+	assert.Error(t, err, "a deleted channel must not keep answering from cache")
 }

--- a/internal/services/branch_surfing_test.go
+++ b/internal/services/branch_surfing_test.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"net/http"
 	"testing"
+	cache2 "xprem/internal/cache"
+	"xprem/internal/providers/expo"
 	"xprem/internal/types"
 	"xprem/internal/validation"
 
@@ -25,6 +27,9 @@ func surfingService(t *testing.T, surfing map[string]*types.BranchSurfing, surfa
 	}
 	for _, runtimeVersion := range []string{"3.0.0", "2.0.0"} {
 		ForgetSurfableBranches(surfingAppID, runtimeVersion, "ios")
+	}
+	for _, channelName := range []string{"qa", "production"} {
+		cache2.GetCache().Delete(channelMappingCacheKey(surfingAppID, channelName))
 	}
 	channelRepo := &fakeChannelRepo{surfing: surfing}
 	return NewChannelService(fakeBranchRepo{surfable: surfable}, channelRepo), channelRepo
@@ -95,9 +100,15 @@ func TestListSurfableBranchesRefusesUnknownChannelIdentically(t *testing.T) {
 	_, disabledErr := service.ListSurfableBranches(context.Background(), surfingAppID, "production", "3.0.0", "ios", false)
 	_, unknownErr := service.ListSurfableBranches(context.Background(), surfingAppID, "nope", "3.0.0", "ios", false)
 
-	require.Error(t, disabledErr)
-	require.Error(t, unknownErr)
-	assert.Equal(t, disabledErr.Error(), unknownErr.Error())
+	// Comparing Error() alone compares only the message: ExpoProtocolError.Error()
+	// returns Message and nothing else, so a 403 on one arm and a 404 on the other
+	// would pass while handing back the very oracle this test exists to close.
+	var disabled, unknown *ExpoProtocolError
+	require.ErrorAs(t, disabledErr, &disabled)
+	require.ErrorAs(t, unknownErr, &unknown)
+	assert.Equal(t, disabled.StatusCode, unknown.StatusCode)
+	assert.Equal(t, http.StatusNotFound, unknown.StatusCode)
+	assert.Equal(t, disabled.Message, unknown.Message)
 }
 
 func TestListSurfableBranchesRejectsInvalidChannelName(t *testing.T) {
@@ -247,4 +258,105 @@ func TestDeletingAChannelDropsItsSurfingPermission(t *testing.T) {
 
 	_, err = service.ListSurfableBranches(context.Background(), surfingAppID, "qa", "3.0.0", "ios", false)
 	assert.Error(t, err, "a deleted channel must not keep answering from cache")
+}
+
+// The channel's own branch is deliberately unselectable: asking for it is treated
+// as asking for nothing, so that a device in a progressive rollout keeps being
+// drawn by the rollout rather than pinned by its own request. Listing it would
+// therefore offer a switch the server will not honour — the tester taps it and
+// nothing happens. Going back is the client's reset, not an entry in this list.
+func TestTheChannelsOwnBranchIsNotOfferedAsASwitch(t *testing.T) {
+	service, channelRepo := surfingService(t,
+		map[string]*types.BranchSurfing{"qa": {Enabled: true, Pattern: "*"}},
+		map[string][]types.SurfableBranch{"3.0.0": {
+			{Name: "pr-1", LastUpdateAt: "2026-08-02T10:00:00Z"},
+			{Name: "staging", LastUpdateAt: "2026-08-01T10:00:00Z"},
+		}})
+	channelRepo.mappings = map[string]*expo.ChannelMapping{
+		"qa": {BranchName: "staging"},
+	}
+
+	list, err := service.ListSurfableBranches(context.Background(), surfingAppID, "qa", "3.0.0", "ios", false)
+
+	require.NoError(t, err)
+	assert.Equal(t, []types.SurfableBranch{{Name: "pr-1", LastUpdateAt: "2026-08-02T10:00:00Z"}}, list.Branches)
+	assert.Equal(t, 1, list.Total, "the excluded branch must not be counted either, or the client offers a see-all that finds nothing")
+}
+
+// A channel that does not exist must be cached exactly like one with surfing
+// off. Leaving it uncached made the two observably different: the disabled
+// channel answered from memory, the unknown one hit Postgres. An unauthenticated
+// caller could time the difference to learn which channel names exist, and drive
+// one uncached query per request while doing it.
+func TestAnUnknownChannelIsCachedLikeADisabledOne(t *testing.T) {
+	channelRepo := &countingChannelRepo{
+		fakeChannelRepo: &fakeChannelRepo{surfing: map[string]*types.BranchSurfing{
+			"production": {Enabled: false, Pattern: "*"},
+		}},
+	}
+	t.Setenv("DB_URL", "postgres://stub")
+	ForgetBranchSurfing(surfingAppID, "production")
+	ForgetBranchSurfing(surfingAppID, "nope")
+	service := NewChannelService(fakeBranchRepo{}, channelRepo)
+
+	for i := 0; i < 3; i++ {
+		_, unknownErr := service.ListSurfableBranches(context.Background(), surfingAppID, "nope", "3.0.0", "ios", false)
+		_, disabledErr := service.ListSurfableBranches(context.Background(), surfingAppID, "production", "3.0.0", "ios", false)
+		require.Error(t, unknownErr)
+		require.Error(t, disabledErr)
+	}
+
+	assert.Equal(t, 2, channelRepo.surfingReads,
+		"one read each, then both answered from cache — an unknown channel that kept reading is a timing oracle")
+}
+
+// The flip side of caching the negative: a channel created under a name someone
+// already asked for must not stay invisible for the rest of the TTL.
+func TestCreatingAChannelClearsTheCachedNegative(t *testing.T) {
+	service, channelRepo := surfingService(t,
+		map[string]*types.BranchSurfing{},
+		map[string][]types.SurfableBranch{"3.0.0": {{Name: "pr-1", LastUpdateAt: "2026-08-01T10:00:00Z"}}})
+	_ = channelRepo
+
+	_, err := service.ListSurfableBranches(context.Background(), surfingAppID, "qa", "3.0.0", "ios", false)
+	require.Error(t, err, "unknown channel, now cached as such")
+
+	_, err = service.CreateChannel(context.Background(), surfingAppID, nil, "qa")
+	require.NoError(t, err)
+	channelRepo.surfing = map[string]*types.BranchSurfing{"qa": {Enabled: true, Pattern: "pr-*"}}
+
+	list, err := service.ListSurfableBranches(context.Background(), surfingAppID, "qa", "3.0.0", "ios", false)
+	require.NoError(t, err, "the cached 'no such channel' must not outlive the channel's creation")
+	assert.Len(t, list.Branches, 1)
+}
+
+// The mapped-branch exclusion depends on a read that can fail. Swallowing that
+// error leaves mappedBranch empty, which turns the filter into a no-op and puts
+// the unselectable branch back in the picker — silently undoing the fix, on a
+// path nobody would think to check.
+func TestAMappingReadFailureIsNotSwallowed(t *testing.T) {
+	channelRepo := &mappingErrorChannelRepo{
+		fakeChannelRepo: &fakeChannelRepo{surfing: map[string]*types.BranchSurfing{
+			"qa": {Enabled: true, Pattern: "*"},
+		}},
+	}
+	t.Setenv("DB_URL", "postgres://stub")
+	ForgetBranchSurfing(surfingAppID, "qa")
+	ForgetSurfableBranches(surfingAppID, "3.0.0", "ios")
+	cache2.GetCache().Delete(channelMappingCacheKey(surfingAppID, "qa"))
+	service := NewChannelService(
+		fakeBranchRepo{surfable: map[string][]types.SurfableBranch{
+			"3.0.0": {{Name: "staging", LastUpdateAt: "2026-08-01T10:00:00Z"}},
+		}},
+		channelRepo)
+
+	_, err := service.ListSurfableBranches(context.Background(), surfingAppID, "qa", "3.0.0", "ios", false)
+
+	assert.Error(t, err, "a list that cannot be filtered must fail rather than come back wrong")
+}
+
+type mappingErrorChannelRepo struct{ *fakeChannelRepo }
+
+func (mappingErrorChannelRepo) GetChannelBranchMapping(_ context.Context, _, _ string) (*expo.ChannelMapping, error) {
+	return nil, assert.AnError
 }

--- a/internal/services/branch_surfing_test.go
+++ b/internal/services/branch_surfing_test.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"testing"
 	"xprem/internal/types"
@@ -13,13 +14,25 @@ import (
 
 const surfingAppID = "1a2b3c4d-0000-0000-0000-000000000001"
 
-func surfingService(surfing map[string]*types.BranchSurfing, surfable map[string][]types.SurfableBranch) (*ChannelService, *fakeChannelRepo) {
+// Both reads are cached now, and the cache is a process-wide singleton keyed on
+// the app id, so each test starts from a cleared one or reads its neighbour's
+// answer. DB_URL has to look set: surfing only exists on the control plane.
+func surfingService(t *testing.T, surfing map[string]*types.BranchSurfing, surfable map[string][]types.SurfableBranch) (*ChannelService, *fakeChannelRepo) {
+	t.Helper()
+	t.Setenv("DB_URL", "postgres://stub")
+	for _, channelName := range []string{"qa", "production", "nope", "qa/../prod"} {
+		ForgetBranchSurfing(surfingAppID, channelName)
+	}
+	for _, runtimeVersion := range []string{"3.0.0", "2.0.0"} {
+		ForgetSurfableBranches(surfingAppID, runtimeVersion)
+	}
 	channelRepo := &fakeChannelRepo{surfing: surfing}
 	return NewChannelService(fakeBranchRepo{surfable: surfable}, channelRepo), channelRepo
 }
 
 func TestListSurfableBranchesFiltersOnPattern(t *testing.T) {
 	service, _ := surfingService(
+		t,
 		map[string]*types.BranchSurfing{"qa": {Enabled: true, Pattern: "pr-*"}},
 		map[string][]types.SurfableBranch{"3.0.0": {
 			{Name: "pr-482", LastUpdateAt: "2026-08-01T10:00:00Z"},
@@ -28,13 +41,13 @@ func TestListSurfableBranchesFiltersOnPattern(t *testing.T) {
 		}},
 	)
 
-	branches, err := service.ListSurfableBranches(context.Background(), surfingAppID, "qa", "3.0.0")
+	list, err := service.ListSurfableBranches(context.Background(), surfingAppID, "qa", "3.0.0", false)
 
 	require.NoError(t, err)
 	assert.Equal(t, []types.SurfableBranch{
 		{Name: "pr-482", LastUpdateAt: "2026-08-01T10:00:00Z"},
 		{Name: "pr-31", LastUpdateAt: "2026-07-29T10:00:00Z"},
-	}, branches)
+	}, list.Branches)
 }
 
 // The runtime version is what the repository is asked for: a branch holding no
@@ -42,6 +55,7 @@ func TestListSurfableBranchesFiltersOnPattern(t *testing.T) {
 // offered.
 func TestListSurfableBranchesScopesToRuntimeVersion(t *testing.T) {
 	service, _ := surfingService(
+		t,
 		map[string]*types.BranchSurfing{"qa": {Enabled: true, Pattern: "*"}},
 		map[string][]types.SurfableBranch{
 			"3.0.0": {{Name: "pr-482", LastUpdateAt: "2026-08-01T10:00:00Z"}},
@@ -49,19 +63,20 @@ func TestListSurfableBranchesScopesToRuntimeVersion(t *testing.T) {
 		},
 	)
 
-	branches, err := service.ListSurfableBranches(context.Background(), surfingAppID, "qa", "2.0.0")
+	list, err := service.ListSurfableBranches(context.Background(), surfingAppID, "qa", "2.0.0", false)
 
 	require.NoError(t, err)
-	assert.Equal(t, []types.SurfableBranch{{Name: "legacy", LastUpdateAt: "2026-01-01T10:00:00Z"}}, branches)
+	assert.Equal(t, []types.SurfableBranch{{Name: "legacy", LastUpdateAt: "2026-01-01T10:00:00Z"}}, list.Branches)
 }
 
 func TestListSurfableBranchesRefusesDisabledChannel(t *testing.T) {
 	service, _ := surfingService(
+		t,
 		map[string]*types.BranchSurfing{"production": {Enabled: false, Pattern: "*"}},
 		map[string][]types.SurfableBranch{"3.0.0": {{Name: "pr-482", LastUpdateAt: "2026-08-01T10:00:00Z"}}},
 	)
 
-	_, err := service.ListSurfableBranches(context.Background(), surfingAppID, "production", "3.0.0")
+	_, err := service.ListSurfableBranches(context.Background(), surfingAppID, "production", "3.0.0", false)
 
 	var protocolErr *ExpoProtocolError
 	require.ErrorAs(t, err, &protocolErr)
@@ -72,12 +87,13 @@ func TestListSurfableBranchesRefusesDisabledChannel(t *testing.T) {
 // cannot be used to enumerate which channels exist.
 func TestListSurfableBranchesRefusesUnknownChannelIdentically(t *testing.T) {
 	service, _ := surfingService(
+		t,
 		map[string]*types.BranchSurfing{"production": {Enabled: false, Pattern: "*"}},
 		nil,
 	)
 
-	_, disabledErr := service.ListSurfableBranches(context.Background(), surfingAppID, "production", "3.0.0")
-	_, unknownErr := service.ListSurfableBranches(context.Background(), surfingAppID, "nope", "3.0.0")
+	_, disabledErr := service.ListSurfableBranches(context.Background(), surfingAppID, "production", "3.0.0", false)
+	_, unknownErr := service.ListSurfableBranches(context.Background(), surfingAppID, "nope", "3.0.0", false)
 
 	require.Error(t, disabledErr)
 	require.Error(t, unknownErr)
@@ -85,16 +101,16 @@ func TestListSurfableBranchesRefusesUnknownChannelIdentically(t *testing.T) {
 }
 
 func TestListSurfableBranchesRejectsInvalidChannelName(t *testing.T) {
-	service, _ := surfingService(nil, nil)
+	service, _ := surfingService(t, nil, nil)
 
-	_, err := service.ListSurfableBranches(context.Background(), surfingAppID, "qa/../prod", "3.0.0")
+	_, err := service.ListSurfableBranches(context.Background(), surfingAppID, "qa/../prod", "3.0.0", false)
 
 	require.Error(t, err)
 	assert.True(t, validation.IsValidationError(err), "a malformed name is a validation error, not a 404")
 }
 
 func TestSetBranchSurfingCollapsesWildcards(t *testing.T) {
-	service, channelRepo := surfingService(map[string]*types.BranchSurfing{"qa": {}}, nil)
+	service, channelRepo := surfingService(t, map[string]*types.BranchSurfing{"qa": {}}, nil)
 
 	err := service.SetBranchSurfing(context.Background(), surfingAppID, "qa", types.BranchSurfing{
 		Enabled: true,
@@ -106,7 +122,7 @@ func TestSetBranchSurfingCollapsesWildcards(t *testing.T) {
 }
 
 func TestSetBranchSurfingRejectsInvalidPattern(t *testing.T) {
-	service, channelRepo := surfingService(map[string]*types.BranchSurfing{"qa": {}}, nil)
+	service, channelRepo := surfingService(t, map[string]*types.BranchSurfing{"qa": {}}, nil)
 
 	err := service.SetBranchSurfing(context.Background(), surfingAppID, "qa", types.BranchSurfing{
 		Enabled: true,
@@ -115,4 +131,102 @@ func TestSetBranchSurfingRejectsInvalidPattern(t *testing.T) {
 
 	require.Error(t, err)
 	assert.Empty(t, channelRepo.surfingWrites)
+}
+
+// Every launch of every build carrying the picker calls this endpoint, so a
+// second reader must not reach the database. This is what makes the client's
+// boot probe affordable at fleet scale.
+func TestListSurfableBranchesIsAnsweredFromCache(t *testing.T) {
+	channelRepo := &countingChannelRepo{
+		fakeChannelRepo: &fakeChannelRepo{surfing: map[string]*types.BranchSurfing{
+			"qa": {Enabled: true, Pattern: "*"},
+		}},
+	}
+	branchRepo := &countingBranchRepo{surfable: map[string][]types.SurfableBranch{
+		"3.0.0": {{Name: "pr-482", LastUpdateAt: "2026-08-01T10:00:00Z"}},
+	}}
+	t.Setenv("DB_URL", "postgres://stub")
+	ForgetBranchSurfing(surfingAppID, "qa")
+	ForgetSurfableBranches(surfingAppID, "3.0.0")
+	service := NewChannelService(branchRepo, channelRepo)
+
+	for i := 0; i < 5; i++ {
+		_, err := service.ListSurfableBranches(context.Background(), surfingAppID, "qa", "3.0.0", false)
+		require.NoError(t, err)
+	}
+
+	assert.Equal(t, 1, channelRepo.surfingReads, "the channel setting must be read once")
+	assert.Equal(t, 1, branchRepo.reads, "the branch list must be read once")
+}
+
+type countingBranchRepo struct {
+	fakeBranchRepo
+	surfable map[string][]types.SurfableBranch
+	reads    int
+}
+
+func (r *countingBranchRepo) GetSurfableBranches(_ context.Context, _, runtimeVersion string) ([]types.SurfableBranch, error) {
+	r.reads++
+	return r.surfable[runtimeVersion], nil
+}
+
+// The cap lands AFTER the pattern filter: a narrow pattern whose matches sit
+// past the fiftieth newest branch must still find them, or a busy monorepo
+// would show teams an empty list while their branches exist.
+func TestListSurfableBranchesCapsAfterTheFilter(t *testing.T) {
+	all := make([]types.SurfableBranch, 0, 120)
+	for i := 0; i < 120; i++ {
+		// Newest first, like the SQL. The pattern targets ONLY the oldest 20.
+		name := fmt.Sprintf("pr-%d", i)
+		if i >= 100 {
+			name = fmt.Sprintf("team-%d", i)
+		}
+		all = append(all, types.SurfableBranch{Name: name, LastUpdateAt: "2026-08-01T10:00:00Z"})
+	}
+
+	wide, _ := surfingService(t,
+		map[string]*types.BranchSurfing{"qa": {Enabled: true, Pattern: "*"}},
+		map[string][]types.SurfableBranch{"3.0.0": all})
+	list, err := wide.ListSurfableBranches(context.Background(), surfingAppID, "qa", "3.0.0", false)
+	require.NoError(t, err)
+	assert.Len(t, list.Branches, maxSurfableBranches)
+	assert.Equal(t, "pr-0", list.Branches[0].Name, "newest first survives the cap")
+	assert.Equal(t, 120, list.Total, "total counts every match, not just the page")
+
+	narrow, _ := surfingService(t,
+		map[string]*types.BranchSurfing{"qa": {Enabled: true, Pattern: "team-*"}},
+		map[string][]types.SurfableBranch{"3.0.0": all})
+	teamList, err := narrow.ListSurfableBranches(context.Background(), surfingAppID, "qa", "3.0.0", false)
+	require.NoError(t, err)
+	// Cap-before-filter would return nothing at all here: the ten newest branches
+	// are all pr-*, so a page taken before the pattern ran would hold no match.
+	assert.Len(t, teamList.Branches, maxSurfableBranches)
+	assert.Equal(t, "team-100", teamList.Branches[0].Name)
+	assert.Equal(t, 20, teamList.Total, "every match past the page is still counted")
+}
+
+// The first page is what every device downloads at launch; "see all" widens it
+// without ever becoming unbounded. Total is the same either way, which is what
+// lets a client know it is looking at part of the list.
+func TestSeeAllWidensThePageWithoutUnboundingIt(t *testing.T) {
+	all := make([]types.SurfableBranch, 0, 600)
+	for i := 0; i < 600; i++ {
+		all = append(all, types.SurfableBranch{
+			Name:         fmt.Sprintf("pr-%d", i),
+			LastUpdateAt: "2026-08-01T10:00:00Z",
+		})
+	}
+	service, _ := surfingService(t,
+		map[string]*types.BranchSurfing{"qa": {Enabled: true, Pattern: "pr-*"}},
+		map[string][]types.SurfableBranch{"3.0.0": all})
+
+	page, err := service.ListSurfableBranches(context.Background(), surfingAppID, "qa", "3.0.0", false)
+	require.NoError(t, err)
+	assert.Len(t, page.Branches, maxSurfableBranches)
+	assert.Equal(t, 600, page.Total, "the count is of every match, so a client can say what it is missing")
+
+	everything, err := service.ListSurfableBranches(context.Background(), surfingAppID, "qa", "3.0.0", true)
+	require.NoError(t, err)
+	assert.Len(t, everything.Branches, maxAllSurfableBranches, "see all is wider, not unbounded")
+	assert.Equal(t, 600, everything.Total)
 }

--- a/internal/services/channel_service.go
+++ b/internal/services/channel_service.go
@@ -109,6 +109,11 @@ func (s *ChannelService) DeleteChannel(ctx context.Context, channelName string, 
 		AppID:         appId,
 	})
 	invalidateChannelCaches(appId)
+	// The surfing setting is cached per channel name, not per channel row, so a
+	// deleted channel would keep answering /branch_lists for the rest of the TTL
+	// — and a channel recreated under the same name would inherit the permission
+	// it was never given.
+	invalidateBranchSurfingCache(appId, channelName)
 	return nil
 }
 
@@ -166,11 +171,11 @@ const (
 
 // ListSurfableBranches returns the branches a device polling channelName may ask
 // to be served: those matching the channel's pattern that have a published
-// update for the device's runtime version, newest first. Only the first page is
+// update for the device's runtime version AND platform, newest first. Only the first page is
 // returned unless all is set, but Total always counts every match, so a client
 // can tell it is looking at part of the list. It refuses a channel that does not
 // exist or has branch surfing off.
-func (s *ChannelService) ListSurfableBranches(ctx context.Context, appId string, channelName string, runtimeVersion string, all bool) (types.SurfableBranchList, error) {
+func (s *ChannelService) ListSurfableBranches(ctx context.Context, appId string, channelName string, runtimeVersion string, platform string, all bool) (types.SurfableBranchList, error) {
 	if err := validation.Name("channelName", channelName); err != nil {
 		return types.SurfableBranchList{}, err
 	}
@@ -180,7 +185,7 @@ func (s *ChannelService) ListSurfableBranches(ctx context.Context, appId string,
 	if !enabled {
 		return types.SurfableBranchList{}, &ExpoProtocolError{StatusCode: http.StatusNotFound, Message: "Branch surfing is not enabled for this channel"}
 	}
-	branches, err := cachedSurfableBranches(ctx, s.branchRepo, appId, runtimeVersion)
+	branches, err := cachedSurfableBranches(ctx, s.branchRepo, appId, runtimeVersion, platform)
 	if err != nil {
 		return types.SurfableBranchList{}, err
 	}

--- a/internal/services/channel_service.go
+++ b/internal/services/channel_service.go
@@ -148,6 +148,7 @@ func (s *ChannelService) SetBranchSurfing(ctx context.Context, appId string, cha
 		},
 	})
 	invalidateChannelCaches(appId)
+	invalidateBranchSurfingCache(appId, channelName)
 	return nil
 }
 

--- a/internal/services/channel_service.go
+++ b/internal/services/channel_service.go
@@ -152,29 +152,54 @@ func (s *ChannelService) SetBranchSurfing(ctx context.Context, appId string, cha
 	return nil
 }
 
-// ListSurfableBranches returns the branches a device polling channelName may
-// ask to be served: those matching the channel's pattern that have a published
-// update for the device's runtime version. It refuses a channel that does not
+// The page every device gets at launch, and the ceiling when one asks for the
+// whole list. In acceptance testing the branch being looked for was published
+// recently, so the first page is the product behaviour and not merely a bound.
+// Ten rather than something roomier so that a team with a few dozen open
+// branches actually meets the "see all" path instead of it lying dormant until
+// some rare scale. The second bound exists so "see all" cannot be turned into an
+// unbounded download.
+const (
+	maxSurfableBranches    = 10
+	maxAllSurfableBranches = 500
+)
+
+// ListSurfableBranches returns the branches a device polling channelName may ask
+// to be served: those matching the channel's pattern that have a published
+// update for the device's runtime version, newest first. Only the first page is
+// returned unless all is set, but Total always counts every match, so a client
+// can tell it is looking at part of the list. It refuses a channel that does not
 // exist or has branch surfing off.
-func (s *ChannelService) ListSurfableBranches(ctx context.Context, appId string, channelName string, runtimeVersion string) ([]types.SurfableBranch, error) {
-	surfing, err := s.GetBranchSurfing(ctx, appId, channelName)
-	if err != nil {
-		return nil, err
+func (s *ChannelService) ListSurfableBranches(ctx context.Context, appId string, channelName string, runtimeVersion string, all bool) (types.SurfableBranchList, error) {
+	if err := validation.Name("channelName", channelName); err != nil {
+		return types.SurfableBranchList{}, err
 	}
+	enabled, pattern := cachedBranchSurfing(ctx, s.channelRepo, appId, channelName)
 	// An unknown channel and a channel with surfing off answer the same way, so
 	// the endpoint never reveals which channels exist.
-	if surfing == nil || !surfing.Enabled {
-		return nil, &ExpoProtocolError{StatusCode: http.StatusNotFound, Message: "Branch surfing is not enabled for this channel"}
+	if !enabled {
+		return types.SurfableBranchList{}, &ExpoProtocolError{StatusCode: http.StatusNotFound, Message: "Branch surfing is not enabled for this channel"}
 	}
-	branches, err := s.branchRepo.GetSurfableBranches(ctx, appId, runtimeVersion)
+	branches, err := cachedSurfableBranches(ctx, s.branchRepo, appId, runtimeVersion)
 	if err != nil {
-		return nil, err
+		return types.SurfableBranchList{}, err
 	}
-	matched := make([]types.SurfableBranch, 0, len(branches))
+	limit := maxSurfableBranches
+	if all {
+		limit = maxAllSurfableBranches
+	}
+	// The cap lands after the pattern filter: a narrow pattern whose matches are
+	// all older than the cut must still find them.
+	matched := make([]types.SurfableBranch, 0, limit)
+	total := 0
 	for _, candidate := range branches {
-		if branch.MatchPattern(surfing.Pattern, candidate.Name) {
+		if !branch.MatchPattern(pattern, candidate.Name) {
+			continue
+		}
+		total++
+		if len(matched) < limit {
 			matched = append(matched, candidate)
 		}
 	}
-	return matched, nil
+	return types.SurfableBranchList{Branches: matched, Total: total}, nil
 }

--- a/internal/services/channel_service.go
+++ b/internal/services/channel_service.go
@@ -90,6 +90,10 @@ func (s *ChannelService) CreateChannel(ctx context.Context, appId string, branch
 		Metadata:      metadata,
 	})
 	invalidateChannelCaches(appId)
+	// A channel that did not exist is now cached as "no surfing" for the TTL, so
+	// creating one under a name that was ever asked for would answer 404 until
+	// that entry aged out.
+	invalidateBranchSurfingCache(appId, channelName)
 	return channelId, nil
 }
 
@@ -189,6 +193,27 @@ func (s *ChannelService) ListSurfableBranches(ctx context.Context, appId string,
 	if err != nil {
 		return types.SurfableBranchList{}, err
 	}
+	// The channel's own branch is left out because asking for it is deliberately
+	// treated as asking for nothing, so picking it here would do nothing and look
+	// broken. Going back is the client's reset, which drops the override.
+	//
+	// Only that branch. A channel mid-rollout also has Mapping.Rollout.BranchName,
+	// and that one IS offered and IS honoured: a tester asking for the rollout
+	// target pins onto it, skipping the percentage draw. That is the point of the
+	// feature — it is the branch under test. The cost is that such a device counts
+	// in the rollout's health without having been drawn into it.
+	// Failing rather than degrading: swallowing the error leaves mappedBranch
+	// empty, which turns the filter below into a no-op and silently puts the
+	// unselectable branch back in the picker. A panel that reports an error is
+	// recoverable; a list that is quietly wrong is not noticed.
+	mapping, err := cachedChannelMapping(ctx, s.channelRepo, appId, channelName)
+	if err != nil {
+		return types.SurfableBranchList{}, err
+	}
+	var mappedBranch string
+	if mapping != nil {
+		mappedBranch = mapping.BranchName
+	}
 	limit := maxSurfableBranches
 	if all {
 		limit = maxAllSurfableBranches
@@ -198,7 +223,7 @@ func (s *ChannelService) ListSurfableBranches(ctx context.Context, appId string,
 	matched := make([]types.SurfableBranch, 0, limit)
 	total := 0
 	for _, candidate := range branches {
-		if !branch.MatchPattern(pattern, candidate.Name) {
+		if candidate.Name == mappedBranch || !branch.MatchPattern(pattern, candidate.Name) {
 			continue
 		}
 		total++

--- a/internal/services/channel_service.go
+++ b/internal/services/channel_service.go
@@ -3,8 +3,10 @@ package services
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"strconv"
 	"xprem/internal/auditlog"
+	"xprem/internal/branch"
 	"xprem/internal/cache"
 	"xprem/internal/dashboard"
 	"xprem/internal/providers/expo"
@@ -34,6 +36,9 @@ type ChannelRepository interface {
 	GetChannelNameByBranchName(ctx context.Context, appId string, branchName string) ([]string, error)
 	GetChannels(ctx context.Context, appId string) ([]types.ChannelMapping, error)
 	GetChannelBranchMapping(ctx context.Context, appId string, channelName string) (*expo.ChannelMapping, error)
+	// GetBranchSurfing returns nil, nil when the channel does not exist.
+	GetBranchSurfing(ctx context.Context, appId string, channelName string) (*types.BranchSurfing, error)
+	SetBranchSurfing(ctx context.Context, appId string, channelName string, surfing types.BranchSurfing) error
 }
 
 // SetOnAuditEvent plugs the audit emission seam (see SetSSOEnforced for the
@@ -109,4 +114,66 @@ func (s *ChannelService) DeleteChannel(ctx context.Context, channelName string, 
 
 func (s *ChannelService) GetChannels(ctx context.Context, appId string) ([]types.ChannelMapping, error) {
 	return s.channelRepo.GetChannels(ctx, appId)
+}
+
+func (s *ChannelService) GetBranchSurfing(ctx context.Context, appId string, channelName string) (*types.BranchSurfing, error) {
+	if err := validation.Name("channelName", channelName); err != nil {
+		return nil, err
+	}
+	return s.channelRepo.GetBranchSurfing(ctx, appId, channelName)
+}
+
+func (s *ChannelService) SetBranchSurfing(ctx context.Context, appId string, channelName string, surfing types.BranchSurfing) error {
+	if err := validation.Name("channelName", channelName); err != nil {
+		return err
+	}
+	if err := validation.NamePattern("branchSurfingPattern", surfing.Pattern); err != nil {
+		return err
+	}
+	// Collapsed on write, as API key access rules are, so patterns naming the
+	// same set of branches are stored identically.
+	surfing.Pattern = branch.CollapseWildcards(surfing.Pattern)
+	if err := s.channelRepo.SetBranchSurfing(ctx, appId, channelName, surfing); err != nil {
+		return err
+	}
+	recordManagementEvent(ctx, s.onAuditEvent, auditlog.Event{
+		Action:        auditlog.ActionBranchSurfingUpdated,
+		TargetType:    "channel",
+		TargetID:      channelName,
+		TargetDisplay: channelName,
+		AppID:         appId,
+		Metadata: map[string]any{
+			"enabled": surfing.Enabled,
+			"pattern": surfing.Pattern,
+		},
+	})
+	invalidateChannelCaches(appId)
+	return nil
+}
+
+// ListSurfableBranches returns the branches a device polling channelName may
+// ask to be served: those matching the channel's pattern that have a published
+// update for the device's runtime version. It refuses a channel that does not
+// exist or has branch surfing off.
+func (s *ChannelService) ListSurfableBranches(ctx context.Context, appId string, channelName string, runtimeVersion string) ([]types.SurfableBranch, error) {
+	surfing, err := s.GetBranchSurfing(ctx, appId, channelName)
+	if err != nil {
+		return nil, err
+	}
+	// An unknown channel and a channel with surfing off answer the same way, so
+	// the endpoint never reveals which channels exist.
+	if surfing == nil || !surfing.Enabled {
+		return nil, &ExpoProtocolError{StatusCode: http.StatusNotFound, Message: "Branch surfing is not enabled for this channel"}
+	}
+	branches, err := s.branchRepo.GetSurfableBranches(ctx, appId, runtimeVersion)
+	if err != nil {
+		return nil, err
+	}
+	matched := make([]types.SurfableBranch, 0, len(branches))
+	for _, candidate := range branches {
+		if branch.MatchPattern(surfing.Pattern, candidate.Name) {
+			matched = append(matched, candidate)
+		}
+	}
+	return matched, nil
 }

--- a/internal/services/expo_protocol_service.go
+++ b/internal/services/expo_protocol_service.go
@@ -12,6 +12,7 @@ import (
 	"time"
 	"xprem/config"
 	"xprem/internal/assets"
+	"xprem/internal/branch"
 	cache2 "xprem/internal/cache"
 	cdn2 "xprem/internal/cdn"
 	"xprem/internal/crypto"
@@ -41,6 +42,7 @@ type ManifestRequestParams struct {
 	CurrentUpdateID       string
 	ExpoFatalError        string
 	RecentFailedUpdateIDs string
+	XpremBranch           string
 }
 
 type ManifestResult struct {
@@ -190,7 +192,7 @@ func (s *ExpoProtocolService) PutUpdateInResponse(w http.ResponseWriter, r *http
 	// Stamped on the copy about to be served, never on the cached manifest: the
 	// manifest cache is keyed by branch, and two channels mapped to one branch
 	// can differ on this. Signing happens downstream, so it covers the stamp.
-	manifest.Extra.BranchSurfing = s.branchSurfingEnabled(r.Context(), appId, r.Header.Get("expo-channel-name"))
+	manifest.Extra.BranchSurfing, _ = s.branchSurfingEnabled(r.Context(), appId, r.Header.Get("expo-channel-name"))
 	if currentUpdateId != "" {
 		metrics.TrackUpdateDownload(appId, platform, lastUpdate.RuntimeVersion, lastUpdate.Branch, manifest.Id, "update")
 	}
@@ -280,7 +282,7 @@ func (s *ExpoProtocolService) ResolveManifestBundle(ctx context.Context, params 
 		return ManifestResult{}, &ExpoProtocolError{StatusCode: http.StatusNotFound, Message: "No branch mapping found"}
 	}
 
-	servedBranch, lastUpdate, err := s.resolveUpdateForDevice(ctx, params.RequestID, params.AppID, params.ChannelName, params.ClientID, params.Platform, params.RuntimeVersion, branchMap)
+	servedBranch, lastUpdate, err := s.resolveUpdateForDevice(ctx, params.RequestID, params.AppID, params.ChannelName, params.ClientID, params.Platform, params.RuntimeVersion, params.XpremBranch, branchMap)
 	if err != nil {
 		return ManifestResult{}, err
 	}
@@ -318,14 +320,19 @@ func (s *ExpoProtocolService) ResolveManifestBundle(ctx context.Context, params 
 // nil (out-of-bucket with no control => noUpdateAvailable, deliberately no fallback to
 // the next candidate). Shared by manifest and asset resolution so the two paths take
 // the same rollout decision for a device.
-func (s *ExpoProtocolService) resolveUpdateForDevice(ctx context.Context, requestID string, appId string, channelName string, clientID string, platform string, runtimeVersion string, branchMap *expo.ChannelMapping) (string, *types.Update, error) {
+func (s *ExpoProtocolService) resolveUpdateForDevice(ctx context.Context, requestID string, appId string, channelName string, clientID string, platform string, runtimeVersion string, requestedBranch string, branchMap *expo.ChannelMapping) (string, *types.Update, error) {
 	req := &BranchResolutionRequest{
-		AppID:          appId,
-		ChannelName:    channelName,
-		ClientID:       clientID,
-		Platform:       platform,
-		RuntimeVersion: runtimeVersion,
-		Mapping:        branchMap,
+		AppID:           appId,
+		ChannelName:     channelName,
+		ClientID:        clientID,
+		Platform:        platform,
+		RuntimeVersion:  runtimeVersion,
+		Mapping:         branchMap,
+		RequestedBranch: requestedBranch,
+	}
+	if requestedBranch != "" {
+		enabled, pattern := s.branchSurfingEnabled(ctx, appId, channelName)
+		req.Surfing = types.BranchSurfing{Enabled: enabled, Pattern: pattern}
 	}
 	candidates, err := ResolveBranchCandidates(ctx, s.branchRules, req)
 	if err != nil {
@@ -435,7 +442,7 @@ func (s *ExpoProtocolService) ResolveAssetBundle(ctx context.Context, params Ass
 // latest-update behavior.
 func (s *ExpoProtocolService) resolveAssetUpdate(ctx context.Context, params AssetResolutionParams, branchMap *expo.ChannelMapping) (string, *types.Update, error) {
 	if config.IsDBMode() {
-		if params.UpdateID != "" && params.Branch != "" && s.isAssetBranchAllowed(params.Branch, branchMap) {
+		if params.UpdateID != "" && params.Branch != "" && s.isAssetBranchAllowed(ctx, params.AppID, params.ChannelName, params.Branch, branchMap) {
 			pinnedUpdate, err := s.updateRepo.GetUpdate(ctx, params.AppID, params.Branch, params.RuntimeVersion, params.UpdateID)
 			if err != nil {
 				log.Printf("[RequestID: %s] Ignoring invalid updateId param %q: %v", params.RequestID, params.UpdateID, err)
@@ -455,23 +462,28 @@ func (s *ExpoProtocolService) resolveAssetUpdate(ctx context.Context, params Ass
 			if err != nil {
 				log.Printf("[RequestID: %s] Ignoring invalid Expo-Requested-Update-ID %q: %v", params.RequestID, params.RequestedUpdateID, err)
 			} else if requestedUpdate != nil {
-				if s.isAssetBranchAllowed(requestedUpdate.Branch, branchMap) {
+				if s.isAssetBranchAllowed(ctx, params.AppID, params.ChannelName, requestedUpdate.Branch, branchMap) {
 					return requestedUpdate.Branch, requestedUpdate, nil
 				}
 				log.Printf("[RequestID: %s] Ignoring Expo-Requested-Update-ID %q: branch %q is not served by channel %q", params.RequestID, params.RequestedUpdateID, requestedUpdate.Branch, params.ChannelName)
 			}
 		}
 	}
-	return s.resolveUpdateForDevice(ctx, params.RequestID, params.AppID, params.ChannelName, params.ClientID, params.Platform, params.RuntimeVersion, branchMap)
+	return s.resolveUpdateForDevice(ctx, params.RequestID, params.AppID, params.ChannelName, params.ClientID, params.Platform, params.RuntimeVersion, params.Branch, branchMap)
 }
 
-// isAssetBranchAllowed restricts the branch query param to the branches the channel
-// can legitimately serve: its mapped branch and, during a channel rollout, the rollout
-// branch. Anything else falls through to the later tiers instead of letting a crafted
-// URL read another branch's files.
-func (s *ExpoProtocolService) isAssetBranchAllowed(branch string, branchMap *expo.ChannelMapping) bool {
-	if branch == branchMap.BranchName {
+// isAssetBranchAllowed answers the mirror of the manifest question: could manifest
+// resolution for this channel have served this branch? It must stay exactly as
+// permissive as that resolution. Wider and the branch query param becomes a
+// cross-branch read primitive; narrower and the assets of a legitimately surfed
+// branch 404.
+func (s *ExpoProtocolService) isAssetBranchAllowed(ctx context.Context, appId string, channelName string, branchName string, branchMap *expo.ChannelMapping) bool {
+	if branchName == branchMap.BranchName {
 		return true
 	}
-	return branchMap.Rollout != nil && branch == branchMap.Rollout.BranchName
+	if branchMap.Rollout != nil && branchName == branchMap.Rollout.BranchName {
+		return true
+	}
+	enabled, pattern := s.branchSurfingEnabled(ctx, appId, channelName)
+	return enabled && branch.MatchPattern(pattern, branchName)
 }

--- a/internal/services/expo_protocol_service.go
+++ b/internal/services/expo_protocol_service.go
@@ -353,9 +353,9 @@ func (s *ExpoProtocolService) resolveUpdateForDevice(ctx context.Context, reques
 	// the branch its own channel maps to. It also keeps the lookups below off the
 	// steady-state path, and off every deployment where surfing is disabled.
 	surfing := HonoursSurf(req)
-	var refused refusedUpdates
+	var blocks surfBlockSet
 	if surfing && (surfBlockTokens != "" || failedUpdateIDsRaw != "") {
-		refused = s.collectRefusedUpdates(ctx, appId, surfBlockTokens, failedUpdateIDsRaw)
+		blocks = s.collectSurfBlocks(ctx, appId, surfBlockTokens, failedUpdateIDsRaw)
 	}
 
 	servedBranch := branchMap.BranchName
@@ -369,7 +369,7 @@ func (s *ExpoProtocolService) resolveUpdateForDevice(ctx context.Context, reques
 			continue
 		}
 		if surfing && candidate == requestedBranch && resolution.Update != nil &&
-			refused.contains(candidate, resolution.Update.UpdateId) {
+			blocks.contains(candidate, resolution.Update.UpdateId) {
 			log.Printf("[RequestID: %s] Refusing surf to %q: update %s failed to launch on this device", requestID, candidate, resolution.Update.UpdateId)
 			blocked = &BlockedSurf{BranchName: candidate, Token: surfBlockToken(candidate, resolution.Update.UpdateId)}
 			continue

--- a/internal/services/expo_protocol_service.go
+++ b/internal/services/expo_protocol_service.go
@@ -43,12 +43,19 @@ type ManifestRequestParams struct {
 	ExpoFatalError        string
 	RecentFailedUpdateIDs string
 	XpremBranch           string
+	// SurfBlockTokens is the xprem-surf-blocked header verbatim: the comma
+	// separated "<branch>@<updateId>" verdicts the device echoes back, having
+	// persisted them from a previous expo-server-defined-headers response.
+	SurfBlockTokens string
 }
 
 type ManifestResult struct {
 	Update     *types.Update
 	BranchName string
 	UpdateType types.UpdateType
+	// BlockedSurf is set when the branch the device asked for was refused; the
+	// response carries the verdict so the device stops asking for it.
+	BlockedSurf *BlockedSurf
 }
 
 type ExpoProtocolError struct {
@@ -170,7 +177,7 @@ func writeResponse(w http.ResponseWriter, writer *multipart.Writer, buf *bytes.B
 	}
 }
 
-func (s *ExpoProtocolService) PutUpdateInResponse(w http.ResponseWriter, r *http.Request, appId string, lastUpdate types.Update, platform string, protocolVersion int64, requestID string) {
+func (s *ExpoProtocolService) PutUpdateInResponse(w http.ResponseWriter, r *http.Request, appId string, lastUpdate types.Update, platform string, protocolVersion int64, requestID string, refusedBranch string) {
 	currentUpdateId := r.Header.Get("expo-current-update-id")
 	metadata, err := update2.GetMetadata(lastUpdate)
 	if err != nil {
@@ -193,6 +200,7 @@ func (s *ExpoProtocolService) PutUpdateInResponse(w http.ResponseWriter, r *http
 	// manifest cache is keyed by branch, and two channels mapped to one branch
 	// can differ on this. Signing happens downstream, so it covers the stamp.
 	manifest.Extra.BranchSurfing, _ = s.branchSurfingEnabled(r.Context(), appId, r.Header.Get("expo-channel-name"))
+	manifest.Extra.BranchSurfingRefused = refusedBranch
 	if currentUpdateId != "" {
 		metrics.TrackUpdateDownload(appId, platform, lastUpdate.RuntimeVersion, lastUpdate.Branch, manifest.Id, "update")
 	}
@@ -282,7 +290,7 @@ func (s *ExpoProtocolService) ResolveManifestBundle(ctx context.Context, params 
 		return ManifestResult{}, &ExpoProtocolError{StatusCode: http.StatusNotFound, Message: "No branch mapping found"}
 	}
 
-	servedBranch, lastUpdate, err := s.resolveUpdateForDevice(ctx, params.RequestID, params.AppID, params.ChannelName, params.ClientID, params.Platform, params.RuntimeVersion, params.XpremBranch, branchMap)
+	servedBranch, lastUpdate, blockedSurfResult, err := s.resolveUpdateForDevice(ctx, params.RequestID, params.AppID, params.ChannelName, params.ClientID, params.Platform, params.RuntimeVersion, params.XpremBranch, params.SurfBlockTokens, params.RecentFailedUpdateIDs, branchMap)
 	if err != nil {
 		return ManifestResult{}, err
 	}
@@ -301,8 +309,9 @@ func (s *ExpoProtocolService) ResolveManifestBundle(ctx context.Context, params 
 
 	if lastUpdate == nil {
 		return ManifestResult{
-			Update:     nil,
-			BranchName: servedBranch,
+			Update:      nil,
+			BranchName:  servedBranch,
+			BlockedSurf: blockedSurfResult,
 		}, nil
 	}
 	updateType, err := s.cachedUpdateType(ctx, *lastUpdate)
@@ -311,7 +320,7 @@ func (s *ExpoProtocolService) ResolveManifestBundle(ctx context.Context, params 
 		return ManifestResult{}, &ExpoProtocolError{StatusCode: http.StatusInternalServerError, Message: "Error determining update type"}
 	}
 
-	return ManifestResult{Update: lastUpdate, BranchName: servedBranch, UpdateType: updateType}, nil
+	return ManifestResult{Update: lastUpdate, BranchName: servedBranch, UpdateType: updateType, BlockedSurf: blockedSurfResult}, nil
 }
 
 // resolveUpdateForDevice runs the branch rule chain, then serves the first candidate
@@ -320,7 +329,7 @@ func (s *ExpoProtocolService) ResolveManifestBundle(ctx context.Context, params 
 // nil (out-of-bucket with no control => noUpdateAvailable, deliberately no fallback to
 // the next candidate). Shared by manifest and asset resolution so the two paths take
 // the same rollout decision for a device.
-func (s *ExpoProtocolService) resolveUpdateForDevice(ctx context.Context, requestID string, appId string, channelName string, clientID string, platform string, runtimeVersion string, requestedBranch string, branchMap *expo.ChannelMapping) (string, *types.Update, error) {
+func (s *ExpoProtocolService) resolveUpdateForDevice(ctx context.Context, requestID string, appId string, channelName string, clientID string, platform string, runtimeVersion string, requestedBranch string, surfBlockTokens string, failedUpdateIDsRaw string, branchMap *expo.ChannelMapping) (servedBranchName string, lastUpdate *types.Update, blocked *BlockedSurf, err error) {
 	req := &BranchResolutionRequest{
 		AppID:           appId,
 		ChannelName:     channelName,
@@ -337,20 +346,37 @@ func (s *ExpoProtocolService) resolveUpdateForDevice(ctx context.Context, reques
 	candidates, err := ResolveBranchCandidates(ctx, s.branchRules, req)
 	if err != nil {
 		log.Printf("[RequestID: %s] Error resolving branch candidates: %v", requestID, err)
-		return "", nil, &ExpoProtocolError{StatusCode: http.StatusInternalServerError, Message: "Error resolving branch"}
+		return "", nil, nil, &ExpoProtocolError{StatusCode: http.StatusInternalServerError, Message: "Error resolving branch"}
 	}
+	// Gated on the rule having honoured the surf, not on the header being present:
+	// a declined request is a plain poll, and refusing one would take a device off
+	// the branch its own channel maps to. It also keeps the lookups below off the
+	// steady-state path, and off every deployment where surfing is disabled.
+	surfing := HonoursSurf(req)
+	var refused refusedUpdates
+	if surfing && (surfBlockTokens != "" || failedUpdateIDsRaw != "") {
+		refused = s.collectRefusedUpdates(ctx, appId, surfBlockTokens, failedUpdateIDsRaw)
+	}
+
 	servedBranch := branchMap.BranchName
 	for _, candidate := range candidates {
 		resolution, err := s.updateService.GetLatestUpdateForClient(ctx, appId, candidate, runtimeVersion, platform, clientID)
 		if err != nil {
 			log.Printf("[RequestID: %s] Error getting latest update: %v", requestID, err)
-			return "", nil, &ExpoProtocolError{StatusCode: http.StatusInternalServerError, Message: "Error getting latest update"}
+			return "", nil, nil, &ExpoProtocolError{StatusCode: http.StatusInternalServerError, Message: "Error getting latest update"}
 		}
-		if resolution.BranchHasUpdate {
-			return candidate, resolution.Update, nil
+		if !resolution.BranchHasUpdate {
+			continue
 		}
+		if surfing && candidate == requestedBranch && resolution.Update != nil &&
+			refused.contains(candidate, resolution.Update.UpdateId) {
+			log.Printf("[RequestID: %s] Refusing surf to %q: update %s failed to launch on this device", requestID, candidate, resolution.Update.UpdateId)
+			blocked = &BlockedSurf{BranchName: candidate, Token: surfBlockToken(candidate, resolution.Update.UpdateId)}
+			continue
+		}
+		return candidate, resolution.Update, blocked, nil
 	}
-	return servedBranch, nil, nil
+	return servedBranch, nil, blocked, nil
 }
 
 func (s *ExpoProtocolService) ResolveAssetBundle(ctx context.Context, params AssetResolutionParams) (*ExpoAssetResult, error) {
@@ -469,7 +495,8 @@ func (s *ExpoProtocolService) resolveAssetUpdate(ctx context.Context, params Ass
 			}
 		}
 	}
-	return s.resolveUpdateForDevice(ctx, params.RequestID, params.AppID, params.ChannelName, params.ClientID, params.Platform, params.RuntimeVersion, params.Branch, branchMap)
+	branchName, lastUpdate, _, err := s.resolveUpdateForDevice(ctx, params.RequestID, params.AppID, params.ChannelName, params.ClientID, params.Platform, params.RuntimeVersion, params.Branch, "", "", branchMap)
+	return branchName, lastUpdate, err
 }
 
 // isAssetBranchAllowed answers the mirror of the manifest question: could manifest

--- a/internal/services/expo_protocol_service.go
+++ b/internal/services/expo_protocol_service.go
@@ -187,6 +187,10 @@ func (s *ExpoProtocolService) PutUpdateInResponse(w http.ResponseWriter, r *http
 		http.Error(w, "Error composing manifest", http.StatusInternalServerError)
 		return
 	}
+	// Stamped on the copy about to be served, never on the cached manifest: the
+	// manifest cache is keyed by branch, and two channels mapped to one branch
+	// can differ on this. Signing happens downstream, so it covers the stamp.
+	manifest.Extra.BranchSurfing = s.branchSurfingEnabled(r.Context(), appId, r.Header.Get("expo-channel-name"))
 	if currentUpdateId != "" {
 		metrics.TrackUpdateDownload(appId, platform, lastUpdate.RuntimeVersion, lastUpdate.Branch, manifest.Id, "update")
 	}

--- a/internal/services/expo_protocol_service.go
+++ b/internal/services/expo_protocol_service.go
@@ -197,9 +197,8 @@ func (s *ExpoProtocolService) PutUpdateInResponse(w http.ResponseWriter, r *http
 		return
 	}
 	// Stamped on the copy about to be served, never on the cached manifest: the
-	// manifest cache is keyed by branch, and two channels mapped to one branch
-	// can differ on this. Signing happens downstream, so it covers the stamp.
-	manifest.Extra.BranchSurfing, _ = s.branchSurfingEnabled(r.Context(), appId, r.Header.Get("expo-channel-name"))
+	// cache is keyed by branch, and this is per request. Signing happens
+	// downstream, so it covers the stamp.
 	manifest.Extra.BranchSurfingRefused = refusedBranch
 	if currentUpdateId != "" {
 		metrics.TrackUpdateDownload(appId, platform, lastUpdate.RuntimeVersion, lastUpdate.Branch, manifest.Id, "update")

--- a/internal/services/header_dictionary.go
+++ b/internal/services/header_dictionary.go
@@ -27,7 +27,24 @@ func (d *HeaderDictionary) Set(key string, value string) {
 	if key == "" || value == "" || len(value) > maxHeaderDictionaryValue {
 		return
 	}
+	// An RFC 8941 string carries 0x20-0x7E and nothing else. Escaping handles the
+	// two characters that end a string early; it cannot rescue a byte the grammar
+	// has no room for. A client that fails to parse the dictionary drops ALL of
+	// it, so one stray byte in any member costs every other member too — today
+	// that would mean re-serving an update this device already crashed on.
+	if !isStructuredStringSafe(value) {
+		return
+	}
 	d.members[key] = value
+}
+
+func isStructuredStringSafe(value string) bool {
+	for i := 0; i < len(value); i++ {
+		if value[i] < 0x20 || value[i] > 0x7e {
+			return false
+		}
+	}
+	return true
 }
 
 // Encode renders the dictionary with keys sorted, so the same state always

--- a/internal/services/header_dictionary.go
+++ b/internal/services/header_dictionary.go
@@ -19,12 +19,13 @@ func NewHeaderDictionary() *HeaderDictionary {
 	return &HeaderDictionary{members: map[string]string{}}
 }
 
+// Set stores a member, dropping one whose value is over the bound rather than
+// cutting it. A structured value is not a string that can be shortened: cutting
+// lands mid-token or mid-escape and produces something that parses but means
+// something else. Callers assemble a value that fits; this is the backstop.
 func (d *HeaderDictionary) Set(key string, value string) {
-	if key == "" || value == "" {
+	if key == "" || value == "" || len(value) > maxHeaderDictionaryValue {
 		return
-	}
-	if len(value) > maxHeaderDictionaryValue {
-		value = value[:maxHeaderDictionaryValue]
 	}
 	d.members[key] = value
 }

--- a/internal/services/header_dictionary.go
+++ b/internal/services/header_dictionary.go
@@ -1,0 +1,66 @@
+package services
+
+import (
+	"sort"
+	"strings"
+)
+
+// maxHeaderDictionaryValue bounds one member.
+const maxHeaderDictionaryValue = 512
+
+// HeaderDictionary accumulates the members of an RFC 8941 dictionary header.
+// Setting a key that is already present replaces it. Held by the caller across a
+// whole response so several features can contribute members to one header.
+type HeaderDictionary struct {
+	members map[string]string
+}
+
+func NewHeaderDictionary() *HeaderDictionary {
+	return &HeaderDictionary{members: map[string]string{}}
+}
+
+func (d *HeaderDictionary) Set(key string, value string) {
+	if key == "" || value == "" {
+		return
+	}
+	if len(value) > maxHeaderDictionaryValue {
+		value = value[:maxHeaderDictionaryValue]
+	}
+	d.members[key] = value
+}
+
+// Encode renders the dictionary with keys sorted, so the same state always
+// produces the same bytes. Empty when there is nothing to carry.
+func (d *HeaderDictionary) Encode() string {
+	if len(d.members) == 0 {
+		return ""
+	}
+	keys := make([]string, 0, len(d.members))
+	for key := range d.members {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	parts := make([]string, 0, len(keys))
+	for _, key := range keys {
+		parts = append(parts, key+`="`+escapeStructuredString(d.members[key])+`"`)
+	}
+	return strings.Join(parts, ", ")
+}
+
+// escapeStructuredString escapes the two characters an RFC 8941 string cannot
+// carry raw. Callers pass branch names, which validation.Name does not screen
+// for quotes.
+func escapeStructuredString(value string) string {
+	if !strings.ContainsAny(value, `"\`) {
+		return value
+	}
+	var escaped strings.Builder
+	escaped.Grow(len(value) + 8)
+	for _, r := range value {
+		if r == '"' || r == '\\' {
+			escaped.WriteByte('\\')
+		}
+		escaped.WriteRune(r)
+	}
+	return escaped.String()
+}

--- a/internal/services/header_dictionary_test.go
+++ b/internal/services/header_dictionary_test.go
@@ -1,0 +1,77 @@
+package services
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Production carries a single member today, so everything below is the part of
+// this type that only the next caller will exercise.
+func TestHeaderDictionaryEncode(t *testing.T) {
+	t.Run("empty carries nothing", func(t *testing.T) {
+		assert.Empty(t, NewHeaderDictionary().Encode())
+	})
+
+	t.Run("one member", func(t *testing.T) {
+		d := NewHeaderDictionary()
+		d.Set("xprem-surf-blocked", "pr-482@200")
+		assert.Equal(t, `xprem-surf-blocked="pr-482@200"`, d.Encode())
+	})
+
+	// Sorted, so the same state always produces the same bytes: an unsorted map
+	// walk would make the header flap between polls and defeat any caching or
+	// diffing downstream.
+	t.Run("members are sorted, not map-ordered", func(t *testing.T) {
+		d := NewHeaderDictionary()
+		d.Set("zulu", "3")
+		d.Set("alpha", "1")
+		d.Set("mike", "2")
+		for i := 0; i < 20; i++ {
+			assert.Equal(t, `alpha="1", mike="2", zulu="3"`, d.Encode())
+		}
+	})
+}
+
+func TestHeaderDictionarySet(t *testing.T) {
+	t.Run("replaces an existing key", func(t *testing.T) {
+		d := NewHeaderDictionary()
+		d.Set("k", "first")
+		d.Set("k", "second")
+		assert.Equal(t, `k="second"`, d.Encode())
+	})
+
+	t.Run("ignores an empty key or value", func(t *testing.T) {
+		d := NewHeaderDictionary()
+		d.Set("", "value")
+		d.Set("k", "")
+		assert.Empty(t, d.Encode())
+	})
+
+	// The client replays every member on every poll, so an oversized value is a
+	// cost paid for ever rather than once.
+	t.Run("truncates an oversized value", func(t *testing.T) {
+		d := NewHeaderDictionary()
+		d.Set("k", strings.Repeat("x", maxHeaderDictionaryValue+50))
+		assert.Equal(t, `k="`+strings.Repeat("x", maxHeaderDictionaryValue)+`"`, d.Encode())
+	})
+}
+
+// Unescaped, either character ends the string early and the client parses a
+// different dictionary than the one sent — silently losing the other members.
+func TestHeaderDictionaryEscapesWhatBreaksTheDictionary(t *testing.T) {
+	cases := map[string]struct{ value, want string }{
+		"quote":     {`pr-"x`, `k="pr-\"x"`},
+		"backslash": {`pr-\x`, `k="pr-\\x"`},
+		"both":      {`a"b\c`, `k="a\"b\\c"`},
+		"untouched": {"pr-482@200", `k="pr-482@200"`},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			d := NewHeaderDictionary()
+			d.Set("k", tc.value)
+			assert.Equal(t, tc.want, d.Encode())
+		})
+	}
+}

--- a/internal/services/header_dictionary_test.go
+++ b/internal/services/header_dictionary_test.go
@@ -50,10 +50,19 @@ func TestHeaderDictionarySet(t *testing.T) {
 	})
 
 	// The client replays every member on every poll, so an oversized value is a
-	// cost paid for ever rather than once.
-	t.Run("truncates an oversized value", func(t *testing.T) {
+	// cost paid for ever rather than once. It is dropped rather than shortened: a
+	// structured value cut to length lands mid-token and yields something that
+	// still parses but no longer means what was sent. Callers size their own
+	// value; this is the backstop, and it must not invent a smaller one.
+	t.Run("drops an oversized value rather than cutting it", func(t *testing.T) {
 		d := NewHeaderDictionary()
 		d.Set("k", strings.Repeat("x", maxHeaderDictionaryValue+50))
+		assert.Empty(t, d.Encode())
+	})
+
+	t.Run("keeps a value exactly on the bound", func(t *testing.T) {
+		d := NewHeaderDictionary()
+		d.Set("k", strings.Repeat("x", maxHeaderDictionaryValue))
 		assert.Equal(t, `k="`+strings.Repeat("x", maxHeaderDictionaryValue)+`"`, d.Encode())
 	})
 }
@@ -74,4 +83,31 @@ func TestHeaderDictionaryEscapesWhatBreaksTheDictionary(t *testing.T) {
 			assert.Equal(t, tc.want, d.Encode())
 		})
 	}
+}
+
+// Branch names may legally contain non-ASCII (validation.Name screens control
+// characters and path separators, not the byte range). An RFC 8941 string cannot
+// carry those bytes, and a client that fails to parse the dictionary discards
+// ALL of it — so one stray byte in any member would cost the device the surf
+// verdicts too, and re-serve an update it already crashed on.
+func TestHeaderDictionaryRefusesBytesAStructuredStringCannotCarry(t *testing.T) {
+	for name, value := range map[string]string{
+		"non-ascii":       "pr-é",
+		"tab":             "pr\tx",
+		"newline":         "pr\nx",
+		"del":             "pr\x7fx",
+		"invalid utf-8":   "pr\xffx",
+		"high code point": "pr-🚀",
+	} {
+		t.Run(name, func(t *testing.T) {
+			d := NewHeaderDictionary()
+			d.Set("k", value)
+			assert.Empty(t, d.Encode(), "the member must be dropped, not emitted unparseable")
+		})
+	}
+
+	// The boundary itself stays usable.
+	d := NewHeaderDictionary()
+	d.Set("k", " ~")
+	assert.Equal(t, `k=" ~"`, d.Encode())
 }

--- a/internal/services/management_audit_test.go
+++ b/internal/services/management_audit_test.go
@@ -68,7 +68,7 @@ func (f *fakeMgmtChannelRepo) SetBranchSurfing(_ context.Context, _ string, _ st
 
 type fakeMgmtBranchRepo struct{}
 
-func (f *fakeMgmtBranchRepo) GetSurfableBranches(_ context.Context, _ string, _ string) ([]types.SurfableBranch, error) {
+func (f *fakeMgmtBranchRepo) GetSurfableBranches(_ context.Context, _ string, _ string, _ string) ([]types.SurfableBranch, error) {
 	return nil, nil
 }
 

--- a/internal/services/management_audit_test.go
+++ b/internal/services/management_audit_test.go
@@ -59,8 +59,18 @@ func (f *fakeMgmtChannelRepo) GetChannels(_ context.Context, _ string) ([]types.
 func (f *fakeMgmtChannelRepo) GetChannelBranchMapping(_ context.Context, _ string, _ string) (*expo.ChannelMapping, error) {
 	return nil, nil
 }
+func (f *fakeMgmtChannelRepo) GetBranchSurfing(_ context.Context, _ string, _ string) (*types.BranchSurfing, error) {
+	return &types.BranchSurfing{}, nil
+}
+func (f *fakeMgmtChannelRepo) SetBranchSurfing(_ context.Context, _ string, _ string, _ types.BranchSurfing) error {
+	return nil
+}
 
 type fakeMgmtBranchRepo struct{}
+
+func (f *fakeMgmtBranchRepo) GetSurfableBranches(_ context.Context, _ string, _ string) ([]types.SurfableBranch, error) {
+	return nil, nil
+}
 
 func (f *fakeMgmtBranchRepo) InsertBranch(_ context.Context, _ pgdb.InsertBranchParams) (int64, error) {
 	return 7, nil

--- a/internal/services/protocol_cache.go
+++ b/internal/services/protocol_cache.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"strings"
 	"xprem/config"
 	cache2 "xprem/internal/cache"
 	"xprem/internal/providers/expo"
@@ -120,22 +121,26 @@ func (s *ExpoProtocolService) channelBranchMapping(ctx context.Context, appId st
 // branchSurfingEnabled answers whether the channel lets devices ask for another
 // branch. It is on the manifest hot path, so it never fails the poll: any error,
 // and stateless mode where the setting does not exist, answer false.
-func (s *ExpoProtocolService) branchSurfingEnabled(ctx context.Context, appId string, channelName string) bool {
+func (s *ExpoProtocolService) branchSurfingEnabled(ctx context.Context, appId string, channelName string) (bool, string) {
 	if !config.IsDBMode() || channelName == "" {
-		return false
+		return false, ""
 	}
 	surfingCache := cache2.GetCache()
 	cacheKey := channelBranchSurfingCacheKey(appId, channelName)
+	// "<0|1>:<pattern>". A value without the separator predates this format, so
+	// it falls through to the read below, which rewrites it.
 	if cached := surfingCache.Get(cacheKey); cached != "" {
-		return cached == "1"
+		if enabled, pattern, ok := strings.Cut(cached, ":"); ok {
+			return enabled == "1", pattern
+		}
 	}
 	surfing, err := s.channelRepo.GetBranchSurfing(ctx, appId, channelName)
 	if err != nil || surfing == nil {
-		return false
+		return false, ""
 	}
 	ttl := channelBranchSurfingCacheTTLSeconds
-	_ = surfingCache.Set(cacheKey, boolCacheValue(surfing.Enabled), &ttl)
-	return surfing.Enabled
+	_ = surfingCache.Set(cacheKey, boolCacheValue(surfing.Enabled)+":"+surfing.Pattern, &ttl)
+	return surfing.Enabled, surfing.Pattern
 }
 
 // invalidateBranchSurfingCache drops the delivery-path entry a setting write

--- a/internal/services/protocol_cache.go
+++ b/internal/services/protocol_cache.go
@@ -29,6 +29,10 @@ const (
 	// the cache is shared: with a local cache and several replicas, the write
 	// clears one process and the TTL bounds the rest.
 	channelBranchSurfingCacheTTLSeconds = 30
+	// Every launch of every build carrying the picker reads the branch list, so
+	// this one absorbs a fleet-wide boot rather than operator edits. Short enough
+	// that a publish shows up the next time a tester opens the panel.
+	surfableBranchesCacheTTLSeconds = 15
 )
 
 func appConfigCacheKey(appId string) string {
@@ -45,6 +49,29 @@ func channelMappingCacheKey(appId string, channelName string) string {
 
 func channelBranchSurfingCacheKey(appId string, channelName string) string {
 	return fmt.Sprintf("channel-branch-surfing:%s:%s:%s", version.Version, appId, channelName)
+}
+
+// Keyed without the channel: the list is per app and runtime version, and the
+// channel's pattern filters it afterwards, so channels share one entry.
+func surfableBranchesCacheKey(appId string, runtimeVersion string) string {
+	return fmt.Sprintf("surfable-branches:%s:%s:%s", version.Version, appId, runtimeVersion)
+}
+
+func cachedSurfableBranches(ctx context.Context, branchRepo BranchRepository, appId string, runtimeVersion string) ([]types.SurfableBranch, error) {
+	branchCache := cache2.GetCache()
+	cacheKey := surfableBranchesCacheKey(appId, runtimeVersion)
+	if branches, ok := cache2.GetJSON[[]types.SurfableBranch](branchCache, cacheKey); ok {
+		return branches, nil
+	}
+	branches, err := branchRepo.GetSurfableBranches(ctx, appId, runtimeVersion)
+	if err != nil {
+		return nil, err
+	}
+	ttl := surfableBranchesCacheTTLSeconds
+	// An empty answer is cached too: a runtime version with nothing built for it
+	// is exactly the request an attacker repeats.
+	cache2.SetJSON(branchCache, cacheKey, branches, &ttl)
+	return branches, nil
 }
 
 func signatureCacheKey(appId string, keyFingerprint string, contentHash string) string {
@@ -122,6 +149,10 @@ func (s *ExpoProtocolService) channelBranchMapping(ctx context.Context, appId st
 // branch. It is on the manifest hot path, so it never fails the poll: any error,
 // and stateless mode where the setting does not exist, answer false.
 func (s *ExpoProtocolService) branchSurfingEnabled(ctx context.Context, appId string, channelName string) (bool, string) {
+	return cachedBranchSurfing(ctx, s.channelRepo, appId, channelName)
+}
+
+func cachedBranchSurfing(ctx context.Context, channelRepo ChannelRepository, appId string, channelName string) (bool, string) {
 	if !config.IsDBMode() || channelName == "" {
 		return false, ""
 	}
@@ -134,7 +165,7 @@ func (s *ExpoProtocolService) branchSurfingEnabled(ctx context.Context, appId st
 			return enabled == "1", pattern
 		}
 	}
-	surfing, err := s.channelRepo.GetBranchSurfing(ctx, appId, channelName)
+	surfing, err := channelRepo.GetBranchSurfing(ctx, appId, channelName)
 	if err != nil || surfing == nil {
 		return false, ""
 	}
@@ -147,6 +178,14 @@ func (s *ExpoProtocolService) branchSurfingEnabled(ctx context.Context, appId st
 // stales. Best effort: see channelBranchSurfingCacheTTLSeconds.
 func invalidateBranchSurfingCache(appId string, channelName string) {
 	cache2.GetCache().Delete(channelBranchSurfingCacheKey(appId, channelName))
+}
+
+func ForgetBranchSurfing(appId string, channelName string) {
+	invalidateBranchSurfingCache(appId, channelName)
+}
+
+func ForgetSurfableBranches(appId string, runtimeVersion string) {
+	cache2.GetCache().Delete(surfableBranchesCacheKey(appId, runtimeVersion))
 }
 
 func boolCacheValue(value bool) string {

--- a/internal/services/protocol_cache.go
+++ b/internal/services/protocol_cache.go
@@ -51,19 +51,21 @@ func channelBranchSurfingCacheKey(appId string, channelName string) string {
 	return fmt.Sprintf("channel-branch-surfing:%s:%s:%s", version.Version, appId, channelName)
 }
 
-// Keyed without the channel: the list is per app and runtime version, and the
-// channel's pattern filters it afterwards, so channels share one entry.
-func surfableBranchesCacheKey(appId string, runtimeVersion string) string {
-	return fmt.Sprintf("surfable-branches:%s:%s:%s", version.Version, appId, runtimeVersion)
+// Keyed without the channel: the list is per app, runtime version and platform,
+// and the channel's pattern filters it afterwards, so channels share one entry.
+// The platform belongs in the key, not just the query — an iOS answer served to
+// an Android device would offer branches it cannot be given.
+func surfableBranchesCacheKey(appId string, runtimeVersion string, platform string) string {
+	return fmt.Sprintf("surfable-branches:%s:%s:%s:%s", version.Version, appId, runtimeVersion, platform)
 }
 
-func cachedSurfableBranches(ctx context.Context, branchRepo BranchRepository, appId string, runtimeVersion string) ([]types.SurfableBranch, error) {
+func cachedSurfableBranches(ctx context.Context, branchRepo BranchRepository, appId string, runtimeVersion string, platform string) ([]types.SurfableBranch, error) {
 	branchCache := cache2.GetCache()
-	cacheKey := surfableBranchesCacheKey(appId, runtimeVersion)
+	cacheKey := surfableBranchesCacheKey(appId, runtimeVersion, platform)
 	if branches, ok := cache2.GetJSON[[]types.SurfableBranch](branchCache, cacheKey); ok {
 		return branches, nil
 	}
-	branches, err := branchRepo.GetSurfableBranches(ctx, appId, runtimeVersion)
+	branches, err := branchRepo.GetSurfableBranches(ctx, appId, runtimeVersion, platform)
 	if err != nil {
 		return nil, err
 	}
@@ -184,8 +186,8 @@ func ForgetBranchSurfing(appId string, channelName string) {
 	invalidateBranchSurfingCache(appId, channelName)
 }
 
-func ForgetSurfableBranches(appId string, runtimeVersion string) {
-	cache2.GetCache().Delete(surfableBranchesCacheKey(appId, runtimeVersion))
+func ForgetSurfableBranches(appId string, runtimeVersion string, platform string) {
+	cache2.GetCache().Delete(surfableBranchesCacheKey(appId, runtimeVersion, platform))
 }
 
 func boolCacheValue(value bool) string {

--- a/internal/services/protocol_cache.go
+++ b/internal/services/protocol_cache.go
@@ -174,10 +174,22 @@ func cachedBranchSurfing(ctx context.Context, channelRepo ChannelRepository, app
 		}
 	}
 	surfing, err := channelRepo.GetBranchSurfing(ctx, appId, channelName)
-	if err != nil || surfing == nil {
+	if err != nil {
+		// Deliberately not cached: an error is not an answer, and caching one
+		// would keep a channel dark for the whole TTL after the database
+		// recovers. Costs a read per poll only while the database is down.
 		return false, ""
 	}
 	ttl := channelBranchSurfingCacheTTLSeconds
+	if surfing == nil {
+		// A channel that does not exist is cached exactly like one with surfing
+		// off. Leaving it uncached made the two observably different: the
+		// disabled channel answered from memory and the unknown one hit
+		// Postgres, so response time told an unauthenticated caller which
+		// channel names exist — and let it drive an unbounded read per request.
+		_ = surfingCache.Set(cacheKey, boolCacheValue(false)+":", &ttl)
+		return false, ""
+	}
 	_ = surfingCache.Set(cacheKey, boolCacheValue(surfing.Enabled)+":"+surfing.Pattern, &ttl)
 	return surfing.Enabled, surfing.Pattern
 }

--- a/internal/services/protocol_cache.go
+++ b/internal/services/protocol_cache.go
@@ -24,6 +24,10 @@ const (
 	// 5s keeps a channel remap or rollout promote near-instant for devices.
 	channelMappingCacheTTLSeconds = 5
 	updateTypeCacheTTLSeconds     = 10
+	// Unlike its neighbours this key IS invalidated on write, but only where
+	// the cache is shared: with a local cache and several replicas, the write
+	// clears one process and the TTL bounds the rest.
+	channelBranchSurfingCacheTTLSeconds = 30
 )
 
 func appConfigCacheKey(appId string) string {
@@ -36,6 +40,10 @@ func updateTypeCacheKey(update types.Update) string {
 
 func channelMappingCacheKey(appId string, channelName string) string {
 	return fmt.Sprintf("channel-mapping:%s:%s:%s", version.Version, appId, channelName)
+}
+
+func channelBranchSurfingCacheKey(appId string, channelName string) string {
+	return fmt.Sprintf("channel-branch-surfing:%s:%s:%s", version.Version, appId, channelName)
 }
 
 func signatureCacheKey(appId string, keyFingerprint string, contentHash string) string {
@@ -107,4 +115,38 @@ func (s *ExpoProtocolService) channelBranchMapping(ctx context.Context, appId st
 	ttl := channelMappingCacheTTLSeconds
 	cache2.SetJSON(mappingCache, cacheKey, mapping, &ttl)
 	return mapping, nil
+}
+
+// branchSurfingEnabled answers whether the channel lets devices ask for another
+// branch. It is on the manifest hot path, so it never fails the poll: any error,
+// and stateless mode where the setting does not exist, answer false.
+func (s *ExpoProtocolService) branchSurfingEnabled(ctx context.Context, appId string, channelName string) bool {
+	if !config.IsDBMode() || channelName == "" {
+		return false
+	}
+	surfingCache := cache2.GetCache()
+	cacheKey := channelBranchSurfingCacheKey(appId, channelName)
+	if cached := surfingCache.Get(cacheKey); cached != "" {
+		return cached == "1"
+	}
+	surfing, err := s.channelRepo.GetBranchSurfing(ctx, appId, channelName)
+	if err != nil || surfing == nil {
+		return false
+	}
+	ttl := channelBranchSurfingCacheTTLSeconds
+	_ = surfingCache.Set(cacheKey, boolCacheValue(surfing.Enabled), &ttl)
+	return surfing.Enabled
+}
+
+// invalidateBranchSurfingCache drops the delivery-path entry a setting write
+// stales. Best effort: see channelBranchSurfingCacheTTLSeconds.
+func invalidateBranchSurfingCache(appId string, channelName string) {
+	cache2.GetCache().Delete(channelBranchSurfingCacheKey(appId, channelName))
+}
+
+func boolCacheValue(value bool) string {
+	if value {
+		return "1"
+	}
+	return "0"
 }

--- a/internal/services/protocol_cache.go
+++ b/internal/services/protocol_cache.go
@@ -133,12 +133,18 @@ func (s *ExpoProtocolService) cachedUpdateType(ctx context.Context, update types
 // reach devices.
 // An unknown or unmapped channel (nil) is never cached.
 func (s *ExpoProtocolService) channelBranchMapping(ctx context.Context, appId string, channelName string) (*expo.ChannelMapping, error) {
+	return cachedChannelMapping(ctx, s.channelRepo, appId, channelName)
+}
+
+// cachedChannelMapping is channelBranchMapping without the service, so the
+// branch list can read the same entry the delivery path already fills.
+func cachedChannelMapping(ctx context.Context, channelRepo ChannelRepository, appId string, channelName string) (*expo.ChannelMapping, error) {
 	mappingCache := cache2.GetCache()
 	cacheKey := channelMappingCacheKey(appId, channelName)
 	if mapping, ok := cache2.GetJSON[expo.ChannelMapping](mappingCache, cacheKey); ok {
 		return &mapping, nil
 	}
-	mapping, err := s.channelRepo.GetChannelBranchMapping(ctx, appId, channelName)
+	mapping, err := channelRepo.GetChannelBranchMapping(ctx, appId, channelName)
 	if err != nil || mapping == nil {
 		return mapping, err
 	}

--- a/internal/services/protocol_cache_test.go
+++ b/internal/services/protocol_cache_test.go
@@ -33,11 +33,23 @@ func TestPayloadCacheKeysEmbedReleaseVersion(t *testing.T) {
 type countingChannelRepo struct {
 	*fakeChannelRepo
 	calls int
+	// surfingReads counts branch-surfing lookups, which is what tells a cache
+	// hit from a miss; surfingErr makes the repository fail.
+	surfingReads int
+	surfingErr   error
 }
 
 func (r *countingChannelRepo) GetChannelBranchMapping(ctx context.Context, appId, channelName string) (*expo.ChannelMapping, error) {
 	r.calls++
 	return r.fakeChannelRepo.GetChannelBranchMapping(ctx, appId, channelName)
+}
+
+func (r *countingChannelRepo) GetBranchSurfing(ctx context.Context, appId, channelName string) (*types.BranchSurfing, error) {
+	r.surfingReads++
+	if r.surfingErr != nil {
+		return nil, r.surfingErr
+	}
+	return r.fakeChannelRepo.GetBranchSurfing(ctx, appId, channelName)
 }
 
 func TestChannelBranchMappingCache(t *testing.T) {

--- a/internal/services/rollout_resolution_test.go
+++ b/internal/services/rollout_resolution_test.go
@@ -421,6 +421,28 @@ func (r *fakeRolloutRepo) ClearUpdateRollout(_ context.Context, appId, branchNam
 
 type fakeChannelRepo struct {
 	mappings map[string]*expo.ChannelMapping
+	// surfing is the branch-surfing setting GetBranchSurfing answers with, per
+	// channel name. A channel absent from the map does not exist.
+	surfing map[string]*types.BranchSurfing
+	// surfingWrites records what SetBranchSurfing was handed.
+	surfingWrites map[string]types.BranchSurfing
+}
+
+func (r *fakeChannelRepo) GetBranchSurfing(_ context.Context, _, channelName string) (*types.BranchSurfing, error) {
+	setting, ok := r.surfing[channelName]
+	if !ok {
+		return nil, nil
+	}
+	settingCopy := *setting
+	return &settingCopy, nil
+}
+
+func (r *fakeChannelRepo) SetBranchSurfing(_ context.Context, _, channelName string, surfing types.BranchSurfing) error {
+	if r.surfingWrites == nil {
+		r.surfingWrites = map[string]types.BranchSurfing{}
+	}
+	r.surfingWrites[channelName] = surfing
+	return nil
 }
 
 func (r *fakeChannelRepo) InsertChannel(_ context.Context, _ string, _ *int64, _ string) (int64, error) {
@@ -466,7 +488,14 @@ func (fakeAppRepo) GetAppByID(_ context.Context, _ string) (config.AppConfig, er
 	return config.AppConfig{}, nil
 }
 
-type fakeBranchRepo struct{}
+type fakeBranchRepo struct {
+	// surfable is what GetSurfableBranches answers with, per runtime version.
+	surfable map[string][]types.SurfableBranch
+}
+
+func (r fakeBranchRepo) GetSurfableBranches(_ context.Context, _, runtimeVersion string) ([]types.SurfableBranch, error) {
+	return r.surfable[runtimeVersion], nil
+}
 
 func (fakeBranchRepo) InsertBranch(_ context.Context, _ pgdb.InsertBranchParams) (int64, error) {
 	return 0, nil

--- a/internal/services/rollout_resolution_test.go
+++ b/internal/services/rollout_resolution_test.go
@@ -58,9 +58,27 @@ type fakeStoredUpdate struct {
 }
 
 type fakeUpdateRepo struct {
-	mu     sync.Mutex
-	rows   []*fakeStoredUpdate
-	events *eventLog
+	mu   sync.Mutex
+	rows []*fakeStoredUpdate
+	// uuidReads counts GetUpdateByUUID calls, which is how a test tells a lookup
+	// that ran from one that was skipped.
+	uuidReads int
+	events    *eventLog
+}
+
+// setUUID stamps the persistent UUID of an already seeded row.
+func (r *fakeUpdateRepo) setUUID(appId, branchName, updateId, updateUUID string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if row := r.findRowLocked(appId, branchName, updateId); row != nil {
+		row.updateUUID = updateUUID
+	}
+}
+
+func (r *fakeUpdateRepo) uuidLookups() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.uuidReads
 }
 
 func (r *fakeUpdateRepo) findRowLocked(appId, branchName, updateId string) *fakeStoredUpdate {
@@ -185,6 +203,7 @@ func (r *fakeUpdateRepo) GetLatestUpdateWithRollout(_ context.Context, appId, br
 func (r *fakeUpdateRepo) GetUpdateByUUID(_ context.Context, appId, updateUUID string) (*types.Update, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	r.uuidReads++
 	for _, row := range r.rows {
 		if row.update.AppId == appId && row.updateUUID == updateUUID && row.checked {
 			updateCopy := row.update

--- a/internal/services/rollout_resolution_test.go
+++ b/internal/services/rollout_resolution_test.go
@@ -512,7 +512,7 @@ type fakeBranchRepo struct {
 	surfable map[string][]types.SurfableBranch
 }
 
-func (r fakeBranchRepo) GetSurfableBranches(_ context.Context, _, runtimeVersion string) ([]types.SurfableBranch, error) {
+func (r fakeBranchRepo) GetSurfableBranches(_ context.Context, _, runtimeVersion string, _ string) ([]types.SurfableBranch, error) {
 	return r.surfable[runtimeVersion], nil
 }
 

--- a/internal/store/branch_bucket.go
+++ b/internal/store/branch_bucket.go
@@ -36,7 +36,7 @@ func (s *BucketBranchStore) DeleteBranchByName(ctx context.Context, appId string
 	return fmt.Errorf("branch deletion is only supported in db mode")
 }
 
-func (s *BucketBranchStore) GetSurfableBranches(ctx context.Context, appId string, runtimeVersion string) ([]types.SurfableBranch, error) {
+func (s *BucketBranchStore) GetSurfableBranches(ctx context.Context, appId string, runtimeVersion string, platform string) ([]types.SurfableBranch, error) {
 	return nil, ErrNotSupportedInStatelessMode
 }
 

--- a/internal/store/branch_bucket.go
+++ b/internal/store/branch_bucket.go
@@ -36,6 +36,10 @@ func (s *BucketBranchStore) DeleteBranchByName(ctx context.Context, appId string
 	return fmt.Errorf("branch deletion is only supported in db mode")
 }
 
+func (s *BucketBranchStore) GetSurfableBranches(ctx context.Context, appId string, runtimeVersion string) ([]types.SurfableBranch, error) {
+	return nil, ErrNotSupportedInStatelessMode
+}
+
 func (s *BucketBranchStore) GetBranches(ctx context.Context, appId string) ([]types.BranchMapping, error) {
 	allBranches, err := s.bucket.GetBranches(appId)
 	if err != nil {

--- a/internal/store/branch_postgres.go
+++ b/internal/store/branch_postgres.go
@@ -71,6 +71,25 @@ func (s *PostgresBranchStore) DeleteBranchByName(ctx context.Context, appId stri
 	return nil
 }
 
+func (s *PostgresBranchStore) GetSurfableBranches(ctx context.Context, appId string, runtimeVersion string) ([]types.SurfableBranch, error) {
+	pgAppID := ToPgUUID(appId)
+	rows, err := s.engine.Queries.GetSurfableBranches(ctx, pgdb.GetSurfableBranchesParams{
+		AppID:   pgAppID,
+		Version: runtimeVersion,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve surfable branches from database: %w", err)
+	}
+	branches := make([]types.SurfableBranch, len(rows))
+	for i, row := range rows {
+		branches[i] = types.SurfableBranch{
+			Name:         row.BranchName,
+			LastUpdateAt: row.LastUpdateAt.Time.UTC().Format(time.RFC3339),
+		}
+	}
+	return branches, nil
+}
+
 func (s *PostgresBranchStore) GetBranches(ctx context.Context, appId string) ([]types.BranchMapping, error) {
 	pgAppID := ToPgUUID(appId)
 	appBranches, err := s.engine.Queries.GetBranchesByAppID(ctx, pgAppID)

--- a/internal/store/branch_postgres.go
+++ b/internal/store/branch_postgres.go
@@ -71,11 +71,12 @@ func (s *PostgresBranchStore) DeleteBranchByName(ctx context.Context, appId stri
 	return nil
 }
 
-func (s *PostgresBranchStore) GetSurfableBranches(ctx context.Context, appId string, runtimeVersion string) ([]types.SurfableBranch, error) {
+func (s *PostgresBranchStore) GetSurfableBranches(ctx context.Context, appId string, runtimeVersion string, platform string) ([]types.SurfableBranch, error) {
 	pgAppID := ToPgUUID(appId)
 	rows, err := s.engine.Queries.GetSurfableBranches(ctx, pgdb.GetSurfableBranchesParams{
-		AppID:   pgAppID,
-		Version: runtimeVersion,
+		AppID:    pgAppID,
+		Version:  runtimeVersion,
+		Platform: platform,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to retrieve surfable branches from database: %w", err)

--- a/internal/store/channel_branch_surfing_postgres_test.go
+++ b/internal/store/channel_branch_surfing_postgres_test.go
@@ -1,0 +1,162 @@
+// Integration tests for the branch-surfing SQL: the channel setting round trip and
+// GetSurfableBranches, whose GROUP BY / MAX() and runtime-version scoping the
+// in-memory fakes cannot exercise. Same harness as branch_postgres_test.go: they skip
+// unless TEST_DATABASE_URL is set.
+package store_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"xprem/internal/database"
+	"xprem/internal/database/postgres/pgdb"
+	"xprem/internal/store"
+	"xprem/internal/types"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func setupChannelStore(t *testing.T) (*store.PostgresChannelStore, *pgxpool.Pool) {
+	t.Helper()
+	_, pool := setupBranchStore(t)
+	return store.NewPostgresChannelStore(&database.Engine{Queries: pgdb.New(pool), DB: pool}), pool
+}
+
+func insertChannel(t *testing.T, pool *pgxpool.Pool, appId, channelName string) {
+	t.Helper()
+	_, err := pool.Exec(context.Background(),
+		"INSERT INTO channels (app_id, name) VALUES ($1, $2)", appId, channelName)
+	require.NoError(t, err)
+}
+
+// seedUpdate puts one published update on a branch for a runtime version. createdAt is
+// explicit so the ordering assertions do not depend on insertion speed.
+func seedUpdate(t *testing.T, pool *pgxpool.Pool, appId, branchName, runtimeVersion string, id int64, createdAt time.Time) {
+	t.Helper()
+	ctx := context.Background()
+	var branchId int64
+	require.NoError(t, pool.QueryRow(ctx,
+		`INSERT INTO branches (app_id, name) VALUES ($1, $2)
+		 ON CONFLICT (app_id, name) DO UPDATE SET name = EXCLUDED.name RETURNING id`,
+		appId, branchName).Scan(&branchId))
+
+	var runtimeVersionId int64
+	require.NoError(t, pool.QueryRow(ctx,
+		`INSERT INTO runtime_versions (app_id, version) VALUES ($1, $2)
+		 ON CONFLICT (app_id, version) DO UPDATE SET version = EXCLUDED.version RETURNING id`,
+		appId, runtimeVersion).Scan(&runtimeVersionId))
+
+	_, err := pool.Exec(ctx,
+		`INSERT INTO updates (id, branch_id, runtime_version_id, update_type, commit_hash, platform, created_at, checked_at)
+		 VALUES ($1, $2, $3, 0, 'deadbeef', 'ios', $4, $4)`,
+		id, branchId, runtimeVersionId, createdAt)
+	require.NoError(t, err)
+}
+
+func TestBranchSurfingSettingRoundTrip(t *testing.T) {
+	channelStore, pool := setupChannelStore(t)
+	ctx := context.Background()
+	appId := insertAppWithBranch(t, pool, "staging", false)
+	insertChannel(t, pool, appId, "qa")
+
+	// A channel starts closed, exposing everything only once opened.
+	initial, err := channelStore.GetBranchSurfing(ctx, appId, "qa")
+	require.NoError(t, err)
+	require.NotNil(t, initial)
+	assert.Equal(t, types.BranchSurfing{Enabled: false, Pattern: "*"}, *initial)
+
+	require.NoError(t, channelStore.SetBranchSurfing(ctx, appId, "qa",
+		types.BranchSurfing{Enabled: true, Pattern: "pr-*"}))
+
+	updated, err := channelStore.GetBranchSurfing(ctx, appId, "qa")
+	require.NoError(t, err)
+	require.NotNil(t, updated)
+	assert.Equal(t, types.BranchSurfing{Enabled: true, Pattern: "pr-*"}, *updated)
+}
+
+// An unknown channel is (nil, nil), not an error: the caller turns that into the same
+// 404 a disabled channel gets.
+func TestGetBranchSurfingOnUnknownChannel(t *testing.T) {
+	channelStore, pool := setupChannelStore(t)
+	appId := insertAppWithBranch(t, pool, "staging", false)
+
+	surfing, err := channelStore.GetBranchSurfing(context.Background(), appId, "ghost")
+
+	require.NoError(t, err)
+	assert.Nil(t, surfing)
+}
+
+func TestSetBranchSurfingOnUnknownChannel(t *testing.T) {
+	channelStore, pool := setupChannelStore(t)
+	appId := insertAppWithBranch(t, pool, "staging", false)
+
+	err := channelStore.SetBranchSurfing(context.Background(), appId, "ghost",
+		types.BranchSurfing{Enabled: true, Pattern: "*"})
+
+	notFoundErr := (*store.ErrResourceNotFound)(nil)
+	assert.ErrorAs(t, err, &notFoundErr)
+}
+
+func TestGetSurfableBranchesScopesToRuntimeVersionAndOrdersByRecency(t *testing.T) {
+	branchStore, pool := setupBranchStore(t)
+	ctx := context.Background()
+	appId := insertAppWithBranch(t, pool, "staging", false)
+	base := time.Date(2026, 8, 1, 10, 0, 0, 0, time.UTC)
+
+	seedUpdate(t, pool, appId, "pr-31", "3.0.0", 1, base)
+	seedUpdate(t, pool, appId, "pr-482", "3.0.0", 2, base.Add(2*time.Hour))
+	// Two updates on one branch: MAX() must report the newest, and the branch must
+	// appear once.
+	seedUpdate(t, pool, appId, "pr-482", "3.0.0", 3, base.Add(4*time.Hour))
+	// Another runtime version, invisible to a 3.0.0 device.
+	seedUpdate(t, pool, appId, "legacy", "2.0.0", 4, base.Add(6*time.Hour))
+
+	branches, err := branchStore.GetSurfableBranches(ctx, appId, "3.0.0")
+
+	require.NoError(t, err)
+	assert.Equal(t, []types.SurfableBranch{
+		{Name: "pr-482", LastUpdateAt: base.Add(4 * time.Hour).Format(time.RFC3339)},
+		{Name: "pr-31", LastUpdateAt: base.Format(time.RFC3339)},
+	}, branches)
+}
+
+// A branch whose only update was never checked has nothing servable on it, so it is
+// not a surfing target.
+func TestGetSurfableBranchesSkipsUncheckedUpdates(t *testing.T) {
+	branchStore, pool := setupBranchStore(t)
+	ctx := context.Background()
+	appId := insertAppWithBranch(t, pool, "staging", false)
+	seedUpdate(t, pool, appId, "pr-482", "3.0.0", 1, time.Date(2026, 8, 1, 10, 0, 0, 0, time.UTC))
+	_, err := pool.Exec(ctx, "UPDATE updates SET checked_at = NULL")
+	require.NoError(t, err)
+
+	branches, err := branchStore.GetSurfableBranches(ctx, appId, "3.0.0")
+
+	require.NoError(t, err)
+	assert.Empty(t, branches)
+}
+
+// Version strings are unique per app, not globally: another tenant's 3.0.0 must not
+// leak its branches into this app's list.
+func TestGetSurfableBranchesIsScopedToTheApp(t *testing.T) {
+	branchStore, pool := setupBranchStore(t)
+	ctx := context.Background()
+	base := time.Date(2026, 8, 1, 10, 0, 0, 0, time.UTC)
+	mine := insertAppWithBranch(t, pool, "staging", false)
+	theirs := uuid.NewString()
+	_, err := pool.Exec(ctx, "INSERT INTO apps (id, name) VALUES ($1, $2)", theirs, "other")
+	require.NoError(t, err)
+
+	seedUpdate(t, pool, mine, "pr-1", "3.0.0", 1, base)
+	seedUpdate(t, pool, theirs, "pr-2", "3.0.0", 2, base)
+
+	branches, err := branchStore.GetSurfableBranches(ctx, mine, "3.0.0")
+
+	require.NoError(t, err)
+	require.Len(t, branches, 1)
+	assert.Equal(t, "pr-1", branches[0].Name)
+}

--- a/internal/store/channel_branch_surfing_postgres_test.go
+++ b/internal/store/channel_branch_surfing_postgres_test.go
@@ -116,7 +116,7 @@ func TestGetSurfableBranchesScopesToRuntimeVersionAndOrdersByRecency(t *testing.
 	// Another runtime version, invisible to a 3.0.0 device.
 	seedUpdate(t, pool, appId, "legacy", "2.0.0", 4, base.Add(6*time.Hour))
 
-	branches, err := branchStore.GetSurfableBranches(ctx, appId, "3.0.0")
+	branches, err := branchStore.GetSurfableBranches(ctx, appId, "3.0.0", "ios")
 
 	require.NoError(t, err)
 	assert.Equal(t, []types.SurfableBranch{
@@ -135,7 +135,7 @@ func TestGetSurfableBranchesSkipsUncheckedUpdates(t *testing.T) {
 	_, err := pool.Exec(ctx, "UPDATE updates SET checked_at = NULL")
 	require.NoError(t, err)
 
-	branches, err := branchStore.GetSurfableBranches(ctx, appId, "3.0.0")
+	branches, err := branchStore.GetSurfableBranches(ctx, appId, "3.0.0", "ios")
 
 	require.NoError(t, err)
 	assert.Empty(t, branches)
@@ -155,7 +155,7 @@ func TestGetSurfableBranchesIsScopedToTheApp(t *testing.T) {
 	seedUpdate(t, pool, mine, "pr-1", "3.0.0", 1, base)
 	seedUpdate(t, pool, theirs, "pr-2", "3.0.0", 2, base)
 
-	branches, err := branchStore.GetSurfableBranches(ctx, mine, "3.0.0")
+	branches, err := branchStore.GetSurfableBranches(ctx, mine, "3.0.0", "ios")
 
 	require.NoError(t, err)
 	require.Len(t, branches, 1)

--- a/internal/store/channel_branch_surfing_postgres_test.go
+++ b/internal/store/channel_branch_surfing_postgres_test.go
@@ -63,11 +63,12 @@ func TestBranchSurfingSettingRoundTrip(t *testing.T) {
 	appId := insertAppWithBranch(t, pool, "staging", false)
 	insertChannel(t, pool, appId, "qa")
 
-	// A channel starts closed, exposing everything only once opened.
+	// A channel starts closed AND with a pattern that names nothing: the default
+	// decides what a first careless click would expose, so it must not be "*".
 	initial, err := channelStore.GetBranchSurfing(ctx, appId, "qa")
 	require.NoError(t, err)
 	require.NotNil(t, initial)
-	assert.Equal(t, types.BranchSurfing{Enabled: false, Pattern: "*"}, *initial)
+	assert.Equal(t, types.BranchSurfing{Enabled: false, Pattern: ""}, *initial)
 
 	require.NoError(t, channelStore.SetBranchSurfing(ctx, appId, "qa",
 		types.BranchSurfing{Enabled: true, Pattern: "pr-*"}))

--- a/internal/store/channel_bucket.go
+++ b/internal/store/channel_bucket.go
@@ -63,3 +63,11 @@ func (s *BucketChannelStore) GetChannels(ctx context.Context, appId string) ([]t
 func (s *BucketChannelStore) GetChannelBranchMapping(ctx context.Context, appId string, channelName string) (*expo.ChannelMapping, error) {
 	return expo.FetchChannelMapping(appId, channelName)
 }
+
+func (s *BucketChannelStore) GetBranchSurfing(ctx context.Context, appId string, channelName string) (*types.BranchSurfing, error) {
+	return nil, ErrNotSupportedInStatelessMode
+}
+
+func (s *BucketChannelStore) SetBranchSurfing(ctx context.Context, appId string, channelName string, surfing types.BranchSurfing) error {
+	return ErrNotSupportedInStatelessMode
+}

--- a/internal/store/channel_postgres.go
+++ b/internal/store/channel_postgres.go
@@ -99,6 +99,10 @@ func (s *PostgresChannelStore) GetChannels(ctx context.Context, appId string) ([
 				channel.RolloutBranchCurrentUpdateCreatedAt,
 				channel.RolloutBranchCurrentRolloutPercentage,
 			),
+			BranchSurfing: &types.BranchSurfing{
+				Enabled: channel.BranchSurfingEnabled,
+				Pattern: channel.BranchSurfingPattern,
+			},
 		}
 		if channel.RolloutID.Valid && channel.BranchName != nil && channel.RolloutBranchName != nil && channel.RolloutPercentage != nil {
 			mapping.Rollout = &types.ChannelRollout{

--- a/internal/store/channel_postgres.go
+++ b/internal/store/channel_postgres.go
@@ -116,6 +116,43 @@ func (s *PostgresChannelStore) GetChannels(ctx context.Context, appId string) ([
 	return channels, nil
 }
 
+func (s *PostgresChannelStore) GetBranchSurfing(ctx context.Context, appId string, channelName string) (*types.BranchSurfing, error) {
+	pgAppID := ToPgUUID(appId)
+	row, err := s.engine.Queries.GetChannelBranchSurfing(ctx, pgdb.GetChannelBranchSurfingParams{
+		AppID: pgAppID,
+		Name:  channelName,
+	})
+	if err != nil {
+		// An unknown channel is a 404 for the caller, not a server error; match
+		// GetChannelBranchMapping's (nil, nil).
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to retrieve channel branch surfing from database: %w", err)
+	}
+	return &types.BranchSurfing{
+		Enabled: row.BranchSurfingEnabled,
+		Pattern: row.BranchSurfingPattern,
+	}, nil
+}
+
+func (s *PostgresChannelStore) SetBranchSurfing(ctx context.Context, appId string, channelName string, surfing types.BranchSurfing) error {
+	pgAppID := ToPgUUID(appId)
+	commandTag, err := s.engine.Queries.UpdateChannelBranchSurfing(ctx, pgdb.UpdateChannelBranchSurfingParams{
+		AppID:                pgAppID,
+		Name:                 channelName,
+		BranchSurfingEnabled: surfing.Enabled,
+		BranchSurfingPattern: surfing.Pattern,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to update channel branch surfing in database: %w", err)
+	}
+	if commandTag.RowsAffected() == 0 {
+		return &ErrResourceNotFound{Resource: "channel", Identifier: fmt.Sprintf("%s (appId: %s)", channelName, appId)}
+	}
+	return nil
+}
+
 func (s *PostgresChannelStore) GetUpdatesByRunTimeVersionAndBranchName(ctx context.Context, appId string, runtimeVersion string, branchName string) ([]pgdb.GetUpdatesByByBranchNameAndRuntimeVersionRow, error) {
 	pgAppID := ToPgUUID(appId)
 	return s.engine.Queries.GetUpdatesByByBranchNameAndRuntimeVersion(ctx, pgdb.GetUpdatesByByBranchNameAndRuntimeVersionParams{

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -138,21 +138,9 @@ type ManifestAsset struct {
 }
 
 type ExtraManifestData struct {
-	ExpoClient json.RawMessage `json:"expoClient"`
-	Branch     string          `json:"branch"`
-	// BranchSurfing tells the app whether the channel it polls lets it ask for
-	// another branch, so it can show the picker without a second call. It is a
-	// property of the CHANNEL, while the manifest is cached per branch, so it is
-	// stamped on the served copy rather than composed into the cached one.
-	//
-	// omitempty on purpose: a deployment with the feature off serves the exact
-	// bytes it served before, which keeps the signed payload unchanged.
-	BranchSurfing bool `json:"branchSurfing,omitempty"`
-	// BranchSurfingRefused names the branch the device asked for and did not get,
-	// because the update it would have received failed to launch on it. The only
-	// channel the app can read: expo-server-defined-headers is stored natively
-	// and never surfaced to JS.
-	BranchSurfingRefused string `json:"branchSurfingRefused,omitempty"`
+	ExpoClient           json.RawMessage `json:"expoClient"`
+	Branch               string          `json:"branch"`
+	BranchSurfingRefused string          `json:"branchSurfingRefused,omitempty"`
 }
 
 type UpdateManifest struct {
@@ -252,6 +240,14 @@ type BranchSurfing struct {
 }
 
 // SurfableBranch is one entry of the branch list a device may surf to.
+// SurfableBranchList is the answer to a device's branch list request. Total
+// counts every branch that matched, so a client showing a truncated page can say
+// so instead of pretending the list is complete.
+type SurfableBranchList struct {
+	Branches []SurfableBranch `json:"branches"`
+	Total    int              `json:"total"`
+}
+
 type SurfableBranch struct {
 	Name         string `json:"name"`
 	LastUpdateAt string `json:"lastUpdateAt"`

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -140,6 +140,14 @@ type ManifestAsset struct {
 type ExtraManifestData struct {
 	ExpoClient json.RawMessage `json:"expoClient"`
 	Branch     string          `json:"branch"`
+	// BranchSurfing tells the app whether the channel it polls lets it ask for
+	// another branch, so it can show the picker without a second call. It is a
+	// property of the CHANNEL, while the manifest is cached per branch, so it is
+	// stamped on the served copy rather than composed into the cached one.
+	//
+	// omitempty on purpose: a deployment with the feature off serves the exact
+	// bytes it served before, which keeps the signed payload unchanged.
+	BranchSurfing bool `json:"branchSurfing,omitempty"`
 }
 
 type UpdateManifest struct {

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -224,6 +224,9 @@ type ChannelMapping struct {
 	RolloutBranchCurrentUpdate *BranchUpdateState `json:"rolloutBranchCurrentUpdate,omitempty"`
 	// Active channel rollout, if any (control-plane mode only); nil otherwise.
 	Rollout *ChannelRollout `json:"rollout,omitempty"`
+	// Branch-surfing setting of the channel; nil in stateless mode, where the
+	// setting does not exist.
+	BranchSurfing *BranchSurfing `json:"branchSurfing,omitempty"`
 }
 
 // BranchSurfing is a channel's branch-surfing setting: whether a device polling

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -226,6 +226,21 @@ type ChannelMapping struct {
 	Rollout *ChannelRollout `json:"rollout,omitempty"`
 }
 
+// BranchSurfing is a channel's branch-surfing setting: whether a device polling
+// the channel may ask to be served a branch other than the mapped one, and
+// which branches it may reach. Pattern uses the "*" wildcard language of
+// branch.MatchPattern.
+type BranchSurfing struct {
+	Enabled bool   `json:"enabled"`
+	Pattern string `json:"pattern"`
+}
+
+// SurfableBranch is one entry of the branch list a device may surf to.
+type SurfableBranch struct {
+	Name         string `json:"name"`
+	LastUpdateAt string `json:"lastUpdateAt"`
+}
+
 type BranchMapping struct {
 	BranchName     string  `json:"branchName"`
 	BranchId       *string `json:"branchId"`

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -148,6 +148,11 @@ type ExtraManifestData struct {
 	// omitempty on purpose: a deployment with the feature off serves the exact
 	// bytes it served before, which keeps the signed payload unchanged.
 	BranchSurfing bool `json:"branchSurfing,omitempty"`
+	// BranchSurfingRefused names the branch the device asked for and did not get,
+	// because the update it would have received failed to launch on it. The only
+	// channel the app can read: expo-server-defined-headers is stored natively
+	// and never surfaced to JS.
+	BranchSurfingRefused string `json:"branchSurfingRefused,omitempty"`
 }
 
 type UpdateManifest struct {

--- a/internal/update/failed_ids.go
+++ b/internal/update/failed_ids.go
@@ -1,0 +1,52 @@
+package update
+
+import (
+	"strings"
+
+	"github.com/google/uuid"
+)
+
+// maxFailedUpdateIDs matches the cap expo-updates applies on its side
+// (SELECT ... WHERE failed_launch_count > 0 ORDER BY commit_time DESC LIMIT 5).
+const maxFailedUpdateIDs = 5
+
+// maxFailedUpdateIDsRaw bounds the header itself, not just the entries kept.
+const maxFailedUpdateIDsRaw = 512
+
+// ParseFailedUpdateIDs reads the Expo-Recent-Failed-Update-IDs header, a
+// quoted-UUID list (RFC 8941 style). Invalid entries are dropped and the
+// result is deduplicated and capped.
+func ParseFailedUpdateIDs(raw string) []string {
+	if raw == "" {
+		return nil
+	}
+	// Bound the input before splitting it: the cap below stops at five VALID
+	// entries, so a header of nothing but invalid ones is walked in full, and Go
+	// accepts request headers up to 1 MiB. Five quoted UUIDs fit in ~200 bytes.
+	if len(raw) > maxFailedUpdateIDsRaw {
+		raw = raw[:maxFailedUpdateIDsRaw]
+	}
+	ids := make([]string, 0, maxFailedUpdateIDs)
+	seen := make(map[string]struct{}, maxFailedUpdateIDs)
+	for _, part := range strings.Split(raw, ",") {
+		part = strings.TrimSpace(part)
+		part = strings.Trim(part, `"`)
+		parsed, err := uuid.Parse(part)
+		if err != nil {
+			continue
+		}
+		id := parsed.String()
+		if _, duplicate := seen[id]; duplicate {
+			continue
+		}
+		seen[id] = struct{}{}
+		ids = append(ids, id)
+		if len(ids) == maxFailedUpdateIDs {
+			break
+		}
+	}
+	if len(ids) == 0 {
+		return nil
+	}
+	return ids
+}

--- a/internal/update/failed_ids_test.go
+++ b/internal/update/failed_ids_test.go
@@ -1,0 +1,20 @@
+package update
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const validUUID = "9f1c1d2e-0000-4000-8000-000000000001"
+
+// The count cap stops at five VALID entries, so filler never trips it: only the
+// input cap keeps a header of nothing but invalid entries from being walked in
+// full. A valid id placed past the boundary must not be reached.
+func TestParseFailedUpdateIDsBoundsTheInput(t *testing.T) {
+	raw := strings.Repeat("not-a-uuid,", maxFailedUpdateIDsRaw) + validUUID
+	assert.Empty(t, ParseFailedUpdateIDs(raw))
+
+	assert.Equal(t, []string{validUUID}, ParseFailedUpdateIDs(`"`+validUUID+`"`))
+}


### PR DESCRIPTION
This PR introduces branch surfing.

It supports an internal test-and-validation flow built on feature branches.
Developers push updates to their feature branches, by hand or from CI — e.g. feat/pr-1 → xprem branch pr-1.
Internal testers can then "surf" between those branches from a single internal release build, in order to validate them.

By internal release build, the idea is to have an internal mirror of the production app in the stores:
com.myapp (production)
com.myapp.uat  (internal)
com.myapp.staging (internal)

These mirrors are real release builds same optimisations, same behaviour as production, no dev-client but they are never submitted for release. They live permanently in pre-release distribution: TestFlight internal groups, Play internal testing tracks, Firebase App Distribution. The separate bundle id also means a tester keeps the production app installed alongside, and each mirror can point at its own backend.

The mirror apps are built against an internal release channel — staging, uat. Those channels can then be flagged in xprem to allow branch surfing.

Authorising it takes two steps, because turning surfing on for a channel without restricting which branches would expose everything on the server to anyone who can guess a branch name.
So a channel has a switch and a pattern — a glob, e.g. pr-*. A request for a branch that doesn't match is ignored: the device gets its normal update, exactly as if it had asked for nothing.
The default pattern is empty, and empty matches nothing, so enabling surfing without setting a pattern gives you nothing at all.

This PR also adds a control center: a package you install in the app, which turns itself on automatically when the build's channel allows branch surfing, and lets a tester switch between branches from inside the app.

<img width="500" height="1087" alt="image" src="https://github.com/user-attachments/assets/f9bf3526-07c7-4178-a7ab-7fd5cf9cf41f" />


An anti-brick mechanism is included as well. If switching to a branch causes a native error, surfing is automatically blocked for that update and the device rolls back to the default branch. The block is per update rather than per branch, so publishing a fix to the same branch makes it available again on its own.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added channel-level branch surfing with configurable wildcard patterns.
  * Added dashboard controls for managing settings and viewing configured branches.
  * Added a mobile control center for browsing, searching, and switching compatible branches.
  * Added runtime- and platform-aware branch discovery.
* **Bug Fixes**
  * Improved fallback behavior when branches are unavailable or updates fail.
  * Added branch-surfing status and refusal details to update responses.
* **Permissions**
  * Added dedicated access controls and audit tracking for branch-surfing changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->