### PR TITLE
feat(env-vars): add environment variable management functionality

### DIFF
--- a/apps/dashboard/src/ee/lib/PermissionsContext.tsx
+++ b/apps/dashboard/src/ee/lib/PermissionsContext.tsx
@@ -25,6 +25,9 @@ export type Permission =
   | 'update-rollout:manage'
   | 'update:publish'
   | 'apikeys:manage'
+  | 'credentials:manage'
+  | 'env:read'
+  | 'env:manage'
   | 'identity:manage'
   | 'identity:read'
   | 'observe:read';

--- a/apps/dashboard/src/ee/lib/auditCatalog.ts
+++ b/apps/dashboard/src/ee/lib/auditCatalog.ts
@@ -77,6 +77,9 @@ export const AUDIT_ACTION_GROUPS: AuditActionGroup[] = [
       'app_identifier.build_number_set',
       'android_credentials.saved',
       'android_credentials.deleted',
+      'env_var.updated',
+      'env_var.deleted',
+      'env_var.revealed',
     ],
   },
   {

--- a/apps/dashboard/src/ee/lib/permissionCatalog.ts
+++ b/apps/dashboard/src/ee/lib/permissionCatalog.ts
@@ -121,6 +121,32 @@ export const PERMISSION_GROUPS: PermissionGroup[] = [
     ],
   },
   {
+    label: 'Store credentials',
+    permissions: [
+      {
+        value: 'credentials:manage',
+        label: 'Manage identifiers and signing credentials',
+        description:
+          'Create and delete application identifiers, upload or delete their signing credentials (Android keystore, submit keys), and set store build numbers.',
+      },
+    ],
+  },
+  {
+    label: 'Environment variables',
+    permissions: [
+      {
+        value: 'env:manage',
+        label: 'Manage environment variables',
+        description: 'Create, overwrite and delete the environment variables of a branch.',
+      },
+      {
+        value: 'env:read',
+        label: 'Reveal environment values',
+        description: 'Read the plaintext value of any environment variable. Listing key names is open to every viewer.',
+      },
+    ],
+  },
+  {
     label: 'Identity',
     permissions: [
       {

--- a/ee/rbac/mcptools_test.go
+++ b/ee/rbac/mcptools_test.go
@@ -38,8 +38,8 @@ func TestMCPDecisionFunctions(t *testing.T) {
 	require.False(t, description.RolesEnforced)
 	require.Equal(t, "member", description.Role)
 	require.Len(t, description.Apps, 1)
-	require.Equal(t, []string{string(PermIdentityRead), string(PermObserveRead)}, description.Apps[0].Granted)
-	require.Len(t, description.Apps[0].Denied, len(AllPermissions)-2)
+	require.Equal(t, []string{string(PermEnvRead), string(PermIdentityRead), string(PermObserveRead)}, description.Apps[0].Granted)
+	require.Len(t, description.Apps[0].Denied, len(AllPermissions)-3)
 
 	adminDescription, err := service.MCPDescribePermissions(ctx, admin, []string{"app-1"})
 	require.NoError(t, err)

--- a/ee/rbac/permissions.go
+++ b/ee/rbac/permissions.go
@@ -62,6 +62,13 @@ const (
 	// identifiers) and their signing credentials (Android keystore, submit
 	// keys). Reading the non-secret metadata is open to any viewer.
 	PermCredentialsManage Permission = "credentials:manage"
+	// PermEnvRead reveals the plaintext values of the app's environment
+	// variables. Listing keys (never values) is open to any viewer.
+	PermEnvRead Permission = "env:read"
+	// PermEnvManage writes and deletes the app's environment variables. It
+	// does not imply PermEnvRead: a config operator can overwrite values
+	// without being able to read them back.
+	PermEnvManage Permission = "env:manage"
 )
 
 // AllPermissions is the catalog, in the order the dashboard displays it.
@@ -80,6 +87,8 @@ var AllPermissions = []Permission{
 	PermUpdateRolloutManage,
 	PermUpdatePublish,
 	PermCredentialsManage,
+	PermEnvRead,
+	PermEnvManage,
 	PermApiKeysManage,
 	PermIdentityManage,
 	PermIdentityRead,
@@ -106,6 +115,7 @@ func IsValidPermission(p string) bool {
 var anyMemberPermissions = map[Permission]bool{
 	PermIdentityRead: true,
 	PermObserveRead:  true,
+	PermEnvRead:      true,
 }
 
 // DefaultFallback is what gates a permission's actions when roles are not

--- a/internal/auditlog/auditlog.go
+++ b/internal/auditlog/auditlog.go
@@ -100,6 +100,9 @@ const (
 	ActionAppIdentifierBuildNumberSet Action = "app_identifier.build_number_set"
 	ActionAndroidCredentialsSaved   Action = "android_credentials.saved"
 	ActionAndroidCredentialsDeleted Action = "android_credentials.deleted"
+	ActionEnvVarUpdated             Action = "env_var.updated"
+	ActionEnvVarDeleted             Action = "env_var.deleted"
+	ActionEnvVarRevealed            Action = "env_var.revealed"
 
 	// Access control. permission.denied is the single event for authorization
 	// refusals (the RBAC middleware emits it, with OutcomeDenied); domain

--- a/internal/database/postgres/migrations/20260810120000_branch_env_vars.sql
+++ b/internal/database/postgres/migrations/20260810120000_branch_env_vars.sql
@@ -1,0 +1,28 @@
+-- +goose Up
+-- +goose StatementBegin
+
+-- Environment variables of a branch, resolved at build/publish time. key is
+-- stored without the EXPO_PUBLIC_ prefix; is_public decides whether injection
+-- adds it. Values are sealed with AES-GCM under the deployment master key.
+CREATE TABLE branch_env_vars (
+    id UUID PRIMARY KEY,
+    app_id UUID NOT NULL,
+    branch_id BIGINT NOT NULL,
+    key VARCHAR(200) NOT NULL,
+    is_public BOOLEAN NOT NULL,
+    sealed_value TEXT NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT fk_branch_env_vars_app FOREIGN KEY (app_id) REFERENCES apps(id) ON DELETE CASCADE,
+    CONSTRAINT fk_branch_env_vars_branch FOREIGN KEY (branch_id) REFERENCES branches(id) ON DELETE CASCADE,
+    CONSTRAINT uq_branch_env_var UNIQUE (app_id, branch_id, key)
+);
+
+CREATE INDEX idx_branch_env_vars_branch ON branch_env_vars (branch_id);
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP TABLE IF EXISTS branch_env_vars;
+-- +goose StatementEnd

--- a/internal/database/postgres/pgdb/models.go
+++ b/internal/database/postgres/pgdb/models.go
@@ -95,6 +95,17 @@ type Branch struct {
 	Protected bool               `json:"protected"`
 }
 
+type BranchEnvVar struct {
+	ID          pgtype.UUID        `json:"id"`
+	AppID       pgtype.UUID        `json:"app_id"`
+	BranchID    int64              `json:"branch_id"`
+	Key         string             `json:"key"`
+	IsPublic    bool               `json:"is_public"`
+	SealedValue string             `json:"sealed_value"`
+	CreatedAt   pgtype.Timestamptz `json:"created_at"`
+	UpdatedAt   pgtype.Timestamptz `json:"updated_at"`
+}
+
 type Channel struct {
 	ID                   int64              `json:"id"`
 	AppID                pgtype.UUID        `json:"app_id"`

--- a/internal/database/postgres/pgdb/queries.sql.go
+++ b/internal/database/postgres/pgdb/queries.sql.go
@@ -583,6 +583,21 @@ func (q *Queries) DeleteEnterpriseLicense(ctx context.Context) error {
 	return err
 }
 
+const deleteEnvVar = `-- name: DeleteEnvVar :execresult
+DELETE FROM branch_env_vars
+WHERE app_id = $1 AND branch_id = $2 AND key = $3
+`
+
+type DeleteEnvVarParams struct {
+	AppID    pgtype.UUID `json:"app_id"`
+	BranchID int64       `json:"branch_id"`
+	Key      string      `json:"key"`
+}
+
+func (q *Queries) DeleteEnvVar(ctx context.Context, arg DeleteEnvVarParams) (pgconn.CommandTag, error) {
+	return q.db.Exec(ctx, deleteEnvVar, arg.AppID, arg.BranchID, arg.Key)
+}
+
 const deleteExpiredOAuthAuthorizationCodes = `-- name: DeleteExpiredOAuthAuthorizationCodes :exec
 DELETE FROM oauth_authorization_codes WHERE expires_at < CURRENT_TIMESTAMP
 `
@@ -1981,6 +1996,25 @@ func (q *Queries) GetSSOConfig(ctx context.Context) (SsoConfig, error) {
 		&i.ManualUserValidation,
 	)
 	return i, err
+}
+
+const getSealedEnvValue = `-- name: GetSealedEnvValue :one
+SELECT sealed_value
+FROM branch_env_vars
+WHERE app_id = $1 AND branch_id = $2 AND key = $3
+`
+
+type GetSealedEnvValueParams struct {
+	AppID    pgtype.UUID `json:"app_id"`
+	BranchID int64       `json:"branch_id"`
+	Key      string      `json:"key"`
+}
+
+func (q *Queries) GetSealedEnvValue(ctx context.Context, arg GetSealedEnvValueParams) (string, error) {
+	row := q.db.QueryRow(ctx, getSealedEnvValue, arg.AppID, arg.BranchID, arg.Key)
+	var sealed_value string
+	err := row.Scan(&sealed_value)
+	return sealed_value, err
 }
 
 const getSurfableBranches = `-- name: GetSurfableBranches :many
@@ -3861,6 +3895,48 @@ func (q *Queries) ListDevices(ctx context.Context, arg ListDevicesParams) ([]Dev
 			&i.AppVersion,
 			&i.CurrentUpdateObservedAt,
 			&i.CurrentUpdateArrivedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listEnvVarsByAppID = `-- name: ListEnvVarsByAppID :many
+SELECT ev.key, ev.is_public, b.name AS branch_name, ev.created_at, ev.updated_at
+FROM branch_env_vars ev
+JOIN branches b ON b.id = ev.branch_id
+WHERE ev.app_id = $1
+ORDER BY b.name ASC, ev.key ASC
+`
+
+type ListEnvVarsByAppIDRow struct {
+	Key        string             `json:"key"`
+	IsPublic   bool               `json:"is_public"`
+	BranchName string             `json:"branch_name"`
+	CreatedAt  pgtype.Timestamptz `json:"created_at"`
+	UpdatedAt  pgtype.Timestamptz `json:"updated_at"`
+}
+
+func (q *Queries) ListEnvVarsByAppID(ctx context.Context, appID pgtype.UUID) ([]ListEnvVarsByAppIDRow, error) {
+	rows, err := q.db.Query(ctx, listEnvVarsByAppID, appID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListEnvVarsByAppIDRow
+	for rows.Next() {
+		var i ListEnvVarsByAppIDRow
+		if err := rows.Scan(
+			&i.Key,
+			&i.IsPublic,
+			&i.BranchName,
+			&i.CreatedAt,
+			&i.UpdatedAt,
 		); err != nil {
 			return nil, err
 		}
@@ -5845,6 +5921,39 @@ func (q *Queries) UpsertAndroidCredentials(ctx context.Context, arg UpsertAndroi
 		arg.SealedKeystorePassword,
 		arg.SealedKeyPassword,
 		arg.SealedGoogleServiceAccountKey,
+	)
+	var id pgtype.UUID
+	err := row.Scan(&id)
+	return id, err
+}
+
+const upsertBranchEnvVar = `-- name: UpsertBranchEnvVar :one
+INSERT INTO branch_env_vars (id, app_id, branch_id, key, is_public, sealed_value)
+VALUES ($1, $2, $3, $4, $5, $6)
+ON CONFLICT (app_id, branch_id, key) DO UPDATE SET
+    is_public = EXCLUDED.is_public,
+    sealed_value = EXCLUDED.sealed_value,
+    updated_at = CURRENT_TIMESTAMP
+RETURNING id
+`
+
+type UpsertBranchEnvVarParams struct {
+	ID          pgtype.UUID `json:"id"`
+	AppID       pgtype.UUID `json:"app_id"`
+	BranchID    int64       `json:"branch_id"`
+	Key         string      `json:"key"`
+	IsPublic    bool        `json:"is_public"`
+	SealedValue string      `json:"sealed_value"`
+}
+
+func (q *Queries) UpsertBranchEnvVar(ctx context.Context, arg UpsertBranchEnvVarParams) (pgtype.UUID, error) {
+	row := q.db.QueryRow(ctx, upsertBranchEnvVar,
+		arg.ID,
+		arg.AppID,
+		arg.BranchID,
+		arg.Key,
+		arg.IsPublic,
+		arg.SealedValue,
 	)
 	var id pgtype.UUID
 	err := row.Scan(&id)

--- a/internal/database/postgres/queries/queries.sql
+++ b/internal/database/postgres/queries/queries.sql
@@ -2376,3 +2376,28 @@ WHERE app_identifiers.app_id = $1 AND app_identifiers.id = $2
   AND NOT EXISTS (
       SELECT 1 FROM android_credentials ac WHERE ac.app_identifier_id = app_identifiers.id
   );
+
+-- name: UpsertBranchEnvVar :one
+INSERT INTO branch_env_vars (id, app_id, branch_id, key, is_public, sealed_value)
+VALUES ($1, $2, $3, $4, $5, $6)
+ON CONFLICT (app_id, branch_id, key) DO UPDATE SET
+    is_public = EXCLUDED.is_public,
+    sealed_value = EXCLUDED.sealed_value,
+    updated_at = CURRENT_TIMESTAMP
+RETURNING id;
+
+-- name: ListEnvVarsByAppID :many
+SELECT ev.key, ev.is_public, b.name AS branch_name, ev.created_at, ev.updated_at
+FROM branch_env_vars ev
+JOIN branches b ON b.id = ev.branch_id
+WHERE ev.app_id = $1
+ORDER BY b.name ASC, ev.key ASC;
+
+-- name: GetSealedEnvValue :one
+SELECT sealed_value
+FROM branch_env_vars
+WHERE app_id = $1 AND branch_id = $2 AND key = $3;
+
+-- name: DeleteEnvVar :execresult
+DELETE FROM branch_env_vars
+WHERE app_id = $1 AND branch_id = $2 AND key = $3;

--- a/internal/handlers/dashboard/credentials_handler.go
+++ b/internal/handlers/dashboard/credentials_handler.go
@@ -36,7 +36,9 @@ func credentialsVars(w http.ResponseWriter, r *http.Request) (string, string) {
 	return appId, identifierId
 }
 
-func renderCredentialsError(w http.ResponseWriter, err error, fallback string) {
+// renderServiceError maps the service-layer error vocabulary shared by the
+// vault handlers (validation, not-found, stateless) to HTTP statuses.
+func renderServiceError(w http.ResponseWriter, err error, fallback string) {
 	var valErr *validation.Error
 	if errors.As(err, &valErr) {
 		handlers.RenderError(w, http.StatusBadRequest, valErr.Error())
@@ -60,7 +62,7 @@ func (h *CredentialsHandler) GetAndroidCredentialsHandler(w http.ResponseWriter,
 	}
 	metadata, err := h.credentialsService.GetAndroidCredentialsMetadata(r.Context(), appId, identifierId)
 	if err != nil {
-		renderCredentialsError(w, err, "An internal error occurred while fetching android credentials.")
+		renderServiceError(w, err, "An internal error occurred while fetching android credentials.")
 		return
 	}
 	if metadata == nil {
@@ -97,7 +99,7 @@ func (h *CredentialsHandler) PutAndroidCredentialsHandler(w http.ResponseWriter,
 		GoogleServiceAccountKeyJSON: requestBody.GoogleServiceAccountKey,
 	})
 	if err != nil {
-		renderCredentialsError(w, err, "An internal error occurred while saving android credentials.")
+		renderServiceError(w, err, "An internal error occurred while saving android credentials.")
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)
@@ -110,7 +112,7 @@ func (h *CredentialsHandler) DeleteAndroidCredentialsHandler(w http.ResponseWrit
 	}
 	err := h.credentialsService.DeleteAndroidCredentials(r.Context(), appId, identifierId)
 	if err != nil {
-		renderCredentialsError(w, err, "An internal error occurred while deleting android credentials.")
+		renderServiceError(w, err, "An internal error occurred while deleting android credentials.")
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)

--- a/internal/handlers/dashboard/env_vars_handler.go
+++ b/internal/handlers/dashboard/env_vars_handler.go
@@ -1,0 +1,77 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"xprem/internal/handlers"
+	"xprem/internal/services"
+
+	"github.com/gorilla/mux"
+)
+
+type EnvVarsHandler struct {
+	envVarService *services.EnvVarService
+}
+
+func NewEnvVarsHandler(envVarService *services.EnvVarService) *EnvVarsHandler {
+	return &EnvVarsHandler{
+		envVarService: envVarService,
+	}
+}
+
+func (h *EnvVarsHandler) ListEnvVarsHandler(w http.ResponseWriter, r *http.Request) {
+	appId := mux.Vars(r)["APP_ID"]
+	envVars, err := h.envVarService.ListEnvVars(r.Context(), appId)
+	if err != nil {
+		renderServiceError(w, err, "An internal error occurred while listing env vars.")
+		return
+	}
+	marshaledResponse, _ := json.Marshal(envVars)
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	w.Write(marshaledResponse)
+}
+
+func (h *EnvVarsHandler) SetEnvVarHandler(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	appId := vars["APP_ID"]
+	branch := vars["BRANCH"]
+	key := vars["KEY"]
+	var requestBody struct {
+		Value    *string `json:"value"`
+		IsPublic bool    `json:"isPublic"`
+	}
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 64<<10)).Decode(&requestBody); err != nil || requestBody.Value == nil {
+		handlers.RenderError(w, http.StatusBadRequest, "invalid request body, expected {\"value\": <string>, \"isPublic\": <bool>}")
+		return
+	}
+	err := h.envVarService.SetEnvVar(r.Context(), appId, branch, key, *requestBody.Value, requestBody.IsPublic)
+	if err != nil {
+		renderServiceError(w, err, "An internal error occurred while saving the env var.")
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (h *EnvVarsHandler) RevealEnvVarHandler(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	value, err := h.envVarService.RevealEnvVar(r.Context(), vars["APP_ID"], vars["BRANCH"], vars["KEY"])
+	if err != nil {
+		renderServiceError(w, err, "An internal error occurred while reading the env var.")
+		return
+	}
+	marshaledResponse, _ := json.Marshal(map[string]string{"value": value})
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	w.Write(marshaledResponse)
+}
+
+func (h *EnvVarsHandler) DeleteEnvVarHandler(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	err := h.envVarService.DeleteEnvVar(r.Context(), vars["APP_ID"], vars["BRANCH"], vars["KEY"])
+	if err != nil {
+		renderServiceError(w, err, "An internal error occurred while deleting the env var.")
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/internal/router/routes_app.go
+++ b/internal/router/routes_app.go
@@ -97,6 +97,15 @@ func registerAppRoutes(
 	app.route(http.MethodDelete, "/identifiers/{IDENTIFIER_ID}/credentials/android", container.CredentialsHandler.DeleteAndroidCredentialsHandler,
 		NeedsPermission(rbac.PermCredentialsManage, rbac.FallbackAdminOnly))
 
+	app.route(http.MethodGet, "/env", container.EnvVarsHandler.ListEnvVarsHandler,
+		AnyViewer())
+	app.route(http.MethodPut, "/env/branch/{BRANCH}/{KEY}", container.EnvVarsHandler.SetEnvVarHandler,
+		NeedsPermission(rbac.PermEnvManage, rbac.FallbackAdminOnly))
+	app.route(http.MethodGet, "/env/branch/{BRANCH}/{KEY}/value", container.EnvVarsHandler.RevealEnvVarHandler,
+		NeedsPermission(rbac.PermEnvRead, rbac.FallbackAnyMember))
+	app.route(http.MethodDelete, "/env/branch/{BRANCH}/{KEY}", container.EnvVarsHandler.DeleteEnvVarHandler,
+		NeedsPermission(rbac.PermEnvManage, rbac.FallbackAdminOnly))
+
 	app.route(http.MethodGet, "/apiKeys", container.ApiKeyHandler.GetApiKeysHandler,
 		AnyViewer())
 	app.route(http.MethodPost, "/apiKeys", container.ApiKeyHandler.CreateApiKeyHandler,

--- a/internal/router/wire.go
+++ b/internal/router/wire.go
@@ -46,6 +46,7 @@ type AppContainer struct {
 	BranchListHandler           *handlers.BranchListHandler
 	ChannelHandler              *dashhandlers.ChannelHandler
 	CredentialsHandler          *dashhandlers.CredentialsHandler
+	EnvVarsHandler              *dashhandlers.EnvVarsHandler
 	ExpoProtocolHandler         *handlers.ExpoProtocolHandler
 	LicenseHandler              *licensing.LicenseHandler
 	RBACHandler                 *rbac.RBACHandler
@@ -98,6 +99,7 @@ func InitDependencies(ctx context.Context) (*AppContainer, func()) {
 	// exist on the control plane.
 	var appIdentifierRepo services.AppIdentifierRepository
 	var credentialsRepo services.CredentialsRepository
+	var envVarRepo services.EnvVarRepository
 	var licenseRepo licensing.LicenseRepository
 	var ssoRepo sso.SSORepository
 	var apiKeyAccessRepo apikeyrestrictions.ApiKeyAccessRepository
@@ -163,6 +165,7 @@ func InitDependencies(ctx context.Context) (*AppContainer, func()) {
 		rolloutRepo = store.NewPostgresRolloutStore(dbEngine)
 		appIdentifierRepo = store.NewPostgresAppIdentifierStore(dbEngine)
 		credentialsRepo = store.NewPostgresCredentialsStore(dbEngine)
+		envVarRepo = store.NewPostgresEnvVarStore(dbEngine)
 
 		if config.IsDeviceTelemetryDisabled() {
 			log.Println("🔕 [TELEMETRY] DISABLE_DEVICE_TELEMETRY is set; nothing is recorded about a device: manifest check-ins, identity ops and telemetry batches are all dropped, and no ClickHouse connection is opened. The Observe and Identity dashboards report the feature as unavailable, and CLICKHOUSE_URL is ignored.")
@@ -255,6 +258,8 @@ func InitDependencies(ctx context.Context) (*AppContainer, func()) {
 	appIdentifierService.SetOnAuditEvent(auditService.Record)
 	credentialsService := services.NewCredentialsService(credentialsRepo, appIdentifierRepo)
 	credentialsService.SetOnAuditEvent(auditService.Record)
+	envVarService := services.NewEnvVarService(envVarRepo, branchRepo)
+	envVarService.SetOnAuditEvent(auditService.Record)
 
 	// Shared across handlers; with Redis configured, also across replicas.
 	rateLimiter := ratelimit.New(cache.GetCache())
@@ -313,6 +318,7 @@ func InitDependencies(ctx context.Context) (*AppContainer, func()) {
 		ChannelHandler:              dashhandlers.NewChannelHandler(channelService),
 		AppIdentifiersHandler:       dashhandlers.NewAppIdentifiersHandler(appIdentifierService),
 		CredentialsHandler:          dashhandlers.NewCredentialsHandler(credentialsService),
+		EnvVarsHandler:              dashhandlers.NewEnvVarsHandler(envVarService),
 		ExpoProtocolHandler:         handlers.NewExpoProtocolHandler(expoProtocolService),
 		LicenseHandler:              licensing.NewLicenseHandler(licenseService),
 		AuditHandler:                audit.NewAuditHandler(auditService),

--- a/internal/services/env_var_service.go
+++ b/internal/services/env_var_service.go
@@ -1,0 +1,221 @@
+package services
+
+import (
+	"context"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+	"xprem/internal/auditlog"
+	"xprem/internal/crypto"
+	"xprem/internal/database"
+	"xprem/internal/keyStore"
+	"xprem/internal/store"
+	"xprem/internal/validation"
+
+	"github.com/google/uuid"
+)
+
+// PublicEnvPrefix is prepended at injection time to entries flagged public;
+// it is never part of the stored key.
+const PublicEnvPrefix = "EXPO_PUBLIC_"
+
+// maxEnvValueBytes caps one value.
+const maxEnvValueBytes = 8 * 1024
+
+var envKeyPattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+
+type EnvVarRepository interface {
+	UpsertEnvVar(ctx context.Context, appId string, branchId int64, key string, isPublic bool, sealedValue string) error
+	ListEnvVars(ctx context.Context, appId string) ([]store.EnvVarRow, error)
+	GetSealedValue(ctx context.Context, appId string, branchId int64, key string) (*string, error)
+	DeleteEnvVar(ctx context.Context, appId string, branchId int64, key string) error
+}
+
+// BranchResolver is the slice of the branch repository the env service needs.
+type BranchResolver interface {
+	GetBranchByName(ctx context.Context, appId string, branchName string) (int64, error)
+}
+
+// EnvVar is the dashboard projection of one entry: branch, key and flag,
+// never the value.
+type EnvVar struct {
+	Key       string `json:"key"`
+	IsPublic  bool   `json:"isPublic"`
+	Branch    string `json:"branch"`
+	CreatedAt string `json:"createdAt"`
+	UpdatedAt string `json:"updatedAt"`
+}
+
+type EnvVarService struct {
+	repo     EnvVarRepository
+	branches BranchResolver
+	// onAuditEvent is the audit emission seam; nil (community) means env
+	// changes leave no events.
+	onAuditEvent auditlog.RecordFunc
+}
+
+// NewEnvVarService builds the service; a nil repo (stateless mode) makes
+// every method answer ErrNotSupportedInStatelessMode.
+func NewEnvVarService(repo EnvVarRepository, branches BranchResolver) *EnvVarService {
+	return &EnvVarService{
+		repo:     repo,
+		branches: branches,
+	}
+}
+
+// SetOnAuditEvent plugs the audit emission seam. Nil-safe.
+func (s *EnvVarService) SetOnAuditEvent(record auditlog.RecordFunc) {
+	s.onAuditEvent = record
+}
+
+// envVarAAD binds a sealed value to the branch row owning it (see
+// keyStore.AppKeyAAD). The app id is canonicalized: every UUID spelling a
+// route accepts must seal and unseal identically.
+func envVarAAD(appId string, branchId int64, key string) []byte {
+	if parsed, err := uuid.Parse(appId); err == nil {
+		appId = parsed.String()
+	}
+	return []byte(appId + "|branch_env|" + strconv.FormatInt(branchId, 10) + "|" + key)
+}
+
+// resolveBranch maps the branch name to its id; unknown branches are a 404,
+// never a silent write elsewhere.
+func (s *EnvVarService) resolveBranch(ctx context.Context, appId string, branchName string) (int64, error) {
+	if err := validation.Name("branch", branchName); err != nil {
+		return 0, err
+	}
+	branchId, err := s.branches.GetBranchByName(ctx, appId, branchName)
+	if err != nil {
+		if database.IsNoRows(err) {
+			return 0, &store.ErrResourceNotFound{Resource: "branch", Identifier: branchName}
+		}
+		return 0, err
+	}
+	return branchId, nil
+}
+
+func validateEnvKey(key string) error {
+	if !envKeyPattern.MatchString(key) || len(key) > 200 {
+		return validation.Errorf("key", "%q is not a valid environment variable name", key)
+	}
+	if strings.HasPrefix(strings.ToUpper(key), PublicEnvPrefix) {
+		return validation.Errorf("key", "do not include the %s prefix, it is added automatically when the entry is public", PublicEnvPrefix)
+	}
+	return nil
+}
+
+func (s *EnvVarService) SetEnvVar(ctx context.Context, appId string, branchName string, key string, value string, isPublic bool) error {
+	if s.repo == nil {
+		return store.ErrNotSupportedInStatelessMode
+	}
+	if err := validateEnvKey(key); err != nil {
+		return err
+	}
+	if len(value) > maxEnvValueBytes {
+		return validation.Errorf("value", "value exceeds the %d KB limit", maxEnvValueBytes/1024)
+	}
+	branchId, err := s.resolveBranch(ctx, appId, branchName)
+	if err != nil {
+		return err
+	}
+	sealedValue, err := crypto.SealAESGCM([]byte(value), []byte(keyStore.ReadDBKeysMasterKey()), envVarAAD(appId, branchId, key))
+	if err != nil {
+		return err
+	}
+	if err := s.repo.UpsertEnvVar(ctx, appId, branchId, key, isPublic, sealedValue); err != nil {
+		return err
+	}
+	recordManagementEvent(ctx, s.onAuditEvent, auditlog.Event{
+		Action:        auditlog.ActionEnvVarUpdated,
+		TargetType:    "env_var",
+		TargetID:      key,
+		TargetDisplay: key,
+		AppID:         appId,
+		Metadata: map[string]any{
+			"branch":    branchName,
+			"is_public": isPublic,
+		},
+	})
+	return nil
+}
+
+func (s *EnvVarService) ListEnvVars(ctx context.Context, appId string) ([]EnvVar, error) {
+	if s.repo == nil {
+		return nil, store.ErrNotSupportedInStatelessMode
+	}
+	rows, err := s.repo.ListEnvVars(ctx, appId)
+	if err != nil {
+		return nil, err
+	}
+	envVars := make([]EnvVar, len(rows))
+	for i, row := range rows {
+		envVars[i] = EnvVar{
+			Key:       row.Key,
+			IsPublic:  row.IsPublic,
+			Branch:    row.BranchName,
+			CreatedAt: row.CreatedAt.UTC().Format(time.RFC3339),
+			UpdatedAt: row.UpdatedAt.UTC().Format(time.RFC3339),
+		}
+	}
+	return envVars, nil
+}
+
+// RevealEnvVar returns the plaintext value; the one read we audit.
+func (s *EnvVarService) RevealEnvVar(ctx context.Context, appId string, branchName string, key string) (string, error) {
+	if s.repo == nil {
+		return "", store.ErrNotSupportedInStatelessMode
+	}
+	if err := validateEnvKey(key); err != nil {
+		return "", err
+	}
+	branchId, err := s.resolveBranch(ctx, appId, branchName)
+	if err != nil {
+		return "", err
+	}
+	sealedValue, err := s.repo.GetSealedValue(ctx, appId, branchId, key)
+	if err != nil {
+		return "", err
+	}
+	if sealedValue == nil {
+		return "", &store.ErrResourceNotFound{Resource: "env var", Identifier: key}
+	}
+	value, err := crypto.UnsealAESGCM(*sealedValue, []byte(keyStore.ReadDBKeysMasterKey()), envVarAAD(appId, branchId, key))
+	if err != nil {
+		return "", err
+	}
+	recordManagementEvent(ctx, s.onAuditEvent, auditlog.Event{
+		Action:        auditlog.ActionEnvVarRevealed,
+		TargetType:    "env_var",
+		TargetID:      key,
+		TargetDisplay: key,
+		AppID:         appId,
+		Metadata:      map[string]any{"branch": branchName},
+	})
+	return string(value), nil
+}
+
+func (s *EnvVarService) DeleteEnvVar(ctx context.Context, appId string, branchName string, key string) error {
+	if s.repo == nil {
+		return store.ErrNotSupportedInStatelessMode
+	}
+	if err := validateEnvKey(key); err != nil {
+		return err
+	}
+	branchId, err := s.resolveBranch(ctx, appId, branchName)
+	if err != nil {
+		return err
+	}
+	if err := s.repo.DeleteEnvVar(ctx, appId, branchId, key); err != nil {
+		return err
+	}
+	recordManagementEvent(ctx, s.onAuditEvent, auditlog.Event{
+		Action:        auditlog.ActionEnvVarDeleted,
+		TargetType:    "env_var",
+		TargetID:      key,
+		TargetDisplay: key,
+		AppID:         appId,
+		Metadata:      map[string]any{"branch": branchName},
+	})
+	return nil
+}

--- a/internal/services/env_var_service_test.go
+++ b/internal/services/env_var_service_test.go
@@ -1,0 +1,173 @@
+// Service-level tests for env vars: key validation (incl. the EXPO_PUBLIC_
+// prefix refusal), sealing with the branch-bound AAD (app id canonicalized),
+// branch resolution, the audited reveal and the stateless refusal. SQL
+// persistence (unique constraint, cascades) is covered by the store tests.
+package services
+
+import (
+	"context"
+	"strconv"
+	"testing"
+	"xprem/internal/auditlog"
+	"xprem/internal/crypto"
+	"xprem/internal/store"
+	"xprem/internal/validation"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeEnvVarRepo struct {
+	// keyed by "<branchId>|<key>"
+	byScopeKey map[string]fakeSealedEnvVar
+}
+
+// fakeBranchResolver mirrors the pgx not-found contract of the real branch
+// repository.
+type fakeBranchResolver struct {
+	branches map[string]int64
+}
+
+func (f *fakeBranchResolver) GetBranchByName(_ context.Context, _ string, branchName string) (int64, error) {
+	if id, ok := f.branches[branchName]; ok {
+		return id, nil
+	}
+	return 0, pgx.ErrNoRows
+}
+
+type fakeSealedEnvVar struct {
+	isPublic    bool
+	sealedValue string
+}
+
+func newFakeEnvVarRepo() *fakeEnvVarRepo {
+	return &fakeEnvVarRepo{
+		byScopeKey: map[string]fakeSealedEnvVar{},
+	}
+}
+
+func newFakeBranchResolver() *fakeBranchResolver {
+	return &fakeBranchResolver{branches: map[string]int64{"staging": 7, "production": 8}}
+}
+
+func envScopeKey(branchId int64, key string) string {
+	return strconv.FormatInt(branchId, 10) + "|" + key
+}
+
+func (f *fakeEnvVarRepo) UpsertEnvVar(_ context.Context, _ string, branchId int64, key string, isPublic bool, sealedValue string) error {
+	f.byScopeKey[envScopeKey(branchId, key)] = fakeSealedEnvVar{isPublic: isPublic, sealedValue: sealedValue}
+	return nil
+}
+
+func (f *fakeEnvVarRepo) ListEnvVars(_ context.Context, _ string) ([]store.EnvVarRow, error) {
+	return nil, nil
+}
+
+func (f *fakeEnvVarRepo) GetSealedValue(_ context.Context, _ string, branchId int64, key string) (*string, error) {
+	envVar, ok := f.byScopeKey[envScopeKey(branchId, key)]
+	if !ok {
+		return nil, nil
+	}
+	return &envVar.sealedValue, nil
+}
+
+func (f *fakeEnvVarRepo) DeleteEnvVar(_ context.Context, _ string, branchId int64, key string) error {
+	scopeKey := envScopeKey(branchId, key)
+	if _, ok := f.byScopeKey[scopeKey]; !ok {
+		return &store.ErrResourceNotFound{Resource: "env var", Identifier: key}
+	}
+	delete(f.byScopeKey, scopeKey)
+	return nil
+}
+
+func TestSetEnvVarSealsWithBranchBoundAAD(t *testing.T) {
+	setMasterKey(t)
+	repo := newFakeEnvVarRepo()
+	service := NewEnvVarService(repo, newFakeBranchResolver())
+	ctx := context.Background()
+
+	require.NoError(t, service.SetEnvVar(ctx, "app-1", "staging", "API_URL", "https://staging.example.com", true))
+	require.NoError(t, service.SetEnvVar(ctx, "app-1", "production", "API_URL", "https://api.example.com", true))
+
+	stagingVar := repo.byScopeKey["7|API_URL"]
+	assert.True(t, stagingVar.isPublic)
+	value, err := crypto.UnsealAESGCM(stagingVar.sealedValue, []byte(testMasterKey), envVarAAD("app-1", 7, "API_URL"))
+	require.NoError(t, err)
+	assert.Equal(t, "https://staging.example.com", string(value))
+
+	// A blob sealed for one branch does not open under another branch's scope.
+	_, err = crypto.UnsealAESGCM(stagingVar.sealedValue, []byte(testMasterKey), envVarAAD("app-1", 8, "API_URL"))
+	assert.Error(t, err)
+}
+
+func TestEnvVarAADCanonicalizesAppId(t *testing.T) {
+	uppercase := envVarAAD("019A7B2C-0000-4000-8000-000000000001", 7, "API_URL")
+	lowercase := envVarAAD("019a7b2c-0000-4000-8000-000000000001", 7, "API_URL")
+	assert.Equal(t, string(lowercase), string(uppercase))
+}
+
+func TestSetEnvVarValidation(t *testing.T) {
+	setMasterKey(t)
+	service := NewEnvVarService(newFakeEnvVarRepo(), newFakeBranchResolver())
+	ctx := context.Background()
+	var valErr *validation.Error
+
+	assert.ErrorAs(t, service.SetEnvVar(ctx, "app-1", "staging", "1BAD", "v", false), &valErr)
+	assert.ErrorAs(t, service.SetEnvVar(ctx, "app-1", "staging", "BAD-DASH", "v", false), &valErr)
+	// The prefix is added automatically for public entries; never stored.
+	assert.ErrorAs(t, service.SetEnvVar(ctx, "app-1", "staging", "EXPO_PUBLIC_API_URL", "v", true), &valErr)
+	assert.ErrorAs(t, service.SetEnvVar(ctx, "app-1", "staging", "expo_public_api_url", "v", true), &valErr)
+
+	// Unknown branch is a 404, not a silent write elsewhere.
+	err := service.SetEnvVar(ctx, "app-1", "nope", "API_URL", "v", true)
+	notFoundErr := (*store.ErrResourceNotFound)(nil)
+	assert.ErrorAs(t, err, &notFoundErr)
+
+	// An empty value is legitimate.
+	assert.NoError(t, service.SetEnvVar(ctx, "app-1", "staging", "EMPTY_ALLOWED", "", false))
+}
+
+func TestRevealEnvVarRoundTripsAndAudits(t *testing.T) {
+	setMasterKey(t)
+	repo := newFakeEnvVarRepo()
+	service := NewEnvVarService(repo, newFakeBranchResolver())
+	var recorded []auditlog.Event
+	service.SetOnAuditEvent(func(_ context.Context, event auditlog.Event) {
+		recorded = append(recorded, event)
+	})
+	ctx := context.Background()
+
+	require.NoError(t, service.SetEnvVar(ctx, "app-1", "staging", "TOKEN", "s3cr3t", false))
+	value, err := service.RevealEnvVar(ctx, "app-1", "staging", "TOKEN")
+	require.NoError(t, err)
+	assert.Equal(t, "s3cr3t", value)
+
+	// Same key on another branch does not exist.
+	_, err = service.RevealEnvVar(ctx, "app-1", "production", "TOKEN")
+	notFoundErr := (*store.ErrResourceNotFound)(nil)
+	assert.ErrorAs(t, err, &notFoundErr)
+
+	require.NoError(t, service.DeleteEnvVar(ctx, "app-1", "staging", "TOKEN"))
+
+	require.Len(t, recorded, 3)
+	assert.Equal(t, auditlog.ActionEnvVarUpdated, recorded[0].Action)
+	assert.Equal(t, "staging", recorded[0].Metadata["branch"])
+	assert.Equal(t, false, recorded[0].Metadata["is_public"])
+	assert.Equal(t, auditlog.ActionEnvVarRevealed, recorded[1].Action)
+	assert.Equal(t, auditlog.ActionEnvVarDeleted, recorded[2].Action)
+	for _, event := range recorded {
+		assert.NotContains(t, event.Metadata, "value")
+	}
+}
+
+func TestEnvVarsUnsupportedInStatelessMode(t *testing.T) {
+	service := NewEnvVarService(nil, nil)
+	ctx := context.Background()
+	assert.ErrorIs(t, service.SetEnvVar(ctx, "app-1", "staging", "K", "v", false), store.ErrNotSupportedInStatelessMode)
+	_, err := service.ListEnvVars(ctx, "app-1")
+	assert.ErrorIs(t, err, store.ErrNotSupportedInStatelessMode)
+	_, err = service.RevealEnvVar(ctx, "app-1", "staging", "K")
+	assert.ErrorIs(t, err, store.ErrNotSupportedInStatelessMode)
+	assert.ErrorIs(t, service.DeleteEnvVar(ctx, "app-1", "staging", "K"), store.ErrNotSupportedInStatelessMode)
+}

--- a/internal/store/env_var_postgres.go
+++ b/internal/store/env_var_postgres.go
@@ -1,0 +1,96 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+	"xprem/internal/database"
+	"xprem/internal/database/postgres/pgdb"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+)
+
+// EnvVarRow is one env entry as listed in the dashboard: never the value.
+type EnvVarRow struct {
+	Key        string
+	IsPublic   bool
+	BranchName string
+	CreatedAt  time.Time
+	UpdatedAt  time.Time
+}
+
+type PostgresEnvVarStore struct {
+	engine *database.Engine
+}
+
+func NewPostgresEnvVarStore(engine *database.Engine) *PostgresEnvVarStore {
+	return &PostgresEnvVarStore{
+		engine: engine,
+	}
+}
+
+func (s *PostgresEnvVarStore) UpsertEnvVar(ctx context.Context, appId string, branchId int64, key string, isPublic bool, sealedValue string) error {
+	_, err := s.engine.Queries.UpsertBranchEnvVar(ctx, pgdb.UpsertBranchEnvVarParams{
+		ID:          ToPgUUID(uuid.NewString()),
+		AppID:       ToPgUUID(appId),
+		BranchID:    branchId,
+		Key:         key,
+		IsPublic:    isPublic,
+		SealedValue: sealedValue,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to save env var in database: %w", err)
+	}
+	return nil
+}
+
+func (s *PostgresEnvVarStore) ListEnvVars(ctx context.Context, appId string) ([]EnvVarRow, error) {
+	rows, err := s.engine.Queries.ListEnvVarsByAppID(ctx, ToPgUUID(appId))
+	if err != nil {
+		return nil, fmt.Errorf("failed to list env vars from database: %w", err)
+	}
+	envVars := make([]EnvVarRow, len(rows))
+	for i, row := range rows {
+		envVars[i] = EnvVarRow{
+			Key:        row.Key,
+			IsPublic:   row.IsPublic,
+			BranchName: row.BranchName,
+			CreatedAt:  row.CreatedAt.Time,
+			UpdatedAt:  row.UpdatedAt.Time,
+		}
+	}
+	return envVars, nil
+}
+
+// GetSealedValue returns (nil, nil) when the entry does not exist on the branch.
+func (s *PostgresEnvVarStore) GetSealedValue(ctx context.Context, appId string, branchId int64, key string) (*string, error) {
+	sealedValue, err := s.engine.Queries.GetSealedEnvValue(ctx, pgdb.GetSealedEnvValueParams{
+		AppID:    ToPgUUID(appId),
+		BranchID: branchId,
+		Key:      key,
+	})
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to retrieve env var from database: %w", err)
+	}
+	return &sealedValue, nil
+}
+
+func (s *PostgresEnvVarStore) DeleteEnvVar(ctx context.Context, appId string, branchId int64, key string) error {
+	commandTag, err := s.engine.Queries.DeleteEnvVar(ctx, pgdb.DeleteEnvVarParams{
+		AppID:    ToPgUUID(appId),
+		BranchID: branchId,
+		Key:      key,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to delete env var from database: %w", err)
+	}
+	if commandTag.RowsAffected() == 0 {
+		return &ErrResourceNotFound{Resource: "env var", Identifier: key}
+	}
+	return nil
+}

--- a/internal/store/env_var_postgres_test.go
+++ b/internal/store/env_var_postgres_test.go
@@ -1,0 +1,102 @@
+// Integration tests for the env var store: the per-branch unique constraint,
+// the branch/app cascades and the scoped delete are enforced by the SQL
+// itself.
+package store_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"xprem/internal/database"
+	"xprem/internal/database/postgres/pgdb"
+	"xprem/internal/store"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func setupEnvVarStore(t *testing.T) (*store.PostgresEnvVarStore, *store.PostgresBranchStore, string, *pgxpool.Pool) {
+	t.Helper()
+	_, _, pool := setupCredentialsStores(t)
+	appId := insertBareApp(t, pool)
+	engine := &database.Engine{Queries: pgdb.New(pool), DB: pool}
+	return store.NewPostgresEnvVarStore(engine), store.NewPostgresBranchStore(engine), appId, pool
+}
+
+func insertBranchRow(t *testing.T, pool *pgxpool.Pool, appId string, name string) int64 {
+	t.Helper()
+	var id int64
+	require.NoError(t, pool.QueryRow(context.Background(),
+		"INSERT INTO branches (app_id, name) VALUES ($1, $2) RETURNING id", appId, name).Scan(&id))
+	return id
+}
+
+func TestEnvVarUpsertIsScopedPerBranch(t *testing.T) {
+	envStore, _, appId, pool := setupEnvVarStore(t)
+	ctx := context.Background()
+	stagingId := insertBranchRow(t, pool, appId, "staging")
+	productionId := insertBranchRow(t, pool, appId, "production")
+
+	require.NoError(t, envStore.UpsertEnvVar(ctx, appId, stagingId, "API_URL", true, "sealed-staging-v1"))
+	// The upsert replaces value AND flag: one row per (branch, key).
+	require.NoError(t, envStore.UpsertEnvVar(ctx, appId, stagingId, "API_URL", false, "sealed-staging-v2"))
+	require.NoError(t, envStore.UpsertEnvVar(ctx, appId, productionId, "API_URL", true, "sealed-production-v1"))
+
+	envVars, err := envStore.ListEnvVars(ctx, appId)
+	require.NoError(t, err)
+	require.Len(t, envVars, 2)
+	for _, row := range envVars {
+		if row.BranchName == "staging" {
+			assert.False(t, row.IsPublic)
+		}
+	}
+
+	stagingValue, err := envStore.GetSealedValue(ctx, appId, stagingId, "API_URL")
+	require.NoError(t, err)
+	require.NotNil(t, stagingValue)
+	assert.Equal(t, "sealed-staging-v2", *stagingValue)
+
+	productionValue, err := envStore.GetSealedValue(ctx, appId, productionId, "API_URL")
+	require.NoError(t, err)
+	require.NotNil(t, productionValue)
+	assert.Equal(t, "sealed-production-v1", *productionValue)
+}
+
+func TestEnvVarDeleteIsScoped(t *testing.T) {
+	envStore, _, appId, pool := setupEnvVarStore(t)
+	ctx := context.Background()
+	stagingId := insertBranchRow(t, pool, appId, "staging")
+	productionId := insertBranchRow(t, pool, appId, "production")
+
+	require.NoError(t, envStore.UpsertEnvVar(ctx, appId, stagingId, "API_URL", true, "sealed-staging"))
+	require.NoError(t, envStore.UpsertEnvVar(ctx, appId, productionId, "API_URL", true, "sealed-production"))
+
+	require.NoError(t, envStore.DeleteEnvVar(ctx, appId, stagingId, "API_URL"))
+	// The production entry survives the staging-scoped delete.
+	productionValue, err := envStore.GetSealedValue(ctx, appId, productionId, "API_URL")
+	require.NoError(t, err)
+	assert.NotNil(t, productionValue)
+
+	err = envStore.DeleteEnvVar(ctx, appId, stagingId, "API_URL")
+	notFoundErr := (*store.ErrResourceNotFound)(nil)
+	require.True(t, errors.As(err, &notFoundErr))
+}
+
+func TestEnvVarsAreDroppedWithTheirBranch(t *testing.T) {
+	envStore, branchStore, appId, pool := setupEnvVarStore(t)
+	ctx := context.Background()
+	ephemeralId := insertBranchRow(t, pool, appId, "ephemeral")
+	keptId := insertBranchRow(t, pool, appId, "kept")
+	require.NoError(t, envStore.UpsertEnvVar(ctx, appId, ephemeralId, "API_URL", true, "sealed"))
+	require.NoError(t, envStore.UpsertEnvVar(ctx, appId, keptId, "API_URL", true, "sealed"))
+
+	require.NoError(t, branchStore.DeleteBranchByName(ctx, appId, "ephemeral"))
+
+	envVars, err := envStore.ListEnvVars(ctx, appId)
+	require.NoError(t, err)
+	require.Len(t, envVars, 1)
+	assert.Equal(t, "kept", envVars[0].BranchName)
+}
+


### PR DESCRIPTION
This PR introduces environment variables. They will be used for native builds as well as for publishing updates.
 I decided to scope variables by branch.
 
*Why branch-scoped?*
 
EXPO_PUBLIC_* values are inlined into the JS bundle at every export: both when building the binary (the embedded update) and on every publish.
Since an OTA update replaces the whole bundle, the values that matter are the ones present at publish time. Build and publish therefore need to resolve the exact same environment, which requires a single, stable anchor.

Channels can't be that anchor: an update is published to a branch, and channels are mobile pointers on top of branches — they get remapped, promoted, split by rollouts (one channel serving two branches at once), or bypassed entirely by branch surfing.
