### PR TITLE
feat: app identifiers as the anchor of store credentials

### DIFF
--- a/apps/dashboard/src/ee/lib/auditCatalog.ts
+++ b/apps/dashboard/src/ee/lib/auditCatalog.ts
@@ -74,6 +74,7 @@ export const AUDIT_ACTION_GROUPS: AuditActionGroup[] = [
       'certificate.downloaded',
       'app_identifier.created',
       'app_identifier.deleted',
+      'app_identifier.build_number_set',
       'android_credentials.saved',
       'android_credentials.deleted',
     ],

--- a/apps/dashboard/src/ee/lib/auditCatalog.ts
+++ b/apps/dashboard/src/ee/lib/auditCatalog.ts
@@ -72,6 +72,8 @@ export const AUDIT_ACTION_GROUPS: AuditActionGroup[] = [
       'api_key.restrictions_updated',
       'branch_protection.updated',
       'certificate.downloaded',
+      'app_identifier.created',
+      'app_identifier.deleted',
       'android_credentials.saved',
       'android_credentials.deleted',
     ],

--- a/ee/rbac/permissions.go
+++ b/ee/rbac/permissions.go
@@ -58,9 +58,9 @@ const (
 	// the embedded bundle. It is distinct from PermUpdateRolloutManage, which
 	// only reverts a rollout already in progress.
 	PermUpdatePublish Permission = "update:publish"
-	// PermCredentialsManage uploads or deletes the app's store signing
-	// credentials (Android keystore, submit keys). Reading the non-secret
-	// metadata is open to any viewer.
+	// PermCredentialsManage manages the app's store identities (application
+	// identifiers) and their signing credentials (Android keystore, submit
+	// keys). Reading the non-secret metadata is open to any viewer.
 	PermCredentialsManage Permission = "credentials:manage"
 )
 

