### PR TITLE
fix(metrics): skip per-client tracking when PROMETHEUS_ENABLED is unset

### DIFF
--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -194,23 +194,8 @@ func TrackUpdateErrorUsers(appId, clientId, platform, runtime, branch, update st
 	updateErrorUsersVec.WithLabelValues(appId, platform, runtime, branch, computedUpdate).Set(float64(count))
 }
 
-// cardinalityMetricsEnabled reports whether anything can ever read the metrics
-// that cost per-client state to maintain.
-//
-// TrackActiveUser and TrackUpdateErrorUsers are the only two Track* functions
-// that remember individual clients: each Sadd's the client id into a cache set
-// held for the metric's TTL (4h and 10m). On the local cache that set lives in
-// the process, so its size tracks unique devices in the window — the "one entry
-// per device on a fleet of a million" the LocalCache sweep comment warns about.
-//
-// /metrics is only registered when PROMETHEUS_ENABLED is true (see
-// registerInfraRoutes), so with it unset that memory backs a gauge no one can
-// scrape. This is the same reasoning as maxSeriesPerMetric above — bound what a
-// remote caller can make the process remember — applied to the cache sets
-// rather than to Prometheus series.
-//
-// Read live rather than cached at init: GetEnv reads the environment on each
-// call, and the tests toggle PROMETHEUS_ENABLED between cases.
+// cardinalityMetricsEnabled reports whether per-client tracking should run;
+// read live because tests toggle PROMETHEUS_ENABLED between cases.
 func cardinalityMetricsEnabled() bool {
 	return config.GetEnv("PROMETHEUS_ENABLED") == "true"
 }

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"strings"
 	"sync"
