### PR TITLE
feat: Android signing credentials vault

### DIFF
--- a/apps/dashboard/src/ee/lib/auditCatalog.ts
+++ b/apps/dashboard/src/ee/lib/auditCatalog.ts
@@ -72,6 +72,8 @@ export const AUDIT_ACTION_GROUPS: AuditActionGroup[] = [
       'api_key.restrictions_updated',
       'branch_protection.updated',
       'certificate.downloaded',
+      'android_credentials.saved',
+      'android_credentials.deleted',
     ],
   },
   {

--- a/ee/rbac/permissions.go
+++ b/ee/rbac/permissions.go
@@ -58,6 +58,10 @@ const (
 	// the embedded bundle. It is distinct from PermUpdateRolloutManage, which
 	// only reverts a rollout already in progress.
 	PermUpdatePublish Permission = "update:publish"
+	// PermCredentialsManage uploads or deletes the app's store signing
+	// credentials (Android keystore, submit keys). Reading the non-secret
+	// metadata is open to any viewer.
+	PermCredentialsManage Permission = "credentials:manage"
 )
 
 // AllPermissions is the catalog, in the order the dashboard displays it.
@@ -75,6 +79,7 @@ var AllPermissions = []Permission{
 	PermChannelRolloutManage,
 	PermUpdateRolloutManage,
 	PermUpdatePublish,
+	PermCredentialsManage,
 	PermApiKeysManage,
 	PermIdentityManage,
 	PermIdentityRead,

--- a/internal/auditlog/auditlog.go
+++ b/internal/auditlog/auditlog.go
@@ -95,6 +95,8 @@ const (
 	ActionAPIKeyRestrictionsUpdated Action = "api_key.restrictions_updated"
 	ActionBranchProtectionUpdated   Action = "branch_protection.updated"
 	ActionCertificateDownloaded     Action = "certificate.downloaded"
+	ActionAndroidCredentialsSaved   Action = "android_credentials.saved"
+	ActionAndroidCredentialsDeleted Action = "android_credentials.deleted"
 
 	// Access control. permission.denied is the single event for authorization
 	// refusals (the RBAC middleware emits it, with OutcomeDenied); domain

--- a/internal/database/postgres/migrations/20260805120000_android_credentials.sql
+++ b/internal/database/postgres/migrations/20260805120000_android_credentials.sql
@@ -1,0 +1,26 @@
+-- +goose Up
+-- +goose StatementBegin
+
+-- Android signing credentials of an app, one set per app. The keystore and
+-- its passwords are sealed with AES-GCM under the deployment master key,
+-- bound to the app id; only android_package and key_alias are readable as-is.
+CREATE TABLE android_credentials (
+    id UUID PRIMARY KEY,
+    app_id UUID NOT NULL UNIQUE,
+    android_package VARCHAR(255) NOT NULL,
+    key_alias VARCHAR(255) NOT NULL,
+    sealed_keystore TEXT NOT NULL,
+    sealed_keystore_password TEXT NOT NULL,
+    sealed_key_password TEXT NOT NULL,
+    sealed_google_service_account_key TEXT,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT fk_android_credentials_app FOREIGN KEY (app_id) REFERENCES apps(id) ON DELETE CASCADE
+);
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP TABLE IF EXISTS android_credentials;
+-- +goose StatementEnd

--- a/internal/database/postgres/pgdb/models.go
+++ b/internal/database/postgres/pgdb/models.go
@@ -10,6 +10,19 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
+type AndroidCredential struct {
+	ID                            pgtype.UUID        `json:"id"`
+	AppID                         pgtype.UUID        `json:"app_id"`
+	AndroidPackage                string             `json:"android_package"`
+	KeyAlias                      string             `json:"key_alias"`
+	SealedKeystore                string             `json:"sealed_keystore"`
+	SealedKeystorePassword        string             `json:"sealed_keystore_password"`
+	SealedKeyPassword             string             `json:"sealed_key_password"`
+	SealedGoogleServiceAccountKey *string            `json:"sealed_google_service_account_key"`
+	CreatedAt                     pgtype.Timestamptz `json:"created_at"`
+	UpdatedAt                     pgtype.Timestamptz `json:"updated_at"`
+}
+
 type ApiKey struct {
 	ID         int64              `json:"id"`
 	AppID      pgtype.UUID        `json:"app_id"`

--- a/internal/database/postgres/pgdb/queries.sql.go
+++ b/internal/database/postgres/pgdb/queries.sql.go
@@ -465,6 +465,14 @@ func (q *Queries) CountUpdateFailures(ctx context.Context, arg CountUpdateFailur
 	return count, err
 }
 
+const deleteAndroidCredentialsByAppID = `-- name: DeleteAndroidCredentialsByAppID :execresult
+DELETE FROM android_credentials WHERE app_id = $1
+`
+
+func (q *Queries) DeleteAndroidCredentialsByAppID(ctx context.Context, appID pgtype.UUID) (pgconn.CommandTag, error) {
+	return q.db.Exec(ctx, deleteAndroidCredentialsByAppID, appID)
+}
+
 const deleteApiKeyBranchRules = `-- name: DeleteApiKeyBranchRules :exec
 DELETE FROM api_key_branch_rules WHERE api_key_id = $1
 `
@@ -815,6 +823,32 @@ func (q *Queries) GetActiveRolloutUpdates(ctx context.Context, arg GetActiveRoll
 		return nil, err
 	}
 	return items, nil
+}
+
+const getAndroidCredentialsByAppID = `-- name: GetAndroidCredentialsByAppID :one
+SELECT id, app_id, android_package, key_alias,
+       sealed_keystore, sealed_keystore_password, sealed_key_password,
+       sealed_google_service_account_key, created_at, updated_at
+FROM android_credentials
+WHERE app_id = $1
+`
+
+func (q *Queries) GetAndroidCredentialsByAppID(ctx context.Context, appID pgtype.UUID) (AndroidCredential, error) {
+	row := q.db.QueryRow(ctx, getAndroidCredentialsByAppID, appID)
+	var i AndroidCredential
+	err := row.Scan(
+		&i.ID,
+		&i.AppID,
+		&i.AndroidPackage,
+		&i.KeyAlias,
+		&i.SealedKeystore,
+		&i.SealedKeystorePassword,
+		&i.SealedKeyPassword,
+		&i.SealedGoogleServiceAccountKey,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
 }
 
 const getApiKeyAccess = `-- name: GetApiKeyAccess :many
@@ -5639,6 +5673,50 @@ type UpdateUserPasswordByIDParams struct {
 // the only thing that ends those sessions.
 func (q *Queries) UpdateUserPasswordByID(ctx context.Context, arg UpdateUserPasswordByIDParams) (pgconn.CommandTag, error) {
 	return q.db.Exec(ctx, updateUserPasswordByID, arg.ID, arg.PasswordHash)
+}
+
+const upsertAndroidCredentials = `-- name: UpsertAndroidCredentials :one
+INSERT INTO android_credentials (
+    id, app_id, android_package, key_alias,
+    sealed_keystore, sealed_keystore_password, sealed_key_password,
+    sealed_google_service_account_key
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+ON CONFLICT (app_id) DO UPDATE SET
+    android_package = EXCLUDED.android_package,
+    key_alias = EXCLUDED.key_alias,
+    sealed_keystore = EXCLUDED.sealed_keystore,
+    sealed_keystore_password = EXCLUDED.sealed_keystore_password,
+    sealed_key_password = EXCLUDED.sealed_key_password,
+    sealed_google_service_account_key = EXCLUDED.sealed_google_service_account_key,
+    updated_at = CURRENT_TIMESTAMP
+RETURNING id
+`
+
+type UpsertAndroidCredentialsParams struct {
+	ID                            pgtype.UUID `json:"id"`
+	AppID                         pgtype.UUID `json:"app_id"`
+	AndroidPackage                string      `json:"android_package"`
+	KeyAlias                      string      `json:"key_alias"`
+	SealedKeystore                string      `json:"sealed_keystore"`
+	SealedKeystorePassword        string      `json:"sealed_keystore_password"`
+	SealedKeyPassword             string      `json:"sealed_key_password"`
+	SealedGoogleServiceAccountKey *string     `json:"sealed_google_service_account_key"`
+}
+
+func (q *Queries) UpsertAndroidCredentials(ctx context.Context, arg UpsertAndroidCredentialsParams) (pgtype.UUID, error) {
+	row := q.db.QueryRow(ctx, upsertAndroidCredentials,
+		arg.ID,
+		arg.AppID,
+		arg.AndroidPackage,
+		arg.KeyAlias,
+		arg.SealedKeystore,
+		arg.SealedKeystorePassword,
+		arg.SealedKeyPassword,
+		arg.SealedGoogleServiceAccountKey,
+	)
+	var id pgtype.UUID
+	err := row.Scan(&id)
+	return id, err
 }
 
 const upsertDeviceUpdateFailure = `-- name: UpsertDeviceUpdateFailure :exec

--- a/internal/database/postgres/queries/queries.sql
+++ b/internal/database/postgres/queries/queries.sql
@@ -2318,3 +2318,29 @@ JOIN runtime_versions rv ON rv.id = u.runtime_version_id AND rv.app_id = $1
 WHERE b.app_id = $1 AND rv.version = $2 AND u.platform = @platform::text
 GROUP BY b.id, b.name
 ORDER BY MAX(u.created_at) DESC, b.name ASC;
+
+-- name: UpsertAndroidCredentials :one
+INSERT INTO android_credentials (
+    id, app_id, android_package, key_alias,
+    sealed_keystore, sealed_keystore_password, sealed_key_password,
+    sealed_google_service_account_key
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+ON CONFLICT (app_id) DO UPDATE SET
+    android_package = EXCLUDED.android_package,
+    key_alias = EXCLUDED.key_alias,
+    sealed_keystore = EXCLUDED.sealed_keystore,
+    sealed_keystore_password = EXCLUDED.sealed_keystore_password,
+    sealed_key_password = EXCLUDED.sealed_key_password,
+    sealed_google_service_account_key = EXCLUDED.sealed_google_service_account_key,
+    updated_at = CURRENT_TIMESTAMP
+RETURNING id;
+
+-- name: GetAndroidCredentialsByAppID :one
+SELECT id, app_id, android_package, key_alias,
+       sealed_keystore, sealed_keystore_password, sealed_key_password,
+       sealed_google_service_account_key, created_at, updated_at
+FROM android_credentials
+WHERE app_id = $1;
+
+-- name: DeleteAndroidCredentialsByAppID :execresult
+DELETE FROM android_credentials WHERE app_id = $1;

--- a/internal/handlers/dashboard/credentials_handler.go
+++ b/internal/handlers/dashboard/credentials_handler.go
@@ -1,0 +1,100 @@
+package handlers
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"xprem/internal/handlers"
+	"xprem/internal/services"
+	"xprem/internal/store"
+	"xprem/internal/validation"
+
+	"github.com/gorilla/mux"
+)
+
+type CredentialsHandler struct {
+	credentialsService *services.CredentialsService
+}
+
+func NewCredentialsHandler(credentialsService *services.CredentialsService) *CredentialsHandler {
+	return &CredentialsHandler{
+		credentialsService: credentialsService,
+	}
+}
+
+func (h *CredentialsHandler) GetAndroidCredentialsHandler(w http.ResponseWriter, r *http.Request) {
+	appId := mux.Vars(r)["APP_ID"]
+	metadata, err := h.credentialsService.GetAndroidCredentialsMetadata(r.Context(), appId)
+	if err != nil {
+		if errors.Is(err, store.ErrNotSupportedInStatelessMode) {
+			handlers.RenderError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		handlers.RenderError(w, http.StatusInternalServerError, "An internal error occurred while fetching android credentials.")
+		return
+	}
+	if metadata == nil {
+		handlers.RenderError(w, http.StatusNotFound, "no android credentials configured for this app")
+		return
+	}
+	marshaledResponse, _ := json.Marshal(metadata)
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	w.Write(marshaledResponse)
+}
+
+func (h *CredentialsHandler) PutAndroidCredentialsHandler(w http.ResponseWriter, r *http.Request) {
+	appId := mux.Vars(r)["APP_ID"]
+	var requestBody struct {
+		AndroidPackage          string `json:"androidPackage"`
+		KeyAlias                string `json:"keyAlias"`
+		Keystore                string `json:"keystore"`
+		KeystorePassword        string `json:"keystorePassword"`
+		KeyPassword             string `json:"keyPassword"`
+		GoogleServiceAccountKey string `json:"googleServiceAccountKey"`
+	}
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 2<<20)).Decode(&requestBody); err != nil {
+		handlers.RenderError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	err := h.credentialsService.SaveAndroidCredentials(r.Context(), appId, services.AndroidCredentialsInput{
+		AndroidPackage:              requestBody.AndroidPackage,
+		KeyAlias:                    requestBody.KeyAlias,
+		KeystoreBase64:              requestBody.Keystore,
+		KeystorePassword:            requestBody.KeystorePassword,
+		KeyPassword:                 requestBody.KeyPassword,
+		GoogleServiceAccountKeyJSON: requestBody.GoogleServiceAccountKey,
+	})
+	if err != nil {
+		var valErr *validation.Error
+		if errors.As(err, &valErr) {
+			handlers.RenderError(w, http.StatusBadRequest, valErr.Error())
+			return
+		}
+		if errors.Is(err, store.ErrNotSupportedInStatelessMode) {
+			handlers.RenderError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		handlers.RenderError(w, http.StatusInternalServerError, "An internal error occurred while saving android credentials.")
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (h *CredentialsHandler) DeleteAndroidCredentialsHandler(w http.ResponseWriter, r *http.Request) {
+	appId := mux.Vars(r)["APP_ID"]
+	err := h.credentialsService.DeleteAndroidCredentials(r.Context(), appId)
+	if err != nil {
+		if notFoundErr := (*store.ErrResourceNotFound)(nil); errors.As(err, &notFoundErr) {
+			handlers.RenderError(w, http.StatusNotFound, notFoundErr.Error())
+			return
+		}
+		if errors.Is(err, store.ErrNotSupportedInStatelessMode) {
+			handlers.RenderError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		handlers.RenderError(w, http.StatusInternalServerError, "An internal error occurred while deleting android credentials.")
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/internal/router/routes_app.go
+++ b/internal/router/routes_app.go
@@ -82,6 +82,13 @@ func registerAppRoutes(
 	app.route(http.MethodPost, "/branch/{BRANCH}/runtimeVersion/{RUNTIME_VERSION}/republish", container.UpdateHandler.RepublishUpdateHandler,
 		NeedsPermission(rbac.PermUpdatePublish, rbac.FallbackAdminOnly))
 
+	app.route(http.MethodGet, "/credentials/android", container.CredentialsHandler.GetAndroidCredentialsHandler,
+		AnyViewer())
+	app.route(http.MethodPut, "/credentials/android", container.CredentialsHandler.PutAndroidCredentialsHandler,
+		NeedsPermission(rbac.PermCredentialsManage, rbac.FallbackAdminOnly))
+	app.route(http.MethodDelete, "/credentials/android", container.CredentialsHandler.DeleteAndroidCredentialsHandler,
+		NeedsPermission(rbac.PermCredentialsManage, rbac.FallbackAdminOnly))
+
 	app.route(http.MethodGet, "/apiKeys", container.ApiKeyHandler.GetApiKeysHandler,
 		AnyViewer())
 	app.route(http.MethodPost, "/apiKeys", container.ApiKeyHandler.CreateApiKeyHandler,

--- a/internal/router/wire.go
+++ b/internal/router/wire.go
@@ -44,6 +44,7 @@ type AppContainer struct {
 	BranchHandler               *dashhandlers.BranchHandler
 	BranchListHandler           *handlers.BranchListHandler
 	ChannelHandler              *dashhandlers.ChannelHandler
+	CredentialsHandler          *dashhandlers.CredentialsHandler
 	ExpoProtocolHandler         *handlers.ExpoProtocolHandler
 	LicenseHandler              *licensing.LicenseHandler
 	RBACHandler                 *rbac.RBACHandler
@@ -92,6 +93,8 @@ func InitDependencies(ctx context.Context) (*AppContainer, func()) {
 	var oauthCodeRepo oauth.CodeRepository
 	var mcpHandler *mcp.MCPHandler
 	var rolloutRepo services.RolloutRepository
+	// nil in stateless mode: signing credentials only exist on the control plane.
+	var credentialsRepo services.CredentialsRepository
 	var licenseRepo licensing.LicenseRepository
 	var ssoRepo sso.SSORepository
 	var apiKeyAccessRepo apikeyrestrictions.ApiKeyAccessRepository
@@ -155,6 +158,7 @@ func InitDependencies(ctx context.Context) (*AppContainer, func()) {
 		pgUpdateStore := store.NewPostgresUpdateStore(dbEngine)
 		updateRepo = pgUpdateStore
 		rolloutRepo = store.NewPostgresRolloutStore(dbEngine)
+		credentialsRepo = store.NewPostgresCredentialsStore(dbEngine)
 
 		if config.IsDeviceTelemetryDisabled() {
 			log.Println("🔕 [TELEMETRY] DISABLE_DEVICE_TELEMETRY is set; nothing is recorded about a device: manifest check-ins, identity ops and telemetry batches are all dropped, and no ClickHouse connection is opened. The Observe and Identity dashboards report the feature as unavailable, and CLICKHOUSE_URL is ignored.")
@@ -243,6 +247,8 @@ func InitDependencies(ctx context.Context) (*AppContainer, func()) {
 	deploymentService.SetOnAuditEvent(auditService.Record)
 	rolloutService := services.NewRolloutService(rolloutRepo, channelRepo, updateRepo, deploymentService)
 	rolloutService.SetOnAuditEvent(auditService.Record)
+	credentialsService := services.NewCredentialsService(credentialsRepo)
+	credentialsService.SetOnAuditEvent(auditService.Record)
 
 	// Shared across handlers; with Redis configured, also across replicas.
 	rateLimiter := ratelimit.New(cache.GetCache())
@@ -299,6 +305,7 @@ func InitDependencies(ctx context.Context) (*AppContainer, func()) {
 		BranchHandler:               dashhandlers.NewBranchHandler(branchService),
 		BranchListHandler:           handlers.NewBranchListHandler(channelService),
 		ChannelHandler:              dashhandlers.NewChannelHandler(channelService),
+		CredentialsHandler:          dashhandlers.NewCredentialsHandler(credentialsService),
 		ExpoProtocolHandler:         handlers.NewExpoProtocolHandler(expoProtocolService),
 		LicenseHandler:              licensing.NewLicenseHandler(licenseService),
 		AuditHandler:                audit.NewAuditHandler(auditService),

--- a/internal/services/credentials_service.go
+++ b/internal/services/credentials_service.go
@@ -1,0 +1,191 @@
+package services
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"time"
+	"xprem/internal/auditlog"
+	"xprem/internal/crypto"
+	"xprem/internal/keyStore"
+	"xprem/internal/store"
+	"xprem/internal/validation"
+)
+
+// maxKeystoreBytes caps the decoded keystore blob; real-world .jks files are
+// a few kilobytes, anything near the cap is not a keystore.
+const maxKeystoreBytes = 512 * 1024
+
+var androidPackagePattern = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9_]*(\.[a-zA-Z][a-zA-Z0-9_]*)+$`)
+
+type CredentialsRepository interface {
+	UpsertAndroidCredentials(ctx context.Context, appId string, credentials store.SealedAndroidCredentials) error
+	GetAndroidCredentials(ctx context.Context, appId string) (*store.SealedAndroidCredentials, error)
+	DeleteAndroidCredentials(ctx context.Context, appId string) error
+}
+
+// AndroidCredentialsInput is one full replacement of an app's Android signing
+// credentials, as received from the dashboard or the CLI.
+type AndroidCredentialsInput struct {
+	AndroidPackage              string
+	KeyAlias                    string
+	KeystoreBase64              string
+	KeystorePassword            string
+	KeyPassword                 string
+	GoogleServiceAccountKeyJSON string
+}
+
+// AndroidCredentialsMetadata is the non-secret projection served to viewers.
+type AndroidCredentialsMetadata struct {
+	AndroidPackage             string `json:"androidPackage"`
+	KeyAlias                   string `json:"keyAlias"`
+	HasGoogleServiceAccountKey bool   `json:"hasGoogleServiceAccountKey"`
+	CreatedAt                  string `json:"createdAt"`
+	UpdatedAt                  string `json:"updatedAt"`
+}
+
+type CredentialsService struct {
+	repo CredentialsRepository
+	// onAuditEvent is the audit emission seam; nil (community) means
+	// credential changes leave no events.
+	onAuditEvent auditlog.RecordFunc
+}
+
+// NewCredentialsService builds the service; a nil repo (stateless mode) makes
+// every method answer ErrNotSupportedInStatelessMode.
+func NewCredentialsService(repo CredentialsRepository) *CredentialsService {
+	return &CredentialsService{
+		repo: repo,
+	}
+}
+
+// SetOnAuditEvent plugs the audit emission seam. Nil-safe.
+func (s *CredentialsService) SetOnAuditEvent(record auditlog.RecordFunc) {
+	s.onAuditEvent = record
+}
+
+// androidCredentialAAD binds each sealed field to the app it belongs to, so a
+// blob copied onto another row fails to unseal (see keyStore.AppKeyAAD).
+func androidCredentialAAD(appId string, field string) []byte {
+	return []byte(appId + "|android_credentials|" + field)
+}
+
+func (s *CredentialsService) SaveAndroidCredentials(ctx context.Context, appId string, input AndroidCredentialsInput) error {
+	if s.repo == nil {
+		return store.ErrNotSupportedInStatelessMode
+	}
+	if !androidPackagePattern.MatchString(input.AndroidPackage) || len(input.AndroidPackage) > 255 {
+		return validation.Errorf("androidPackage", "%q is not a valid Android application id", input.AndroidPackage)
+	}
+	if input.KeyAlias == "" || len(input.KeyAlias) > 255 {
+		return validation.Errorf("keyAlias", "key alias must be between 1 and 255 characters")
+	}
+	if input.KeystorePassword == "" {
+		return validation.Errorf("keystorePassword", "keystore password is empty")
+	}
+	if input.KeyPassword == "" {
+		return validation.Errorf("keyPassword", "key password is empty")
+	}
+	keystore, err := base64.StdEncoding.DecodeString(input.KeystoreBase64)
+	if err != nil {
+		return validation.Errorf("keystore", "keystore is not valid base64")
+	}
+	if len(keystore) == 0 {
+		return validation.Errorf("keystore", "keystore is empty")
+	}
+	if len(keystore) > maxKeystoreBytes {
+		return validation.Errorf("keystore", "keystore exceeds the %d KB limit", maxKeystoreBytes/1024)
+	}
+	if input.GoogleServiceAccountKeyJSON != "" && !json.Valid([]byte(input.GoogleServiceAccountKeyJSON)) {
+		return validation.Errorf("googleServiceAccountKey", "google service account key is not valid JSON")
+	}
+
+	masterKey := []byte(keyStore.ReadDBKeysMasterKey())
+	sealedKeystore, err := crypto.SealAESGCM(keystore, masterKey, androidCredentialAAD(appId, "keystore"))
+	if err != nil {
+		return fmt.Errorf("failed to seal keystore: %w", err)
+	}
+	sealedKeystorePassword, err := crypto.SealAESGCM([]byte(input.KeystorePassword), masterKey, androidCredentialAAD(appId, "keystore_password"))
+	if err != nil {
+		return fmt.Errorf("failed to seal keystore password: %w", err)
+	}
+	sealedKeyPassword, err := crypto.SealAESGCM([]byte(input.KeyPassword), masterKey, androidCredentialAAD(appId, "key_password"))
+	if err != nil {
+		return fmt.Errorf("failed to seal key password: %w", err)
+	}
+	sealed := store.SealedAndroidCredentials{
+		AndroidPackage:         input.AndroidPackage,
+		KeyAlias:               input.KeyAlias,
+		SealedKeystore:         sealedKeystore,
+		SealedKeystorePassword: sealedKeystorePassword,
+		SealedKeyPassword:      sealedKeyPassword,
+	}
+	if input.GoogleServiceAccountKeyJSON != "" {
+		sealedGSA, err := crypto.SealAESGCM([]byte(input.GoogleServiceAccountKeyJSON), masterKey, androidCredentialAAD(appId, "google_service_account_key"))
+		if err != nil {
+			return fmt.Errorf("failed to seal google service account key: %w", err)
+		}
+		sealed.SealedGoogleServiceAccountKey = &sealedGSA
+	}
+
+	if err := s.repo.UpsertAndroidCredentials(ctx, appId, sealed); err != nil {
+		return err
+	}
+	recordManagementEvent(ctx, s.onAuditEvent, auditlog.Event{
+		Action:        auditlog.ActionAndroidCredentialsSaved,
+		TargetType:    "android_credentials",
+		TargetID:      appId,
+		TargetDisplay: input.AndroidPackage,
+		AppID:         appId,
+		Metadata: map[string]any{
+			"android_package":                input.AndroidPackage,
+			"key_alias":                      input.KeyAlias,
+			"has_google_service_account_key": input.GoogleServiceAccountKeyJSON != "",
+		},
+	})
+	return nil
+}
+
+// GetAndroidCredentialsMetadata returns (nil, nil) when the app has no
+// Android credentials configured.
+func (s *CredentialsService) GetAndroidCredentialsMetadata(ctx context.Context, appId string) (*AndroidCredentialsMetadata, error) {
+	if s.repo == nil {
+		return nil, store.ErrNotSupportedInStatelessMode
+	}
+	credentials, err := s.repo.GetAndroidCredentials(ctx, appId)
+	if err != nil || credentials == nil {
+		return nil, err
+	}
+	return &AndroidCredentialsMetadata{
+		AndroidPackage:             credentials.AndroidPackage,
+		KeyAlias:                   credentials.KeyAlias,
+		HasGoogleServiceAccountKey: credentials.SealedGoogleServiceAccountKey != nil,
+		CreatedAt:                  credentials.CreatedAt.UTC().Format(time.RFC3339),
+		UpdatedAt:                  credentials.UpdatedAt.UTC().Format(time.RFC3339),
+	}, nil
+}
+
+func (s *CredentialsService) DeleteAndroidCredentials(ctx context.Context, appId string) error {
+	if s.repo == nil {
+		return store.ErrNotSupportedInStatelessMode
+	}
+	// Read before the delete: afterwards there is no row left to name in the
+	// audit entry. Best-effort, like the entry itself.
+	displayName := appId
+	if credentials, err := s.repo.GetAndroidCredentials(ctx, appId); err == nil && credentials != nil {
+		displayName = credentials.AndroidPackage
+	}
+	if err := s.repo.DeleteAndroidCredentials(ctx, appId); err != nil {
+		return err
+	}
+	recordManagementEvent(ctx, s.onAuditEvent, auditlog.Event{
+		Action:        auditlog.ActionAndroidCredentialsDeleted,
+		TargetType:    "android_credentials",
+		TargetID:      appId,
+		TargetDisplay: displayName,
+		AppID:         appId,
+	})
+	return nil
+}

--- a/internal/services/credentials_service_test.go
+++ b/internal/services/credentials_service_test.go
@@ -1,0 +1,166 @@
+// Service-level tests for the Android credentials vault: sealing (with the
+// app-bound AAD), validation, the metadata projection, audit emission and the
+// stateless-mode refusal. SQL persistence is covered by the store tests.
+package services
+
+import (
+	"context"
+	"encoding/base64"
+	"testing"
+	"xprem/internal/auditlog"
+	"xprem/internal/crypto"
+	"xprem/internal/store"
+	"xprem/internal/validation"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeCredentialsRepo struct {
+	byAppId map[string]store.SealedAndroidCredentials
+}
+
+func newFakeCredentialsRepo() *fakeCredentialsRepo {
+	return &fakeCredentialsRepo{byAppId: map[string]store.SealedAndroidCredentials{}}
+}
+
+func (f *fakeCredentialsRepo) UpsertAndroidCredentials(_ context.Context, appId string, credentials store.SealedAndroidCredentials) error {
+	f.byAppId[appId] = credentials
+	return nil
+}
+
+func (f *fakeCredentialsRepo) GetAndroidCredentials(_ context.Context, appId string) (*store.SealedAndroidCredentials, error) {
+	credentials, ok := f.byAppId[appId]
+	if !ok {
+		return nil, nil
+	}
+	return &credentials, nil
+}
+
+func (f *fakeCredentialsRepo) DeleteAndroidCredentials(_ context.Context, appId string) error {
+	if _, ok := f.byAppId[appId]; !ok {
+		return &store.ErrResourceNotFound{Resource: "android credentials", Identifier: appId}
+	}
+	delete(f.byAppId, appId)
+	return nil
+}
+
+const testMasterKey = "0123456789abcdef0123456789abcdef"
+
+func setMasterKey(t *testing.T) {
+	t.Helper()
+	t.Setenv("AWSSM_DB_KEYS_MASTER_KEY_SECRET_ID", "")
+	t.Setenv("DB_KEYS_MASTER_KEY_B64", base64.StdEncoding.EncodeToString([]byte(testMasterKey)))
+}
+
+func validAndroidInput() AndroidCredentialsInput {
+	return AndroidCredentialsInput{
+		AndroidPackage:   "com.example.app",
+		KeyAlias:         "upload",
+		KeystoreBase64:   base64.StdEncoding.EncodeToString([]byte("fake-jks-bytes")),
+		KeystorePassword: "keystore-pass",
+		KeyPassword:      "key-pass",
+	}
+}
+
+func TestSaveAndroidCredentialsSealsEveryTouchedSecret(t *testing.T) {
+	setMasterKey(t)
+	repo := newFakeCredentialsRepo()
+	service := NewCredentialsService(repo)
+
+	input := validAndroidInput()
+	input.GoogleServiceAccountKeyJSON = `{"type":"service_account"}`
+	require.NoError(t, service.SaveAndroidCredentials(context.Background(), "app-1", input))
+
+	sealed := repo.byAppId["app-1"]
+	assert.Equal(t, "com.example.app", sealed.AndroidPackage)
+	assert.Equal(t, "upload", sealed.KeyAlias)
+
+	keystore, err := crypto.UnsealAESGCM(sealed.SealedKeystore, []byte(testMasterKey), androidCredentialAAD("app-1", "keystore"))
+	require.NoError(t, err)
+	assert.Equal(t, "fake-jks-bytes", string(keystore))
+	keystorePassword, err := crypto.UnsealAESGCM(sealed.SealedKeystorePassword, []byte(testMasterKey), androidCredentialAAD("app-1", "keystore_password"))
+	require.NoError(t, err)
+	assert.Equal(t, "keystore-pass", string(keystorePassword))
+	keyPassword, err := crypto.UnsealAESGCM(sealed.SealedKeyPassword, []byte(testMasterKey), androidCredentialAAD("app-1", "key_password"))
+	require.NoError(t, err)
+	assert.Equal(t, "key-pass", string(keyPassword))
+	require.NotNil(t, sealed.SealedGoogleServiceAccountKey)
+	gsa, err := crypto.UnsealAESGCM(*sealed.SealedGoogleServiceAccountKey, []byte(testMasterKey), androidCredentialAAD("app-1", "google_service_account_key"))
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"type":"service_account"}`, string(gsa))
+
+	// No sealed field is readable without the exact app binding.
+	_, err = crypto.UnsealAESGCM(sealed.SealedKeystore, []byte(testMasterKey), androidCredentialAAD("app-2", "keystore"))
+	assert.Error(t, err)
+}
+
+func TestSaveAndroidCredentialsRejectsInvalidInput(t *testing.T) {
+	setMasterKey(t)
+	service := NewCredentialsService(newFakeCredentialsRepo())
+	ctx := context.Background()
+
+	for name, mutate := range map[string]func(*AndroidCredentialsInput){
+		"bad package":        func(i *AndroidCredentialsInput) { i.AndroidPackage = "no-dots" },
+		"empty alias":        func(i *AndroidCredentialsInput) { i.KeyAlias = "" },
+		"empty keystore pwd": func(i *AndroidCredentialsInput) { i.KeystorePassword = "" },
+		"empty key pwd":      func(i *AndroidCredentialsInput) { i.KeyPassword = "" },
+		"bad base64":         func(i *AndroidCredentialsInput) { i.KeystoreBase64 = "not base64!!" },
+		"empty keystore":     func(i *AndroidCredentialsInput) { i.KeystoreBase64 = "" },
+		"bad gsa json":       func(i *AndroidCredentialsInput) { i.GoogleServiceAccountKeyJSON = "{broken" },
+	} {
+		input := validAndroidInput()
+		mutate(&input)
+		err := service.SaveAndroidCredentials(ctx, "app-1", input)
+		require.Error(t, err, name)
+		var valErr *validation.Error
+		assert.ErrorAs(t, err, &valErr, name)
+	}
+}
+
+func TestAndroidCredentialsMetadataCarriesNoSecret(t *testing.T) {
+	setMasterKey(t)
+	repo := newFakeCredentialsRepo()
+	service := NewCredentialsService(repo)
+	require.NoError(t, service.SaveAndroidCredentials(context.Background(), "app-1", validAndroidInput()))
+
+	metadata, err := service.GetAndroidCredentialsMetadata(context.Background(), "app-1")
+	require.NoError(t, err)
+	require.NotNil(t, metadata)
+	assert.Equal(t, "com.example.app", metadata.AndroidPackage)
+	assert.Equal(t, "upload", metadata.KeyAlias)
+	assert.False(t, metadata.HasGoogleServiceAccountKey)
+
+	missing, err := service.GetAndroidCredentialsMetadata(context.Background(), "unknown-app")
+	require.NoError(t, err)
+	assert.Nil(t, missing)
+}
+
+func TestAndroidCredentialsAuditEvents(t *testing.T) {
+	setMasterKey(t)
+	repo := newFakeCredentialsRepo()
+	service := NewCredentialsService(repo)
+	var recorded []auditlog.Event
+	service.SetOnAuditEvent(func(_ context.Context, event auditlog.Event) {
+		recorded = append(recorded, event)
+	})
+
+	require.NoError(t, service.SaveAndroidCredentials(context.Background(), "app-1", validAndroidInput()))
+	require.NoError(t, service.DeleteAndroidCredentials(context.Background(), "app-1"))
+
+	require.Len(t, recorded, 2)
+	assert.Equal(t, auditlog.ActionAndroidCredentialsSaved, recorded[0].Action)
+	assert.Equal(t, "com.example.app", recorded[0].TargetDisplay)
+	assert.NotContains(t, recorded[0].Metadata, "keystore")
+	assert.Equal(t, auditlog.ActionAndroidCredentialsDeleted, recorded[1].Action)
+	assert.Equal(t, "com.example.app", recorded[1].TargetDisplay)
+}
+
+func TestAndroidCredentialsUnsupportedInStatelessMode(t *testing.T) {
+	service := NewCredentialsService(nil)
+	ctx := context.Background()
+	assert.ErrorIs(t, service.SaveAndroidCredentials(ctx, "app-1", validAndroidInput()), store.ErrNotSupportedInStatelessMode)
+	_, err := service.GetAndroidCredentialsMetadata(ctx, "app-1")
+	assert.ErrorIs(t, err, store.ErrNotSupportedInStatelessMode)
+	assert.ErrorIs(t, service.DeleteAndroidCredentials(ctx, "app-1"), store.ErrNotSupportedInStatelessMode)
+}

--- a/internal/store/credentials_postgres.go
+++ b/internal/store/credentials_postgres.go
@@ -1,0 +1,84 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+	"xprem/internal/database"
+	"xprem/internal/database/postgres/pgdb"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+)
+
+// SealedAndroidCredentials is the at-rest shape of an app's Android signing
+// credentials: every secret field is an AES-GCM sealed blob, never plaintext.
+type SealedAndroidCredentials struct {
+	AndroidPackage                string
+	KeyAlias                      string
+	SealedKeystore                string
+	SealedKeystorePassword        string
+	SealedKeyPassword             string
+	SealedGoogleServiceAccountKey *string
+	CreatedAt                     time.Time
+	UpdatedAt                     time.Time
+}
+
+type PostgresCredentialsStore struct {
+	engine *database.Engine
+}
+
+func NewPostgresCredentialsStore(engine *database.Engine) *PostgresCredentialsStore {
+	return &PostgresCredentialsStore{
+		engine: engine,
+	}
+}
+
+func (s *PostgresCredentialsStore) UpsertAndroidCredentials(ctx context.Context, appId string, credentials SealedAndroidCredentials) error {
+	_, err := s.engine.Queries.UpsertAndroidCredentials(ctx, pgdb.UpsertAndroidCredentialsParams{
+		ID:                            ToPgUUID(uuid.NewString()),
+		AppID:                         ToPgUUID(appId),
+		AndroidPackage:                credentials.AndroidPackage,
+		KeyAlias:                      credentials.KeyAlias,
+		SealedKeystore:                credentials.SealedKeystore,
+		SealedKeystorePassword:        credentials.SealedKeystorePassword,
+		SealedKeyPassword:             credentials.SealedKeyPassword,
+		SealedGoogleServiceAccountKey: credentials.SealedGoogleServiceAccountKey,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to save android credentials in database: %w", err)
+	}
+	return nil
+}
+
+func (s *PostgresCredentialsStore) GetAndroidCredentials(ctx context.Context, appId string) (*SealedAndroidCredentials, error) {
+	row, err := s.engine.Queries.GetAndroidCredentialsByAppID(ctx, ToPgUUID(appId))
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to retrieve android credentials from database: %w", err)
+	}
+	return &SealedAndroidCredentials{
+		AndroidPackage:                row.AndroidPackage,
+		KeyAlias:                      row.KeyAlias,
+		SealedKeystore:                row.SealedKeystore,
+		SealedKeystorePassword:        row.SealedKeystorePassword,
+		SealedKeyPassword:             row.SealedKeyPassword,
+		SealedGoogleServiceAccountKey: row.SealedGoogleServiceAccountKey,
+		CreatedAt:                     row.CreatedAt.Time,
+		UpdatedAt:                     row.UpdatedAt.Time,
+	}, nil
+}
+
+func (s *PostgresCredentialsStore) DeleteAndroidCredentials(ctx context.Context, appId string) error {
+	commandTag, err := s.engine.Queries.DeleteAndroidCredentialsByAppID(ctx, ToPgUUID(appId))
+	if err != nil {
+		return fmt.Errorf("failed to delete android credentials from database: %w", err)
+	}
+	if commandTag.RowsAffected() == 0 {
+		return &ErrResourceNotFound{Resource: "android credentials", Identifier: fmt.Sprintf("appId: %s", appId)}
+	}
+	return nil
+}

--- a/internal/store/credentials_postgres_test.go
+++ b/internal/store/credentials_postgres_test.go
@@ -1,0 +1,123 @@
+// Integration tests for the Android credentials store: the one-row-per-app
+// upsert and the not-found delete are enforced by the SQL itself, which the
+// in-memory fakes cannot exercise. Same TEST_DATABASE_URL contract as the
+// branch store tests.
+package store_test
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+
+	"xprem/internal/database"
+	"xprem/internal/database/postgres"
+	"xprem/internal/database/postgres/pgdb"
+	"xprem/internal/store"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func setupCredentialsStore(t *testing.T) (*store.PostgresCredentialsStore, *pgxpool.Pool) {
+	t.Helper()
+	dbURL := os.Getenv("TEST_DATABASE_URL")
+	if dbURL == "" {
+		if os.Getenv("CI") != "" {
+			t.Fatal("TEST_DATABASE_URL must be set in CI: these tests cover SQL that the in-memory fakes cannot reach")
+		}
+		t.Skip("TEST_DATABASE_URL not set, start a Postgres and set it to run the guarded-query tests")
+	}
+	// The seed migration fails fast on an empty database without the bootstrap pair.
+	t.Setenv("ADMIN_EMAIL", "seed-admin@example.com")
+	t.Setenv("ADMIN_PASSWORD", "Sup3rSecret!")
+	postgres.RunDBMigrations(dbURL)
+
+	pool, err := pgxpool.New(context.Background(), dbURL)
+	require.NoError(t, err)
+	t.Cleanup(pool.Close)
+	return store.NewPostgresCredentialsStore(&database.Engine{Queries: pgdb.New(pool), DB: pool}), pool
+}
+
+func insertBareApp(t *testing.T, pool *pgxpool.Pool) string {
+	t.Helper()
+	appId := uuid.NewString()
+	_, err := pool.Exec(context.Background(), "INSERT INTO apps (id, name) VALUES ($1, $2)", appId, "app-"+appId[:8])
+	require.NoError(t, err)
+	return appId
+}
+
+func sealedFixture(marker string) store.SealedAndroidCredentials {
+	return store.SealedAndroidCredentials{
+		AndroidPackage:         "com.example." + marker,
+		KeyAlias:               "upload",
+		SealedKeystore:         "sealed-keystore-" + marker,
+		SealedKeystorePassword: "sealed-keystore-password-" + marker,
+		SealedKeyPassword:      "sealed-key-password-" + marker,
+	}
+}
+
+func TestAndroidCredentialsUpsertReplacesTheSingleRow(t *testing.T) {
+	credentialsStore, pool := setupCredentialsStore(t)
+	ctx := context.Background()
+	appId := insertBareApp(t, pool)
+
+	require.NoError(t, credentialsStore.UpsertAndroidCredentials(ctx, appId, sealedFixture("v1")))
+	gsa := "sealed-gsa-v2"
+	second := sealedFixture("v2")
+	second.SealedGoogleServiceAccountKey = &gsa
+	require.NoError(t, credentialsStore.UpsertAndroidCredentials(ctx, appId, second))
+
+	var count int
+	require.NoError(t, pool.QueryRow(ctx, "SELECT COUNT(*) FROM android_credentials WHERE app_id = $1", appId).Scan(&count))
+	assert.Equal(t, 1, count)
+
+	stored, err := credentialsStore.GetAndroidCredentials(ctx, appId)
+	require.NoError(t, err)
+	require.NotNil(t, stored)
+	assert.Equal(t, "com.example.v2", stored.AndroidPackage)
+	assert.Equal(t, "sealed-keystore-v2", stored.SealedKeystore)
+	require.NotNil(t, stored.SealedGoogleServiceAccountKey)
+	assert.Equal(t, "sealed-gsa-v2", *stored.SealedGoogleServiceAccountKey)
+}
+
+func TestAndroidCredentialsGetReturnsNilWhenAbsent(t *testing.T) {
+	credentialsStore, pool := setupCredentialsStore(t)
+	appId := insertBareApp(t, pool)
+
+	stored, err := credentialsStore.GetAndroidCredentials(context.Background(), appId)
+	require.NoError(t, err)
+	assert.Nil(t, stored)
+}
+
+func TestAndroidCredentialsDeleteReportsNotFound(t *testing.T) {
+	credentialsStore, pool := setupCredentialsStore(t)
+	ctx := context.Background()
+	appId := insertBareApp(t, pool)
+
+	err := credentialsStore.DeleteAndroidCredentials(ctx, appId)
+	notFoundErr := (*store.ErrResourceNotFound)(nil)
+	require.True(t, errors.As(err, &notFoundErr))
+
+	require.NoError(t, credentialsStore.UpsertAndroidCredentials(ctx, appId, sealedFixture("v1")))
+	require.NoError(t, credentialsStore.DeleteAndroidCredentials(ctx, appId))
+	stored, err := credentialsStore.GetAndroidCredentials(ctx, appId)
+	require.NoError(t, err)
+	assert.Nil(t, stored)
+}
+
+func TestAndroidCredentialsRowsAreDroppedWithTheApp(t *testing.T) {
+	credentialsStore, pool := setupCredentialsStore(t)
+	ctx := context.Background()
+	appId := insertBareApp(t, pool)
+	require.NoError(t, credentialsStore.UpsertAndroidCredentials(ctx, appId, sealedFixture("v1")))
+
+	_, err := pool.Exec(ctx, "DELETE FROM apps WHERE id = $1", appId)
+	require.NoError(t, err)
+
+	var count int
+	require.NoError(t, pool.QueryRow(ctx, "SELECT COUNT(*) FROM android_credentials WHERE app_id = $1", appId).Scan(&count))
+	assert.Equal(t, 0, count)
+}


### PR DESCRIPTION
First slice of the native-builds track: server-side storage of an app's Android signing credentials, with the same UX contract as EAS credentials (upload once, builds fetch them later).

## What
- New `android_credentials` table: one credential set per app (`UNIQUE app_id`, `ON DELETE CASCADE`). Keystore, keystore password and key password are sealed with AES-GCM under the existing DB master key; the optional Google Service Account key (for the future submit flow) is sealed too. `android_package` and `key_alias` stay readable for display.
- Each sealed blob is bound to its app via AES-GCM AAD (`appId|android_credentials|<field>`), same rationale as `keyStore.AppKeyAAD`: a blob copied onto another row fails to unseal at the point of the mistake.
- Dashboard API under `/api/apps/{APP_ID}/credentials/android`:
  - `GET` → non-secret metadata only (package, alias, hasGSA, timestamps), any viewer
  - `PUT` (full replace) / `DELETE` → new `credentials:manage` RBAC permission, admin-only fallback
- Both writes emit audit events (`android_credentials.saved` / `.deleted`), never carrying secret material; catalog parity kept in `auditCatalog.ts`.
- Stateless (flat-env) mode answers with the standard `ErrNotSupportedInStatelessMode`.

## Deliberately out of scope (next PRs)
- No endpoint returns decrypted secrets — the read path ships with `eoas build --local` so its access control and audit trail are reviewed together.
- Dashboard UI, build profiles, builds table, iOS.

## Tests
- Service: seal/unseal roundtrip incl. AAD cross-app rejection, input validation matrix, metadata projection, audit emission, stateless refusal.
- Store (TEST_DATABASE_URL): single-row upsert semantics, nil-when-absent, not-found delete, cascade with app deletion.
- Full `go test ./...` and `make lint` green.