--- a/internal/auditlog/auditlog.go
+++ b/internal/auditlog/auditlog.go
@@ -95,6 +95,8 @@ const (
 	ActionAPIKeyRestrictionsUpdated Action = "api_key.restrictions_updated"
 	ActionBranchProtectionUpdated   Action = "branch_protection.updated"
 	ActionCertificateDownloaded     Action = "certificate.downloaded"
+	ActionAppIdentifierCreated      Action = "app_identifier.created"
+	ActionAppIdentifierDeleted      Action = "app_identifier.deleted"
 	ActionAndroidCredentialsSaved   Action = "android_credentials.saved"
 	ActionAndroidCredentialsDeleted Action = "android_credentials.deleted"
 

--- a/internal/auditlog/auditlog.go
+++ b/internal/auditlog/auditlog.go
@@ -95,8 +95,9 @@ const (
 	ActionAPIKeyRestrictionsUpdated Action = "api_key.restrictions_updated"
 	ActionBranchProtectionUpdated   Action = "branch_protection.updated"
 	ActionCertificateDownloaded     Action = "certificate.downloaded"
-	ActionAppIdentifierCreated      Action = "app_identifier.created"
-	ActionAppIdentifierDeleted      Action = "app_identifier.deleted"
+	ActionAppIdentifierCreated        Action = "app_identifier.created"
+	ActionAppIdentifierDeleted        Action = "app_identifier.deleted"
+	ActionAppIdentifierBuildNumberSet Action = "app_identifier.build_number_set"
 	ActionAndroidCredentialsSaved   Action = "android_credentials.saved"
 	ActionAndroidCredentialsDeleted Action = "android_credentials.deleted"
 

--- a/internal/database/postgres/migrations/20260805120000_android_credentials.sql
+++ b/internal/database/postgres/migrations/20260805120000_android_credentials.sql
@@ -6,6 +6,7 @@ CREATE TABLE app_identifiers (
     app_id UUID NOT NULL,
     platform VARCHAR(10) NOT NULL,
     identifier VARCHAR(255) NOT NULL,
+    build_number BIGINT NOT NULL DEFAULT 0,
     created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
     CONSTRAINT fk_app_identifiers_app FOREIGN KEY (app_id) REFERENCES apps(id) ON DELETE CASCADE,
     CONSTRAINT uq_app_identifier UNIQUE (app_id, platform, identifier)

--- a/internal/database/postgres/migrations/20260805120000_android_credentials.sql
+++ b/internal/database/postgres/migrations/20260805120000_android_credentials.sql
@@ -1,13 +1,20 @@
 -- +goose Up
 -- +goose StatementBegin
 
--- Android signing credentials of an app, one set per app. The keystore and
--- its passwords are sealed with AES-GCM under the deployment master key,
--- bound to the app id; only android_package and key_alias are readable as-is.
+CREATE TABLE app_identifiers (
+    id UUID PRIMARY KEY,
+    app_id UUID NOT NULL,
+    platform VARCHAR(10) NOT NULL,
+    identifier VARCHAR(255) NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT fk_app_identifiers_app FOREIGN KEY (app_id) REFERENCES apps(id) ON DELETE CASCADE,
+    CONSTRAINT uq_app_identifier UNIQUE (app_id, platform, identifier)
+);
+
+DROP TABLE IF EXISTS android_credentials;
 CREATE TABLE android_credentials (
     id UUID PRIMARY KEY,
-    app_id UUID NOT NULL UNIQUE,
-    android_package VARCHAR(255) NOT NULL,
+    app_identifier_id UUID NOT NULL UNIQUE,
     key_alias VARCHAR(255) NOT NULL,
     sealed_keystore TEXT NOT NULL,
     sealed_keystore_password TEXT NOT NULL,
@@ -15,7 +22,7 @@ CREATE TABLE android_credentials (
     sealed_google_service_account_key TEXT,
     created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    CONSTRAINT fk_android_credentials_app FOREIGN KEY (app_id) REFERENCES apps(id) ON DELETE CASCADE
+    CONSTRAINT fk_android_credentials_identifier FOREIGN KEY (app_identifier_id) REFERENCES app_identifiers(id) ON DELETE CASCADE
 );
 
 -- +goose StatementEnd
@@ -23,4 +30,5 @@ CREATE TABLE android_credentials (
 -- +goose Down
 -- +goose StatementBegin
 DROP TABLE IF EXISTS android_credentials;
+DROP TABLE IF EXISTS app_identifiers;
 -- +goose StatementEnd

--- a/internal/database/postgres/pgdb/models.go
+++ b/internal/database/postgres/pgdb/models.go
@@ -12,8 +12,7 @@ import (
 
 type AndroidCredential struct {
 	ID                            pgtype.UUID        `json:"id"`
-	AppID                         pgtype.UUID        `json:"app_id"`
-	AndroidPackage                string             `json:"android_package"`
+	AppIdentifierID               pgtype.UUID        `json:"app_identifier_id"`
 	KeyAlias                      string             `json:"key_alias"`
 	SealedKeystore                string             `json:"sealed_keystore"`
 	SealedKeystorePassword        string             `json:"sealed_keystore_password"`
@@ -55,6 +54,14 @@ type App struct {
 	AwsSecretIDPrivate *string            `json:"aws_secret_id_private"`
 	CreatedAt          pgtype.Timestamptz `json:"created_at"`
 	UpdatedAt          pgtype.Timestamptz `json:"updated_at"`
+}
+
+type AppIdentifier struct {
+	ID         pgtype.UUID        `json:"id"`
+	AppID      pgtype.UUID        `json:"app_id"`
+	Platform   string             `json:"platform"`
+	Identifier string             `json:"identifier"`
+	CreatedAt  pgtype.Timestamptz `json:"created_at"`
 }
 
 type AuditExportState struct {

--- a/internal/database/postgres/pgdb/models.go
+++ b/internal/database/postgres/pgdb/models.go
@@ -57,11 +57,12 @@ type App struct {
 }
 
 type AppIdentifier struct {
-	ID         pgtype.UUID        `json:"id"`
-	AppID      pgtype.UUID        `json:"app_id"`
-	Platform   string             `json:"platform"`
-	Identifier string             `json:"identifier"`
-	CreatedAt  pgtype.Timestamptz `json:"created_at"`
+	ID          pgtype.UUID        `json:"id"`
+	AppID       pgtype.UUID        `json:"app_id"`
+	Platform    string             `json:"platform"`
+	Identifier  string             `json:"identifier"`
+	BuildNumber int64              `json:"build_number"`
+	CreatedAt   pgtype.Timestamptz `json:"created_at"`
 }
 
 type AuditExportState struct {

--- a/internal/database/postgres/pgdb/queries.sql.go
+++ b/internal/database/postgres/pgdb/queries.sql.go
@@ -1043,7 +1043,7 @@ func (q *Queries) GetAppByID(ctx context.Context, id pgtype.UUID) (App, error) {
 }
 
 const getAppIdentifierByID = `-- name: GetAppIdentifierByID :one
-SELECT id, platform, identifier
+SELECT id, platform, identifier, build_number
 FROM app_identifiers
 WHERE app_id = $1 AND id = $2
 `
@@ -1054,20 +1054,26 @@ type GetAppIdentifierByIDParams struct {
 }
 
 type GetAppIdentifierByIDRow struct {
-	ID         pgtype.UUID `json:"id"`
-	Platform   string      `json:"platform"`
-	Identifier string      `json:"identifier"`
+	ID          pgtype.UUID `json:"id"`
+	Platform    string      `json:"platform"`
+	Identifier  string      `json:"identifier"`
+	BuildNumber int64       `json:"build_number"`
 }
 
 func (q *Queries) GetAppIdentifierByID(ctx context.Context, arg GetAppIdentifierByIDParams) (GetAppIdentifierByIDRow, error) {
 	row := q.db.QueryRow(ctx, getAppIdentifierByID, arg.AppID, arg.ID)
 	var i GetAppIdentifierByIDRow
-	err := row.Scan(&i.ID, &i.Platform, &i.Identifier)
+	err := row.Scan(
+		&i.ID,
+		&i.Platform,
+		&i.Identifier,
+		&i.BuildNumber,
+	)
 	return i, err
 }
 
 const getAppIdentifiersByAppID = `-- name: GetAppIdentifiersByAppID :many
-SELECT ai.id, ai.platform, ai.identifier, ai.created_at,
+SELECT ai.id, ai.platform, ai.identifier, ai.build_number, ai.created_at,
        (ac.id IS NOT NULL)::bool AS has_android_credentials
 FROM app_identifiers ai
 LEFT JOIN android_credentials ac ON ac.app_identifier_id = ai.id
@@ -1079,6 +1085,7 @@ type GetAppIdentifiersByAppIDRow struct {
 	ID                    pgtype.UUID        `json:"id"`
 	Platform              string             `json:"platform"`
 	Identifier            string             `json:"identifier"`
+	BuildNumber           int64              `json:"build_number"`
 	CreatedAt             pgtype.Timestamptz `json:"created_at"`
 	HasAndroidCredentials bool               `json:"has_android_credentials"`
 }
@@ -1096,6 +1103,7 @@ func (q *Queries) GetAppIdentifiersByAppID(ctx context.Context, appID pgtype.UUI
 			&i.ID,
 			&i.Platform,
 			&i.Identifier,
+			&i.BuildNumber,
 			&i.CreatedAt,
 			&i.HasAndroidCredentials,
 		); err != nil {
@@ -5154,6 +5162,22 @@ func (q *Queries) SearchIdentityValues(ctx context.Context, arg SearchIdentityVa
 		return nil, err
 	}
 	return items, nil
+}
+
+const setAppIdentifierBuildNumber = `-- name: SetAppIdentifierBuildNumber :execresult
+UPDATE app_identifiers
+SET build_number = $3
+WHERE app_id = $1 AND id = $2
+`
+
+type SetAppIdentifierBuildNumberParams struct {
+	AppID       pgtype.UUID `json:"app_id"`
+	ID          pgtype.UUID `json:"id"`
+	BuildNumber int64       `json:"build_number"`
+}
+
+func (q *Queries) SetAppIdentifierBuildNumber(ctx context.Context, arg SetAppIdentifierBuildNumberParams) (pgconn.CommandTag, error) {
+	return q.db.Exec(ctx, setAppIdentifierBuildNumber, arg.AppID, arg.ID, arg.BuildNumber)
 }
 
 const setBranchProtected = `-- name: SetBranchProtected :execrows

--- a/internal/database/postgres/pgdb/queries.sql.go
+++ b/internal/database/postgres/pgdb/queries.sql.go
@@ -465,12 +465,12 @@ func (q *Queries) CountUpdateFailures(ctx context.Context, arg CountUpdateFailur
 	return count, err
 }
 
-const deleteAndroidCredentialsByAppID = `-- name: DeleteAndroidCredentialsByAppID :execresult
-DELETE FROM android_credentials WHERE app_id = $1
+const deleteAndroidCredentialsByIdentifierID = `-- name: DeleteAndroidCredentialsByIdentifierID :execresult
+DELETE FROM android_credentials WHERE app_identifier_id = $1
 `
 
-func (q *Queries) DeleteAndroidCredentialsByAppID(ctx context.Context, appID pgtype.UUID) (pgconn.CommandTag, error) {
-	return q.db.Exec(ctx, deleteAndroidCredentialsByAppID, appID)
+func (q *Queries) DeleteAndroidCredentialsByIdentifierID(ctx context.Context, appIdentifierID pgtype.UUID) (pgconn.CommandTag, error) {
+	return q.db.Exec(ctx, deleteAndroidCredentialsByIdentifierID, appIdentifierID)
 }
 
 const deleteApiKeyBranchRules = `-- name: DeleteApiKeyBranchRules :exec
@@ -492,6 +492,26 @@ WHERE id = $1
 
 func (q *Queries) DeleteAppByID(ctx context.Context, id pgtype.UUID) (pgconn.CommandTag, error) {
 	return q.db.Exec(ctx, deleteAppByID, id)
+}
+
+const deleteAppIdentifierByID = `-- name: DeleteAppIdentifierByID :execresult
+DELETE FROM app_identifiers
+WHERE app_identifiers.app_id = $1 AND app_identifiers.id = $2
+  AND NOT EXISTS (
+      SELECT 1 FROM android_credentials ac WHERE ac.app_identifier_id = app_identifiers.id
+  )
+`
+
+type DeleteAppIdentifierByIDParams struct {
+	AppID pgtype.UUID `json:"app_id"`
+	ID    pgtype.UUID `json:"id"`
+}
+
+// Guarded: an identifier still holding credentials is NOT deleted, its
+// keystore must be removed explicitly first. The caller disambiguates the
+// 0-rows result into has-credentials vs not-found.
+func (q *Queries) DeleteAppIdentifierByID(ctx context.Context, arg DeleteAppIdentifierByIDParams) (pgconn.CommandTag, error) {
+	return q.db.Exec(ctx, deleteAppIdentifierByID, arg.AppID, arg.ID)
 }
 
 const deleteBranchByName = `-- name: DeleteBranchByName :execresult
@@ -825,21 +845,20 @@ func (q *Queries) GetActiveRolloutUpdates(ctx context.Context, arg GetActiveRoll
 	return items, nil
 }
 
-const getAndroidCredentialsByAppID = `-- name: GetAndroidCredentialsByAppID :one
-SELECT id, app_id, android_package, key_alias,
+const getAndroidCredentialsByIdentifierID = `-- name: GetAndroidCredentialsByIdentifierID :one
+SELECT id, app_identifier_id, key_alias,
        sealed_keystore, sealed_keystore_password, sealed_key_password,
        sealed_google_service_account_key, created_at, updated_at
 FROM android_credentials
-WHERE app_id = $1
+WHERE app_identifier_id = $1
 `
 
-func (q *Queries) GetAndroidCredentialsByAppID(ctx context.Context, appID pgtype.UUID) (AndroidCredential, error) {
-	row := q.db.QueryRow(ctx, getAndroidCredentialsByAppID, appID)
+func (q *Queries) GetAndroidCredentialsByIdentifierID(ctx context.Context, appIdentifierID pgtype.UUID) (AndroidCredential, error) {
+	row := q.db.QueryRow(ctx, getAndroidCredentialsByIdentifierID, appIdentifierID)
 	var i AndroidCredential
 	err := row.Scan(
 		&i.ID,
-		&i.AppID,
-		&i.AndroidPackage,
+		&i.AppIdentifierID,
 		&i.KeyAlias,
 		&i.SealedKeystore,
 		&i.SealedKeystorePassword,
@@ -1021,6 +1040,73 @@ func (q *Queries) GetAppByID(ctx context.Context, id pgtype.UUID) (App, error) {
 		&i.UpdatedAt,
 	)
 	return i, err
+}
+
+const getAppIdentifierByID = `-- name: GetAppIdentifierByID :one
+SELECT id, platform, identifier
+FROM app_identifiers
+WHERE app_id = $1 AND id = $2
+`
+
+type GetAppIdentifierByIDParams struct {
+	AppID pgtype.UUID `json:"app_id"`
+	ID    pgtype.UUID `json:"id"`
+}
+
+type GetAppIdentifierByIDRow struct {
+	ID         pgtype.UUID `json:"id"`
+	Platform   string      `json:"platform"`
+	Identifier string      `json:"identifier"`
+}
+
+func (q *Queries) GetAppIdentifierByID(ctx context.Context, arg GetAppIdentifierByIDParams) (GetAppIdentifierByIDRow, error) {
+	row := q.db.QueryRow(ctx, getAppIdentifierByID, arg.AppID, arg.ID)
+	var i GetAppIdentifierByIDRow
+	err := row.Scan(&i.ID, &i.Platform, &i.Identifier)
+	return i, err
+}
+
+const getAppIdentifiersByAppID = `-- name: GetAppIdentifiersByAppID :many
+SELECT ai.id, ai.platform, ai.identifier, ai.created_at,
+       (ac.id IS NOT NULL)::bool AS has_android_credentials
+FROM app_identifiers ai
+LEFT JOIN android_credentials ac ON ac.app_identifier_id = ai.id
+WHERE ai.app_id = $1
+ORDER BY ai.platform ASC, ai.identifier ASC
+`
+
+type GetAppIdentifiersByAppIDRow struct {
+	ID                    pgtype.UUID        `json:"id"`
+	Platform              string             `json:"platform"`
+	Identifier            string             `json:"identifier"`
+	CreatedAt             pgtype.Timestamptz `json:"created_at"`
+	HasAndroidCredentials bool               `json:"has_android_credentials"`
+}
+
+func (q *Queries) GetAppIdentifiersByAppID(ctx context.Context, appID pgtype.UUID) ([]GetAppIdentifiersByAppIDRow, error) {
+	rows, err := q.db.Query(ctx, getAppIdentifiersByAppID, appID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []GetAppIdentifiersByAppIDRow
+	for rows.Next() {
+		var i GetAppIdentifiersByAppIDRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.Platform,
+			&i.Identifier,
+			&i.CreatedAt,
+			&i.HasAndroidCredentials,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
 }
 
 const getApps = `-- name: GetApps :many
@@ -2680,6 +2766,31 @@ func (q *Queries) InsertApp(ctx context.Context, arg InsertAppParams) (pgtype.UU
 		arg.PathPrivateKey,
 		arg.AwsSecretIDPublic,
 		arg.AwsSecretIDPrivate,
+	)
+	var id pgtype.UUID
+	err := row.Scan(&id)
+	return id, err
+}
+
+const insertAppIdentifier = `-- name: InsertAppIdentifier :one
+INSERT INTO app_identifiers (id, app_id, platform, identifier)
+VALUES ($1, $2, $3, $4)
+RETURNING id
+`
+
+type InsertAppIdentifierParams struct {
+	ID         pgtype.UUID `json:"id"`
+	AppID      pgtype.UUID `json:"app_id"`
+	Platform   string      `json:"platform"`
+	Identifier string      `json:"identifier"`
+}
+
+func (q *Queries) InsertAppIdentifier(ctx context.Context, arg InsertAppIdentifierParams) (pgtype.UUID, error) {
+	row := q.db.QueryRow(ctx, insertAppIdentifier,
+		arg.ID,
+		arg.AppID,
+		arg.Platform,
+		arg.Identifier,
 	)
 	var id pgtype.UUID
 	err := row.Scan(&id)
@@ -5677,12 +5788,11 @@ func (q *Queries) UpdateUserPasswordByID(ctx context.Context, arg UpdateUserPass
 
 const upsertAndroidCredentials = `-- name: UpsertAndroidCredentials :one
 INSERT INTO android_credentials (
-    id, app_id, android_package, key_alias,
+    id, app_identifier_id, key_alias,
     sealed_keystore, sealed_keystore_password, sealed_key_password,
     sealed_google_service_account_key
-) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
-ON CONFLICT (app_id) DO UPDATE SET
-    android_package = EXCLUDED.android_package,
+) VALUES ($1, $2, $3, $4, $5, $6, $7)
+ON CONFLICT (app_identifier_id) DO UPDATE SET
     key_alias = EXCLUDED.key_alias,
     sealed_keystore = EXCLUDED.sealed_keystore,
     sealed_keystore_password = EXCLUDED.sealed_keystore_password,
@@ -5694,8 +5804,7 @@ RETURNING id
 
 type UpsertAndroidCredentialsParams struct {
 	ID                            pgtype.UUID `json:"id"`
-	AppID                         pgtype.UUID `json:"app_id"`
-	AndroidPackage                string      `json:"android_package"`
+	AppIdentifierID               pgtype.UUID `json:"app_identifier_id"`
 	KeyAlias                      string      `json:"key_alias"`
 	SealedKeystore                string      `json:"sealed_keystore"`
 	SealedKeystorePassword        string      `json:"sealed_keystore_password"`
@@ -5706,8 +5815,7 @@ type UpsertAndroidCredentialsParams struct {
 func (q *Queries) UpsertAndroidCredentials(ctx context.Context, arg UpsertAndroidCredentialsParams) (pgtype.UUID, error) {
 	row := q.db.QueryRow(ctx, upsertAndroidCredentials,
 		arg.ID,
-		arg.AppID,
-		arg.AndroidPackage,
+		arg.AppIdentifierID,
 		arg.KeyAlias,
 		arg.SealedKeystore,
 		arg.SealedKeystorePassword,

--- a/internal/database/postgres/queries/queries.sql
+++ b/internal/database/postgres/queries/queries.sql
@@ -2350,7 +2350,7 @@ VALUES ($1, $2, $3, $4)
 RETURNING id;
 
 -- name: GetAppIdentifiersByAppID :many
-SELECT ai.id, ai.platform, ai.identifier, ai.created_at,
+SELECT ai.id, ai.platform, ai.identifier, ai.build_number, ai.created_at,
        (ac.id IS NOT NULL)::bool AS has_android_credentials
 FROM app_identifiers ai
 LEFT JOIN android_credentials ac ON ac.app_identifier_id = ai.id
@@ -2358,8 +2358,13 @@ WHERE ai.app_id = $1
 ORDER BY ai.platform ASC, ai.identifier ASC;
 
 -- name: GetAppIdentifierByID :one
-SELECT id, platform, identifier
+SELECT id, platform, identifier, build_number
 FROM app_identifiers
+WHERE app_id = $1 AND id = $2;
+
+-- name: SetAppIdentifierBuildNumber :execresult
+UPDATE app_identifiers
+SET build_number = $3
 WHERE app_id = $1 AND id = $2;
 
 -- name: DeleteAppIdentifierByID :execresult

--- a/internal/database/postgres/queries/queries.sql
+++ b/internal/database/postgres/queries/queries.sql
@@ -2321,12 +2321,11 @@ ORDER BY MAX(u.created_at) DESC, b.name ASC;
 
 -- name: UpsertAndroidCredentials :one
 INSERT INTO android_credentials (
-    id, app_id, android_package, key_alias,
+    id, app_identifier_id, key_alias,
     sealed_keystore, sealed_keystore_password, sealed_key_password,
     sealed_google_service_account_key
-) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
-ON CONFLICT (app_id) DO UPDATE SET
-    android_package = EXCLUDED.android_package,
+) VALUES ($1, $2, $3, $4, $5, $6, $7)
+ON CONFLICT (app_identifier_id) DO UPDATE SET
     key_alias = EXCLUDED.key_alias,
     sealed_keystore = EXCLUDED.sealed_keystore,
     sealed_keystore_password = EXCLUDED.sealed_keystore_password,
@@ -2335,12 +2334,40 @@ ON CONFLICT (app_id) DO UPDATE SET
     updated_at = CURRENT_TIMESTAMP
 RETURNING id;
 
--- name: GetAndroidCredentialsByAppID :one
-SELECT id, app_id, android_package, key_alias,
+-- name: GetAndroidCredentialsByIdentifierID :one
+SELECT id, app_identifier_id, key_alias,
        sealed_keystore, sealed_keystore_password, sealed_key_password,
        sealed_google_service_account_key, created_at, updated_at
 FROM android_credentials
-WHERE app_id = $1;
+WHERE app_identifier_id = $1;
 
--- name: DeleteAndroidCredentialsByAppID :execresult
-DELETE FROM android_credentials WHERE app_id = $1;
+-- name: DeleteAndroidCredentialsByIdentifierID :execresult
+DELETE FROM android_credentials WHERE app_identifier_id = $1;
+
+-- name: InsertAppIdentifier :one
+INSERT INTO app_identifiers (id, app_id, platform, identifier)
+VALUES ($1, $2, $3, $4)
+RETURNING id;
+
+-- name: GetAppIdentifiersByAppID :many
+SELECT ai.id, ai.platform, ai.identifier, ai.created_at,
+       (ac.id IS NOT NULL)::bool AS has_android_credentials
+FROM app_identifiers ai
+LEFT JOIN android_credentials ac ON ac.app_identifier_id = ai.id
+WHERE ai.app_id = $1
+ORDER BY ai.platform ASC, ai.identifier ASC;
+
+-- name: GetAppIdentifierByID :one
+SELECT id, platform, identifier
+FROM app_identifiers
+WHERE app_id = $1 AND id = $2;
+
+-- name: DeleteAppIdentifierByID :execresult
+-- Guarded: an identifier still holding credentials is NOT deleted, its
+-- keystore must be removed explicitly first. The caller disambiguates the
+-- 0-rows result into has-credentials vs not-found.
+DELETE FROM app_identifiers
+WHERE app_identifiers.app_id = $1 AND app_identifiers.id = $2
+  AND NOT EXISTS (
+      SELECT 1 FROM android_credentials ac WHERE ac.app_identifier_id = app_identifiers.id
+  );

--- a/internal/handlers/dashboard/app_identifiers_handler.go
+++ b/internal/handlers/dashboard/app_identifiers_handler.go
@@ -76,6 +76,42 @@ func (h *AppIdentifiersHandler) CreateAppIdentifierHandler(w http.ResponseWriter
 	w.Write(marshaledResponse)
 }
 
+func (h *AppIdentifiersHandler) SetBuildNumberHandler(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	appId := vars["APP_ID"]
+	identifierId := vars["IDENTIFIER_ID"]
+	if _, err := uuid.Parse(identifierId); err != nil {
+		handlers.RenderError(w, http.StatusBadRequest, "invalid identifier id")
+		return
+	}
+	var requestBody struct {
+		BuildNumber *int64 `json:"buildNumber"`
+	}
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 4<<10)).Decode(&requestBody); err != nil || requestBody.BuildNumber == nil {
+		handlers.RenderError(w, http.StatusBadRequest, "invalid request body, expected {\"buildNumber\": <integer>}")
+		return
+	}
+	err := h.identifierService.SetBuildNumber(r.Context(), appId, identifierId, *requestBody.BuildNumber)
+	if err != nil {
+		var valErr *validation.Error
+		if errors.As(err, &valErr) {
+			handlers.RenderError(w, http.StatusBadRequest, valErr.Error())
+			return
+		}
+		if notFoundErr := (*store.ErrResourceNotFound)(nil); errors.As(err, &notFoundErr) {
+			handlers.RenderError(w, http.StatusNotFound, notFoundErr.Error())
+			return
+		}
+		if errors.Is(err, store.ErrNotSupportedInStatelessMode) {
+			handlers.RenderError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		handlers.RenderError(w, http.StatusInternalServerError, "An internal error occurred while setting the build number.")
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
 func (h *AppIdentifiersHandler) DeleteAppIdentifierHandler(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	appId := vars["APP_ID"]

--- a/internal/handlers/dashboard/app_identifiers_handler.go
+++ b/internal/handlers/dashboard/app_identifiers_handler.go
@@ -1,0 +1,105 @@
+package handlers
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"xprem/internal/handlers"
+	"xprem/internal/services"
+	"xprem/internal/store"
+	"xprem/internal/validation"
+
+	"github.com/google/uuid"
+	"github.com/gorilla/mux"
+)
+
+type AppIdentifiersHandler struct {
+	identifierService *services.AppIdentifierService
+}
+
+func NewAppIdentifiersHandler(identifierService *services.AppIdentifierService) *AppIdentifiersHandler {
+	return &AppIdentifiersHandler{
+		identifierService: identifierService,
+	}
+}
+
+func (h *AppIdentifiersHandler) GetAppIdentifiersHandler(w http.ResponseWriter, r *http.Request) {
+	appId := mux.Vars(r)["APP_ID"]
+	identifiers, err := h.identifierService.GetAppIdentifiers(r.Context(), appId)
+	if err != nil {
+		if errors.Is(err, store.ErrNotSupportedInStatelessMode) {
+			handlers.RenderError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		handlers.RenderError(w, http.StatusInternalServerError, "An internal error occurred while fetching app identifiers.")
+		return
+	}
+	marshaledResponse, _ := json.Marshal(identifiers)
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	w.Write(marshaledResponse)
+}
+
+func (h *AppIdentifiersHandler) CreateAppIdentifierHandler(w http.ResponseWriter, r *http.Request) {
+	appId := mux.Vars(r)["APP_ID"]
+	var requestBody struct {
+		Platform   string `json:"platform"`
+		Identifier string `json:"identifier"`
+	}
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 4<<10)).Decode(&requestBody); err != nil {
+		handlers.RenderError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	identifierId, err := h.identifierService.CreateAppIdentifier(r.Context(), appId, requestBody.Platform, requestBody.Identifier)
+	if err != nil {
+		var valErr *validation.Error
+		if errors.As(err, &valErr) {
+			handlers.RenderError(w, http.StatusBadRequest, valErr.Error())
+			return
+		}
+		if alreadyExistsErr := (*store.ErrResourceAlreadyExists)(nil); errors.As(err, &alreadyExistsErr) {
+			handlers.RenderError(w, http.StatusConflict, alreadyExistsErr.Error())
+			return
+		}
+		if errors.Is(err, store.ErrNotSupportedInStatelessMode) {
+			handlers.RenderError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		handlers.RenderError(w, http.StatusInternalServerError, "An internal error occurred while creating the app identifier.")
+		return
+	}
+	marshaledResponse, _ := json.Marshal(map[string]any{
+		"identifierId": identifierId,
+	})
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	w.Write(marshaledResponse)
+}
+
+func (h *AppIdentifiersHandler) DeleteAppIdentifierHandler(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	appId := vars["APP_ID"]
+	identifierId := vars["IDENTIFIER_ID"]
+	if _, err := uuid.Parse(identifierId); err != nil {
+		handlers.RenderError(w, http.StatusBadRequest, "invalid identifier id")
+		return
+	}
+	err := h.identifierService.DeleteAppIdentifier(r.Context(), appId, identifierId)
+	if err != nil {
+		if hasCredsErr := (*store.ErrIdentifierHasCredentials)(nil); errors.As(err, &hasCredsErr) {
+			handlers.RenderError(w, http.StatusConflict, hasCredsErr.Error())
+			return
+		}
+		if notFoundErr := (*store.ErrResourceNotFound)(nil); errors.As(err, &notFoundErr) {
+			handlers.RenderError(w, http.StatusNotFound, notFoundErr.Error())
+			return
+		}
+		if errors.Is(err, store.ErrNotSupportedInStatelessMode) {
+			handlers.RenderError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		handlers.RenderError(w, http.StatusInternalServerError, "An internal error occurred while deleting the app identifier.")
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/internal/handlers/dashboard/credentials_handler.go
+++ b/internal/handlers/dashboard/credentials_handler.go
@@ -9,6 +9,7 @@ import (
 	"xprem/internal/store"
 	"xprem/internal/validation"
 
+	"github.com/google/uuid"
 	"github.com/gorilla/mux"
 )
 
@@ -22,19 +23,48 @@ func NewCredentialsHandler(credentialsService *services.CredentialsService) *Cre
 	}
 }
 
+// credentialsVars extracts and validates the route vars shared by the three
+// handlers; a "" identifier id means the response was already written.
+func credentialsVars(w http.ResponseWriter, r *http.Request) (string, string) {
+	vars := mux.Vars(r)
+	appId := vars["APP_ID"]
+	identifierId := vars["IDENTIFIER_ID"]
+	if _, err := uuid.Parse(identifierId); err != nil {
+		handlers.RenderError(w, http.StatusBadRequest, "invalid identifier id")
+		return "", ""
+	}
+	return appId, identifierId
+}
+
+func renderCredentialsError(w http.ResponseWriter, err error, fallback string) {
+	var valErr *validation.Error
+	if errors.As(err, &valErr) {
+		handlers.RenderError(w, http.StatusBadRequest, valErr.Error())
+		return
+	}
+	if notFoundErr := (*store.ErrResourceNotFound)(nil); errors.As(err, &notFoundErr) {
+		handlers.RenderError(w, http.StatusNotFound, notFoundErr.Error())
+		return
+	}
+	if errors.Is(err, store.ErrNotSupportedInStatelessMode) {
+		handlers.RenderError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	handlers.RenderError(w, http.StatusInternalServerError, fallback)
+}
+
 func (h *CredentialsHandler) GetAndroidCredentialsHandler(w http.ResponseWriter, r *http.Request) {
-	appId := mux.Vars(r)["APP_ID"]
-	metadata, err := h.credentialsService.GetAndroidCredentialsMetadata(r.Context(), appId)
+	appId, identifierId := credentialsVars(w, r)
+	if identifierId == "" {
+		return
+	}
+	metadata, err := h.credentialsService.GetAndroidCredentialsMetadata(r.Context(), appId, identifierId)
 	if err != nil {
-		if errors.Is(err, store.ErrNotSupportedInStatelessMode) {
-			handlers.RenderError(w, http.StatusBadRequest, err.Error())
-			return
-		}
-		handlers.RenderError(w, http.StatusInternalServerError, "An internal error occurred while fetching android credentials.")
+		renderCredentialsError(w, err, "An internal error occurred while fetching android credentials.")
 		return
 	}
 	if metadata == nil {
-		handlers.RenderError(w, http.StatusNotFound, "no android credentials configured for this app")
+		handlers.RenderError(w, http.StatusNotFound, "no android credentials configured for this identifier")
 		return
 	}
 	marshaledResponse, _ := json.Marshal(metadata)
@@ -44,9 +74,11 @@ func (h *CredentialsHandler) GetAndroidCredentialsHandler(w http.ResponseWriter,
 }
 
 func (h *CredentialsHandler) PutAndroidCredentialsHandler(w http.ResponseWriter, r *http.Request) {
-	appId := mux.Vars(r)["APP_ID"]
+	appId, identifierId := credentialsVars(w, r)
+	if identifierId == "" {
+		return
+	}
 	var requestBody struct {
-		AndroidPackage          string `json:"androidPackage"`
 		KeyAlias                string `json:"keyAlias"`
 		Keystore                string `json:"keystore"`
 		KeystorePassword        string `json:"keystorePassword"`
@@ -57,8 +89,7 @@ func (h *CredentialsHandler) PutAndroidCredentialsHandler(w http.ResponseWriter,
 		handlers.RenderError(w, http.StatusBadRequest, "invalid request body")
 		return
 	}
-	err := h.credentialsService.SaveAndroidCredentials(r.Context(), appId, services.AndroidCredentialsInput{
-		AndroidPackage:              requestBody.AndroidPackage,
+	err := h.credentialsService.SaveAndroidCredentials(r.Context(), appId, identifierId, services.AndroidCredentialsInput{
 		KeyAlias:                    requestBody.KeyAlias,
 		KeystoreBase64:              requestBody.Keystore,
 		KeystorePassword:            requestBody.KeystorePassword,
@@ -66,34 +97,20 @@ func (h *CredentialsHandler) PutAndroidCredentialsHandler(w http.ResponseWriter,
 		GoogleServiceAccountKeyJSON: requestBody.GoogleServiceAccountKey,
 	})
 	if err != nil {
-		var valErr *validation.Error
-		if errors.As(err, &valErr) {
-			handlers.RenderError(w, http.StatusBadRequest, valErr.Error())
-			return
-		}
-		if errors.Is(err, store.ErrNotSupportedInStatelessMode) {
-			handlers.RenderError(w, http.StatusBadRequest, err.Error())
-			return
-		}
-		handlers.RenderError(w, http.StatusInternalServerError, "An internal error occurred while saving android credentials.")
+		renderCredentialsError(w, err, "An internal error occurred while saving android credentials.")
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)
 }
 
 func (h *CredentialsHandler) DeleteAndroidCredentialsHandler(w http.ResponseWriter, r *http.Request) {
-	appId := mux.Vars(r)["APP_ID"]
-	err := h.credentialsService.DeleteAndroidCredentials(r.Context(), appId)
+	appId, identifierId := credentialsVars(w, r)
+	if identifierId == "" {
+		return
+	}
+	err := h.credentialsService.DeleteAndroidCredentials(r.Context(), appId, identifierId)
 	if err != nil {
-		if notFoundErr := (*store.ErrResourceNotFound)(nil); errors.As(err, &notFoundErr) {
-			handlers.RenderError(w, http.StatusNotFound, notFoundErr.Error())
-			return
-		}
-		if errors.Is(err, store.ErrNotSupportedInStatelessMode) {
-			handlers.RenderError(w, http.StatusBadRequest, err.Error())
-			return
-		}
-		handlers.RenderError(w, http.StatusInternalServerError, "An internal error occurred while deleting android credentials.")
+		renderCredentialsError(w, err, "An internal error occurred while deleting android credentials.")
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)

--- a/internal/router/routes_app.go
+++ b/internal/router/routes_app.go
@@ -88,6 +88,8 @@ func registerAppRoutes(
 		NeedsPermission(rbac.PermCredentialsManage, rbac.FallbackAdminOnly))
 	app.route(http.MethodDelete, "/identifiers/{IDENTIFIER_ID}", container.AppIdentifiersHandler.DeleteAppIdentifierHandler,
 		NeedsPermission(rbac.PermCredentialsManage, rbac.FallbackAdminOnly))
+	app.route(http.MethodPut, "/identifiers/{IDENTIFIER_ID}/build-number", container.AppIdentifiersHandler.SetBuildNumberHandler,
+		NeedsPermission(rbac.PermCredentialsManage, rbac.FallbackAdminOnly))
 	app.route(http.MethodGet, "/identifiers/{IDENTIFIER_ID}/credentials/android", container.CredentialsHandler.GetAndroidCredentialsHandler,
 		AnyViewer())
 	app.route(http.MethodPut, "/identifiers/{IDENTIFIER_ID}/credentials/android", container.CredentialsHandler.PutAndroidCredentialsHandler,

--- a/internal/router/routes_app.go
+++ b/internal/router/routes_app.go
@@ -82,11 +82,17 @@ func registerAppRoutes(
 	app.route(http.MethodPost, "/branch/{BRANCH}/runtimeVersion/{RUNTIME_VERSION}/republish", container.UpdateHandler.RepublishUpdateHandler,
 		NeedsPermission(rbac.PermUpdatePublish, rbac.FallbackAdminOnly))
 
-	app.route(http.MethodGet, "/credentials/android", container.CredentialsHandler.GetAndroidCredentialsHandler,
+	app.route(http.MethodGet, "/identifiers", container.AppIdentifiersHandler.GetAppIdentifiersHandler,
 		AnyViewer())
-	app.route(http.MethodPut, "/credentials/android", container.CredentialsHandler.PutAndroidCredentialsHandler,
+	app.route(http.MethodPost, "/identifiers", container.AppIdentifiersHandler.CreateAppIdentifierHandler,
 		NeedsPermission(rbac.PermCredentialsManage, rbac.FallbackAdminOnly))
-	app.route(http.MethodDelete, "/credentials/android", container.CredentialsHandler.DeleteAndroidCredentialsHandler,
+	app.route(http.MethodDelete, "/identifiers/{IDENTIFIER_ID}", container.AppIdentifiersHandler.DeleteAppIdentifierHandler,
+		NeedsPermission(rbac.PermCredentialsManage, rbac.FallbackAdminOnly))
+	app.route(http.MethodGet, "/identifiers/{IDENTIFIER_ID}/credentials/android", container.CredentialsHandler.GetAndroidCredentialsHandler,
+		AnyViewer())
+	app.route(http.MethodPut, "/identifiers/{IDENTIFIER_ID}/credentials/android", container.CredentialsHandler.PutAndroidCredentialsHandler,
+		NeedsPermission(rbac.PermCredentialsManage, rbac.FallbackAdminOnly))
+	app.route(http.MethodDelete, "/identifiers/{IDENTIFIER_ID}/credentials/android", container.CredentialsHandler.DeleteAndroidCredentialsHandler,
 		NeedsPermission(rbac.PermCredentialsManage, rbac.FallbackAdminOnly))
 
 	app.route(http.MethodGet, "/apiKeys", container.ApiKeyHandler.GetApiKeysHandler,

--- a/internal/router/wire.go
+++ b/internal/router/wire.go
@@ -42,6 +42,7 @@ type AppContainer struct {
 	AppHandler                  *dashhandlers.AppHandler
 	AppRepo                     services.AppRepository
 	BranchHandler               *dashhandlers.BranchHandler
+	AppIdentifiersHandler       *dashhandlers.AppIdentifiersHandler
 	BranchListHandler           *handlers.BranchListHandler
 	ChannelHandler              *dashhandlers.ChannelHandler
 	CredentialsHandler          *dashhandlers.CredentialsHandler
@@ -93,7 +94,9 @@ func InitDependencies(ctx context.Context) (*AppContainer, func()) {
 	var oauthCodeRepo oauth.CodeRepository
 	var mcpHandler *mcp.MCPHandler
 	var rolloutRepo services.RolloutRepository
-	// nil in stateless mode: signing credentials only exist on the control plane.
+	// nil in stateless mode: store identities and signing credentials only
+	// exist on the control plane.
+	var appIdentifierRepo services.AppIdentifierRepository
 	var credentialsRepo services.CredentialsRepository
 	var licenseRepo licensing.LicenseRepository
 	var ssoRepo sso.SSORepository
@@ -158,6 +161,7 @@ func InitDependencies(ctx context.Context) (*AppContainer, func()) {
 		pgUpdateStore := store.NewPostgresUpdateStore(dbEngine)
 		updateRepo = pgUpdateStore
 		rolloutRepo = store.NewPostgresRolloutStore(dbEngine)
+		appIdentifierRepo = store.NewPostgresAppIdentifierStore(dbEngine)
 		credentialsRepo = store.NewPostgresCredentialsStore(dbEngine)
 
 		if config.IsDeviceTelemetryDisabled() {
@@ -247,7 +251,9 @@ func InitDependencies(ctx context.Context) (*AppContainer, func()) {
 	deploymentService.SetOnAuditEvent(auditService.Record)
 	rolloutService := services.NewRolloutService(rolloutRepo, channelRepo, updateRepo, deploymentService)
 	rolloutService.SetOnAuditEvent(auditService.Record)
-	credentialsService := services.NewCredentialsService(credentialsRepo)
+	appIdentifierService := services.NewAppIdentifierService(appIdentifierRepo)
+	appIdentifierService.SetOnAuditEvent(auditService.Record)
+	credentialsService := services.NewCredentialsService(credentialsRepo, appIdentifierRepo)
 	credentialsService.SetOnAuditEvent(auditService.Record)
 
 	// Shared across handlers; with Redis configured, also across replicas.
@@ -305,6 +311,7 @@ func InitDependencies(ctx context.Context) (*AppContainer, func()) {
 		BranchHandler:               dashhandlers.NewBranchHandler(branchService),
 		BranchListHandler:           handlers.NewBranchListHandler(channelService),
 		ChannelHandler:              dashhandlers.NewChannelHandler(channelService),
+		AppIdentifiersHandler:       dashhandlers.NewAppIdentifiersHandler(appIdentifierService),
 		CredentialsHandler:          dashhandlers.NewCredentialsHandler(credentialsService),
 		ExpoProtocolHandler:         handlers.NewExpoProtocolHandler(expoProtocolService),
 		LicenseHandler:              licensing.NewLicenseHandler(licenseService),

--- a/internal/services/app_identifier_service.go
+++ b/internal/services/app_identifier_service.go
@@ -17,11 +17,16 @@ const (
 var androidPackagePattern = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9_]*(\.[a-zA-Z][a-zA-Z0-9_]*)+$`)
 var iosBundleIdPattern = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9.-]*$`)
 
+// maxBuildNumber is the Play Store's hard versionCode ceiling; Apple has no
+// documented one, so the stricter bound applies to both platforms.
+const maxBuildNumber = 2_100_000_000
+
 type AppIdentifierRepository interface {
 	InsertAppIdentifier(ctx context.Context, appId string, platform string, identifier string) (string, error)
 	GetAppIdentifiers(ctx context.Context, appId string) ([]store.AppIdentifierRow, error)
 	GetAppIdentifierByID(ctx context.Context, appId string, identifierId string) (*store.AppIdentifierRef, error)
 	DeleteAppIdentifier(ctx context.Context, appId string, identifierId string) error
+	SetBuildNumber(ctx context.Context, appId string, identifierId string, buildNumber int64) error
 }
 
 // AppIdentifier is the dashboard projection of one store identity.
@@ -29,6 +34,7 @@ type AppIdentifier struct {
 	Id                    string `json:"id"`
 	Platform              string `json:"platform"`
 	Identifier            string `json:"identifier"`
+	BuildNumber           int64  `json:"buildNumber"`
 	HasAndroidCredentials bool   `json:"hasAndroidCredentials"`
 	CreatedAt             string `json:"createdAt"`
 }
@@ -108,11 +114,46 @@ func (s *AppIdentifierService) GetAppIdentifiers(ctx context.Context, appId stri
 			Id:                    row.Id,
 			Platform:              row.Platform,
 			Identifier:            row.Identifier,
+			BuildNumber:           row.BuildNumber,
 			HasAndroidCredentials: row.HasAndroidCredentials,
 			CreatedAt:             row.CreatedAt.UTC().Format(time.RFC3339),
 		}
 	}
 	return identifiers, nil
+}
+
+// SetBuildNumber overwrites the store build counter, the manual escape hatch
+// when it drifts from what the store actually holds.
+func (s *AppIdentifierService) SetBuildNumber(ctx context.Context, appId string, identifierId string, buildNumber int64) error {
+	if s.repo == nil {
+		return store.ErrNotSupportedInStatelessMode
+	}
+	if buildNumber < 0 || buildNumber > maxBuildNumber {
+		return validation.Errorf("buildNumber", "build number must be between 0 and %d", maxBuildNumber)
+	}
+	ref, err := s.repo.GetAppIdentifierByID(ctx, appId, identifierId)
+	if err != nil {
+		return err
+	}
+	if ref == nil {
+		return &store.ErrResourceNotFound{Resource: "app identifier", Identifier: identifierId}
+	}
+	if err := s.repo.SetBuildNumber(ctx, appId, identifierId, buildNumber); err != nil {
+		return err
+	}
+	recordManagementEvent(ctx, s.onAuditEvent, auditlog.Event{
+		Action:        auditlog.ActionAppIdentifierBuildNumberSet,
+		TargetType:    "app_identifier",
+		TargetID:      identifierId,
+		TargetDisplay: ref.Identifier,
+		AppID:         appId,
+		Metadata: map[string]any{
+			"platform": ref.Platform,
+			"from":     ref.BuildNumber,
+			"to":       buildNumber,
+		},
+	})
+	return nil
 }
 
 func (s *AppIdentifierService) DeleteAppIdentifier(ctx context.Context, appId string, identifierId string) error {

--- a/internal/services/app_identifier_service.go
+++ b/internal/services/app_identifier_service.go
@@ -1,0 +1,142 @@
+package services
+
+import (
+	"context"
+	"regexp"
+	"time"
+	"xprem/internal/auditlog"
+	"xprem/internal/store"
+	"xprem/internal/validation"
+)
+
+const (
+	PlatformAndroid = "android"
+	PlatformIOS     = "ios"
+)
+
+var androidPackagePattern = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9_]*(\.[a-zA-Z][a-zA-Z0-9_]*)+$`)
+var iosBundleIdPattern = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9.-]*$`)
+
+type AppIdentifierRepository interface {
+	InsertAppIdentifier(ctx context.Context, appId string, platform string, identifier string) (string, error)
+	GetAppIdentifiers(ctx context.Context, appId string) ([]store.AppIdentifierRow, error)
+	GetAppIdentifierByID(ctx context.Context, appId string, identifierId string) (*store.AppIdentifierRef, error)
+	DeleteAppIdentifier(ctx context.Context, appId string, identifierId string) error
+}
+
+// AppIdentifier is the dashboard projection of one store identity.
+type AppIdentifier struct {
+	Id                    string `json:"id"`
+	Platform              string `json:"platform"`
+	Identifier            string `json:"identifier"`
+	HasAndroidCredentials bool   `json:"hasAndroidCredentials"`
+	CreatedAt             string `json:"createdAt"`
+}
+
+type AppIdentifierService struct {
+	repo AppIdentifierRepository
+	// onAuditEvent is the audit emission seam; nil (community) means
+	// identifier changes leave no events.
+	onAuditEvent auditlog.RecordFunc
+}
+
+// NewAppIdentifierService builds the service; a nil repo (stateless mode)
+// makes every method answer ErrNotSupportedInStatelessMode.
+func NewAppIdentifierService(repo AppIdentifierRepository) *AppIdentifierService {
+	return &AppIdentifierService{
+		repo: repo,
+	}
+}
+
+// SetOnAuditEvent plugs the audit emission seam. Nil-safe.
+func (s *AppIdentifierService) SetOnAuditEvent(record auditlog.RecordFunc) {
+	s.onAuditEvent = record
+}
+
+func validateIdentifier(platform string, identifier string) error {
+	if len(identifier) > 255 {
+		return validation.Errorf("identifier", "identifier must be at most 255 characters")
+	}
+	switch platform {
+	case PlatformAndroid:
+		if !androidPackagePattern.MatchString(identifier) {
+			return validation.Errorf("identifier", "%q is not a valid Android application id", identifier)
+		}
+	case PlatformIOS:
+		if !iosBundleIdPattern.MatchString(identifier) {
+			return validation.Errorf("identifier", "%q is not a valid iOS bundle identifier", identifier)
+		}
+	default:
+		return validation.Errorf("platform", "platform must be %q or %q", PlatformAndroid, PlatformIOS)
+	}
+	return nil
+}
+
+func (s *AppIdentifierService) CreateAppIdentifier(ctx context.Context, appId string, platform string, identifier string) (string, error) {
+	if s.repo == nil {
+		return "", store.ErrNotSupportedInStatelessMode
+	}
+	if err := validateIdentifier(platform, identifier); err != nil {
+		return "", err
+	}
+	identifierId, err := s.repo.InsertAppIdentifier(ctx, appId, platform, identifier)
+	if err != nil {
+		return "", err
+	}
+	recordManagementEvent(ctx, s.onAuditEvent, auditlog.Event{
+		Action:        auditlog.ActionAppIdentifierCreated,
+		TargetType:    "app_identifier",
+		TargetID:      identifierId,
+		TargetDisplay: identifier,
+		AppID:         appId,
+		Metadata:      map[string]any{"platform": platform},
+	})
+	return identifierId, nil
+}
+
+func (s *AppIdentifierService) GetAppIdentifiers(ctx context.Context, appId string) ([]AppIdentifier, error) {
+	if s.repo == nil {
+		return nil, store.ErrNotSupportedInStatelessMode
+	}
+	rows, err := s.repo.GetAppIdentifiers(ctx, appId)
+	if err != nil {
+		return nil, err
+	}
+	identifiers := make([]AppIdentifier, len(rows))
+	for i, row := range rows {
+		identifiers[i] = AppIdentifier{
+			Id:                    row.Id,
+			Platform:              row.Platform,
+			Identifier:            row.Identifier,
+			HasAndroidCredentials: row.HasAndroidCredentials,
+			CreatedAt:             row.CreatedAt.UTC().Format(time.RFC3339),
+		}
+	}
+	return identifiers, nil
+}
+
+func (s *AppIdentifierService) DeleteAppIdentifier(ctx context.Context, appId string, identifierId string) error {
+	if s.repo == nil {
+		return store.ErrNotSupportedInStatelessMode
+	}
+	// Read before the delete: afterwards there is no row left to name in the
+	// audit entry. Best-effort, like the entry itself.
+	displayName := identifierId
+	var platform string
+	if ref, err := s.repo.GetAppIdentifierByID(ctx, appId, identifierId); err == nil && ref != nil {
+		displayName = ref.Identifier
+		platform = ref.Platform
+	}
+	if err := s.repo.DeleteAppIdentifier(ctx, appId, identifierId); err != nil {
+		return err
+	}
+	recordManagementEvent(ctx, s.onAuditEvent, auditlog.Event{
+		Action:        auditlog.ActionAppIdentifierDeleted,
+		TargetType:    "app_identifier",
+		TargetID:      identifierId,
+		TargetDisplay: displayName,
+		AppID:         appId,
+		Metadata:      map[string]any{"platform": platform},
+	})
+	return nil
+}

--- a/internal/services/app_identifier_service_test.go
+++ b/internal/services/app_identifier_service_test.go
@@ -15,7 +15,8 @@ import (
 )
 
 type fakeAppIdentifierRepo struct {
-	inserted []string
+	inserted    []string
+	buildNumber int64
 }
 
 func (f *fakeAppIdentifierRepo) InsertAppIdentifier(_ context.Context, _ string, platform string, identifier string) (string, error) {
@@ -32,6 +33,11 @@ func (f *fakeAppIdentifierRepo) GetAppIdentifierByID(_ context.Context, _ string
 }
 
 func (f *fakeAppIdentifierRepo) DeleteAppIdentifier(_ context.Context, _ string, _ string) error {
+	return nil
+}
+
+func (f *fakeAppIdentifierRepo) SetBuildNumber(_ context.Context, _ string, _ string, buildNumber int64) error {
+	f.buildNumber = buildNumber
 	return nil
 }
 
@@ -73,6 +79,28 @@ func TestAppIdentifierAuditEvents(t *testing.T) {
 	assert.Equal(t, PlatformAndroid, recorded[0].Metadata["platform"])
 	assert.Equal(t, auditlog.ActionAppIdentifierDeleted, recorded[1].Action)
 	assert.Equal(t, "com.example.app", recorded[1].TargetDisplay)
+}
+
+func TestSetBuildNumberValidatesBoundsAndAudits(t *testing.T) {
+	repo := &fakeAppIdentifierRepo{}
+	service := NewAppIdentifierService(repo)
+	var recorded []auditlog.Event
+	service.SetOnAuditEvent(func(_ context.Context, event auditlog.Event) {
+		recorded = append(recorded, event)
+	})
+	ctx := context.Background()
+
+	var valErr *validation.Error
+	assert.ErrorAs(t, service.SetBuildNumber(ctx, "app-1", "id-1", -1), &valErr)
+	assert.ErrorAs(t, service.SetBuildNumber(ctx, "app-1", "id-1", 2_100_000_001), &valErr)
+	assert.Empty(t, recorded)
+
+	require.NoError(t, service.SetBuildNumber(ctx, "app-1", "id-1", 87))
+	assert.Equal(t, int64(87), repo.buildNumber)
+	require.Len(t, recorded, 1)
+	assert.Equal(t, auditlog.ActionAppIdentifierBuildNumberSet, recorded[0].Action)
+	assert.Equal(t, "com.example.app", recorded[0].TargetDisplay)
+	assert.Equal(t, int64(87), recorded[0].Metadata["to"])
 }
 
 func TestAppIdentifiersUnsupportedInStatelessMode(t *testing.T) {

--- a/internal/services/app_identifier_service_test.go
+++ b/internal/services/app_identifier_service_test.go
@@ -1,0 +1,86 @@
+// Service-level tests for app identifiers: per-platform format validation,
+// audit emission and the stateless refusal. The guarded delete lives in SQL
+// and is covered by the store tests.
+package services
+
+import (
+	"context"
+	"testing"
+	"xprem/internal/auditlog"
+	"xprem/internal/store"
+	"xprem/internal/validation"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeAppIdentifierRepo struct {
+	inserted []string
+}
+
+func (f *fakeAppIdentifierRepo) InsertAppIdentifier(_ context.Context, _ string, platform string, identifier string) (string, error) {
+	f.inserted = append(f.inserted, platform+"/"+identifier)
+	return "id-1", nil
+}
+
+func (f *fakeAppIdentifierRepo) GetAppIdentifiers(_ context.Context, _ string) ([]store.AppIdentifierRow, error) {
+	return nil, nil
+}
+
+func (f *fakeAppIdentifierRepo) GetAppIdentifierByID(_ context.Context, _ string, _ string) (*store.AppIdentifierRef, error) {
+	return &store.AppIdentifierRef{Id: "id-1", Platform: PlatformAndroid, Identifier: "com.example.app"}, nil
+}
+
+func (f *fakeAppIdentifierRepo) DeleteAppIdentifier(_ context.Context, _ string, _ string) error {
+	return nil
+}
+
+func TestCreateAppIdentifierValidatesPerPlatform(t *testing.T) {
+	service := NewAppIdentifierService(&fakeAppIdentifierRepo{})
+	ctx := context.Background()
+
+	var valErr *validation.Error
+	_, err := service.CreateAppIdentifier(ctx, "app-1", "windows", "com.example.app")
+	assert.ErrorAs(t, err, &valErr)
+	_, err = service.CreateAppIdentifier(ctx, "app-1", PlatformAndroid, "no-dots")
+	assert.ErrorAs(t, err, &valErr)
+	_, err = service.CreateAppIdentifier(ctx, "app-1", PlatformAndroid, "com.1bad.app")
+	assert.ErrorAs(t, err, &valErr)
+	_, err = service.CreateAppIdentifier(ctx, "app-1", PlatformIOS, "com/bad")
+	assert.ErrorAs(t, err, &valErr)
+
+	_, err = service.CreateAppIdentifier(ctx, "app-1", PlatformAndroid, "com.example.app")
+	assert.NoError(t, err)
+	// A single-segment bundle id is legal on ios.
+	_, err = service.CreateAppIdentifier(ctx, "app-1", PlatformIOS, "com.example-app.ios")
+	assert.NoError(t, err)
+}
+
+func TestAppIdentifierAuditEvents(t *testing.T) {
+	service := NewAppIdentifierService(&fakeAppIdentifierRepo{})
+	var recorded []auditlog.Event
+	service.SetOnAuditEvent(func(_ context.Context, event auditlog.Event) {
+		recorded = append(recorded, event)
+	})
+
+	_, err := service.CreateAppIdentifier(context.Background(), "app-1", PlatformAndroid, "com.example.app")
+	require.NoError(t, err)
+	require.NoError(t, service.DeleteAppIdentifier(context.Background(), "app-1", "id-1"))
+
+	require.Len(t, recorded, 2)
+	assert.Equal(t, auditlog.ActionAppIdentifierCreated, recorded[0].Action)
+	assert.Equal(t, "com.example.app", recorded[0].TargetDisplay)
+	assert.Equal(t, PlatformAndroid, recorded[0].Metadata["platform"])
+	assert.Equal(t, auditlog.ActionAppIdentifierDeleted, recorded[1].Action)
+	assert.Equal(t, "com.example.app", recorded[1].TargetDisplay)
+}
+
+func TestAppIdentifiersUnsupportedInStatelessMode(t *testing.T) {
+	service := NewAppIdentifierService(nil)
+	ctx := context.Background()
+	_, err := service.CreateAppIdentifier(ctx, "app-1", PlatformAndroid, "com.example.app")
+	assert.ErrorIs(t, err, store.ErrNotSupportedInStatelessMode)
+	_, err = service.GetAppIdentifiers(ctx, "app-1")
+	assert.ErrorIs(t, err, store.ErrNotSupportedInStatelessMode)
+	assert.ErrorIs(t, service.DeleteAppIdentifier(ctx, "app-1", "id-1"), store.ErrNotSupportedInStatelessMode)
+}

--- a/internal/services/credentials_service.go
+++ b/internal/services/credentials_service.go
@@ -5,7 +5,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"regexp"
 	"time"
 	"xprem/internal/auditlog"
 	"xprem/internal/crypto"
@@ -18,18 +17,15 @@ import (
 // a few kilobytes, anything near the cap is not a keystore.
 const maxKeystoreBytes = 512 * 1024
 
-var androidPackagePattern = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9_]*(\.[a-zA-Z][a-zA-Z0-9_]*)+$`)
-
 type CredentialsRepository interface {
-	UpsertAndroidCredentials(ctx context.Context, appId string, credentials store.SealedAndroidCredentials) error
-	GetAndroidCredentials(ctx context.Context, appId string) (*store.SealedAndroidCredentials, error)
-	DeleteAndroidCredentials(ctx context.Context, appId string) error
+	UpsertAndroidCredentials(ctx context.Context, identifierId string, credentials store.SealedAndroidCredentials) error
+	GetAndroidCredentials(ctx context.Context, identifierId string) (*store.SealedAndroidCredentials, error)
+	DeleteAndroidCredentials(ctx context.Context, identifierId string) error
 }
 
-// AndroidCredentialsInput is one full replacement of an app's Android signing
-// credentials, as received from the dashboard or the CLI.
+// AndroidCredentialsInput is one full replacement of an identifier's Android
+// signing credentials, as received from the dashboard or the CLI.
 type AndroidCredentialsInput struct {
-	AndroidPackage              string
 	KeyAlias                    string
 	KeystoreBase64              string
 	KeystorePassword            string
@@ -39,7 +35,7 @@ type AndroidCredentialsInput struct {
 
 // AndroidCredentialsMetadata is the non-secret projection served to viewers.
 type AndroidCredentialsMetadata struct {
-	AndroidPackage             string `json:"androidPackage"`
+	Identifier                 string `json:"identifier"`
 	KeyAlias                   string `json:"keyAlias"`
 	HasGoogleServiceAccountKey bool   `json:"hasGoogleServiceAccountKey"`
 	CreatedAt                  string `json:"createdAt"`
@@ -47,17 +43,19 @@ type AndroidCredentialsMetadata struct {
 }
 
 type CredentialsService struct {
-	repo CredentialsRepository
+	repo        CredentialsRepository
+	identifiers AppIdentifierRepository
 	// onAuditEvent is the audit emission seam; nil (community) means
 	// credential changes leave no events.
 	onAuditEvent auditlog.RecordFunc
 }
 
-// NewCredentialsService builds the service; a nil repo (stateless mode) makes
+// NewCredentialsService builds the service; nil repos (stateless mode) make
 // every method answer ErrNotSupportedInStatelessMode.
-func NewCredentialsService(repo CredentialsRepository) *CredentialsService {
+func NewCredentialsService(repo CredentialsRepository, identifiers AppIdentifierRepository) *CredentialsService {
 	return &CredentialsService{
-		repo: repo,
+		repo:        repo,
+		identifiers: identifiers,
 	}
 }
 
@@ -66,18 +64,35 @@ func (s *CredentialsService) SetOnAuditEvent(record auditlog.RecordFunc) {
 	s.onAuditEvent = record
 }
 
-// androidCredentialAAD binds each sealed field to the app it belongs to, so a
-// blob copied onto another row fails to unseal (see keyStore.AppKeyAAD).
-func androidCredentialAAD(appId string, field string) []byte {
-	return []byte(appId + "|android_credentials|" + field)
+// androidCredentialAAD binds each sealed field to the identifier owning it,
+// so a blob copied onto another row fails to unseal (see keyStore.AppKeyAAD).
+func androidCredentialAAD(identifierId string, field string) []byte {
+	return []byte(identifierId + "|android_credentials|" + field)
 }
 
-func (s *CredentialsService) SaveAndroidCredentials(ctx context.Context, appId string, input AndroidCredentialsInput) error {
-	if s.repo == nil {
-		return store.ErrNotSupportedInStatelessMode
+// resolveAndroidIdentifier maps (app, identifier id) to the identifier row,
+// refusing unknown ids and non-android platforms.
+func (s *CredentialsService) resolveAndroidIdentifier(ctx context.Context, appId string, identifierId string) (*store.AppIdentifierRef, error) {
+	if s.repo == nil || s.identifiers == nil {
+		return nil, store.ErrNotSupportedInStatelessMode
 	}
-	if !androidPackagePattern.MatchString(input.AndroidPackage) || len(input.AndroidPackage) > 255 {
-		return validation.Errorf("androidPackage", "%q is not a valid Android application id", input.AndroidPackage)
+	ref, err := s.identifiers.GetAppIdentifierByID(ctx, appId, identifierId)
+	if err != nil {
+		return nil, err
+	}
+	if ref == nil {
+		return nil, &store.ErrResourceNotFound{Resource: "app identifier", Identifier: identifierId}
+	}
+	if ref.Platform != PlatformAndroid {
+		return nil, validation.Errorf("identifier", "identifier %q is an %s identifier, android credentials require an android one", ref.Identifier, ref.Platform)
+	}
+	return ref, nil
+}
+
+func (s *CredentialsService) SaveAndroidCredentials(ctx context.Context, appId string, identifierId string, input AndroidCredentialsInput) error {
+	ref, err := s.resolveAndroidIdentifier(ctx, appId, identifierId)
+	if err != nil {
+		return err
 	}
 	if input.KeyAlias == "" || len(input.KeyAlias) > 255 {
 		return validation.Errorf("keyAlias", "key alias must be between 1 and 255 characters")
@@ -103,44 +118,43 @@ func (s *CredentialsService) SaveAndroidCredentials(ctx context.Context, appId s
 	}
 
 	masterKey := []byte(keyStore.ReadDBKeysMasterKey())
-	sealedKeystore, err := crypto.SealAESGCM(keystore, masterKey, androidCredentialAAD(appId, "keystore"))
+	sealedKeystore, err := crypto.SealAESGCM(keystore, masterKey, androidCredentialAAD(identifierId, "keystore"))
 	if err != nil {
 		return fmt.Errorf("failed to seal keystore: %w", err)
 	}
-	sealedKeystorePassword, err := crypto.SealAESGCM([]byte(input.KeystorePassword), masterKey, androidCredentialAAD(appId, "keystore_password"))
+	sealedKeystorePassword, err := crypto.SealAESGCM([]byte(input.KeystorePassword), masterKey, androidCredentialAAD(identifierId, "keystore_password"))
 	if err != nil {
 		return fmt.Errorf("failed to seal keystore password: %w", err)
 	}
-	sealedKeyPassword, err := crypto.SealAESGCM([]byte(input.KeyPassword), masterKey, androidCredentialAAD(appId, "key_password"))
+	sealedKeyPassword, err := crypto.SealAESGCM([]byte(input.KeyPassword), masterKey, androidCredentialAAD(identifierId, "key_password"))
 	if err != nil {
 		return fmt.Errorf("failed to seal key password: %w", err)
 	}
 	sealed := store.SealedAndroidCredentials{
-		AndroidPackage:         input.AndroidPackage,
 		KeyAlias:               input.KeyAlias,
 		SealedKeystore:         sealedKeystore,
 		SealedKeystorePassword: sealedKeystorePassword,
 		SealedKeyPassword:      sealedKeyPassword,
 	}
 	if input.GoogleServiceAccountKeyJSON != "" {
-		sealedGSA, err := crypto.SealAESGCM([]byte(input.GoogleServiceAccountKeyJSON), masterKey, androidCredentialAAD(appId, "google_service_account_key"))
+		sealedGSA, err := crypto.SealAESGCM([]byte(input.GoogleServiceAccountKeyJSON), masterKey, androidCredentialAAD(identifierId, "google_service_account_key"))
 		if err != nil {
 			return fmt.Errorf("failed to seal google service account key: %w", err)
 		}
 		sealed.SealedGoogleServiceAccountKey = &sealedGSA
 	}
 
-	if err := s.repo.UpsertAndroidCredentials(ctx, appId, sealed); err != nil {
+	if err := s.repo.UpsertAndroidCredentials(ctx, identifierId, sealed); err != nil {
 		return err
 	}
 	recordManagementEvent(ctx, s.onAuditEvent, auditlog.Event{
 		Action:        auditlog.ActionAndroidCredentialsSaved,
 		TargetType:    "android_credentials",
-		TargetID:      appId,
-		TargetDisplay: input.AndroidPackage,
+		TargetID:      identifierId,
+		TargetDisplay: ref.Identifier,
 		AppID:         appId,
 		Metadata: map[string]any{
-			"android_package":                input.AndroidPackage,
+			"identifier":                     ref.Identifier,
 			"key_alias":                      input.KeyAlias,
 			"has_google_service_account_key": input.GoogleServiceAccountKeyJSON != "",
 		},
@@ -148,18 +162,19 @@ func (s *CredentialsService) SaveAndroidCredentials(ctx context.Context, appId s
 	return nil
 }
 
-// GetAndroidCredentialsMetadata returns (nil, nil) when the app has no
-// Android credentials configured.
-func (s *CredentialsService) GetAndroidCredentialsMetadata(ctx context.Context, appId string) (*AndroidCredentialsMetadata, error) {
-	if s.repo == nil {
-		return nil, store.ErrNotSupportedInStatelessMode
+// GetAndroidCredentialsMetadata returns (nil, nil) when the identifier has no
+// credentials configured yet.
+func (s *CredentialsService) GetAndroidCredentialsMetadata(ctx context.Context, appId string, identifierId string) (*AndroidCredentialsMetadata, error) {
+	ref, err := s.resolveAndroidIdentifier(ctx, appId, identifierId)
+	if err != nil {
+		return nil, err
 	}
-	credentials, err := s.repo.GetAndroidCredentials(ctx, appId)
+	credentials, err := s.repo.GetAndroidCredentials(ctx, identifierId)
 	if err != nil || credentials == nil {
 		return nil, err
 	}
 	return &AndroidCredentialsMetadata{
-		AndroidPackage:             credentials.AndroidPackage,
+		Identifier:                 ref.Identifier,
 		KeyAlias:                   credentials.KeyAlias,
 		HasGoogleServiceAccountKey: credentials.SealedGoogleServiceAccountKey != nil,
 		CreatedAt:                  credentials.CreatedAt.UTC().Format(time.RFC3339),
@@ -167,24 +182,19 @@ func (s *CredentialsService) GetAndroidCredentialsMetadata(ctx context.Context, 
 	}, nil
 }
 
-func (s *CredentialsService) DeleteAndroidCredentials(ctx context.Context, appId string) error {
-	if s.repo == nil {
-		return store.ErrNotSupportedInStatelessMode
+func (s *CredentialsService) DeleteAndroidCredentials(ctx context.Context, appId string, identifierId string) error {
+	ref, err := s.resolveAndroidIdentifier(ctx, appId, identifierId)
+	if err != nil {
+		return err
 	}
-	// Read before the delete: afterwards there is no row left to name in the
-	// audit entry. Best-effort, like the entry itself.
-	displayName := appId
-	if credentials, err := s.repo.GetAndroidCredentials(ctx, appId); err == nil && credentials != nil {
-		displayName = credentials.AndroidPackage
-	}
-	if err := s.repo.DeleteAndroidCredentials(ctx, appId); err != nil {
+	if err := s.repo.DeleteAndroidCredentials(ctx, identifierId); err != nil {
 		return err
 	}
 	recordManagementEvent(ctx, s.onAuditEvent, auditlog.Event{
 		Action:        auditlog.ActionAndroidCredentialsDeleted,
 		TargetType:    "android_credentials",
-		TargetID:      appId,
-		TargetDisplay: displayName,
+		TargetID:      identifierId,
+		TargetDisplay: ref.Identifier,
 		AppID:         appId,
 	})
 	return nil

--- a/internal/services/credentials_service_test.go
+++ b/internal/services/credentials_service_test.go
@@ -54,6 +54,10 @@ func (f *fakeIdentifierRepo) DeleteAppIdentifier(_ context.Context, _ string, _ 
 	panic("not used in credentials tests")
 }
 
+func (f *fakeIdentifierRepo) SetBuildNumber(_ context.Context, _ string, _ string, _ int64) error {
+	panic("not used in credentials tests")
+}
+
 type fakeCredentialsRepo struct {
 	byIdentifierId map[string]store.SealedAndroidCredentials
 }

--- a/internal/services/credentials_service_test.go
+++ b/internal/services/credentials_service_test.go
@@ -1,6 +1,7 @@
 // Service-level tests for the Android credentials vault: sealing (with the
-// app-bound AAD), validation, the metadata projection, audit emission and the
-// stateless-mode refusal. SQL persistence is covered by the store tests.
+// identifier-bound AAD), validation, identifier resolution, the metadata
+// projection, audit emission and the stateless-mode refusal. SQL persistence
+// is covered by the store tests.
 package services
 
 import (
@@ -16,36 +17,78 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type fakeIdentifierRepo struct {
+	byId map[string]store.AppIdentifierRef
+	// appId every identifier belongs to; a mismatch resolves to nil.
+	appId string
+}
+
+func newFakeIdentifierRepo(appId string) *fakeIdentifierRepo {
+	return &fakeIdentifierRepo{byId: map[string]store.AppIdentifierRef{}, appId: appId}
+}
+
+func (f *fakeIdentifierRepo) add(id, platform, identifier string) {
+	f.byId[id] = store.AppIdentifierRef{Id: id, Platform: platform, Identifier: identifier}
+}
+
+func (f *fakeIdentifierRepo) InsertAppIdentifier(_ context.Context, _ string, _ string, _ string) (string, error) {
+	panic("not used in credentials tests")
+}
+
+func (f *fakeIdentifierRepo) GetAppIdentifiers(_ context.Context, _ string) ([]store.AppIdentifierRow, error) {
+	panic("not used in credentials tests")
+}
+
+func (f *fakeIdentifierRepo) GetAppIdentifierByID(_ context.Context, appId string, identifierId string) (*store.AppIdentifierRef, error) {
+	if appId != f.appId {
+		return nil, nil
+	}
+	ref, ok := f.byId[identifierId]
+	if !ok {
+		return nil, nil
+	}
+	return &ref, nil
+}
+
+func (f *fakeIdentifierRepo) DeleteAppIdentifier(_ context.Context, _ string, _ string) error {
+	panic("not used in credentials tests")
+}
+
 type fakeCredentialsRepo struct {
-	byAppId map[string]store.SealedAndroidCredentials
+	byIdentifierId map[string]store.SealedAndroidCredentials
 }
 
 func newFakeCredentialsRepo() *fakeCredentialsRepo {
-	return &fakeCredentialsRepo{byAppId: map[string]store.SealedAndroidCredentials{}}
+	return &fakeCredentialsRepo{byIdentifierId: map[string]store.SealedAndroidCredentials{}}
 }
 
-func (f *fakeCredentialsRepo) UpsertAndroidCredentials(_ context.Context, appId string, credentials store.SealedAndroidCredentials) error {
-	f.byAppId[appId] = credentials
+func (f *fakeCredentialsRepo) UpsertAndroidCredentials(_ context.Context, identifierId string, credentials store.SealedAndroidCredentials) error {
+	f.byIdentifierId[identifierId] = credentials
 	return nil
 }
 
-func (f *fakeCredentialsRepo) GetAndroidCredentials(_ context.Context, appId string) (*store.SealedAndroidCredentials, error) {
-	credentials, ok := f.byAppId[appId]
+func (f *fakeCredentialsRepo) GetAndroidCredentials(_ context.Context, identifierId string) (*store.SealedAndroidCredentials, error) {
+	credentials, ok := f.byIdentifierId[identifierId]
 	if !ok {
 		return nil, nil
 	}
 	return &credentials, nil
 }
 
-func (f *fakeCredentialsRepo) DeleteAndroidCredentials(_ context.Context, appId string) error {
-	if _, ok := f.byAppId[appId]; !ok {
-		return &store.ErrResourceNotFound{Resource: "android credentials", Identifier: appId}
+func (f *fakeCredentialsRepo) DeleteAndroidCredentials(_ context.Context, identifierId string) error {
+	if _, ok := f.byIdentifierId[identifierId]; !ok {
+		return &store.ErrResourceNotFound{Resource: "android credentials", Identifier: identifierId}
 	}
-	delete(f.byAppId, appId)
+	delete(f.byIdentifierId, identifierId)
 	return nil
 }
 
 const testMasterKey = "0123456789abcdef0123456789abcdef"
+
+const (
+	testAppId        = "app-1"
+	testIdentifierId = "11111111-1111-1111-1111-111111111111"
+)
 
 func setMasterKey(t *testing.T) {
 	t.Helper()
@@ -53,9 +96,15 @@ func setMasterKey(t *testing.T) {
 	t.Setenv("DB_KEYS_MASTER_KEY_B64", base64.StdEncoding.EncodeToString([]byte(testMasterKey)))
 }
 
+func newCredentialsFixture() (*CredentialsService, *fakeCredentialsRepo, *fakeIdentifierRepo) {
+	identifiers := newFakeIdentifierRepo(testAppId)
+	identifiers.add(testIdentifierId, PlatformAndroid, "com.example.app")
+	repo := newFakeCredentialsRepo()
+	return NewCredentialsService(repo, identifiers), repo, identifiers
+}
+
 func validAndroidInput() AndroidCredentialsInput {
 	return AndroidCredentialsInput{
-		AndroidPackage:   "com.example.app",
 		KeyAlias:         "upload",
 		KeystoreBase64:   base64.StdEncoding.EncodeToString([]byte("fake-jks-bytes")),
 		KeystorePassword: "keystore-pass",
@@ -65,43 +114,61 @@ func validAndroidInput() AndroidCredentialsInput {
 
 func TestSaveAndroidCredentialsSealsEveryTouchedSecret(t *testing.T) {
 	setMasterKey(t)
-	repo := newFakeCredentialsRepo()
-	service := NewCredentialsService(repo)
+	service, repo, _ := newCredentialsFixture()
 
 	input := validAndroidInput()
 	input.GoogleServiceAccountKeyJSON = `{"type":"service_account"}`
-	require.NoError(t, service.SaveAndroidCredentials(context.Background(), "app-1", input))
+	require.NoError(t, service.SaveAndroidCredentials(context.Background(), testAppId, testIdentifierId, input))
 
-	sealed := repo.byAppId["app-1"]
-	assert.Equal(t, "com.example.app", sealed.AndroidPackage)
+	sealed := repo.byIdentifierId[testIdentifierId]
 	assert.Equal(t, "upload", sealed.KeyAlias)
 
-	keystore, err := crypto.UnsealAESGCM(sealed.SealedKeystore, []byte(testMasterKey), androidCredentialAAD("app-1", "keystore"))
+	keystore, err := crypto.UnsealAESGCM(sealed.SealedKeystore, []byte(testMasterKey), androidCredentialAAD(testIdentifierId, "keystore"))
 	require.NoError(t, err)
 	assert.Equal(t, "fake-jks-bytes", string(keystore))
-	keystorePassword, err := crypto.UnsealAESGCM(sealed.SealedKeystorePassword, []byte(testMasterKey), androidCredentialAAD("app-1", "keystore_password"))
+	keystorePassword, err := crypto.UnsealAESGCM(sealed.SealedKeystorePassword, []byte(testMasterKey), androidCredentialAAD(testIdentifierId, "keystore_password"))
 	require.NoError(t, err)
 	assert.Equal(t, "keystore-pass", string(keystorePassword))
-	keyPassword, err := crypto.UnsealAESGCM(sealed.SealedKeyPassword, []byte(testMasterKey), androidCredentialAAD("app-1", "key_password"))
+	keyPassword, err := crypto.UnsealAESGCM(sealed.SealedKeyPassword, []byte(testMasterKey), androidCredentialAAD(testIdentifierId, "key_password"))
 	require.NoError(t, err)
 	assert.Equal(t, "key-pass", string(keyPassword))
 	require.NotNil(t, sealed.SealedGoogleServiceAccountKey)
-	gsa, err := crypto.UnsealAESGCM(*sealed.SealedGoogleServiceAccountKey, []byte(testMasterKey), androidCredentialAAD("app-1", "google_service_account_key"))
+	gsa, err := crypto.UnsealAESGCM(*sealed.SealedGoogleServiceAccountKey, []byte(testMasterKey), androidCredentialAAD(testIdentifierId, "google_service_account_key"))
 	require.NoError(t, err)
 	assert.JSONEq(t, `{"type":"service_account"}`, string(gsa))
 
-	// No sealed field is readable without the exact app binding.
-	_, err = crypto.UnsealAESGCM(sealed.SealedKeystore, []byte(testMasterKey), androidCredentialAAD("app-2", "keystore"))
+	// No sealed field is readable under another identifier's binding.
+	_, err = crypto.UnsealAESGCM(sealed.SealedKeystore, []byte(testMasterKey), androidCredentialAAD("22222222-2222-2222-2222-222222222222", "keystore"))
 	assert.Error(t, err)
+}
+
+func TestSaveAndroidCredentialsResolvesTheIdentifier(t *testing.T) {
+	setMasterKey(t)
+	service, _, identifiers := newCredentialsFixture()
+	ctx := context.Background()
+
+	// Unknown identifier id.
+	err := service.SaveAndroidCredentials(ctx, testAppId, "33333333-3333-3333-3333-333333333333", validAndroidInput())
+	notFoundErr := (*store.ErrResourceNotFound)(nil)
+	assert.ErrorAs(t, err, &notFoundErr)
+
+	// Identifier of another app resolves to not-found too.
+	err = service.SaveAndroidCredentials(ctx, "other-app", testIdentifierId, validAndroidInput())
+	assert.ErrorAs(t, err, &notFoundErr)
+
+	// An ios identifier cannot carry android credentials.
+	identifiers.add("44444444-4444-4444-4444-444444444444", PlatformIOS, "com.example.app")
+	err = service.SaveAndroidCredentials(ctx, testAppId, "44444444-4444-4444-4444-444444444444", validAndroidInput())
+	var valErr *validation.Error
+	assert.ErrorAs(t, err, &valErr)
 }
 
 func TestSaveAndroidCredentialsRejectsInvalidInput(t *testing.T) {
 	setMasterKey(t)
-	service := NewCredentialsService(newFakeCredentialsRepo())
+	service, _, _ := newCredentialsFixture()
 	ctx := context.Background()
 
 	for name, mutate := range map[string]func(*AndroidCredentialsInput){
-		"bad package":        func(i *AndroidCredentialsInput) { i.AndroidPackage = "no-dots" },
 		"empty alias":        func(i *AndroidCredentialsInput) { i.KeyAlias = "" },
 		"empty keystore pwd": func(i *AndroidCredentialsInput) { i.KeystorePassword = "" },
 		"empty key pwd":      func(i *AndroidCredentialsInput) { i.KeyPassword = "" },
@@ -111,7 +178,7 @@ func TestSaveAndroidCredentialsRejectsInvalidInput(t *testing.T) {
 	} {
 		input := validAndroidInput()
 		mutate(&input)
-		err := service.SaveAndroidCredentials(ctx, "app-1", input)
+		err := service.SaveAndroidCredentials(ctx, testAppId, testIdentifierId, input)
 		require.Error(t, err, name)
 		var valErr *validation.Error
 		assert.ErrorAs(t, err, &valErr, name)
@@ -120,36 +187,31 @@ func TestSaveAndroidCredentialsRejectsInvalidInput(t *testing.T) {
 
 func TestAndroidCredentialsMetadataCarriesNoSecret(t *testing.T) {
 	setMasterKey(t)
-	repo := newFakeCredentialsRepo()
-	service := NewCredentialsService(repo)
-	require.NoError(t, service.SaveAndroidCredentials(context.Background(), "app-1", validAndroidInput()))
+	service, _, _ := newCredentialsFixture()
+	require.NoError(t, service.SaveAndroidCredentials(context.Background(), testAppId, testIdentifierId, validAndroidInput()))
 
-	metadata, err := service.GetAndroidCredentialsMetadata(context.Background(), "app-1")
+	metadata, err := service.GetAndroidCredentialsMetadata(context.Background(), testAppId, testIdentifierId)
 	require.NoError(t, err)
 	require.NotNil(t, metadata)
-	assert.Equal(t, "com.example.app", metadata.AndroidPackage)
+	assert.Equal(t, "com.example.app", metadata.Identifier)
 	assert.Equal(t, "upload", metadata.KeyAlias)
 	assert.False(t, metadata.HasGoogleServiceAccountKey)
-
-	missing, err := service.GetAndroidCredentialsMetadata(context.Background(), "unknown-app")
-	require.NoError(t, err)
-	assert.Nil(t, missing)
 }
 
 func TestAndroidCredentialsAuditEvents(t *testing.T) {
 	setMasterKey(t)
-	repo := newFakeCredentialsRepo()
-	service := NewCredentialsService(repo)
+	service, _, _ := newCredentialsFixture()
 	var recorded []auditlog.Event
 	service.SetOnAuditEvent(func(_ context.Context, event auditlog.Event) {
 		recorded = append(recorded, event)
 	})
 
-	require.NoError(t, service.SaveAndroidCredentials(context.Background(), "app-1", validAndroidInput()))
-	require.NoError(t, service.DeleteAndroidCredentials(context.Background(), "app-1"))
+	require.NoError(t, service.SaveAndroidCredentials(context.Background(), testAppId, testIdentifierId, validAndroidInput()))
+	require.NoError(t, service.DeleteAndroidCredentials(context.Background(), testAppId, testIdentifierId))
 
 	require.Len(t, recorded, 2)
 	assert.Equal(t, auditlog.ActionAndroidCredentialsSaved, recorded[0].Action)
+	assert.Equal(t, testIdentifierId, recorded[0].TargetID)
 	assert.Equal(t, "com.example.app", recorded[0].TargetDisplay)
 	assert.NotContains(t, recorded[0].Metadata, "keystore")
 	assert.Equal(t, auditlog.ActionAndroidCredentialsDeleted, recorded[1].Action)
@@ -157,10 +219,10 @@ func TestAndroidCredentialsAuditEvents(t *testing.T) {
 }
 
 func TestAndroidCredentialsUnsupportedInStatelessMode(t *testing.T) {
-	service := NewCredentialsService(nil)
+	service := NewCredentialsService(nil, nil)
 	ctx := context.Background()
-	assert.ErrorIs(t, service.SaveAndroidCredentials(ctx, "app-1", validAndroidInput()), store.ErrNotSupportedInStatelessMode)
-	_, err := service.GetAndroidCredentialsMetadata(ctx, "app-1")
+	assert.ErrorIs(t, service.SaveAndroidCredentials(ctx, testAppId, testIdentifierId, validAndroidInput()), store.ErrNotSupportedInStatelessMode)
+	_, err := service.GetAndroidCredentialsMetadata(ctx, testAppId, testIdentifierId)
 	assert.ErrorIs(t, err, store.ErrNotSupportedInStatelessMode)
-	assert.ErrorIs(t, service.DeleteAndroidCredentials(ctx, "app-1"), store.ErrNotSupportedInStatelessMode)
+	assert.ErrorIs(t, service.DeleteAndroidCredentials(ctx, testAppId, testIdentifierId), store.ErrNotSupportedInStatelessMode)
 }

--- a/internal/store/app_identifier_postgres.go
+++ b/internal/store/app_identifier_postgres.go
@@ -1,0 +1,113 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+	"xprem/internal/database"
+	"xprem/internal/database/postgres/pgdb"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+)
+
+// AppIdentifierRow is one store identity of an app with its credential state,
+// as listed in the dashboard.
+type AppIdentifierRow struct {
+	Id                    string
+	Platform              string
+	Identifier            string
+	HasAndroidCredentials bool
+	CreatedAt             time.Time
+}
+
+// AppIdentifierRef is the resolution of an identifier id within an app.
+type AppIdentifierRef struct {
+	Id         string
+	Platform   string
+	Identifier string
+}
+
+type PostgresAppIdentifierStore struct {
+	engine *database.Engine
+}
+
+func NewPostgresAppIdentifierStore(engine *database.Engine) *PostgresAppIdentifierStore {
+	return &PostgresAppIdentifierStore{
+		engine: engine,
+	}
+}
+
+func (s *PostgresAppIdentifierStore) InsertAppIdentifier(ctx context.Context, appId string, platform string, identifier string) (string, error) {
+	id := uuid.NewString()
+	_, err := s.engine.Queries.InsertAppIdentifier(ctx, pgdb.InsertAppIdentifierParams{
+		ID:         ToPgUUID(id),
+		AppID:      ToPgUUID(appId),
+		Platform:   platform,
+		Identifier: identifier,
+	})
+	if err != nil {
+		if database.IsUniqueViolation(err) {
+			return "", &ErrResourceAlreadyExists{Resource: "app identifier", Identifier: fmt.Sprintf("%s/%s (appId: %s)", platform, identifier, appId)}
+		}
+		return "", fmt.Errorf("failed to create app identifier in database: %w", err)
+	}
+	return id, nil
+}
+
+func (s *PostgresAppIdentifierStore) GetAppIdentifiers(ctx context.Context, appId string) ([]AppIdentifierRow, error) {
+	rows, err := s.engine.Queries.GetAppIdentifiersByAppID(ctx, ToPgUUID(appId))
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve app identifiers from database: %w", err)
+	}
+	identifiers := make([]AppIdentifierRow, len(rows))
+	for i, row := range rows {
+		identifiers[i] = AppIdentifierRow{
+			Id:                    row.ID.String(),
+			Platform:              row.Platform,
+			Identifier:            row.Identifier,
+			HasAndroidCredentials: row.HasAndroidCredentials,
+			CreatedAt:             row.CreatedAt.Time,
+		}
+	}
+	return identifiers, nil
+}
+
+func (s *PostgresAppIdentifierStore) GetAppIdentifierByID(ctx context.Context, appId string, identifierId string) (*AppIdentifierRef, error) {
+	row, err := s.engine.Queries.GetAppIdentifierByID(ctx, pgdb.GetAppIdentifierByIDParams{
+		AppID: ToPgUUID(appId),
+		ID:    ToPgUUID(identifierId),
+	})
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to retrieve app identifier from database: %w", err)
+	}
+	return &AppIdentifierRef{
+		Id:         row.ID.String(),
+		Platform:   row.Platform,
+		Identifier: row.Identifier,
+	}, nil
+}
+
+func (s *PostgresAppIdentifierStore) DeleteAppIdentifier(ctx context.Context, appId string, identifierId string) error {
+	commandTag, err := s.engine.Queries.DeleteAppIdentifierByID(ctx, pgdb.DeleteAppIdentifierByIDParams{
+		AppID: ToPgUUID(appId),
+		ID:    ToPgUUID(identifierId),
+	})
+	if err != nil {
+		return fmt.Errorf("failed to delete app identifier from database: %w", err)
+	}
+	if commandTag.RowsAffected() == 0 {
+		// The guarded DELETE reports 0 rows for both an unknown identifier and
+		// one still holding credentials; disambiguate.
+		ref, refErr := s.GetAppIdentifierByID(ctx, appId, identifierId)
+		if refErr == nil && ref != nil {
+			return &ErrIdentifierHasCredentials{Identifier: ref.Identifier}
+		}
+		return &ErrResourceNotFound{Resource: "app identifier", Identifier: identifierId}
+	}
+	return nil
+}

--- a/internal/store/app_identifier_postgres.go
+++ b/internal/store/app_identifier_postgres.go
@@ -18,15 +18,17 @@ type AppIdentifierRow struct {
 	Id                    string
 	Platform              string
 	Identifier            string
+	BuildNumber           int64
 	HasAndroidCredentials bool
 	CreatedAt             time.Time
 }
 
 // AppIdentifierRef is the resolution of an identifier id within an app.
 type AppIdentifierRef struct {
-	Id         string
-	Platform   string
-	Identifier string
+	Id          string
+	Platform    string
+	Identifier  string
+	BuildNumber int64
 }
 
 type PostgresAppIdentifierStore struct {
@@ -67,6 +69,7 @@ func (s *PostgresAppIdentifierStore) GetAppIdentifiers(ctx context.Context, appI
 			Id:                    row.ID.String(),
 			Platform:              row.Platform,
 			Identifier:            row.Identifier,
+			BuildNumber:           row.BuildNumber,
 			HasAndroidCredentials: row.HasAndroidCredentials,
 			CreatedAt:             row.CreatedAt.Time,
 		}
@@ -86,10 +89,26 @@ func (s *PostgresAppIdentifierStore) GetAppIdentifierByID(ctx context.Context, a
 		return nil, fmt.Errorf("failed to retrieve app identifier from database: %w", err)
 	}
 	return &AppIdentifierRef{
-		Id:         row.ID.String(),
-		Platform:   row.Platform,
-		Identifier: row.Identifier,
+		Id:          row.ID.String(),
+		Platform:    row.Platform,
+		Identifier:  row.Identifier,
+		BuildNumber: row.BuildNumber,
 	}, nil
+}
+
+func (s *PostgresAppIdentifierStore) SetBuildNumber(ctx context.Context, appId string, identifierId string, buildNumber int64) error {
+	commandTag, err := s.engine.Queries.SetAppIdentifierBuildNumber(ctx, pgdb.SetAppIdentifierBuildNumberParams{
+		AppID:       ToPgUUID(appId),
+		ID:          ToPgUUID(identifierId),
+		BuildNumber: buildNumber,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to set build number in database: %w", err)
+	}
+	if commandTag.RowsAffected() == 0 {
+		return &ErrResourceNotFound{Resource: "app identifier", Identifier: identifierId}
+	}
+	return nil
 }
 
 func (s *PostgresAppIdentifierStore) DeleteAppIdentifier(ctx context.Context, appId string, identifierId string) error {

--- a/internal/store/app_identifier_postgres_test.go
+++ b/internal/store/app_identifier_postgres_test.go
@@ -1,0 +1,108 @@
+// Integration tests for the app identifier store: the per-app uniqueness,
+// the credentials-guarded delete and the app-deletion cascade are enforced
+// by the SQL itself, which the in-memory fakes cannot exercise.
+package store_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"xprem/internal/store"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAppIdentifierUniquePerAppPlatformIdentifier(t *testing.T) {
+	_, identifierStore, pool := setupCredentialsStores(t)
+	ctx := context.Background()
+	appId := insertBareApp(t, pool)
+
+	_, err := identifierStore.InsertAppIdentifier(ctx, appId, "android", "com.example.app")
+	require.NoError(t, err)
+	// Same identifier on the other platform is a distinct identity.
+	_, err = identifierStore.InsertAppIdentifier(ctx, appId, "ios", "com.example.app")
+	require.NoError(t, err)
+
+	_, err = identifierStore.InsertAppIdentifier(ctx, appId, "android", "com.example.app")
+	alreadyExistsErr := (*store.ErrResourceAlreadyExists)(nil)
+	require.True(t, errors.As(err, &alreadyExistsErr))
+
+	// The same identifier under another app is fine.
+	otherAppId := insertBareApp(t, pool)
+	_, err = identifierStore.InsertAppIdentifier(ctx, otherAppId, "android", "com.example.app")
+	require.NoError(t, err)
+}
+
+func TestAppIdentifierListReportsCredentialState(t *testing.T) {
+	credentialsStore, identifierStore, pool := setupCredentialsStores(t)
+	ctx := context.Background()
+	appId := insertBareApp(t, pool)
+	withCreds := insertIdentifier(t, identifierStore, appId, "android", "com.example.app")
+	insertIdentifier(t, identifierStore, appId, "android", "com.example.staging")
+	require.NoError(t, credentialsStore.UpsertAndroidCredentials(ctx, withCreds, sealedFixture("v1")))
+
+	identifiers, err := identifierStore.GetAppIdentifiers(ctx, appId)
+	require.NoError(t, err)
+	require.Len(t, identifiers, 2)
+	byIdentifier := map[string]bool{}
+	for _, row := range identifiers {
+		byIdentifier[row.Identifier] = row.HasAndroidCredentials
+	}
+	assert.True(t, byIdentifier["com.example.app"])
+	assert.False(t, byIdentifier["com.example.staging"])
+}
+
+func TestAppIdentifierDeleteIsGuardedByCredentials(t *testing.T) {
+	credentialsStore, identifierStore, pool := setupCredentialsStores(t)
+	ctx := context.Background()
+	appId := insertBareApp(t, pool)
+	identifierId := insertIdentifier(t, identifierStore, appId, "android", "com.example.app")
+	require.NoError(t, credentialsStore.UpsertAndroidCredentials(ctx, identifierId, sealedFixture("v1")))
+
+	err := identifierStore.DeleteAppIdentifier(ctx, appId, identifierId)
+	hasCredsErr := (*store.ErrIdentifierHasCredentials)(nil)
+	require.True(t, errors.As(err, &hasCredsErr))
+	assert.Equal(t, "com.example.app", hasCredsErr.Identifier)
+
+	require.NoError(t, credentialsStore.DeleteAndroidCredentials(ctx, identifierId))
+	require.NoError(t, identifierStore.DeleteAppIdentifier(ctx, appId, identifierId))
+
+	err = identifierStore.DeleteAppIdentifier(ctx, appId, identifierId)
+	notFoundErr := (*store.ErrResourceNotFound)(nil)
+	require.True(t, errors.As(err, &notFoundErr))
+}
+
+func TestAppIdentifierScopedToItsApp(t *testing.T) {
+	_, identifierStore, pool := setupCredentialsStores(t)
+	ctx := context.Background()
+	appId := insertBareApp(t, pool)
+	otherAppId := insertBareApp(t, pool)
+	identifierId := insertIdentifier(t, identifierStore, appId, "android", "com.example.app")
+
+	ref, err := identifierStore.GetAppIdentifierByID(ctx, otherAppId, identifierId)
+	require.NoError(t, err)
+	assert.Nil(t, ref)
+
+	err = identifierStore.DeleteAppIdentifier(ctx, otherAppId, identifierId)
+	notFoundErr := (*store.ErrResourceNotFound)(nil)
+	require.True(t, errors.As(err, &notFoundErr))
+}
+
+func TestAppIdentifierRowsAreDroppedWithTheApp(t *testing.T) {
+	credentialsStore, identifierStore, pool := setupCredentialsStores(t)
+	ctx := context.Background()
+	appId := insertBareApp(t, pool)
+	identifierId := insertIdentifier(t, identifierStore, appId, "android", "com.example.app")
+	require.NoError(t, credentialsStore.UpsertAndroidCredentials(ctx, identifierId, sealedFixture("v1")))
+
+	_, err := pool.Exec(ctx, "DELETE FROM apps WHERE id = $1", appId)
+	require.NoError(t, err)
+
+	var identifierCount, credentialsCount int
+	require.NoError(t, pool.QueryRow(ctx, "SELECT COUNT(*) FROM app_identifiers WHERE app_id = $1", appId).Scan(&identifierCount))
+	require.NoError(t, pool.QueryRow(ctx, "SELECT COUNT(*) FROM android_credentials WHERE app_identifier_id = $1", identifierId).Scan(&credentialsCount))
+	assert.Equal(t, 0, identifierCount)
+	assert.Equal(t, 0, credentialsCount)
+}

--- a/internal/store/app_identifier_postgres_test.go
+++ b/internal/store/app_identifier_postgres_test.go
@@ -74,6 +74,29 @@ func TestAppIdentifierDeleteIsGuardedByCredentials(t *testing.T) {
 	require.True(t, errors.As(err, &notFoundErr))
 }
 
+func TestAppIdentifierBuildNumberDefaultsAndSets(t *testing.T) {
+	_, identifierStore, pool := setupCredentialsStores(t)
+	ctx := context.Background()
+	appId := insertBareApp(t, pool)
+	identifierId := insertIdentifier(t, identifierStore, appId, "android", "com.example.app")
+
+	ref, err := identifierStore.GetAppIdentifierByID(ctx, appId, identifierId)
+	require.NoError(t, err)
+	require.NotNil(t, ref)
+	assert.Equal(t, int64(0), ref.BuildNumber)
+
+	require.NoError(t, identifierStore.SetBuildNumber(ctx, appId, identifierId, 87))
+	ref, err = identifierStore.GetAppIdentifierByID(ctx, appId, identifierId)
+	require.NoError(t, err)
+	assert.Equal(t, int64(87), ref.BuildNumber)
+
+	// Scoped: another app cannot touch the counter.
+	otherAppId := insertBareApp(t, pool)
+	err = identifierStore.SetBuildNumber(ctx, otherAppId, identifierId, 999)
+	notFoundErr := (*store.ErrResourceNotFound)(nil)
+	require.True(t, errors.As(err, &notFoundErr))
+}
+
 func TestAppIdentifierScopedToItsApp(t *testing.T) {
 	_, identifierStore, pool := setupCredentialsStores(t)
 	ctx := context.Background()

--- a/internal/store/credentials_postgres.go
+++ b/internal/store/credentials_postgres.go
@@ -12,10 +12,10 @@ import (
 	"github.com/jackc/pgx/v5"
 )
 
-// SealedAndroidCredentials is the at-rest shape of an app's Android signing
-// credentials: every secret field is an AES-GCM sealed blob, never plaintext.
+// SealedAndroidCredentials is the at-rest shape of an identifier's Android
+// signing credentials: every secret field is an AES-GCM sealed blob, never
+// plaintext.
 type SealedAndroidCredentials struct {
-	AndroidPackage                string
 	KeyAlias                      string
 	SealedKeystore                string
 	SealedKeystorePassword        string
@@ -35,11 +35,10 @@ func NewPostgresCredentialsStore(engine *database.Engine) *PostgresCredentialsSt
 	}
 }
 
-func (s *PostgresCredentialsStore) UpsertAndroidCredentials(ctx context.Context, appId string, credentials SealedAndroidCredentials) error {
+func (s *PostgresCredentialsStore) UpsertAndroidCredentials(ctx context.Context, identifierId string, credentials SealedAndroidCredentials) error {
 	_, err := s.engine.Queries.UpsertAndroidCredentials(ctx, pgdb.UpsertAndroidCredentialsParams{
 		ID:                            ToPgUUID(uuid.NewString()),
-		AppID:                         ToPgUUID(appId),
-		AndroidPackage:                credentials.AndroidPackage,
+		AppIdentifierID:               ToPgUUID(identifierId),
 		KeyAlias:                      credentials.KeyAlias,
 		SealedKeystore:                credentials.SealedKeystore,
 		SealedKeystorePassword:        credentials.SealedKeystorePassword,
@@ -52,8 +51,8 @@ func (s *PostgresCredentialsStore) UpsertAndroidCredentials(ctx context.Context,
 	return nil
 }
 
-func (s *PostgresCredentialsStore) GetAndroidCredentials(ctx context.Context, appId string) (*SealedAndroidCredentials, error) {
-	row, err := s.engine.Queries.GetAndroidCredentialsByAppID(ctx, ToPgUUID(appId))
+func (s *PostgresCredentialsStore) GetAndroidCredentials(ctx context.Context, identifierId string) (*SealedAndroidCredentials, error) {
+	row, err := s.engine.Queries.GetAndroidCredentialsByIdentifierID(ctx, ToPgUUID(identifierId))
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, nil
@@ -61,7 +60,6 @@ func (s *PostgresCredentialsStore) GetAndroidCredentials(ctx context.Context, ap
 		return nil, fmt.Errorf("failed to retrieve android credentials from database: %w", err)
 	}
 	return &SealedAndroidCredentials{
-		AndroidPackage:                row.AndroidPackage,
 		KeyAlias:                      row.KeyAlias,
 		SealedKeystore:                row.SealedKeystore,
 		SealedKeystorePassword:        row.SealedKeystorePassword,
@@ -72,13 +70,13 @@ func (s *PostgresCredentialsStore) GetAndroidCredentials(ctx context.Context, ap
 	}, nil
 }
 
-func (s *PostgresCredentialsStore) DeleteAndroidCredentials(ctx context.Context, appId string) error {
-	commandTag, err := s.engine.Queries.DeleteAndroidCredentialsByAppID(ctx, ToPgUUID(appId))
+func (s *PostgresCredentialsStore) DeleteAndroidCredentials(ctx context.Context, identifierId string) error {
+	commandTag, err := s.engine.Queries.DeleteAndroidCredentialsByIdentifierID(ctx, ToPgUUID(identifierId))
 	if err != nil {
 		return fmt.Errorf("failed to delete android credentials from database: %w", err)
 	}
 	if commandTag.RowsAffected() == 0 {
-		return &ErrResourceNotFound{Resource: "android credentials", Identifier: fmt.Sprintf("appId: %s", appId)}
+		return &ErrResourceNotFound{Resource: "android credentials", Identifier: fmt.Sprintf("identifierId: %s", identifierId)}
 	}
 	return nil
 }

--- a/internal/store/credentials_postgres_test.go
+++ b/internal/store/credentials_postgres_test.go
@@ -1,7 +1,7 @@
-// Integration tests for the Android credentials store: the one-row-per-app
-// upsert and the not-found delete are enforced by the SQL itself, which the
-// in-memory fakes cannot exercise. Same TEST_DATABASE_URL contract as the
-// branch store tests.
+// Integration tests for the Android credentials store: the one-row-per-
+// identifier upsert and the not-found delete are enforced by the SQL itself,
+// which the in-memory fakes cannot exercise. Same TEST_DATABASE_URL contract
+// as the branch store tests.
 package store_test
 
 import (
@@ -21,7 +21,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func setupCredentialsStore(t *testing.T) (*store.PostgresCredentialsStore, *pgxpool.Pool) {
+func setupCredentialsStores(t *testing.T) (*store.PostgresCredentialsStore, *store.PostgresAppIdentifierStore, *pgxpool.Pool) {
 	t.Helper()
 	dbURL := os.Getenv("TEST_DATABASE_URL")
 	if dbURL == "" {
@@ -38,7 +38,8 @@ func setupCredentialsStore(t *testing.T) (*store.PostgresCredentialsStore, *pgxp
 	pool, err := pgxpool.New(context.Background(), dbURL)
 	require.NoError(t, err)
 	t.Cleanup(pool.Close)
-	return store.NewPostgresCredentialsStore(&database.Engine{Queries: pgdb.New(pool), DB: pool}), pool
+	engine := &database.Engine{Queries: pgdb.New(pool), DB: pool}
+	return store.NewPostgresCredentialsStore(engine), store.NewPostgresAppIdentifierStore(engine), pool
 }
 
 func insertBareApp(t *testing.T, pool *pgxpool.Pool) string {
@@ -49,9 +50,15 @@ func insertBareApp(t *testing.T, pool *pgxpool.Pool) string {
 	return appId
 }
 
+func insertIdentifier(t *testing.T, identifierStore *store.PostgresAppIdentifierStore, appId string, platform string, identifier string) string {
+	t.Helper()
+	id, err := identifierStore.InsertAppIdentifier(context.Background(), appId, platform, identifier)
+	require.NoError(t, err)
+	return id
+}
+
 func sealedFixture(marker string) store.SealedAndroidCredentials {
 	return store.SealedAndroidCredentials{
-		AndroidPackage:         "com.example." + marker,
 		KeyAlias:               "upload",
 		SealedKeystore:         "sealed-keystore-" + marker,
 		SealedKeystorePassword: "sealed-keystore-password-" + marker,
@@ -60,64 +67,52 @@ func sealedFixture(marker string) store.SealedAndroidCredentials {
 }
 
 func TestAndroidCredentialsUpsertReplacesTheSingleRow(t *testing.T) {
-	credentialsStore, pool := setupCredentialsStore(t)
+	credentialsStore, identifierStore, pool := setupCredentialsStores(t)
 	ctx := context.Background()
 	appId := insertBareApp(t, pool)
+	identifierId := insertIdentifier(t, identifierStore, appId, "android", "com.example.app")
 
-	require.NoError(t, credentialsStore.UpsertAndroidCredentials(ctx, appId, sealedFixture("v1")))
+	require.NoError(t, credentialsStore.UpsertAndroidCredentials(ctx, identifierId, sealedFixture("v1")))
 	gsa := "sealed-gsa-v2"
 	second := sealedFixture("v2")
 	second.SealedGoogleServiceAccountKey = &gsa
-	require.NoError(t, credentialsStore.UpsertAndroidCredentials(ctx, appId, second))
+	require.NoError(t, credentialsStore.UpsertAndroidCredentials(ctx, identifierId, second))
 
 	var count int
-	require.NoError(t, pool.QueryRow(ctx, "SELECT COUNT(*) FROM android_credentials WHERE app_id = $1", appId).Scan(&count))
+	require.NoError(t, pool.QueryRow(ctx, "SELECT COUNT(*) FROM android_credentials WHERE app_identifier_id = $1", identifierId).Scan(&count))
 	assert.Equal(t, 1, count)
 
-	stored, err := credentialsStore.GetAndroidCredentials(ctx, appId)
+	stored, err := credentialsStore.GetAndroidCredentials(ctx, identifierId)
 	require.NoError(t, err)
 	require.NotNil(t, stored)
-	assert.Equal(t, "com.example.v2", stored.AndroidPackage)
 	assert.Equal(t, "sealed-keystore-v2", stored.SealedKeystore)
 	require.NotNil(t, stored.SealedGoogleServiceAccountKey)
 	assert.Equal(t, "sealed-gsa-v2", *stored.SealedGoogleServiceAccountKey)
 }
 
 func TestAndroidCredentialsGetReturnsNilWhenAbsent(t *testing.T) {
-	credentialsStore, pool := setupCredentialsStore(t)
+	credentialsStore, identifierStore, pool := setupCredentialsStores(t)
 	appId := insertBareApp(t, pool)
+	identifierId := insertIdentifier(t, identifierStore, appId, "android", "com.example.app")
 
-	stored, err := credentialsStore.GetAndroidCredentials(context.Background(), appId)
+	stored, err := credentialsStore.GetAndroidCredentials(context.Background(), identifierId)
 	require.NoError(t, err)
 	assert.Nil(t, stored)
 }
 
 func TestAndroidCredentialsDeleteReportsNotFound(t *testing.T) {
-	credentialsStore, pool := setupCredentialsStore(t)
+	credentialsStore, identifierStore, pool := setupCredentialsStores(t)
 	ctx := context.Background()
 	appId := insertBareApp(t, pool)
+	identifierId := insertIdentifier(t, identifierStore, appId, "android", "com.example.app")
 
-	err := credentialsStore.DeleteAndroidCredentials(ctx, appId)
+	err := credentialsStore.DeleteAndroidCredentials(ctx, identifierId)
 	notFoundErr := (*store.ErrResourceNotFound)(nil)
 	require.True(t, errors.As(err, &notFoundErr))
 
-	require.NoError(t, credentialsStore.UpsertAndroidCredentials(ctx, appId, sealedFixture("v1")))
-	require.NoError(t, credentialsStore.DeleteAndroidCredentials(ctx, appId))
-	stored, err := credentialsStore.GetAndroidCredentials(ctx, appId)
+	require.NoError(t, credentialsStore.UpsertAndroidCredentials(ctx, identifierId, sealedFixture("v1")))
+	require.NoError(t, credentialsStore.DeleteAndroidCredentials(ctx, identifierId))
+	stored, err := credentialsStore.GetAndroidCredentials(ctx, identifierId)
 	require.NoError(t, err)
 	assert.Nil(t, stored)
-}
-
-func TestAndroidCredentialsRowsAreDroppedWithTheApp(t *testing.T) {
-	credentialsStore, pool := setupCredentialsStore(t)
-	ctx := context.Background()
-	appId := insertBareApp(t, pool)
-	require.NoError(t, credentialsStore.UpsertAndroidCredentials(ctx, appId, sealedFixture("v1")))
-
-	_, err := pool.Exec(ctx, "DELETE FROM apps WHERE id = $1", appId)
-	require.NoError(t, err)
-
-	var count int
-	require.NoError(t, pool.QueryRow(ctx, "SELECT COUNT(*) FROM android_credentials WHERE app_id = $1", appId).Scan(&count))
-	assert.Equal(t, 0, count)
 }

--- a/internal/store/errors.go
+++ b/internal/store/errors.go
@@ -55,6 +55,16 @@ func (e *ErrChannelHasActiveRollout) Error() string {
 	return fmt.Sprintf("cannot change the branch mapping of channel %q while it has an active rollout. Promote or revert the rollout first.", e.ChannelName)
 }
 
+// ErrIdentifierHasCredentials refuses deleting an app identifier that still
+// holds signing credentials; the keystore must be removed explicitly first.
+type ErrIdentifierHasCredentials struct {
+	Identifier string
+}
+
+func (e *ErrIdentifierHasCredentials) Error() string {
+	return fmt.Sprintf("cannot delete identifier %q because it still holds signing credentials. Delete its credentials first.", e.Identifier)
+}
+
 type ErrResourceAlreadyExists struct {
 	Resource   string
 	Identifier string


### PR DESCRIPTION
Normalizes the store-identity model discussed for native builds: an **app identifier** (package name on Android, bundle id on iOS) becomes a first-class entity, and everything store-related hangs off it — credentials now, build profiles and version counters in the next PRs.

## What
- New `app_identifiers` table: one row per (app, platform, identifier), e.g. `com.skeat` android and `com.skeat.staging` android as two identities of the same xprem app. CRUD under `/api/apps/{APP_ID}/identifiers` (list shows `hasAndroidCredentials`), writes behind `credentials:manage`, audited (`app_identifier.created`/`.deleted`).
- `android_credentials` rekeyed: `app_identifier_id UNIQUE` replaces `app_id` + `android_package`. Endpoints move to `/identifiers/{IDENTIFIER_ID}/credentials/android`; the AES-GCM AAD of every sealed blob is now bound to the identifier row.
- **Guarded delete**: deleting an identifier still holding credentials is refused inside the DELETE statement itself (0-rows disambiguated into 409 has-credentials vs 404), so a keystore can never disappear as a side effect. Full app deletion still cascades.
- The original credentials migration is rewritten **in place** rather than chained: it never shipped in any release and the rekeyed blobs could not be unsealed across the AAD change anyway. Dev DBs that applied the old version need a reset.

## Out of scope (next PRs)
Build profiles (will reference `android_app_identifier_id`), version counters per identifier, decrypted-secrets read path for `eoas build`.

## Tests
- Service: identifier format validation per platform, identifier resolution (unknown id, wrong app, ios identifier refused for android credentials), seal/unseal roundtrip with cross-identifier AAD rejection, audit emission, stateless refusal.
- Store (TEST_DATABASE_URL): uniqueness per (app, platform, identifier), credential-state listing, guarded delete disambiguation, app-scoping, cascade on app deletion.
- Full `go test ./...` and `make lint` green.