+	"xprem/config"
 	"xprem/internal/cache"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -165,6 +166,9 @@ func CleanupMetrics() {
 }
 
 func TrackUpdateErrorUsers(appId, clientId, platform, runtime, branch, update string) {
+	if !cardinalityMetricsEnabled() {
+		return
+	}
 	computedUpdate := update
 	if computedUpdate == "" {
 		computedUpdate = "unknown"
@@ -190,7 +194,31 @@ func TrackUpdateErrorUsers(appId, clientId, platform, runtime, branch, update st
 	updateErrorUsersVec.WithLabelValues(appId, platform, runtime, branch, computedUpdate).Set(float64(count))
 }
 
+// cardinalityMetricsEnabled reports whether anything can ever read the metrics
+// that cost per-client state to maintain.
+//
+// TrackActiveUser and TrackUpdateErrorUsers are the only two Track* functions
+// that remember individual clients: each Sadd's the client id into a cache set
+// held for the metric's TTL (4h and 10m). On the local cache that set lives in
+// the process, so its size tracks unique devices in the window — the "one entry
+// per device on a fleet of a million" the LocalCache sweep comment warns about.
+//
+// /metrics is only registered when PROMETHEUS_ENABLED is true (see
+// registerInfraRoutes), so with it unset that memory backs a gauge no one can
+// scrape. This is the same reasoning as maxSeriesPerMetric above — bound what a
+// remote caller can make the process remember — applied to the cache sets
+// rather than to Prometheus series.
+//
+// Read live rather than cached at init: GetEnv reads the environment on each
+// call, and the tests toggle PROMETHEUS_ENABLED between cases.
+func cardinalityMetricsEnabled() bool {
+	return config.GetEnv("PROMETHEUS_ENABLED") == "true"
+}
+
 func TrackActiveUser(appId, clientId, platform, runtime, branch, update string) {
+	if !cardinalityMetricsEnabled() {
+		return
+	}
 	if appId == "" || clientId == "" || platform == "" || branch == "" || update == "" || runtime == "" {
 		return
 	}

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -305,12 +305,6 @@ func TestTrackUpdateErrorUsersFoldsOversizedLabels(t *testing.T) {
 	}
 }
 
-// TrackActiveUser and TrackUpdateErrorUsers are the only Track* functions that
-// remember individual clients, by Sadd-ing the client id into a cache set held
-// for the metric's TTL. On the local cache that set lives in the process, so it
-// grows with unique devices in the window. /metrics is only served when
-// PROMETHEUS_ENABLED is true, so with it unset that memory backs a gauge nobody
-// can scrape — these assert the per-client state is not paid for in that case.
 func TestPerClientTrackingSkippedWhenPrometheusDisabled(t *testing.T) {
 	cleanup := setupMetrics(t)
 	defer cleanup()

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"xprem/internal/cache"
 	"xprem/internal/metrics"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -301,5 +302,40 @@ func TestTrackUpdateErrorUsersFoldsOversizedLabels(t *testing.T) {
 		"appId": "err-app", "update": "^other$", "runtime": "^other$",
 	}); got != 1 {
 		t.Errorf("expected the folded error series to carry the count, got %v", got)
+	}
+}
+
+// TrackActiveUser and TrackUpdateErrorUsers are the only Track* functions that
+// remember individual clients, by Sadd-ing the client id into a cache set held
+// for the metric's TTL. On the local cache that set lives in the process, so it
+// grows with unique devices in the window. /metrics is only served when
+// PROMETHEUS_ENABLED is true, so with it unset that memory backs a gauge nobody
+// can scrape — these assert the per-client state is not paid for in that case.
+func TestPerClientTrackingSkippedWhenPrometheusDisabled(t *testing.T) {
+	cleanup := setupMetrics(t)
+	defer cleanup()
+	defer os.Setenv("PROMETHEUS_ENABLED", "true")
+
+	c := cache.GetCache()
+	appId := "disabled-metrics-app"
+	key := fmt.Sprintf("seen_users:%s:%s:%s:%s:%s", appId, "main", "ios", "1.0.0", "update-1")
+	errKey := fmt.Sprintf("update_error_users:%s:%s:%s:%s:%s", appId, "main", "ios", "1.0.0", "update-1")
+
+	os.Setenv("PROMETHEUS_ENABLED", "false")
+	metrics.TrackActiveUser(appId, "client-a", "ios", "1.0.0", "main", "update-1")
+	metrics.TrackUpdateErrorUsers(appId, "client-a", "ios", "1.0.0", "main", "update-1")
+
+	if n, _ := c.Scard(key); n != 0 {
+		t.Fatalf("active-user set grew while PROMETHEUS_ENABLED=false: got %d, want 0", n)
+	}
+	if n, _ := c.Scard(errKey); n != 0 {
+		t.Fatalf("error-user set grew while PROMETHEUS_ENABLED=false: got %d, want 0", n)
+	}
+
+	// Re-enabling must restore the behaviour, so this is a gate and not a removal.
+	os.Setenv("PROMETHEUS_ENABLED", "true")
+	metrics.TrackActiveUser(appId, "client-a", "ios", "1.0.0", "main", "update-1")
+	if n, _ := c.Scard(key); n != 1 {
+		t.Fatalf("active-user set did not record with PROMETHEUS_ENABLED=true: got %d, want 1", n)
 	}
 }


### PR DESCRIPTION
## Problem

`TrackActiveUser` and `TrackUpdateErrorUsers` are the only `Track*` functions that remember **individual clients**. Each `Sadd`s the client id into a cache set held for the metric's TTL (4h and 10m):

```go
activeUserKey       = "seen_users:<app>:<branch>:<platform>:<runtime>:<update>"
globalActiveUserKey = "global_active_users:<app>:<platform>"
Sadd(key, []string{clientId}, &ttl)
```

On the local cache that set lives in the process, so its size tracks **unique devices in the window** — exactly the *"one entry per device on a fleet of a million"* that the `LocalCache` sweep comment already warns about.

`/metrics` is only registered when `PROMETHEUS_ENABLED` is true (`registerInfraRoutes`), but both functions ran **unconditionally**. A deployment that never enabled Prometheus still paid the full per-device memory cost for a gauge nobody can scrape.

## What we observed

Single-node deployment, 1 GB RAM, local cache, `PROMETHEUS_ENABLED` never set, ~1.7 manifest requests/sec:

- process grew to roughly **2.5 GB of anonymous memory** (RSS + swap) within a minute or two of each start
- OOM-killed and restarted **every ~2 minutes for several hours** following a publish
- manifest availability measured **5/10** during the episode; asset serving was unaffected (12/12) since those are edge-cacheable and manifests are not

The publish is what tips it over — every device checks in at once — and device retries then keep it there.

## Fix

Gate both functions on the same flag that decides whether the metrics are readable at all.

This is the reasoning **already applied to Prometheus series** by `maxSeriesPerMetric` / `seriesLimiter` — bound what a remote caller can make the process remember — extended to the cache sets those two functions populate.

It's a **gate, not a removal**: with `PROMETHEUS_ENABLED=true` behaviour is identical. Read live via `config.GetEnv` rather than cached at init, since `GetEnv` reads the environment per call and the existing tests toggle the variable between cases.

## Tests

Added `TestPerClientTrackingSkippedWhenPrometheusDisabled`, asserting neither set grows while disabled **and** that re-enabling restores recording — so it pins the gate rather than the absence of the feature.

Verified it actually catches the bug:

```
with guards:     --- PASS
guards removed:  --- FAIL: active-user set grew while PROMETHEUS_ENABLED=false: got 1, want 0
```

`go build ./...`, `go vet`, `gofmt` clean; full suite **41 packages passing, 0 failing** on Go 1.25.

## Notes for reviewers

- Happy to extend the gate to the other `Track*` functions, but they only touch Prometheus vectors (bounded by `seriesLimiter`) rather than cache sets, so they don't carry the same growth.
- An alternative would be bounding the sets themselves (cap + eviction), which would help Redis-backed deployments too. That felt like a larger design call than this PR should make — glad to follow up if you'd prefer that direction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configuration-based control for high-cardinality Prometheus metrics.
  * Active-user and update-error metrics are recorded only when `PROMETHEUS_ENABLED` is set to `true`.

* **Bug Fixes**
  * Prevented disabled metrics from modifying tracking data.
  * Confirmed metric tracking resumes when Prometheus monitoring is re-enabled.
  * Ensured metric-related tracking remains consistent when monitoring is disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->