### PR TITLE
feat(publish): add upload rate control for asset uploads

### DIFF
--- a/apps/eoas/src/commands/__tests__/publish.test.ts
+++ b/apps/eoas/src/commands/__tests__/publish.test.ts
@@ -16,7 +16,17 @@ import Log from '../../lib/log';
 import Publish from '../publish';
 
 vi.mock('@expo/spawn-async', () => ({ default: vi.fn() }));
-vi.mock('../../lib/fetch', () => ({ fetchWithRetries: vi.fn() }));
+vi.mock('../../lib/fetch', () => {
+  const fetchWithRetries = vi.fn();
+  return {
+    fetchWithRetries,
+    // Forwards to the same spy with the built options, so putCalls() sees the
+    // multipart uploads exactly like the plain ones.
+    fetchWithRetriesRebuildingBody: vi.fn(async (url: string, makeOptions: () => unknown) =>
+      fetchWithRetries(url, makeOptions() as any)
+    ),
+  };
+});
 vi.mock('../../lib/auth', () => ({
   retrieveCredentials: () => ({ token: 'test-token' }),
   validateCredentials: () => true,

--- a/apps/eoas/src/commands/publish.ts
+++ b/apps/eoas/src/commands/publish.ts
@@ -22,7 +22,7 @@ import {
   requireExpoAppId,
   resolveServerUrl,
 } from '../lib/expoConfig';
-import { fetchWithRetries } from '../lib/fetch';
+import { fetchWithRetries, fetchWithRetriesRebuildingBody } from '../lib/fetch';
 import Log from '../lib/log';
 import { ora } from '../lib/ora';
 import { isExpoInstalled } from '../lib/package';
@@ -387,11 +387,15 @@ export default class Publish extends Command {
             `${serverUrl}/${appId}/uploadLocalFile`
           );
           if (isLocalBucketFileUpload) {
-            const formData = new FormData();
-            const file = fs.createReadStream(absolutePath);
-            formData.append(itm.fileName, file);
-            try {
-              const response = await fetchWithRetries(itm.requestUploadUrl, {
+            // A stream-backed body is consumed by the first attempt, so each
+            // retry rebuilds the multipart body from a buffer.
+            const fileBuffer = await fs.readFile(absolutePath);
+            const response = await fetchWithRetriesRebuildingBody(itm.requestUploadUrl, () => {
+              const formData = new FormData();
+              formData.append(itm.fileName, fileBuffer, {
+                filename: path.basename(absolutePath),
+              });
+              return {
                 method: 'PUT',
                 headers: {
                   ...formData.getHeaders(),
@@ -401,13 +405,11 @@ export default class Publish extends Command {
                 // The URL was validated as a string; following a redirect would
                 // send these bytes to an origin nothing ever checked.
                 redirect: 'error',
-              });
-              if (!response.ok) {
-                Log.error('Failed to upload file', await response.text());
-                throw new Error('Failed to upload file');
-              }
-            } finally {
-              file.close();
+              };
+            });
+            if (!response.ok) {
+              Log.error('Failed to upload file', await response.text());
+              throw new Error('Failed to upload file');
             }
             return;
           }

--- a/apps/eoas/src/commands/publish.ts
+++ b/apps/eoas/src/commands/publish.ts
@@ -28,6 +28,7 @@ import { ora } from '../lib/ora';
 import { isExpoInstalled } from '../lib/package';
 import { resolvePackageRunner, splitPackageRunner } from '../lib/packageRunner';
 import { confirmAsync } from '../lib/prompts';
+import { RateLimiter } from '../lib/rateLimiter';
 import { ensureRepoIsCleanAsync } from '../lib/repo';
 import { resolveRuntimeVersionAsync } from '../lib/runtimeVersion';
 import { resolveVcsClient } from '../lib/vcs';
@@ -97,6 +98,11 @@ export default class Publish extends Command {
       description:
         'Publish this update as a progressive rollout served to N% of devices (1-99). The remaining devices keep receiving the previous update of each branch/runtime version. With --platform all, the rollout applies independently to each platform. Progression (increase, end, revert) is managed from the dashboard.',
     }),
+    'upload-rate': Flags.string({
+      description:
+        'Maximum number of asset uploads started per second. Accepts decimals (e.g. 1.5). Lower this if your storage provider rate-limits uploads.',
+      default: '10',
+    }),
   };
   private sanitizeFlags(flags: any): {
     platform: RequestedPlatform;
@@ -110,7 +116,13 @@ export default class Publish extends Command {
     message?: string;
     dumpSourcemap: boolean;
     rolloutPercentage?: number;
+    uploadRate: number;
   } {
+    const uploadRate = Number(flags['upload-rate']);
+    if (!Number.isFinite(uploadRate) || uploadRate <= 0) {
+      Log.error('--upload-rate must be a positive number');
+      process.exit(1);
+    }
     return {
       disableRepositoryCheck: flags.disableRepositoryCheck,
       platform: flags.platform,
@@ -123,6 +135,7 @@ export default class Publish extends Command {
       message: flags.message,
       dumpSourcemap: flags.dumpSourcemap,
       rolloutPercentage: flags['rollout-percentage'],
+      uploadRate,
     };
   }
   public async run(): Promise<void> {
@@ -147,11 +160,19 @@ export default class Publish extends Command {
       message,
       dumpSourcemap,
       rolloutPercentage,
+      uploadRate,
     } = this.sanitizeFlags(flags);
     if (!branch) {
       Log.error('Branch name is required');
       process.exit(1);
     }
+    // Bucket capacity is ~1s of budget so a low --upload-rate also caps the
+    // initial burst, not just the steady rate.
+    const publishAssetsRateLimiter = new RateLimiter(
+      'publish-eoas-assets',
+      Math.max(1, Math.ceil(uploadRate)),
+      uploadRate
+    );
     const projectDir = process.cwd();
     const hasExpo = isExpoInstalled(projectDir);
     if (!hasExpo) {
@@ -361,6 +382,7 @@ export default class Publish extends Command {
       ).flat();
       await Promise.all(
         resolvedUploads.map(async ({ item: itm, absolutePath, manifestEntry }) => {
+          await publishAssetsRateLimiter.take();
           const isLocalBucketFileUpload = itm.requestUploadUrl.startsWith(
             `${serverUrl}/${appId}/uploadLocalFile`
           );
@@ -415,6 +437,7 @@ export default class Publish extends Command {
           }
         })
       );
+
       uploadFilesSpinner.succeed('✅ Files uploaded successfully');
     } catch (e) {
       uploadFilesSpinner.fail('❌ Failed to upload static files');

--- a/apps/eoas/src/lib/__tests__/fetch.test.ts
+++ b/apps/eoas/src/lib/__tests__/fetch.test.ts
@@ -1,7 +1,15 @@
+import FormData from 'form-data';
 import { Response } from 'node-fetch';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { fetchWithRetries, isRetryableStatus, retryAfterMs } from '../fetch';
+import {
+  fetchWithRetries,
+  fetchWithRetriesRebuildingBody,
+  isRetryableStatus,
+  redactUrl,
+  retryAfterMs,
+} from '../fetch';
+import Log from '../log';
 
 vi.mock('node-fetch', async importOriginal => {
   const actual = await importOriginal<typeof import('node-fetch')>();
@@ -117,5 +125,75 @@ describe('#fetchWithRetries', () => {
     await vi.advanceTimersByTimeAsync(1_100);
     expect(mockFetch).toHaveBeenCalledTimes(2);
     expect((await promise).status).toBe(200);
+  });
+
+  it('does not log upload credentials on retry', async () => {
+    const warn = vi.spyOn(Log, 'warn').mockImplementation(() => {});
+    mockFetch.mockResolvedValueOnce(response(503)).mockResolvedValueOnce(response(200));
+    await settled(fetchWithRetries('https://storage.example.com/upload?token=supersecret', {}));
+    const logged = warn.mock.calls.flat().join(' ');
+    expect(logged).toContain('https://storage.example.com/upload');
+    expect(logged).not.toContain('supersecret');
+    warn.mockRestore();
+  });
+});
+
+describe('#redactUrl', () => {
+  it('strips the query string', () => {
+    expect(redactUrl('https://bucket.s3.example.com/key?X-Amz-Signature=secret')).toBe(
+      'https://bucket.s3.example.com/key'
+    );
+  });
+
+  it('never throws on garbage', () => {
+    expect(redactUrl('not a url')).toBe('<unparseable url>');
+  });
+});
+
+describe('#fetchWithRetriesRebuildingBody', () => {
+  it('rebuilds the multipart body for each attempt', async () => {
+    mockFetch.mockResolvedValueOnce(response(503)).mockResolvedValueOnce(response(200));
+    const bodies: FormData[] = [];
+    const res = await settled(
+      fetchWithRetriesRebuildingBody('https://server.example.com/uploadLocalFile', () => {
+        const formData = new FormData();
+        formData.append('asset', Buffer.from('file-bytes'), { filename: 'asset.png' });
+        bodies.push(formData);
+        return { method: 'PUT', body: formData };
+      })
+    );
+    expect(res.status).toBe(200);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(bodies).toHaveLength(2);
+    expect(bodies[0]).not.toBe(bodies[1]);
+    // The retried attempt carries the full payload, not a drained stream.
+    const retriedBody = mockFetch.mock.calls[1][1]?.body as FormData;
+    expect(retriedBody.getBuffer().toString()).toContain('file-bytes');
+  });
+
+  it('retries a network error with a fresh body', async () => {
+    mockFetch
+      .mockRejectedValueOnce(new Error('socket hang up'))
+      .mockResolvedValueOnce(response(200));
+    let built = 0;
+    const res = await settled(
+      fetchWithRetriesRebuildingBody('https://server.example.com/upload', () => {
+        built += 1;
+        return { method: 'PUT' };
+      })
+    );
+    expect(res.status).toBe(200);
+    expect(built).toBe(2);
+  });
+
+  it('gives up after the retry budget and returns the last response', async () => {
+    mockFetch.mockResolvedValue(response(503));
+    const res = await settled(
+      fetchWithRetriesRebuildingBody('https://server.example.com/upload', () => ({
+        method: 'PUT',
+      }))
+    );
+    expect(res.status).toBe(503);
+    expect(mockFetch).toHaveBeenCalledTimes(5);
   });
 });

--- a/apps/eoas/src/lib/__tests__/fetch.test.ts
+++ b/apps/eoas/src/lib/__tests__/fetch.test.ts
@@ -1,0 +1,121 @@
+import { Response } from 'node-fetch';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { fetchWithRetries, isRetryableStatus, retryAfterMs } from '../fetch';
+
+vi.mock('node-fetch', async importOriginal => {
+  const actual = await importOriginal<typeof import('node-fetch')>();
+  return { ...actual, default: vi.fn() };
+});
+
+const mockFetch = vi.mocked((await import('node-fetch')).default);
+
+function response(status: number, headers: Record<string, string> = {}): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    headers: {
+      get: (name: string) => headers[name.toLowerCase()] ?? null,
+    },
+  } as unknown as Response;
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  mockFetch.mockReset();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+async function settled<T>(promise: Promise<T>): Promise<T> {
+  // Walks through every backoff timer fetch-retry schedules along the way.
+  await vi.advanceTimersByTimeAsync(120_000);
+  return await promise;
+}
+
+describe('#isRetryableStatus', () => {
+  it('retries 429 and 5xx only', () => {
+    expect(isRetryableStatus(429)).toBe(true);
+    expect(isRetryableStatus(500)).toBe(true);
+    expect(isRetryableStatus(503)).toBe(true);
+    expect(isRetryableStatus(200)).toBe(false);
+    expect(isRetryableStatus(400)).toBe(false);
+    expect(isRetryableStatus(404)).toBe(false);
+  });
+});
+
+describe('#retryAfterMs', () => {
+  it('parses delay-seconds', () => {
+    expect(retryAfterMs('2')).toBe(2000);
+    expect(retryAfterMs('0')).toBe(0);
+  });
+
+  it('parses an HTTP-date relative to now', () => {
+    vi.setSystemTime(new Date('2026-08-13T00:00:00Z'));
+    expect(retryAfterMs('Thu, 13 Aug 2026 00:00:05 GMT')).toBe(5000);
+  });
+
+  it('returns null on missing or garbage input', () => {
+    expect(retryAfterMs(null)).toBe(null);
+    expect(retryAfterMs('')).toBe(null);
+    expect(retryAfterMs('soon')).toBe(null);
+  });
+});
+
+describe('#fetchWithRetries', () => {
+  it('returns a successful response without retrying', async () => {
+    mockFetch.mockResolvedValueOnce(response(200));
+    const res = await settled(fetchWithRetries('https://example.com', {}));
+    expect(res.status).toBe(200);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not retry non-retryable statuses', async () => {
+    mockFetch.mockResolvedValueOnce(response(400));
+    const res = await settled(fetchWithRetries('https://example.com', {}));
+    expect(res.status).toBe(400);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries a 503 until it succeeds', async () => {
+    mockFetch
+      .mockResolvedValueOnce(response(503))
+      .mockResolvedValueOnce(response(503))
+      .mockResolvedValueOnce(response(200));
+    const res = await settled(fetchWithRetries('https://example.com', {}));
+    expect(res.status).toBe(200);
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+  });
+
+  it('retries a network error until it succeeds', async () => {
+    mockFetch
+      .mockRejectedValueOnce(new Error('socket hang up'))
+      .mockResolvedValueOnce(response(200));
+    const res = await settled(fetchWithRetries('https://example.com', {}));
+    expect(res.status).toBe(200);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('gives up after the retry budget and returns the last response', async () => {
+    mockFetch.mockResolvedValue(response(503));
+    const res = await settled(fetchWithRetries('https://example.com', {}));
+    expect(res.status).toBe(503);
+    // attempt > 3 stops the loop: initial request + 4 retries.
+    expect(mockFetch).toHaveBeenCalledTimes(5);
+  });
+
+  it('waits at least Retry-After before retrying', async () => {
+    mockFetch
+      .mockResolvedValueOnce(response(429, { 'retry-after': '10' }))
+      .mockResolvedValueOnce(response(200));
+
+    const promise = fetchWithRetries('https://example.com', {});
+    await vi.advanceTimersByTimeAsync(9_000);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(1_100);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect((await promise).status).toBe(200);
+  });
+});

--- a/apps/eoas/src/lib/__tests__/rateLimiter.test.ts
+++ b/apps/eoas/src/lib/__tests__/rateLimiter.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { RateLimiter } from '../rateLimiter';
+
+// State is shared through a module-level store keyed by name, so every test
+// uses its own key.
+let key: number = 0;
+function limiter(capacity: number, refillRate: number): RateLimiter {
+  key += 1;
+  return new RateLimiter(`test-${key}`, capacity, refillRate);
+}
+
+async function isResolved(promise: Promise<unknown>): Promise<boolean> {
+  let resolved = false;
+  void promise.then(() => {
+    resolved = true;
+  });
+  await vi.advanceTimersByTimeAsync(0);
+  return resolved;
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('RateLimiter', () => {
+  it('serves the initial burst without waiting', async () => {
+    const l = limiter(3, 10);
+    expect(await isResolved(l.take())).toBe(true);
+    expect(await isResolved(l.take())).toBe(true);
+    expect(await isResolved(l.take())).toBe(true);
+  });
+
+  it('makes the caller wait once the bucket is empty', async () => {
+    const l = limiter(2, 10);
+    await l.take();
+    await l.take();
+
+    const blocked = l.take();
+    expect(await isResolved(blocked)).toBe(false);
+
+    // 10 tokens/s -> one token every 100ms.
+    await vi.advanceTimersByTimeAsync(50);
+    expect(await isResolved(blocked)).toBe(false);
+    await vi.advanceTimersByTimeAsync(60);
+    expect(await isResolved(blocked)).toBe(true);
+  });
+
+  it('supports fractional refill rates', async () => {
+    const l = limiter(1, 2);
+    await l.take();
+
+    const blocked = l.take();
+    // 2 tokens/s -> one token every 500ms.
+    await vi.advanceTimersByTimeAsync(400);
+    expect(await isResolved(blocked)).toBe(false);
+    await vi.advanceTimersByTimeAsync(150);
+    expect(await isResolved(blocked)).toBe(true);
+  });
+
+  it('never refills beyond capacity', async () => {
+    const l = limiter(2, 10);
+    await l.take();
+    await l.take();
+
+    // A long idle period must not bank more than `capacity` tokens.
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(await isResolved(l.take())).toBe(true);
+    expect(await isResolved(l.take())).toBe(true);
+    expect(await isResolved(l.take())).toBe(false);
+  });
+
+  it('sustains the configured rate over time', async () => {
+    const l = limiter(1, 10);
+    let done = 0;
+    for (let i = 0; i < 11; i++) {
+      void l.take().then(() => {
+        done += 1;
+      });
+    }
+    await vi.advanceTimersByTimeAsync(0);
+    expect(done).toBe(1);
+
+    // 10 tokens/s: after 1s, the 10 queued takes have all been served.
+    await vi.advanceTimersByTimeAsync(1100);
+    expect(done).toBe(11);
+  });
+});

--- a/apps/eoas/src/lib/fetch.ts
+++ b/apps/eoas/src/lib/fetch.ts
@@ -4,18 +4,49 @@ import originalFetch, { RequestInit, Response } from 'node-fetch';
 import Log from './log';
 const fetch = fetchRetry(originalFetch);
 
+export function isRetryableStatus(status: number): boolean {
+  return status === 429 || status >= 500;
+}
+
+// Retry-After is either delay-seconds or an HTTP-date.
+export function retryAfterMs(header: string | null): number | null {
+  if (!header) {
+    return null;
+  }
+  const seconds = Number(header);
+  if (Number.isFinite(seconds)) {
+    return seconds * 1000;
+  }
+  const dateMs = Date.parse(header);
+  if (!Number.isNaN(dateMs)) {
+    return dateMs - Date.now();
+  }
+  return null;
+}
+
+const MAX_RETRY_DELAY_MS = 60_000;
+
 export async function fetchWithRetries(url: string, options: RequestInit): Promise<Response> {
   return await fetch(url, {
     ...options,
-    retryDelay(attempt) {
+    retryDelay(attempt, _error, response) {
+      if (response) {
+        const serverDelay = retryAfterMs(response.headers.get('retry-after'));
+        const backoff = Math.pow(2, attempt) * 2000;
+        return Math.min(Math.max(serverDelay ?? 0, backoff), MAX_RETRY_DELAY_MS);
+      }
       return Math.pow(2, attempt) * 500;
     },
-    retryOn: (attempt, error) => {
+    retryOn: (attempt, error, response) => {
       if (attempt > 3) {
         return false;
       }
       if (error) {
         Log.warn(`Retry ${attempt} after network error:`, error.message);
+        return true;
+      }
+      if (response && isRetryableStatus(response.status)) {
+        Log.warn(`Retry ${attempt} after HTTP ${response.status} from ${url}`);
         return true;
       }
       return false;

--- a/apps/eoas/src/lib/fetch.ts
+++ b/apps/eoas/src/lib/fetch.ts
@@ -25,20 +25,36 @@ export function retryAfterMs(header: string | null): number | null {
 }
 
 const MAX_RETRY_DELAY_MS = 60_000;
+const MAX_RETRIED_ATTEMPT = 3;
+
+// Upload URLs carry their credentials in the query string (S3 presign, Azure
+// SAS, the local bucket's upload token), so logs may only show origin and path.
+export function redactUrl(url: string): string {
+  try {
+    const parsed = new URL(url);
+    return parsed.origin + parsed.pathname;
+  } catch {
+    return '<unparseable url>';
+  }
+}
+
+function retryDelayForResponse(attempt: number, response: Response): number {
+  const serverDelay = retryAfterMs(response.headers.get('retry-after'));
+  const backoff = Math.pow(2, attempt) * 2000;
+  return Math.min(Math.max(serverDelay ?? 0, backoff), MAX_RETRY_DELAY_MS);
+}
 
 export async function fetchWithRetries(url: string, options: RequestInit): Promise<Response> {
   return await fetch(url, {
     ...options,
     retryDelay(attempt, _error, response) {
       if (response) {
-        const serverDelay = retryAfterMs(response.headers.get('retry-after'));
-        const backoff = Math.pow(2, attempt) * 2000;
-        return Math.min(Math.max(serverDelay ?? 0, backoff), MAX_RETRY_DELAY_MS);
+        return retryDelayForResponse(attempt, response);
       }
       return Math.pow(2, attempt) * 500;
     },
     retryOn: (attempt, error, response) => {
-      if (attempt > 3) {
+      if (attempt > MAX_RETRIED_ATTEMPT) {
         return false;
       }
       if (error) {
@@ -46,10 +62,43 @@ export async function fetchWithRetries(url: string, options: RequestInit): Promi
         return true;
       }
       if (response && isRetryableStatus(response.status)) {
-        Log.warn(`Retry ${attempt} after HTTP ${response.status} from ${url}`);
+        Log.warn(`Retry ${attempt} after HTTP ${response.status} from ${redactUrl(url)}`);
         return true;
       }
       return false;
     },
   });
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+// fetch-retry re-sends the same RequestInit on every attempt, which silently
+// replays an already-consumed stream body as empty. Callers with a one-shot
+// body (multipart uploads) use this variant: makeOptions rebuilds the body
+// for each attempt. Same retry policy as fetchWithRetries.
+export async function fetchWithRetriesRebuildingBody(
+  url: string,
+  makeOptions: () => RequestInit
+): Promise<Response> {
+  for (let attempt = 0; ; attempt++) {
+    let response: Response;
+    try {
+      response = await originalFetch(url, makeOptions());
+    } catch (error: any) {
+      if (attempt > MAX_RETRIED_ATTEMPT) {
+        throw error;
+      }
+      Log.warn(`Retry ${attempt} after network error:`, error.message);
+      await sleep(Math.pow(2, attempt) * 500);
+      continue;
+    }
+    if (attempt <= MAX_RETRIED_ATTEMPT && isRetryableStatus(response.status)) {
+      Log.warn(`Retry ${attempt} after HTTP ${response.status} from ${redactUrl(url)}`);
+      await sleep(retryDelayForResponse(attempt, response));
+      continue;
+    }
+    return response;
+  }
 }

--- a/apps/eoas/src/lib/rateLimiter.ts
+++ b/apps/eoas/src/lib/rateLimiter.ts
@@ -1,0 +1,36 @@
+const kv: Record<
+  string,
+  {
+    tokens: number;
+    lastRefill: number;
+  }
+> = {};
+
+export class RateLimiter {
+  constructor(
+    private readonly key: string,
+    private readonly capacity: number,
+    private readonly refillRate: number
+  ) {}
+
+  async take(): Promise<void> {
+    const now = Date.now();
+    const bucket = kv[this.key];
+    let tokens = bucket ? bucket.tokens : this.capacity;
+    const lastRefill = bucket ? bucket.lastRefill : now;
+    const elapsed = (now - lastRefill) / 1000;
+    tokens = Math.min(this.capacity, tokens + elapsed * this.refillRate);
+
+    if (tokens < 1) {
+      const waitMs = ((1 - tokens) / this.refillRate) * 1000;
+      await new Promise(res => setTimeout(res, waitMs));
+      await this.take();
+      return;
+    }
+    tokens -= 1;
+    kv[this.key] = {
+      tokens,
+      lastRefill: now,
+    };
+  }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an `--upload-rate` option to control asset upload speed and limit initial upload bursts.
  - Uploads now automatically retry after rate-limit and server errors, respecting server-provided delays when available.

- **Reliability**
  - Network and HTTP retries use capped exponential backoff for improved resilience during temporary service issues.
  - Local-file uploads can be retried reliably without restarting the publish operation.

- **Tests**
  - Added coverage for upload rate limiting, retry behavior, backoff delays, multipart uploads, and retry exhaustion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->