### PR TITLE
skip re-uploading assets that already exist in the previous update

### DIFF
--- a/internal/bucket/azureBucket.go
+++ b/internal/bucket/azureBucket.go
@@ -293,6 +293,30 @@ func copyBlobAndWait(ctx context.Context, cc *container.Client, sourceURL, destK
 	return nil
 }
 
+func (b *AzureBucket) CopyFileIntoUpdate(source types.Update, target types.Update, fileName string) error {
+	if b.ContainerName == "" {
+		return errors.New("ContainerName not set")
+	}
+	cc, err := b.containerClient()
+	if err != nil {
+		return err
+	}
+	srcKey := b.prefixedKey(fmt.Sprintf("%s/%s/%s/%s/%s", source.AppId, source.Branch, source.RuntimeVersion, source.UpdateId, fileName))
+	dstKey := b.prefixedKey(fmt.Sprintf("%s/%s/%s/%s/%s", target.AppId, target.Branch, target.RuntimeVersion, target.UpdateId, fileName))
+	// StartCopyFromURL authorizes the source through its URL, so the
+	// same-account source gets a short-lived read SAS.
+	srcURL, err := azure.SignBlobSAS(b.ContainerName, srcKey, sas.BlobPermissions{Read: true}, 10*time.Minute)
+	if err != nil {
+		return fmt.Errorf("sign source %s: %w", srcKey, err)
+	}
+	copyCtx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	if err := copyBlobAndWait(copyCtx, cc, srcURL, dstKey); err != nil {
+		return fmt.Errorf("copy %s -> %s: %w", srcKey, dstKey, err)
+	}
+	return nil
+}
+
 func (b *AzureBucket) CreateUpdateFrom(previousUpdate *types.Update, newUpdateId string) (*types.Update, error) {
 	if b.ContainerName == "" {
 		return nil, errors.New("ContainerName not set")

--- a/internal/bucket/azureBucket.go
+++ b/internal/bucket/azureBucket.go
@@ -309,7 +309,7 @@ func (b *AzureBucket) CopyFileIntoUpdate(source types.Update, target types.Updat
 	if err != nil {
 		return fmt.Errorf("sign source %s: %w", srcKey, err)
 	}
-	copyCtx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	copyCtx, cancel := context.WithTimeout(context.Background(), copyFileTimeout)
 	defer cancel()
 	if err := copyBlobAndWait(copyCtx, cc, srcURL, dstKey); err != nil {
 		return fmt.Errorf("copy %s -> %s: %w", srcKey, dstKey, err)

--- a/internal/bucket/bucket.go
+++ b/internal/bucket/bucket.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"time"
 	"unicode"
 	"xprem/config"
 	"xprem/internal/types"
@@ -20,6 +21,10 @@ var s3KeyPrefixDeprecationOnce sync.Once
 // filesystem paths while staying comfortably above realistic names
 // (UUIDs are 36, semver+build metadata under 100).
 const maxSegmentLen = 128
+
+// copyFileTimeout bounds a single CopyFileIntoUpdate provider call, so a
+// stalled copy degrades into a regular upload instead of hanging the publish.
+const copyFileTimeout = 30 * time.Second
 
 // validateSegment ensures a single-segment identifier (branch, runtimeVersion,
 // updateId, migrationId) is safe to embed in a storage path / object key.

--- a/internal/bucket/bucket.go
+++ b/internal/bucket/bucket.go
@@ -146,6 +146,7 @@ type Bucket interface {
 	GetFile(update types.Update, assetPath string) (*types.BucketFile, error)
 	RequestUploadUrlForFileUpdate(appId string, branch string, runtimeVersion string, updateId string, fileName string) (string, error)
 	UploadFileIntoUpdate(update types.Update, fileName string, file io.Reader) error
+	CopyFileIntoUpdate(source types.Update, target types.Update, fileName string) error
 	DeleteUpdateFolder(appId string, branch string, runtimeVersion string, updateId string) error
 	CreateUpdateFrom(previousUpdate *types.Update, newUpdateId string) (*types.Update, error)
 	RetrieveMigrationHistory() ([]string, error)

--- a/internal/bucket/gcsBucket.go
+++ b/internal/bucket/gcsBucket.go
@@ -270,6 +270,23 @@ func (b *GCSBucket) PutObject(ctx context.Context, key string, body []byte) erro
 	return w.Close()
 }
 
+func (b *GCSBucket) CopyFileIntoUpdate(source types.Update, target types.Update, fileName string) error {
+	if b.BucketName == "" {
+		return errors.New("BucketName not set")
+	}
+	ctx := context.Background()
+	bh, err := b.bucketHandle(ctx)
+	if err != nil {
+		return err
+	}
+	src := b.prefixedKey(fmt.Sprintf("%s/%s/%s/%s/%s", source.AppId, source.Branch, source.RuntimeVersion, source.UpdateId, fileName))
+	dst := b.prefixedKey(fmt.Sprintf("%s/%s/%s/%s/%s", target.AppId, target.Branch, target.RuntimeVersion, target.UpdateId, fileName))
+	if _, err := bh.Object(dst).CopierFrom(bh.Object(src)).Run(ctx); err != nil {
+		return fmt.Errorf("copy %s -> %s: %w", src, dst, err)
+	}
+	return nil
+}
+
 func (b *GCSBucket) CreateUpdateFrom(previousUpdate *types.Update, newUpdateId string) (*types.Update, error) {
 	if b.BucketName == "" {
 		return nil, errors.New("BucketName not set")

--- a/internal/bucket/gcsBucket.go
+++ b/internal/bucket/gcsBucket.go
@@ -274,7 +274,10 @@ func (b *GCSBucket) CopyFileIntoUpdate(source types.Update, target types.Update,
 	if b.BucketName == "" {
 		return errors.New("BucketName not set")
 	}
-	ctx := context.Background()
+	// Bounded so a stalled provider call cannot hold up the publish response;
+	// the caller treats a timed-out copy as "upload it instead".
+	ctx, cancel := context.WithTimeout(context.Background(), copyFileTimeout)
+	defer cancel()
 	bh, err := b.bucketHandle(ctx)
 	if err != nil {
 		return err

--- a/internal/bucket/localBucket.go
+++ b/internal/bucket/localBucket.go
@@ -250,6 +250,16 @@ func (b *LocalBucket) UploadFileIntoUpdate(update types.Update, fileName string,
 	return nil
 }
 
+func (b *LocalBucket) CopyFileIntoUpdate(source types.Update, target types.Update, fileName string) error {
+	sourcePath := filepath.Join(b.rootPath(), source.AppId, source.Branch, source.RuntimeVersion, source.UpdateId, fileName)
+	in, err := os.Open(sourcePath)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	return b.UploadFileIntoUpdate(target, fileName, in)
+}
+
 // GetSubjectForApp resolves the tamper-proof identity token subject (sub) based
 // on the active runtime environment mode. If no relational database configuration
 // is present, it defaults to the legacy dual-mode behavior by requesting the account

--- a/internal/bucket/localBucket_test.go
+++ b/internal/bucket/localBucket_test.go
@@ -204,3 +204,27 @@ func TestUploadPathIsInBranchRefusesWithoutABucketRoot(t *testing.T) {
 	t.Setenv("LOCAL_BUCKET_BASE_PATH", "")
 	assert.False(t, uploadPathIsInBranch("/updates/app1/main/1.0.0/17/bundle.js", "app1", "main"))
 }
+
+func TestLocalBucket_CopyFileIntoUpdate(t *testing.T) {
+	base := t.TempDir()
+	b := &LocalBucket{BasePath: base}
+	source := types.Update{AppId: "app1", Branch: "main", RuntimeVersion: "1.0.0", UpdateId: "100"}
+	target := types.Update{AppId: "app1", Branch: "main", RuntimeVersion: "1.0.0", UpdateId: "200"}
+
+	sourceFile := filepath.Join(base, "app1", "main", "1.0.0", "100", "assets", "img.png")
+	assert.Nil(t, os.MkdirAll(filepath.Dir(sourceFile), 0o755))
+	assert.Nil(t, os.WriteFile(sourceFile, []byte("png-bytes"), 0o644))
+
+	assert.Nil(t, b.CopyFileIntoUpdate(source, target, "assets/img.png"))
+
+	copied, err := os.ReadFile(filepath.Join(base, "app1", "main", "1.0.0", "200", "assets", "img.png"))
+	assert.Nil(t, err)
+	assert.Equal(t, []byte("png-bytes"), copied)
+}
+
+func TestLocalBucket_CopyFileIntoUpdate_MissingSourceErrors(t *testing.T) {
+	b := &LocalBucket{BasePath: t.TempDir()}
+	source := types.Update{AppId: "app1", Branch: "main", RuntimeVersion: "1.0.0", UpdateId: "100"}
+	target := types.Update{AppId: "app1", Branch: "main", RuntimeVersion: "1.0.0", UpdateId: "200"}
+	assert.NotNil(t, b.CopyFileIntoUpdate(source, target, "assets/absent.png"))
+}

--- a/internal/bucket/s3Bucket.go
+++ b/internal/bucket/s3Bucket.go
@@ -333,7 +333,11 @@ func (b *S3Bucket) CopyFileIntoUpdate(source types.Update, target types.Update, 
 	}
 	sourceKey := b.prefixedKey(fmt.Sprintf("%s/%s/%s/%s/%s", source.AppId, source.Branch, source.RuntimeVersion, source.UpdateId, fileName))
 	targetKey := b.prefixedKey(fmt.Sprintf("%s/%s/%s/%s/%s", target.AppId, target.Branch, target.RuntimeVersion, target.UpdateId, fileName))
-	_, err = s3Client.CopyObject(context.TODO(), &s3.CopyObjectInput{
+	// Bounded so a stalled provider call cannot hold up the publish response;
+	// the caller treats a timed-out copy as "upload it instead".
+	copyCtx, cancel := context.WithTimeout(context.Background(), copyFileTimeout)
+	defer cancel()
+	_, err = s3Client.CopyObject(copyCtx, &s3.CopyObjectInput{
 		Bucket:     awssdk.String(b.BucketName),
 		CopySource: awssdk.String(url.QueryEscape(b.BucketName + "/" + sourceKey)),
 		Key:        awssdk.String(targetKey),

--- a/internal/bucket/s3Bucket.go
+++ b/internal/bucket/s3Bucket.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/url"
 	"runtime"
 	"sort"
 	"strconv"
@@ -318,6 +319,27 @@ func (b *S3Bucket) PutObject(ctx context.Context, key string, body []byte) error
 	}
 	if _, err := s3Client.PutObject(ctx, input); err != nil {
 		return fmt.Errorf("PutObject error: %w", err)
+	}
+	return nil
+}
+
+func (b *S3Bucket) CopyFileIntoUpdate(source types.Update, target types.Update, fileName string) error {
+	if b.BucketName == "" {
+		return errors.New("BucketName not set")
+	}
+	s3Client, err := aws.GetS3Client()
+	if err != nil {
+		return fmt.Errorf("error getting S3 client: %w", err)
+	}
+	sourceKey := b.prefixedKey(fmt.Sprintf("%s/%s/%s/%s/%s", source.AppId, source.Branch, source.RuntimeVersion, source.UpdateId, fileName))
+	targetKey := b.prefixedKey(fmt.Sprintf("%s/%s/%s/%s/%s", target.AppId, target.Branch, target.RuntimeVersion, target.UpdateId, fileName))
+	_, err = s3Client.CopyObject(context.TODO(), &s3.CopyObjectInput{
+		Bucket:     awssdk.String(b.BucketName),
+		CopySource: awssdk.String(url.QueryEscape(b.BucketName + "/" + sourceKey)),
+		Key:        awssdk.String(targetKey),
+	})
+	if err != nil {
+		return fmt.Errorf("error copying object %s -> %s: %w", sourceKey, targetKey, err)
 	}
 	return nil
 }

--- a/internal/bucket/validatingBucket.go
+++ b/internal/bucket/validatingBucket.go
@@ -84,6 +84,19 @@ func (v *validatingBucket) UploadFileIntoUpdate(update types.Update, fileName st
 	return v.Inner.UploadFileIntoUpdate(update, fileName, file)
 }
 
+func (v *validatingBucket) CopyFileIntoUpdate(source types.Update, target types.Update, fileName string) error {
+	if err := validateUpdate(&source); err != nil {
+		return err
+	}
+	if err := validateUpdate(&target); err != nil {
+		return err
+	}
+	if err := validateRelativePath("fileName", fileName); err != nil {
+		return err
+	}
+	return v.Inner.CopyFileIntoUpdate(source, target, fileName)
+}
+
 func (v *validatingBucket) DeleteUpdateFolder(appId, branch, runtimeVersion, updateId string) error {
 	if err := validateSegment("appId", appId); err != nil {
 		return err

--- a/internal/bucket/validatingBucket_test.go
+++ b/internal/bucket/validatingBucket_test.go
@@ -40,6 +40,10 @@ func (s *stubBucket) UploadFileIntoUpdate(update types.Update, fileName string, 
 	s.mark()
 	return nil
 }
+func (s *stubBucket) CopyFileIntoUpdate(source types.Update, target types.Update, fileName string) error {
+	s.mark()
+	return nil
+}
 func (s *stubBucket) DeleteUpdateFolder(appId, branch, runtimeVersion, updateId string) error {
 	s.mark()
 	return nil
@@ -214,6 +218,42 @@ func TestValidatingBucket_UploadFileIntoUpdate_RejectsTraversalInFileName(t *tes
 	err := v.UploadFileIntoUpdate(validUpdate(), "../evil.js", bytes.NewReader(nil))
 	assert.Error(t, err)
 	assert.False(t, stub.called)
+}
+
+func TestValidatingBucket_CopyFileIntoUpdate_RejectsTraversalInFileName(t *testing.T) {
+	stub := &stubBucket{}
+	v := &validatingBucket{Inner: stub}
+	err := v.CopyFileIntoUpdate(validUpdate(), validUpdate(), "../evil.js")
+	assert.Error(t, err)
+	assert.False(t, stub.called)
+}
+
+func TestValidatingBucket_CopyFileIntoUpdate_RejectsInvalidUpdates(t *testing.T) {
+	badUpdate := validUpdate()
+	badUpdate.UpdateId = "123/../456"
+	for _, c := range []struct {
+		name           string
+		source, target types.Update
+	}{
+		{"bad source", badUpdate, validUpdate()},
+		{"bad target", validUpdate(), badUpdate},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			stub := &stubBucket{}
+			v := &validatingBucket{Inner: stub}
+			err := v.CopyFileIntoUpdate(c.source, c.target, "assets/img.png")
+			assert.Error(t, err)
+			assert.False(t, stub.called)
+		})
+	}
+}
+
+func TestValidatingBucket_CopyFileIntoUpdate_DelegatesOnValidInput(t *testing.T) {
+	stub := &stubBucket{}
+	v := &validatingBucket{Inner: stub}
+	err := v.CopyFileIntoUpdate(validUpdate(), validUpdate(), "assets/img.png")
+	assert.NoError(t, err)
+	assert.True(t, stub.called)
 }
 
 func TestValidatingBucket_DeleteUpdateFolder_RejectsSlashInUpdateId(t *testing.T) {

--- a/internal/bucketmigrations/20260422_v2_scope_data_under_appid/20260422_v2_scope_data_under_appid_test.go
+++ b/internal/bucketmigrations/20260422_v2_scope_data_under_appid/20260422_v2_scope_data_under_appid_test.go
@@ -43,6 +43,10 @@ func (u unreachableBucket) UploadFileIntoUpdate(types.Update, string, io.Reader)
 	u.t.Fatal("migration should have skipped")
 	return nil
 }
+func (u unreachableBucket) CopyFileIntoUpdate(types.Update, types.Update, string) error {
+	u.t.Fatal("migration should have skipped")
+	return nil
+}
 func (u unreachableBucket) DeleteUpdateFolder(string, string, string, string) error {
 	u.t.Fatal("migration should have skipped")
 	return nil

--- a/internal/services/deployment_dedup_test.go
+++ b/internal/services/deployment_dedup_test.go
@@ -1,0 +1,155 @@
+package services
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"xprem/internal/bucket"
+	"xprem/internal/types"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newDedupTestHarness wires the rollout harness fakes to the real local bucket,
+// which dedup needs both to read the previous update's metadata.json (through
+// the bucket singleton) and to copy files.
+func newDedupTestHarness(t *testing.T) (*DeploymentService, *rolloutTestHarness, string) {
+	t.Helper()
+	base := t.TempDir()
+	t.Setenv("STORAGE_MODE", "local")
+	t.Setenv("LOCAL_BUCKET_BASE_PATH", base)
+	t.Setenv("BASE_URL", "http://localhost:3000")
+	t.Setenv("JWT_SECRET", "test_jwt_secret")
+	bucket.ResetBucketInstance()
+	t.Cleanup(bucket.ResetBucketInstance)
+
+	h := newRolloutTestHarness(t)
+	svc := NewDeploymentService(
+		NewBranchService(fakeBranchRepo{}, h.channelRepo, h.updateRepo, h.rolloutRepo, fakeRolloutBucket{}),
+		h.updateService,
+		h.updateRepo,
+		bucket.GetBucket(),
+	)
+	return svc, h, base
+}
+
+func writePreviousUpdateFiles(t *testing.T, base, appId string, update types.Update, metadata types.MetadataObject, assetContents map[string]string) {
+	t.Helper()
+	dir := filepath.Join(base, appId, update.Branch, update.RuntimeVersion, update.UpdateId)
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	raw, err := json.Marshal(metadata)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "metadata.json"), raw, 0o644))
+	for name, content := range assetContents {
+		filePath := filepath.Join(dir, filepath.FromSlash(name))
+		require.NoError(t, os.MkdirAll(filepath.Dir(filePath), 0o755))
+		require.NoError(t, os.WriteFile(filePath, []byte(content), 0o644))
+	}
+}
+
+func requestedFilePaths(resp *RequestUploadURLResponse) []string {
+	paths := make([]string, 0, len(resp.UploadRequests))
+	for _, request := range resp.UploadRequests {
+		paths = append(paths, request.FilePath)
+	}
+	return paths
+}
+
+func TestRequestUploadURLs_DedupsUnchangedAssets(t *testing.T) {
+	svc, h, base := newDedupTestHarness(t)
+	ctx := context.Background()
+
+	prev := h.seed(seedRow{branch: "main", rtv: "1", platform: "ios", id: 100, checked: true})
+	// "assets/ghost" is listed in the previous metadata but absent from the
+	// bucket: its copy fails, so it must stay in the upload list.
+	writePreviousUpdateFiles(t, base, h.appId, prev, types.MetadataObject{
+		Version: 0,
+		Bundler: "metro",
+		FileMetadata: types.FileMetadata{
+			IOS: types.PlatformMetadata{
+				Bundle: "bundles/ios-old.hbc",
+				Assets: []types.Asset{
+					{Path: "assets/unchanged", Ext: "png"},
+					{Path: "assets/ghost", Ext: "png"},
+				},
+			},
+		},
+	}, map[string]string{"assets/unchanged": "png-bytes"})
+
+	resp, err := svc.RequestUploadURLs(ctx, RequestUploadURLParams{
+		RequestID:      "test",
+		AppID:          h.appId,
+		BranchName:     "main",
+		Platform:       "ios",
+		RuntimeVersion: "1",
+		FileNames: []string{
+			"metadata.json",
+			"expoConfig.json",
+			"bundles/ios-new.hbc",
+			"assets/unchanged",
+			"assets/ghost",
+		},
+	})
+	require.NoError(t, err)
+
+	assert.ElementsMatch(t, []string{
+		"metadata.json",
+		"expoConfig.json",
+		"bundles/ios-new.hbc",
+		"assets/ghost",
+	}, requestedFilePaths(resp))
+
+	copied, err := os.ReadFile(filepath.Join(base, h.appId, "main", "1", strconv.FormatInt(resp.UpdateID, 10), "assets", "unchanged"))
+	require.NoError(t, err)
+	assert.Equal(t, "png-bytes", string(copied))
+}
+
+func TestRequestUploadURLs_FirstPublishSkipsDedup(t *testing.T) {
+	svc, h, _ := newDedupTestHarness(t)
+	ctx := context.Background()
+
+	resp, err := svc.RequestUploadURLs(ctx, RequestUploadURLParams{
+		RequestID:      "test",
+		AppID:          h.appId,
+		BranchName:     "main",
+		Platform:       "ios",
+		RuntimeVersion: "1",
+		FileNames:      []string{"metadata.json", "assets/aaa"},
+	})
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"metadata.json", "assets/aaa"}, requestedFilePaths(resp))
+}
+
+func TestRequestUploadURLs_DedupIgnoresOtherPlatformUpdates(t *testing.T) {
+	svc, h, base := newDedupTestHarness(t)
+	ctx := context.Background()
+
+	prev := h.seed(seedRow{branch: "main", rtv: "1", platform: "ios", id: 100, checked: true})
+	writePreviousUpdateFiles(t, base, h.appId, prev, types.MetadataObject{
+		Version: 0,
+		Bundler: "metro",
+		FileMetadata: types.FileMetadata{
+			IOS: types.PlatformMetadata{
+				Bundle: "bundles/ios-old.hbc",
+				Assets: []types.Asset{{Path: "assets/shared", Ext: "png"}},
+			},
+		},
+	}, map[string]string{"assets/shared": "png-bytes"})
+
+	// No android update exists yet, so an android publish must upload
+	// everything even though an ios update holds the same asset.
+	resp, err := svc.RequestUploadURLs(ctx, RequestUploadURLParams{
+		RequestID:      "test",
+		AppID:          h.appId,
+		BranchName:     "main",
+		Platform:       "android",
+		RuntimeVersion: "1",
+		FileNames:      []string{"metadata.json", "assets/shared"},
+	})
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"metadata.json", "assets/shared"}, requestedFilePaths(resp))
+}

--- a/internal/services/deployment_service.go
+++ b/internal/services/deployment_service.go
@@ -7,7 +7,10 @@ import (
 	"log"
 	"mime/multipart"
 	"net/http"
+	"runtime"
+	"slices"
 	"strconv"
+	"sync"
 	"xprem/internal/auditlog"
 	"xprem/internal/bucket"
 	"xprem/internal/cache"
@@ -19,6 +22,7 @@ import (
 	update2 "xprem/internal/update"
 
 	"github.com/google/uuid"
+	"golang.org/x/sync/errgroup"
 )
 
 var (
@@ -285,6 +289,58 @@ func (s *DeploymentService) RequestUploadLocalFile(ctx context.Context, params R
 	return nil
 }
 
+// dedupExistingUploadAssets copies the requested files that already exist in
+// the branch's latest update into newUpdate's folder and returns the file
+// names it copied, so the caller can skip requesting uploads for them. Any
+// failure falls back to uploading: the returned slice just omits the file.
+func (s *DeploymentService) dedupExistingUploadAssets(ctx context.Context, params RequestUploadURLParams, newUpdate types.Update) []string {
+	latestUpdate, err := s.updateService.GetLatestUpdate(ctx, params.AppID, params.BranchName, params.RuntimeVersion, params.Platform)
+	if err != nil {
+		log.Printf("[RequestID: %s] Skipping asset dedup: %v", params.RequestID, err)
+		return nil
+	}
+	if latestUpdate == nil {
+		return nil
+	}
+	latestUpdateMetadata, err := update2.GetMetadata(*latestUpdate)
+	if err != nil {
+		log.Printf("[RequestID: %s] Skipping asset dedup: %v", params.RequestID, err)
+		return nil
+	}
+	previousAssets := latestUpdateMetadata.MetadataJSON.FileMetadata.Android.Assets
+	if params.Platform == "ios" {
+		previousAssets = latestUpdateMetadata.MetadataJSON.FileMetadata.IOS.Assets
+	}
+
+	var dedupedAssets []string
+	var mu sync.Mutex
+	var g errgroup.Group
+	g.SetLimit(runtime.NumCPU())
+	// FileNames repeats assets shared by both platforms; copy each once.
+	seen := make(map[string]struct{}, len(params.FileNames))
+	for _, file := range params.FileNames {
+		if _, alreadySeen := seen[file]; alreadySeen {
+			continue
+		}
+		seen[file] = struct{}{}
+		if !slices.ContainsFunc(previousAssets, func(a types.Asset) bool { return a.Path == file }) {
+			continue
+		}
+		g.Go(func() error {
+			if err := s.bucket.CopyFileIntoUpdate(*latestUpdate, newUpdate, file); err != nil {
+				log.Printf("[RequestID: %s] Error copying %s into update: %v", params.RequestID, file, err)
+				return nil
+			}
+			mu.Lock()
+			dedupedAssets = append(dedupedAssets, file)
+			mu.Unlock()
+			return nil
+		})
+	}
+	_ = g.Wait()
+	return dedupedAssets
+}
+
 func (s *DeploymentService) RequestUploadURLs(ctx context.Context, params RequestUploadURLParams) (*RequestUploadURLResponse, error) {
 	err := s.branchService.UpsertBranchAndRuntimeVersion(ctx, params.AppID, params.BranchName, params.RuntimeVersion)
 	if err != nil {
@@ -305,12 +361,27 @@ func (s *DeploymentService) RequestUploadURLs(ctx context.Context, params Reques
 	updateId := update2.GenerateUpdateTimestamp(params.Platform)
 	updateStr := update2.ConvertUpdateTimestampToString(updateId)
 
+	dedupedAssets := s.dedupExistingUploadAssets(ctx, params, types.Update{
+		AppId:          params.AppID,
+		Branch:         params.BranchName,
+		RuntimeVersion: params.RuntimeVersion,
+		UpdateId:       updateStr,
+	})
+
+	filesToUpload := params.FileNames
+	if len(dedupedAssets) > 0 {
+		log.Printf("[RequestID: %s] Reusing %d unchanged assets from the previous update", params.RequestID, len(dedupedAssets))
+		filesToUpload = slices.DeleteFunc(slices.Clone(params.FileNames), func(file string) bool {
+			return slices.Contains(dedupedAssets, file)
+		})
+	}
+
 	updateRequests, err := bucket.RequestUploadUrlsForFileUpdates(
 		params.AppID,
 		params.BranchName,
 		params.RuntimeVersion,
 		updateStr,
-		params.FileNames,
+		filesToUpload,
 	)
 	if err != nil {
 		log.Printf("[RequestID: %s] Error requesting upload urls: %v", params.RequestID, err)

--- a/internal/services/rollout_resolution_test.go
+++ b/internal/services/rollout_resolution_test.go
@@ -575,6 +575,10 @@ func (fakeRolloutBucket) UploadFileIntoUpdate(_ types.Update, _ string, _ io.Rea
 	return nil
 }
 
+func (fakeRolloutBucket) CopyFileIntoUpdate(_ types.Update, _ types.Update, _ string) error {
+	return nil
+}
+
 func (fakeRolloutBucket) DeleteUpdateFolder(_, _, _, _ string) error { return nil }
 
 func (fakeRolloutBucket) CreateUpdateFrom(previousUpdate *types.Update, newUpdateId string) (*types.Update, error) {

--- a/test/migrations_test.go
+++ b/test/migrations_test.go
@@ -42,6 +42,10 @@ func (b *dummyMigrationsBucket) UploadFileIntoUpdate(_ types.Update, _ string, _
 	b.actionsRecorded = append(b.actionsRecorded, "UploadFileIntoUpdate")
 	return nil
 }
+func (b *dummyMigrationsBucket) CopyFileIntoUpdate(_ types.Update, _ types.Update, _ string) error {
+	b.actionsRecorded = append(b.actionsRecorded, "CopyFileIntoUpdate")
+	return nil
+}
 func (b *dummyMigrationsBucket) CreateUpdateFrom(_ *types.Update, _ string) (*types.Update, error) {
 	b.actionsRecorded = append(b.actionsRecorded, "CreateUpdateFrom")
 	return nil, nil


### PR DESCRIPTION
Every publish re-uploads all assets, even when almost none changed: asset keys are `{appId}/{branch}/{runtimeVersion}/{updateId}/assets/{hash}`.

## How it works

When the CLI calls `requestUploadUrl`, the server now:

1. loads the previous update's `metadata.json` on the same
   app/branch/runtime version/platform;
2. server-side copies every requested file already present there into the new
   update's folder — no bytes go through the client;
3. returns upload URLs only for the remaining files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added asset deduplication during deployments by reusing unchanged files from the most recent platform-specific update.
  * Successfully reused assets no longer require new upload URLs, reducing unnecessary uploads.
  * Supported copying assets across local and cloud storage.

* **Bug Fixes**
  * Failed or unavailable asset copies continue through the normal upload process.

* **Tests**
  * Added coverage for asset reuse, failed copies, first publishes, validation, and platform-specific update isolation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->