### PR TITLE
add telemetry + enterprise license management API

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
   <a href="https://insiders.vscode.dev/redirect/mcp/install?name=xprem-docs&config=%7B%22type%22%3A%22http%22%2C%22url%22%3A%22https%3A%2F%2Fmercure-technologies.gitbook.io%2Fxprem%2F~gitbook%2Fmcp%22%7D"><img src="https://img.shields.io/badge/VS_Code-Install_docs_MCP-0098FF?logo=githubcopilot&logoColor=white" alt="Install the docs MCP server in VS Code" height="28" /></a>
 </p>
 <p align="center">
-  <sub>The documentation is exposed as an <a href="#ask-the-docs-from-your-ai-assistant">MCP server</a>: plug it into Cursor, VS Code, Claude Code or any MCP client. And your xprem deployment is <a href="#mcp-server">one too</a>.</sub>
+  <sub>The documentation is exposed as an <a href="#ask-the-docs-from-your-ai-assistant">MCP server</a>: plug it into Cursor, VS Code, Claude Code or any MCP client.</sub>
 </p>
 
 

--- a/apps/dashboard/src/containers/Layout/index.tsx
+++ b/apps/dashboard/src/containers/Layout/index.tsx
@@ -1,4 +1,5 @@
 import { AppSidebar } from '@/components/app-sidebar';
+import { LicenseGraceBanner } from '@/ee/components/LicenseGraceBanner';
 import { XpremMark } from '@/components/xprem-mark';
 import { useEffect, useState } from 'react';
 import { Menu } from 'lucide-react';
@@ -33,6 +34,7 @@ export const Layout = ({ children }: { children: React.ReactNode }) => {
       <div className="flex min-h-screen w-full bg-background">
         <AppSidebar onOpenCommandPalette={openCommandPalette} />
         <main className="min-w-0 flex-1">
+          <LicenseGraceBanner />
           <header className="sticky top-0 z-30 flex h-14 items-center justify-between border-b border-border/80 bg-background/95 px-4 backdrop-blur lg:hidden">
             <div className="flex items-center gap-2.5">
               <XpremMark className="h-8 w-8 rounded-lg" />

--- a/apps/dashboard/src/ee/components/EnterpriseBadge.tsx
+++ b/apps/dashboard/src/ee/components/EnterpriseBadge.tsx
@@ -37,9 +37,9 @@ export const EnterpriseBadge = () => {
           Enterprise
         </div>
         <div
-          className="truncate font-mono text-[10px] text-emerald-700/70 dark:text-emerald-300/60"
-          title={license.licenseId}>
-          {license.licenseId?.split('-')[0]}
+          className="truncate text-[10px] text-emerald-700/70 dark:text-emerald-300/60"
+          title={license.orgName}>
+          {license.orgName}
         </div>
       </div>
     </div>

--- a/apps/dashboard/src/ee/components/LicenseGraceBanner.tsx
+++ b/apps/dashboard/src/ee/components/LicenseGraceBanner.tsx
@@ -1,0 +1,70 @@
+// Copyright (c) 2026 Axel Marciano (Mercure Technologies). All rights reserved.
+// This file is governed by the Mercure Technologies Enterprise Edition License
+// (see ee/LICENSE at the repository root); it is NOT covered by the MIT
+// license of this repository.
+
+import { useQuery } from '@tanstack/react-query';
+import { Link, useLocation } from 'react-router';
+import { TriangleAlert } from 'lucide-react';
+import { api } from '@/lib/api';
+import { formatTimestamp } from '@/lib/utils';
+import { useSettings } from '@/lib/SettingsContext';
+import { licenseErrorMessage } from '@/ee/lib/licenseErrors';
+
+// Deployment-wide warning shown on every page while the license server keeps
+// refusing (grace window running) or after it dropped the license (grace
+// exhausted). Shares the ['license'] query with the License page; the refetch
+// interval keeps long-lived tabs from missing the window entirely.
+export const LicenseGraceBanner = () => {
+  const { CONTROL_PLANE_ENABLED } = useSettings();
+  const location = useLocation();
+
+  const licenseQuery = useQuery({
+    queryKey: ['license'],
+    queryFn: () => api.getLicense(),
+    enabled: CONTROL_PLANE_ENABLED,
+    refetchInterval: 5 * 60 * 1000,
+  });
+
+  // The License page already shows the same warning inline.
+  if (location.pathname === '/license') {
+    return null;
+  }
+
+  const license = licenseQuery.data;
+  if (!license?.hasKey || !license.validationFailedAt) {
+    return null;
+  }
+
+  const reason = licenseErrorMessage(license.validationErrorCode);
+  const graceEndsAt = license.graceEndsAt ? formatTimestamp(license.graceEndsAt) : null;
+
+  return (
+    <div className="border-b border-red-800/40 bg-red-600 px-4 py-2.5 text-sm font-medium text-white dark:bg-red-700">
+      <div className="mx-auto flex max-w-[1480px] flex-wrap items-center gap-x-2 gap-y-1">
+        <TriangleAlert className="h-4 w-4 shrink-0" />
+        {license.suspended ? (
+          <span>
+            Your Enterprise license has been deactivated. {reason} Contact{' '}
+            <a className="underline" href="mailto:support@xprem.dev">
+              support@xprem.dev
+            </a>{' '}
+            to restore it.
+          </span>
+        ) : (
+          <span>
+            We can&apos;t verify your Enterprise license. {reason} Enterprise features will be
+            disabled {graceEndsAt ? `on ${graceEndsAt}` : 'soon'}. Contact{' '}
+            <a className="underline" href="mailto:support@xprem.dev">
+              support@xprem.dev
+            </a>{' '}
+            as soon as possible.
+          </span>
+        )}
+        <Link to="/license" className="ml-auto shrink-0 underline">
+          View license
+        </Link>
+      </div>
+    </div>
+  );
+};

--- a/apps/dashboard/src/ee/lib/auditCatalog.ts
+++ b/apps/dashboard/src/ee/lib/auditCatalog.ts
@@ -35,7 +35,13 @@ export const AUDIT_ACTION_GROUPS: AuditActionGroup[] = [
   },
   {
     label: 'Enterprise administration',
-    actions: ['license.activated', 'license.removed', 'sso_config.saved', 'sso_config.deleted'],
+    actions: [
+      'license.activated',
+      'license.removed',
+      'license.suspended',
+      'sso_config.saved',
+      'sso_config.deleted',
+    ],
   },
   {
     label: 'App management',

--- a/apps/dashboard/src/ee/lib/licenseErrors.ts
+++ b/apps/dashboard/src/ee/lib/licenseErrors.ts
@@ -1,0 +1,28 @@
+// Copyright (c) 2026 Axel Marciano (Mercure Technologies). All rights reserved.
+// This file is governed by the Mercure Technologies Enterprise Edition License
+// (see ee/LICENSE at the repository root); it is NOT covered by the MIT
+// license of this repository.
+
+// Human messages for the license server's error codes, shared by the License
+// page (check outcome) and the grace-period banner (validation failures).
+const LICENSE_ERROR_MESSAGES: Record<string, string> = {
+  LICENSE_KEY_NOT_FOUND: 'This license key does not exist.',
+  LICENSE_KEY_ALREADY_USED:
+    'This license key has already been used. Contact support@xprem.dev to release it.',
+  LICENSE_KEY_EXPIRED: 'This license key expired before it was activated.',
+  INVALID_INSTANCE_URL: "This server's URL is not allowed for this license.",
+  SUBSCRIPTION_INACTIVE: 'The subscription behind this license is inactive.',
+  LICENSE_EXPIRED: 'The subscription behind this license has ended.',
+  INVALID_ACTIVATION: 'The license server no longer recognizes this activation.',
+  LICENSE_SERVER_UNREACHABLE: 'The license server could not be reached.',
+  LICENSE_SERVER_REJECTED: 'The license server rejected the request.',
+  PLAN_NOT_SUPPORTED:
+    'This license is not on the Enterprise plan. Only Enterprise licenses are supported for now.',
+};
+
+export const licenseErrorMessage = (code?: string): string => {
+  if (code && LICENSE_ERROR_MESSAGES[code]) return LICENSE_ERROR_MESSAGES[code];
+  return code
+    ? `The license server refused the request (${code}).`
+    : 'The license server refused the request.';
+};

--- a/apps/dashboard/src/ee/pages/License/index.tsx
+++ b/apps/dashboard/src/ee/pages/License/index.tsx
@@ -5,14 +5,25 @@
 
 import { useRef, useState } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { BadgeCheck, FileUp, ShieldAlert } from 'lucide-react';
-import { api, describeApiError } from '@/lib/api';
+import { BadgeCheck, FileUp, ShieldAlert, TriangleAlert } from 'lucide-react';
+import { api, describeApiError, type LicenseCheckResult } from '@/lib/api';
+import { formatTimestamp } from '@/lib/utils';
 import { useSettings } from '@/lib/SettingsContext';
 import { useCurrentUser } from '@/lib/CurrentUserContext';
 import { useToast } from '@/hooks/use-toast';
+import { licenseErrorMessage } from '@/ee/lib/licenseErrors';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
 import { DeleteDialog } from '@/components/ui/delete-dialog';
 import { PageHeader } from '@/components/PageHeader';
 import { Skeleton } from '@/components/ui/skeleton';
@@ -32,6 +43,14 @@ export const License = () => {
   const queryClient = useQueryClient();
 
   const [keyInput, setKeyInput] = useState('');
+  const [isChecking, setIsChecking] = useState(false);
+  const [checkError, setCheckError] = useState<string | null>(null);
+  // A valid check result awaiting the admin's confirmation in the dialog; the
+  // key is frozen at check time so later edits to the textarea cannot attach
+  // an unchecked key.
+  const [pendingActivation, setPendingActivation] = useState<
+    (LicenseCheckResult & { key: string }) | null
+  >(null);
   const [isActivating, setIsActivating] = useState(false);
   const [isRemoveDialogOpen, setIsRemoveDialogOpen] = useState(false);
   const [isRemoving, setIsRemoving] = useState(false);
@@ -46,19 +65,38 @@ export const License = () => {
   const notifyError = (error: unknown, fallbackTitle: string) =>
     toast({ ...describeApiError(error, fallbackTitle), variant: 'destructive' });
 
-  const handleActivate = async () => {
+  const handleVerify = async () => {
     const key = keyInput.trim();
     if (!key) return;
+    setIsChecking(true);
+    setCheckError(null);
+    try {
+      const result = await api.checkLicense(key);
+      if (result.valid) {
+        setPendingActivation({ ...result, key });
+      } else {
+        setCheckError(licenseErrorMessage(result.errorCode));
+      }
+    } catch (error) {
+      notifyError(error, 'License check failed');
+    } finally {
+      setIsChecking(false);
+    }
+  };
+
+  const handleConfirmActivation = async () => {
+    if (!pendingActivation) return;
     setIsActivating(true);
     try {
-      const status = await api.activateLicense(key);
+      const status = await api.activateLicense(pendingActivation.key);
       queryClient.invalidateQueries({ queryKey: ['license'] });
+      // rbacEnabled is derived server-side from the license.
+      queryClient.invalidateQueries({ queryKey: ['me', 'permissions'] });
+      setPendingActivation(null);
       setKeyInput('');
       toast({
         title: 'License activated',
-        description: status.expiresAt
-          ? `Enterprise edition is enabled until ${new Date(status.expiresAt).toLocaleDateString()}.`
-          : 'Enterprise edition is enabled (perpetual license).',
+        description: `Enterprise edition is enabled for ${status.orgName ?? 'your organization'}.`,
       });
     } catch (error) {
       notifyError(error, 'License activation failed');
@@ -70,6 +108,7 @@ export const License = () => {
   const handleImportFile = async (file: File | undefined) => {
     if (!file) return;
     setKeyInput((await file.text()).trim());
+    setCheckError(null);
     // Reset so picking the same file again still fires onChange.
     if (fileInputRef.current) fileInputRef.current.value = '';
   };
@@ -79,6 +118,7 @@ export const License = () => {
     try {
       await api.removeLicense();
       queryClient.invalidateQueries({ queryKey: ['license'] });
+      queryClient.invalidateQueries({ queryKey: ['me', 'permissions'] });
       setIsRemoveDialogOpen(false);
       toast({
         title: 'License removed',
@@ -104,20 +144,31 @@ export const License = () => {
   }
 
   const license = licenseQuery.data;
+  const isFailingValidation = Boolean(license?.hasKey && license.validationFailedAt);
 
   const activationForm = (
     <div className="space-y-3">
       <textarea
         value={keyInput}
-        onChange={event => setKeyInput(event.target.value)}
-        placeholder="key/…"
+        onChange={event => {
+          setKeyInput(event.target.value);
+          setCheckError(null);
+        }}
+        placeholder="XPREM-…"
         rows={4}
         spellCheck={false}
         className="w-full resize-y rounded-md border border-input bg-transparent px-3 py-2 font-mono text-xs shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
       />
+      {checkError && (
+        <Alert variant="destructive">
+          <ShieldAlert className="h-4 w-4" />
+          <AlertTitle>This key cannot be activated</AlertTitle>
+          <AlertDescription>{checkError}</AlertDescription>
+        </Alert>
+      )}
       <div className="flex items-center gap-2">
-        <Button onClick={handleActivate} disabled={!keyInput.trim() || isActivating}>
-          {isActivating ? 'Verifying…' : 'Verify & activate'}
+        <Button onClick={handleVerify} disabled={!keyInput.trim() || isChecking}>
+          {isChecking ? 'Verifying…' : 'Verify key'}
         </Button>
         <Button variant="outline" onClick={() => fileInputRef.current?.click()}>
           <FileUp className="h-4 w-4" />
@@ -138,7 +189,7 @@ export const License = () => {
     <div className="w-full">
       <PageHeader
         title="License"
-        description="Enterprise Edition license for this deployment. Keys are verified offline against the Mercure Technologies signing key (no phone home) and stored in the database."
+        description="Enterprise Edition license for this deployment. Keys are verified against the Mercure Technologies license server and re-checked periodically."
       />
 
       {licenseQuery.isLoading && (
@@ -153,8 +204,57 @@ export const License = () => {
         </Card>
       )}
 
-      {!licenseQuery.isLoading && (
+      {licenseQuery.isError && (
+        <Alert variant="destructive">
+          <TriangleAlert className="h-4 w-4" />
+          <AlertTitle>License status unavailable</AlertTitle>
+          <AlertDescription>
+            The license status could not be loaded. This does not affect the license itself; refresh
+            the page or try again later.
+          </AlertDescription>
+        </Alert>
+      )}
+
+      {!licenseQuery.isLoading && !licenseQuery.isError && (
         <div className="space-y-6">
+          {license?.suspended && (
+            <Alert variant="destructive">
+              <TriangleAlert className="h-4 w-4" />
+              <AlertTitle>Enterprise features are disabled</AlertTitle>
+              <AlertDescription>
+                {licenseErrorMessage(license.validationErrorCode)} Verification had been failing
+                since{' '}
+                {license.validationFailedAt
+                  ? formatTimestamp(license.validationFailedAt)
+                  : 'recently'}{' '}
+                and the grace period has ended. Contact{' '}
+                <a className="font-medium underline" href="mailto:support@xprem.dev">
+                  support@xprem.dev
+                </a>{' '}
+                to restore it.
+              </AlertDescription>
+            </Alert>
+          )}
+          {isFailingValidation && !license?.suspended && (
+            <Alert variant="destructive">
+              <TriangleAlert className="h-4 w-4" />
+              <AlertTitle>We can&apos;t verify your license</AlertTitle>
+              <AlertDescription>
+                {licenseErrorMessage(license?.validationErrorCode)} Verification has been failing
+                since{' '}
+                {license?.validationFailedAt
+                  ? formatTimestamp(license.validationFailedAt)
+                  : 'recently'}
+                . Enterprise features stay enabled until{' '}
+                {license?.graceEndsAt ? formatTimestamp(license.graceEndsAt) : 'soon'}; contact{' '}
+                <a className="font-medium underline" href="mailto:support@xprem.dev">
+                  support@xprem.dev
+                </a>{' '}
+                as soon as possible.
+              </AlertDescription>
+            </Alert>
+          )}
+
           <Card>
             <CardHeader>
               <CardTitle className="flex items-center gap-2">
@@ -164,6 +264,11 @@ export const License = () => {
                     Enterprise edition
                     <Badge>Active</Badge>
                   </>
+                ) : license?.hasKey ? (
+                  <>
+                    Enterprise edition
+                    <Badge variant="destructive">Suspended</Badge>
+                  </>
                 ) : (
                   <>
                     Community edition
@@ -171,33 +276,38 @@ export const License = () => {
                   </>
                 )}
               </CardTitle>
-              {license?.hasKey && !license.valid && (
-                <CardDescription className="flex items-center gap-1.5 text-destructive">
-                  <ShieldAlert className="h-4 w-4 shrink-0" />
-                  {license.error ?? 'The stored license key is not usable.'}
-                </CardDescription>
-              )}
             </CardHeader>
-            {license?.hasKey && license.licenseId && (
+            {license?.hasKey && (
               <CardContent>
                 <div className="divide-y">
-                  <StatusRow label="License ID">
-                    <code className="rounded bg-muted px-1.5 py-0.5 text-xs">
-                      {license.licenseId}
-                    </code>
+                  <StatusRow label="Organization">
+                    <span className="font-medium">{license.orgName || '—'}</span>
                   </StatusRow>
-                  <StatusRow label="Issued">
-                    <TimestampCell dateString={license.issuedAt ?? null} />
+                  <StatusRow label="Plan">
+                    <Badge variant="secondary" className="capitalize">
+                      {license.planCode || 'unknown'}
+                    </Badge>
                   </StatusRow>
-                  <StatusRow label="Expires">
-                    {license.expiresAt ? (
-                      <TimestampCell dateString={license.expiresAt} />
+                  <StatusRow label="Subscription started">
+                    <TimestampCell dateString={license.subscriptionStartAt ?? null} />
+                  </StatusRow>
+                  <StatusRow label="Subscription ends">
+                    {license.subscriptionEndAt ? (
+                      <TimestampCell dateString={license.subscriptionEndAt} />
                     ) : (
-                      <span className="text-muted-foreground">Never (perpetual)</span>
+                      <span className="text-muted-foreground">No end date</span>
                     )}
                   </StatusRow>
+                  {license.subscriptionRenewalAt && (
+                    <StatusRow label="Renews">
+                      <TimestampCell dateString={license.subscriptionRenewalAt} />
+                    </StatusRow>
+                  )}
                   <StatusRow label="Activated">
                     <TimestampCell dateString={license.activatedAt ?? null} />
+                  </StatusRow>
+                  <StatusRow label="Last verified">
+                    <TimestampCell dateString={license.lastValidatedAt ?? null} />
                   </StatusRow>
                 </div>
                 {isAdmin && (
@@ -215,11 +325,12 @@ export const License = () => {
             <Card>
               <CardHeader>
                 <CardTitle>
-                  {license?.valid ? 'Replace license key' : 'Activate a license key'}
+                  {license?.hasKey ? 'Replace license key' : 'Activate a license key'}
                 </CardTitle>
                 <CardDescription>
                   Paste the license key you received with your Enterprise subscription, or import
-                  the file it was delivered in. The key is verified before anything is stored.
+                  the file it was delivered in. The key is verified with the license server before
+                  anything is activated.
                 </CardDescription>
               </CardHeader>
               <CardContent>{activationForm}</CardContent>
@@ -232,14 +343,52 @@ export const License = () => {
         </div>
       )}
 
+      <Dialog
+        open={pendingActivation !== null}
+        onOpenChange={open => {
+          if (!open) setPendingActivation(null);
+        }}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Activate this license?</DialogTitle>
+            <DialogDescription>
+              You are about to activate an Enterprise license for{' '}
+              <span className="font-semibold text-foreground">
+                {pendingActivation?.orgName ?? 'an organization'}
+              </span>{' '}
+              ({pendingActivation?.planCode ?? 'unknown'} plan) on this server.
+            </DialogDescription>
+          </DialogHeader>
+          <Alert>
+            <ShieldAlert className="h-4 w-4" />
+            <AlertTitle>Make sure this license is yours</AlertTitle>
+            <AlertDescription>
+              Only activate a license issued to your organization. A key can only be attached to one
+              server: activating a license that does not belong to you burns its activation for its
+              rightful owner.
+            </AlertDescription>
+          </Alert>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setPendingActivation(null)}>
+              Cancel
+            </Button>
+            <Button onClick={handleConfirmActivation} disabled={isActivating}>
+              {isActivating
+                ? 'Activating…'
+                : `Activate for ${pendingActivation?.orgName ?? 'this organization'}`}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
       <DeleteDialog
         isOpen={isRemoveDialogOpen}
         onClose={() => setIsRemoveDialogOpen(false)}
         onConfirm={handleRemove}
         isDeleting={isRemoving}
         title="Remove license"
-        resourceName={license?.licenseId}
-        descriptionText="Enterprise features will be disabled and this deployment drops back to community edition. You can re-activate the same key later."
+        resourceName={license?.orgName}
+        descriptionText="Enterprise features will be disabled and this deployment drops back to community edition. The key stays attached to this server on the license server; contact support@xprem.dev if you need it released."
         confirmButtonText="Remove license"
         isDeletingButtonText="Removing…"
       />

--- a/apps/dashboard/src/lib/api.ts
+++ b/apps/dashboard/src/lib/api.ts
@@ -674,17 +674,36 @@ export type GrantRecord = {
 
 // The deployment's Enterprise Edition license status (/api/license,
 // control-plane only). `valid` is the single source of truth for "enterprise
-// features are on": `hasKey` can be true with `valid` false when the stored
-// key is expired or malformed, in which case `error` says why. `expiresAt` is
-// absent for a perpetual license.
+// features are on": it stays true through the grace window while
+// `validationFailedAt` warns that the license server refuses or cannot be
+// reached, and flips to false (`suspended` true) once `graceEndsAt` passes.
 export type LicenseStatus = {
   hasKey: boolean;
   valid: boolean;
-  error?: string;
-  licenseId?: string;
-  issuedAt?: string;
-  expiresAt?: string;
+  suspended?: boolean;
+  orgName?: string;
+  planCode?: string;
+  subscriptionStartAt?: string;
+  subscriptionEndAt?: string;
+  subscriptionRenewalAt?: string;
   activatedAt?: string;
+  lastValidatedAt?: string;
+  validationFailedAt?: string;
+  validationErrorCode?: string;
+  graceEndsAt?: string;
+};
+
+// Outcome of the no-side-effect key check (/api/license/check): either valid
+// with the license descriptor to confirm before attaching, or an errorCode
+// saying why the key is not usable.
+export type LicenseCheckResult = {
+  valid: boolean;
+  errorCode?: string;
+  orgName?: string;
+  planCode?: string;
+  subscriptionStartAt?: string;
+  subscriptionEndAt?: string;
+  subscriptionRenewalAt?: string;
 };
 
 // Pre-auth SSO state (/auth/sso/config), read by the login page to decide
@@ -1172,6 +1191,15 @@ export class ApiClient {
   public async deleteSsoSettings() {
     return this.request<void>(`/api/sso`, {
       method: 'DELETE',
+    });
+  }
+
+  // Asks the license server whether the key is usable, without consuming it.
+  public async checkLicense(key: string) {
+    return this.request<LicenseCheckResult>(`/api/license/check`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ key }),
     });
   }
 

--- a/config/config.go
+++ b/config/config.go
@@ -54,6 +54,11 @@ func IsDeviceTelemetryDisabled() bool {
 	return disabled
 }
 
+func IsServerTelemetryDisabled() bool {
+	disabled, _ := strconv.ParseBool(GetEnv("DISABLE_TELEMETRY"))
+	return disabled
+}
+
 func ValidateMasterKey() error {
 	awsKeyId := GetEnv("AWSSM_DB_KEYS_MASTER_KEY_SECRET_ID")
 	localKey := GetEnv("DB_KEYS_MASTER_KEY_B64")

--- a/ee/README.md
+++ b/ee/README.md
@@ -16,13 +16,16 @@ Everything outside `ee/` directories is and will remain MIT.
 ## How gating works
 
 Enterprise features are compiled into the regular server binary but stay
-dormant until a valid license key is activated. Licenses are issued through
-[Keygen](https://keygen.sh) using the `ED25519_SIGN` scheme and verified fully
-offline by `ee/licensing` against the account's embedded Ed25519 verify key —
-no network calls, no phone home.
+dormant until a valid license key is activated. Keys are checked and attached
+from the dashboard against the Mercure Technologies license server
+(`https://api.xprem.dev`); the resulting activation is persisted in the
+database and re-validated every 15 minutes. When the server refuses or cannot
+be reached, enterprise features stay on for a 7-day grace window (the
+dashboard warns to contact support@xprem.dev) before the license drops back
+to community edition.
 
-- `ee/licensing` — signed-key parsing, signature verification, and runtime
-  activation state (`licensing.IsEnterprise()`).
+- `ee/licensing` — license server client (check/attach/validate), grace
+  window handling, and runtime activation state (`licensing.IsEnterprise()`).
 
 ## Conventions
 

--- a/ee/licensing/client.go
+++ b/ee/licensing/client.go
@@ -1,0 +1,214 @@
+// Copyright (c) 2026 Axel Marciano (Mercure Technologies). All rights reserved.
+// This file is governed by the Mercure Technologies Enterprise Edition License
+// (see ee/LICENSE); it is NOT covered by the MIT license of this repository.
+
+package licensing
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// DefaultAPIBaseURL is the production license server.
+const DefaultAPIBaseURL = "https://api.xprem.dev"
+
+// Error codes answered by the license server on check, attach and validate.
+const (
+	CodeLicenseKeyNotFound    = "LICENSE_KEY_NOT_FOUND"
+	CodeLicenseKeyAlreadyUsed = "LICENSE_KEY_ALREADY_USED"
+	CodeLicenseKeyExpired     = "LICENSE_KEY_EXPIRED"
+	CodeInvalidInstanceURL    = "INVALID_INSTANCE_URL"
+	CodeSubscriptionInactive  = "SUBSCRIPTION_INACTIVE"
+	CodeLicenseExpired        = "LICENSE_EXPIRED"
+	CodeInvalidActivation     = "INVALID_ACTIVATION"
+
+	// Minted locally, never sent by the server.
+	CodeServerUnreachable = "LICENSE_SERVER_UNREACHABLE"
+	CodeServerRejected    = "LICENSE_SERVER_REJECTED"
+	CodePlanNotSupported  = "PLAN_NOT_SUPPORTED"
+)
+
+// ErrServerUnreachable wraps every transport-level failure, as opposed to a
+// license decision.
+var ErrServerUnreachable = errors.New("licensing: could not reach the license server")
+
+// ErrServerRejected is a request the server refused to process (schema
+// validation, rate limit), as opposed to a license decision.
+var ErrServerRejected = errors.New("licensing: the license server rejected the request")
+
+// DecisionError is a refusal decided by the license server.
+type DecisionError struct {
+	Code string
+}
+
+func (e *DecisionError) Error() string {
+	return "licensing: the license server refused: " + e.Code
+}
+
+// Client calls the license server.
+type Client struct {
+	baseURL    string
+	httpClient *http.Client
+}
+
+// NewClient falls back to DefaultAPIBaseURL when baseURL is empty.
+func NewClient(baseURL string) *Client {
+	if baseURL == "" {
+		baseURL = DefaultAPIBaseURL
+	}
+	baseURL = strings.TrimRight(baseURL, "/")
+	return &Client{baseURL: baseURL, httpClient: &http.Client{Timeout: 15 * time.Second}}
+}
+
+// KeyParams is the request body of check and attach.
+type KeyParams struct {
+	InstanceId string `json:"instanceId"`
+	LicenseKey string `json:"licenseKey"`
+	BaseUrl    string `json:"baseUrl"`
+	Version    string `json:"version"`
+}
+
+// ValidateParams is the request body of validate.
+type ValidateParams struct {
+	InstanceId       string `json:"instanceId"`
+	ActivationSecret string `json:"activationSecret"`
+	BaseUrl          string `json:"baseUrl"`
+}
+
+// CheckResult is the outcome of a no-side-effect key check.
+type CheckResult struct {
+	Valid     bool
+	ErrorCode string
+	License   *License
+}
+
+// Activation is a successful attach.
+type Activation struct {
+	ActivationSecret string
+	License          License
+}
+
+type licenseInformationsPayload struct {
+	Org struct {
+		Name string `json:"name"`
+	} `json:"org"`
+	PlanCode     string `json:"planCode"`
+	Subscription struct {
+		StartAt   time.Time  `json:"startAt"`
+		EndAt     *time.Time `json:"endAt"`
+		RenewalAt *time.Time `json:"renewalAt"`
+	} `json:"subscription"`
+}
+
+func (p *licenseInformationsPayload) toLicense() License {
+	return License{
+		OrgName:               p.Org.Name,
+		PlanCode:              p.PlanCode,
+		SubscriptionStartAt:   p.Subscription.StartAt,
+		SubscriptionEndAt:     p.Subscription.EndAt,
+		SubscriptionRenewalAt: p.Subscription.RenewalAt,
+	}
+}
+
+// serverResponse is the union of the three endpoints' bodies.
+type serverResponse struct {
+	Valid               *bool                       `json:"valid"`
+	IsActive            *bool                       `json:"isActive"`
+	ErrorCode           string                      `json:"errorCode"`
+	ActivationSecret    string                      `json:"activationSecret"`
+	LicenseInformations *licenseInformationsPayload `json:"licenseInformations"`
+}
+
+func (c *Client) post(ctx context.Context, path string, payload any) (*serverResponse, int, error) {
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return nil, 0, fmt.Errorf("marshal license request: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+path, bytes.NewReader(body))
+	if err != nil {
+		return nil, 0, fmt.Errorf("build license request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, 0, fmt.Errorf("%w: %w", ErrServerUnreachable, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusBadRequest {
+		// Drained so the keep-alive connection can be reused.
+		_, _ = io.Copy(io.Discard, resp.Body)
+		return nil, resp.StatusCode, fmt.Errorf("%w: unexpected status %s", ErrServerUnreachable, resp.Status)
+	}
+	var decoded serverResponse
+	if err := json.NewDecoder(resp.Body).Decode(&decoded); err != nil {
+		return nil, resp.StatusCode, fmt.Errorf("%w: undecodable response: %v", ErrServerUnreachable, err)
+	}
+	return &decoded, resp.StatusCode, nil
+}
+
+func decision(resp *serverResponse) error {
+	if resp.ErrorCode != "" {
+		return &DecisionError{Code: resp.ErrorCode}
+	}
+	return fmt.Errorf("%w: no error code in the response", ErrServerRejected)
+}
+
+// Check asks whether a key is usable, without consuming it.
+func (c *Client) Check(ctx context.Context, params KeyParams) (CheckResult, error) {
+	resp, status, err := c.post(ctx, "/v1/licenses/check", params)
+	if err != nil {
+		return CheckResult{}, err
+	}
+	if status != http.StatusOK {
+		return CheckResult{}, decision(resp)
+	}
+	if resp.Valid != nil && *resp.Valid && resp.LicenseInformations != nil {
+		license := resp.LicenseInformations.toLicense()
+		return CheckResult{Valid: true, License: &license}, nil
+	}
+	if resp.ErrorCode == "" {
+		return CheckResult{}, fmt.Errorf("%w: unintelligible check response", ErrServerUnreachable)
+	}
+	return CheckResult{ErrorCode: resp.ErrorCode}, nil
+}
+
+// Attach consumes the key and binds it to this instance.
+func (c *Client) Attach(ctx context.Context, params KeyParams) (*Activation, error) {
+	resp, status, err := c.post(ctx, "/v1/licenses/attach", params)
+	if err != nil {
+		return nil, err
+	}
+	if status != http.StatusOK {
+		return nil, decision(resp)
+	}
+	if resp.IsActive == nil || !*resp.IsActive || resp.ActivationSecret == "" || resp.LicenseInformations == nil {
+		return nil, fmt.Errorf("%w: unintelligible attach response", ErrServerUnreachable)
+	}
+	return &Activation{
+		ActivationSecret: resp.ActivationSecret,
+		License:          resp.LicenseInformations.toLicense(),
+	}, nil
+}
+
+// Validate re-checks an activation and returns the fresh license descriptor.
+func (c *Client) Validate(ctx context.Context, params ValidateParams) (*License, error) {
+	resp, status, err := c.post(ctx, "/v1/licenses/validate", params)
+	if err != nil {
+		return nil, err
+	}
+	if status != http.StatusOK {
+		return nil, decision(resp)
+	}
+	if resp.IsActive == nil || !*resp.IsActive || resp.LicenseInformations == nil {
+		return nil, fmt.Errorf("%w: unintelligible validate response", ErrServerUnreachable)
+	}
+	license := resp.LicenseInformations.toLicense()
+	return &license, nil
+}

--- a/ee/licensing/client_test.go
+++ b/ee/licensing/client_test.go
@@ -1,0 +1,199 @@
+// Copyright (c) 2026 Axel Marciano (Mercure Technologies). All rights reserved.
+// This file is governed by the Mercure Technologies Enterprise Edition License
+// (see ee/LICENSE); it is NOT covered by the MIT license of this repository.
+
+package licensing
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const acmeInformationsJSON = `{
+	"org": {"name": "Acme Corp"},
+	"planCode": "enterprise",
+	"subscription": {
+		"startAt": "2026-01-01T00:00:00.000Z",
+		"endAt": null,
+		"renewalAt": "2027-01-01T00:00:00.000Z"
+	}
+}`
+
+// fakeLicenseServer stubs the three license server endpoints; nil handlers
+// answer 404, which the client reports as unreachable.
+type fakeLicenseServer struct {
+	check    http.HandlerFunc
+	attach   http.HandlerFunc
+	validate http.HandlerFunc
+}
+
+func (f *fakeLicenseServer) client(t *testing.T) *Client {
+	t.Helper()
+	router := http.NewServeMux()
+	if f.check != nil {
+		router.HandleFunc("/v1/licenses/check", f.check)
+	}
+	if f.attach != nil {
+		router.HandleFunc("/v1/licenses/attach", f.attach)
+	}
+	if f.validate != nil {
+		router.HandleFunc("/v1/licenses/validate", f.validate)
+	}
+	server := httptest.NewServer(router)
+	t.Cleanup(server.Close)
+	return NewClient(server.URL)
+}
+
+func writeJSONBody(w http.ResponseWriter, status int, body string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	w.Write([]byte(body))
+}
+
+func testKeyParams(key string) KeyParams {
+	return KeyParams{
+		InstanceId: "instance-1",
+		LicenseKey: key,
+		BaseUrl:    "https://updates.example.com",
+		Version:    "1.2.3",
+	}
+}
+
+func TestClientCheckValidKey(t *testing.T) {
+	fake := &fakeLicenseServer{
+		check: func(w http.ResponseWriter, r *http.Request) {
+			var body map[string]string
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+			assert.Equal(t, "instance-1", body["instanceId"])
+			assert.Equal(t, "XPREM-KEY", body["licenseKey"])
+			assert.Equal(t, "https://updates.example.com", body["baseUrl"])
+			assert.Equal(t, "1.2.3", body["version"])
+			writeJSONBody(w, http.StatusOK, `{"valid": true, "licenseInformations": `+acmeInformationsJSON+`}`)
+		},
+	}
+	result, err := fake.client(t).Check(context.Background(), testKeyParams("XPREM-KEY"))
+	require.NoError(t, err)
+	assert.True(t, result.Valid)
+	require.NotNil(t, result.License)
+	assert.Equal(t, "Acme Corp", result.License.OrgName)
+	assert.Equal(t, "enterprise", result.License.PlanCode)
+	assert.Nil(t, result.License.SubscriptionEndAt)
+	require.NotNil(t, result.License.SubscriptionRenewalAt)
+}
+
+func TestClientCheckInvalidKeyIsNotAnError(t *testing.T) {
+	fake := &fakeLicenseServer{
+		check: func(w http.ResponseWriter, r *http.Request) {
+			writeJSONBody(w, http.StatusOK, `{"valid": false, "errorCode": "LICENSE_KEY_NOT_FOUND"}`)
+		},
+	}
+	result, err := fake.client(t).Check(context.Background(), testKeyParams("nope"))
+	require.NoError(t, err)
+	assert.False(t, result.Valid)
+	assert.Equal(t, CodeLicenseKeyNotFound, result.ErrorCode)
+	assert.Nil(t, result.License)
+}
+
+func TestClientAttachSuccess(t *testing.T) {
+	fake := &fakeLicenseServer{
+		attach: func(w http.ResponseWriter, r *http.Request) {
+			writeJSONBody(w, http.StatusOK, `{"isActive": true, "activationSecret": "secret-42", "licenseInformations": `+acmeInformationsJSON+`}`)
+		},
+	}
+	activation, err := fake.client(t).Attach(context.Background(), testKeyParams("XPREM-KEY"))
+	require.NoError(t, err)
+	assert.Equal(t, "secret-42", activation.ActivationSecret)
+	assert.Equal(t, "Acme Corp", activation.License.OrgName)
+}
+
+func TestClientAttachRefusalIsADecision(t *testing.T) {
+	fake := &fakeLicenseServer{
+		attach: func(w http.ResponseWriter, r *http.Request) {
+			writeJSONBody(w, http.StatusBadRequest, `{"valid": false, "errorCode": "LICENSE_KEY_ALREADY_USED"}`)
+		},
+	}
+	_, err := fake.client(t).Attach(context.Background(), testKeyParams("XPREM-KEY"))
+	var refusal *DecisionError
+	require.ErrorAs(t, err, &refusal)
+	assert.Equal(t, CodeLicenseKeyAlreadyUsed, refusal.Code)
+}
+
+func TestClientAttachMalformedBodyRejectionIsNotADecision(t *testing.T) {
+	fake := &fakeLicenseServer{
+		attach: func(w http.ResponseWriter, r *http.Request) {
+			writeJSONBody(w, http.StatusBadRequest, `{"statusCode": 400, "error": "Bad Request", "message": "Request validation failed"}`)
+		},
+	}
+	_, err := fake.client(t).Attach(context.Background(), testKeyParams("XPREM-KEY"))
+	require.ErrorIs(t, err, ErrServerRejected)
+	var refusal *DecisionError
+	assert.False(t, errors.As(err, &refusal))
+}
+
+func TestClientTrimsTrailingSlashFromBaseURL(t *testing.T) {
+	router := http.NewServeMux()
+	router.HandleFunc("/v1/licenses/check", func(w http.ResponseWriter, r *http.Request) {
+		writeJSONBody(w, http.StatusOK, `{"valid": true, "licenseInformations": `+acmeInformationsJSON+`}`)
+	})
+	server := httptest.NewServer(router)
+	t.Cleanup(server.Close)
+
+	result, err := NewClient(server.URL+"/").Check(context.Background(), testKeyParams("XPREM-KEY"))
+	require.NoError(t, err)
+	assert.True(t, result.Valid)
+}
+
+func TestClientValidateSuccess(t *testing.T) {
+	fake := &fakeLicenseServer{
+		validate: func(w http.ResponseWriter, r *http.Request) {
+			var body map[string]string
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+			assert.Equal(t, "secret-42", body["activationSecret"])
+			assert.NotContains(t, body, "licenseKey")
+			writeJSONBody(w, http.StatusOK, `{"isActive": true, "licenseInformations": `+acmeInformationsJSON+`}`)
+		},
+	}
+	license, err := fake.client(t).Validate(context.Background(), ValidateParams{
+		InstanceId:       "instance-1",
+		ActivationSecret: "secret-42",
+		BaseUrl:          "https://updates.example.com",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "Acme Corp", license.OrgName)
+}
+
+func TestClientValidateRefusalIsADecision(t *testing.T) {
+	fake := &fakeLicenseServer{
+		validate: func(w http.ResponseWriter, r *http.Request) {
+			writeJSONBody(w, http.StatusBadRequest, `{"valid": false, "errorCode": "INVALID_ACTIVATION"}`)
+		},
+	}
+	_, err := fake.client(t).Validate(context.Background(), ValidateParams{})
+	var refusal *DecisionError
+	require.ErrorAs(t, err, &refusal)
+	assert.Equal(t, CodeInvalidActivation, refusal.Code)
+}
+
+func TestClientUnexpectedStatusIsUnreachable(t *testing.T) {
+	fake := &fakeLicenseServer{
+		validate: func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		},
+	}
+	_, err := fake.client(t).Validate(context.Background(), ValidateParams{})
+	require.ErrorIs(t, err, ErrServerUnreachable)
+}
+
+func TestClientConnectionFailureIsUnreachable(t *testing.T) {
+	server := httptest.NewServer(http.NotFoundHandler())
+	server.Close()
+	_, err := NewClient(server.URL).Check(context.Background(), testKeyParams("XPREM-KEY"))
+	require.ErrorIs(t, err, ErrServerUnreachable)
+}

--- a/ee/licensing/handler.go
+++ b/ee/licensing/handler.go
@@ -7,6 +7,7 @@ package licensing
 import (
 	"encoding/json"
 	"errors"
+	"log"
 	"net/http"
 	"strings"
 	"time"
@@ -133,6 +134,7 @@ func renderLicenseServiceError(w http.ResponseWriter, err error) {
 		errors.Is(err, ErrInstanceIdUnavailable):
 		handlers.RenderError(w, http.StatusBadRequest, err.Error())
 	default:
+		log.Printf("🚨 [LICENSE] Unexpected license operation error: %v", err)
 		handlers.RenderError(w, http.StatusInternalServerError, "An internal error occurred.")
 	}
 }

--- a/ee/licensing/handler.go
+++ b/ee/licensing/handler.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"strings"
 	"time"
 	"xprem/internal/handlers"
 )
@@ -21,56 +22,135 @@ func NewLicenseHandler(service *LicenseService) *LicenseHandler {
 }
 
 // LicenseResponse is the public shape of the deployment's license status.
-// Valid is the single source of truth for "enterprise features are on":
-// HasKey can be true with Valid false when the stored key is expired or
-// malformed, in which case Error says why. ExpiresAt is empty for a
-// perpetual license.
+// Valid stays true through the grace window and flips once it is exhausted.
 type LicenseResponse struct {
-	HasKey      bool   `json:"hasKey"`
-	Valid       bool   `json:"valid"`
-	Error       string `json:"error,omitempty"`
-	LicenseId   string `json:"licenseId,omitempty"`
-	IssuedAt    string `json:"issuedAt,omitempty"`
-	ExpiresAt   string `json:"expiresAt,omitempty"`
-	ActivatedAt string `json:"activatedAt,omitempty"`
+	HasKey                bool   `json:"hasKey"`
+	Valid                 bool   `json:"valid"`
+	Suspended             bool   `json:"suspended,omitempty"`
+	OrgName               string `json:"orgName,omitempty"`
+	PlanCode              string `json:"planCode,omitempty"`
+	SubscriptionStartAt   string `json:"subscriptionStartAt,omitempty"`
+	SubscriptionEndAt     string `json:"subscriptionEndAt,omitempty"`
+	SubscriptionRenewalAt string `json:"subscriptionRenewalAt,omitempty"`
+	ActivatedAt           string `json:"activatedAt,omitempty"`
+	LastValidatedAt       string `json:"lastValidatedAt,omitempty"`
+	ValidationFailedAt    string `json:"validationFailedAt,omitempty"`
+	ValidationErrorCode   string `json:"validationErrorCode,omitempty"`
+	GraceEndsAt           string `json:"graceEndsAt,omitempty"`
+}
+
+// CheckLicenseResponse mirrors the license server's check outcome.
+type CheckLicenseResponse struct {
+	Valid                 bool   `json:"valid"`
+	ErrorCode             string `json:"errorCode,omitempty"`
+	OrgName               string `json:"orgName,omitempty"`
+	PlanCode              string `json:"planCode,omitempty"`
+	SubscriptionStartAt   string `json:"subscriptionStartAt,omitempty"`
+	SubscriptionEndAt     string `json:"subscriptionEndAt,omitempty"`
+	SubscriptionRenewalAt string `json:"subscriptionRenewalAt,omitempty"`
+}
+
+func formatTime(t time.Time) string {
+	if t.IsZero() {
+		return ""
+	}
+	return t.UTC().Format(time.RFC3339)
+}
+
+func formatTimePtr(t *time.Time) string {
+	if t == nil {
+		return ""
+	}
+	return formatTime(*t)
 }
 
 func licenseResponseFrom(status LicenseStatus) LicenseResponse {
 	response := LicenseResponse{
-		HasKey: status.HasKey,
-		Valid:  status.Valid(),
-	}
-	if status.Err != nil {
-		response.Error = status.Err.Error()
-	}
-	if !status.ActivatedAt.IsZero() {
-		response.ActivatedAt = status.ActivatedAt.UTC().Format(time.RFC3339)
+		HasKey:              status.HasKey,
+		Valid:               status.Valid(),
+		Suspended:           status.Suspended(),
+		ActivatedAt:         formatTime(status.ActivatedAt),
+		LastValidatedAt:     formatTimePtr(status.LastValidatedAt),
+		ValidationFailedAt:  formatTimePtr(status.ValidationFailedAt),
+		ValidationErrorCode: status.ValidationErrorCode,
+		GraceEndsAt:         formatTimePtr(status.GraceDeadline()),
 	}
 	if status.License != nil {
-		response.LicenseId = status.License.LicenseID
-		if !status.License.Created.IsZero() {
-			response.IssuedAt = status.License.Created.UTC().Format(time.RFC3339)
-		}
-		if status.License.Expiry != nil {
-			response.ExpiresAt = status.License.Expiry.UTC().Format(time.RFC3339)
-		}
+		response.OrgName = status.License.OrgName
+		response.PlanCode = status.License.PlanCode
+		response.SubscriptionStartAt = formatTime(status.License.SubscriptionStartAt)
+		response.SubscriptionEndAt = formatTimePtr(status.License.SubscriptionEndAt)
+		response.SubscriptionRenewalAt = formatTimePtr(status.License.SubscriptionRenewalAt)
 	}
 	return response
 }
 
-// renderLicenseServiceError maps key-validation failures onto 400s with the
-// actionable reason; anything unrecognized stays an opaque 500.
+func checkResponseFrom(result CheckResult) CheckLicenseResponse {
+	response := CheckLicenseResponse{Valid: result.Valid, ErrorCode: result.ErrorCode}
+	if result.License != nil {
+		response.OrgName = result.License.OrgName
+		response.PlanCode = result.License.PlanCode
+		response.SubscriptionStartAt = formatTime(result.License.SubscriptionStartAt)
+		response.SubscriptionEndAt = formatTimePtr(result.License.SubscriptionEndAt)
+		response.SubscriptionRenewalAt = formatTimePtr(result.License.SubscriptionRenewalAt)
+	}
+	return response
+}
+
+func decisionMessage(code string) string {
+	switch code {
+	case CodeLicenseKeyNotFound:
+		return "This license key does not exist."
+	case CodeLicenseKeyAlreadyUsed:
+		return "This license key has already been used. Contact support@xprem.dev to release it."
+	case CodeLicenseKeyExpired:
+		return "This license key expired before it was activated."
+	case CodeInvalidInstanceURL:
+		return "This server's URL (BASE_URL) is not allowed for this license."
+	case CodeSubscriptionInactive:
+		return "The subscription behind this license is inactive."
+	case CodeLicenseExpired:
+		return "The subscription behind this license has ended."
+	case CodeInvalidActivation:
+		return "The license server no longer recognizes this activation."
+	case CodePlanNotSupported:
+		return "This license is not on the Enterprise plan. Only Enterprise licenses are supported for now."
+	default:
+		return "The license server refused the request (" + code + ")."
+	}
+}
+
 func renderLicenseServiceError(w http.ResponseWriter, err error) {
+	var refusal *DecisionError
 	switch {
+	case errors.As(err, &refusal):
+		handlers.RenderError(w, http.StatusBadRequest, decisionMessage(refusal.Code))
+	case errors.Is(err, ErrServerRejected):
+		handlers.RenderError(w, http.StatusBadGateway, "The license server rejected the request. Check the key and this server's BASE_URL, and contact support@xprem.dev if this persists.")
+	case errors.Is(err, ErrServerUnreachable):
+		handlers.RenderError(w, http.StatusBadGateway, "The license server could not be reached. Try again in a few minutes.")
 	case errors.Is(err, ErrLicenseRequiresControlPlane),
-		errors.Is(err, ErrMalformedKey),
-		errors.Is(err, ErrInvalidSignature),
-		errors.Is(err, ErrExpired),
-		errors.Is(err, ErrNoVerifyKey):
+		errors.Is(err, ErrInstanceIdUnavailable):
 		handlers.RenderError(w, http.StatusBadRequest, err.Error())
 	default:
 		handlers.RenderError(w, http.StatusInternalServerError, "An internal error occurred.")
 	}
+}
+
+func decodeKeyBody(w http.ResponseWriter, r *http.Request) (string, bool) {
+	var requestBody struct {
+		Key string `json:"key"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&requestBody); err != nil {
+		handlers.RenderError(w, http.StatusBadRequest, "Invalid request body: "+err.Error())
+		return "", false
+	}
+	key := strings.TrimSpace(requestBody.Key)
+	if key == "" {
+		handlers.RenderError(w, http.StatusBadRequest, "key is required")
+		return "", false
+	}
+	return key, true
 }
 
 func (h *LicenseHandler) GetLicenseHandler(w http.ResponseWriter, r *http.Request) {
@@ -82,19 +162,26 @@ func (h *LicenseHandler) GetLicenseHandler(w http.ResponseWriter, r *http.Reques
 	handlers.RenderJSON(w, http.StatusOK, licenseResponseFrom(status))
 }
 
+// CheckLicenseHandler answers 200 with valid false for an unusable key.
+func (h *LicenseHandler) CheckLicenseHandler(w http.ResponseWriter, r *http.Request) {
+	key, ok := decodeKeyBody(w, r)
+	if !ok {
+		return
+	}
+	result, err := h.service.Check(r.Context(), key)
+	if err != nil {
+		renderLicenseServiceError(w, err)
+		return
+	}
+	handlers.RenderJSON(w, http.StatusOK, checkResponseFrom(result))
+}
+
 func (h *LicenseHandler) ActivateLicenseHandler(w http.ResponseWriter, r *http.Request) {
-	var requestBody struct {
-		Key string `json:"key"`
-	}
-	if err := json.NewDecoder(r.Body).Decode(&requestBody); err != nil {
-		handlers.RenderError(w, http.StatusBadRequest, "Invalid request body: "+err.Error())
+	key, ok := decodeKeyBody(w, r)
+	if !ok {
 		return
 	}
-	if requestBody.Key == "" {
-		handlers.RenderError(w, http.StatusBadRequest, "key is required")
-		return
-	}
-	status, err := h.service.Activate(r.Context(), requestBody.Key)
+	status, err := h.service.Attach(r.Context(), key)
 	if err != nil {
 		renderLicenseServiceError(w, err)
 		return

--- a/ee/licensing/handler_test.go
+++ b/ee/licensing/handler_test.go
@@ -1,0 +1,36 @@
+// Copyright (c) 2026 Axel Marciano (Mercure Technologies). All rights reserved.
+// This file is governed by the Mercure Technologies Enterprise Edition License
+// (see ee/LICENSE); it is NOT covered by the MIT license of this repository.
+
+package licensing
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLicenseResponsesNeverExposeKeyOrSecret(t *testing.T) {
+	repo := repoWithAcme()
+	fake := &fakeLicenseServer{check: checkAnswersValidAcme}
+	service := newTestService(t, repo, fake.client(t))
+	handler := NewLicenseHandler(service)
+
+	get := httptest.NewRecorder()
+	handler.GetLicenseHandler(get, httptest.NewRequest(http.MethodGet, "/license", nil))
+	require.Equal(t, http.StatusOK, get.Code)
+
+	check := httptest.NewRecorder()
+	checkRequest := httptest.NewRequest(http.MethodPost, "/license/check", strings.NewReader(`{"key":"XPREM-KEY"}`))
+	handler.CheckLicenseHandler(check, checkRequest)
+	require.Equal(t, http.StatusOK, check.Code)
+
+	for name, body := range map[string]string{"get": get.Body.String(), "check": check.Body.String()} {
+		assert.NotContains(t, body, repo.stored.Key, name)
+		assert.NotContains(t, body, repo.secret, name)
+	}
+}

--- a/ee/licensing/licensing.go
+++ b/ee/licensing/licensing.go
@@ -2,146 +2,41 @@
 // This file is governed by the Mercure Technologies Enterprise Edition License
 // (see ee/LICENSE); it is NOT covered by the MIT license of this repository.
 
-// Package licensing implements offline validation of Mercure Technologies
-// Enterprise license keys issued through Keygen (https://keygen.sh) with the
-// ED25519_SIGN scheme. A key looks like:
-//
-//	key/{base64url(JSON dataset)}.{base64url(Ed25519 signature)}
-//
-// The signature covers the literal string "key/" + the base64url dataset and
-// is verified against the Keygen account's Ed25519 verify key embedded below,
-// so validation works fully offline, no network calls, no phone home.
+// Package licensing manages the Enterprise Edition license of a deployment
+// against the Mercure Technologies license server (api.xprem.dev).
 package licensing
 
 import (
-	"crypto/ed25519"
-	"encoding/base64"
-	"encoding/hex"
-	"encoding/json"
-	"errors"
-	"strings"
 	"sync"
 	"time"
 )
 
-// verifyKeyHex is the Ed25519 verify key of the Mercure Technologies Keygen
-// account (dashboard > Settings > Ed25519 Verify Key). It is public by
-// nature; only Keygen holds the matching signing key.
-var verifyKeyHex = "55575e10d6b6857c295895e05e06671bebdcf99aaa9b1a17c1538c32360984bf"
+// PlanEnterprise is the only plan code this deployment accepts.
+const PlanEnterprise = "enterprise"
 
-const keyPrefix = "key/"
-
-// License is the payload embedded in a signed Keygen license key.
+// License is the descriptive payload of an attached license, as returned by
+// the license server.
 type License struct {
-	LicenseID string
-	ProductID string
-	PolicyID  string
-	Created   time.Time
-	Expiry    *time.Time // nil means the license never expires
+	OrgName               string
+	PlanCode              string
+	SubscriptionStartAt   time.Time
+	SubscriptionEndAt     *time.Time // nil means no end date
+	SubscriptionRenewalAt *time.Time
 }
-
-func (l *License) Expired() bool {
-	return l.Expiry != nil && time.Now().After(*l.Expiry)
-}
-
-var (
-	ErrNoVerifyKey      = errors.New("licensing: no verify key configured in this build")
-	ErrMalformedKey     = errors.New("licensing: malformed license key")
-	ErrInvalidSignature = errors.New("licensing: invalid signature")
-	ErrExpired          = errors.New("licensing: license key is expired")
-)
 
 var (
 	mu      sync.RWMutex
 	current *License
 )
 
-// keygenDataset mirrors the JSON dataset Keygen embeds in ED25519_SIGN keys.
-type keygenDataset struct {
-	Account struct {
-		ID string `json:"id"`
-	} `json:"account"`
-	Product struct {
-		ID string `json:"id"`
-	} `json:"product"`
-	Policy struct {
-		ID       string `json:"id"`
-		Duration *int64 `json:"duration"`
-	} `json:"policy"`
-	License struct {
-		ID      string     `json:"id"`
-		Created time.Time  `json:"created"`
-		Expiry  *time.Time `json:"expiry"`
-	} `json:"license"`
-}
-
-// b64urlDecode accepts both raw and padded base64url, since encoders differ.
-func b64urlDecode(s string) ([]byte, error) {
-	if decoded, err := base64.RawURLEncoding.DecodeString(strings.TrimRight(s, "=")); err == nil {
-		return decoded, nil
-	}
-	return base64.URLEncoding.DecodeString(s)
-}
-
-// Parse verifies the signature of a license key and returns its payload.
-// It does not check expiration; Activate does.
-func Parse(key string) (*License, error) {
-	if verifyKeyHex == "" {
-		return nil, ErrNoVerifyKey
-	}
-	pub, err := hex.DecodeString(verifyKeyHex)
-	if err != nil || len(pub) != ed25519.PublicKeySize {
-		return nil, ErrNoVerifyKey
-	}
-	key = strings.TrimSpace(key)
-	if !strings.HasPrefix(key, keyPrefix) {
-		return nil, ErrMalformedKey
-	}
-	parts := strings.SplitN(strings.TrimPrefix(key, keyPrefix), ".", 2)
-	if len(parts) != 2 {
-		return nil, ErrMalformedKey
-	}
-	sig, err := b64urlDecode(parts[1])
-	if err != nil {
-		return nil, ErrMalformedKey
-	}
-	if !ed25519.Verify(ed25519.PublicKey(pub), []byte(keyPrefix+parts[0]), sig) {
-		return nil, ErrInvalidSignature
-	}
-	payload, err := b64urlDecode(parts[0])
-	if err != nil {
-		return nil, ErrMalformedKey
-	}
-	var dataset keygenDataset
-	if err := json.Unmarshal(payload, &dataset); err != nil {
-		return nil, ErrMalformedKey
-	}
-	return &License{
-		LicenseID: dataset.License.ID,
-		ProductID: dataset.Product.ID,
-		PolicyID:  dataset.Policy.ID,
-		Created:   dataset.License.Created,
-		Expiry:    dataset.License.Expiry,
-	}, nil
-}
-
-// Activate verifies a key and, if valid and unexpired, makes it the active
-// license for this process.
-func Activate(key string) (*License, error) {
-	l, err := Parse(key)
-	if err != nil {
-		return nil, err
-	}
-	if l.Expired() {
-		return nil, ErrExpired
-	}
+// Activate makes l the active license for this process.
+func Activate(l License) {
 	mu.Lock()
-	current = l
+	current = &l
 	mu.Unlock()
-	return l, nil
 }
 
-// Deactivate clears the active license (e.g. when the stored key is removed).
+// Deactivate clears the active license (community edition).
 func Deactivate() {
 	mu.Lock()
 	current = nil
@@ -149,17 +44,14 @@ func Deactivate() {
 }
 
 // Current returns the active license, or nil when running as community
-// edition (no key, or the active key has expired).
+// edition.
 func Current() *License {
 	mu.RLock()
 	defer mu.RUnlock()
-	if current == nil || current.Expired() {
-		return nil
-	}
 	return current
 }
 
-// IsEnterprise reports whether a valid, unexpired license is active.
+// IsEnterprise reports whether a license is active.
 func IsEnterprise() bool {
 	return Current() != nil
 }

--- a/ee/licensing/licensing_test.go
+++ b/ee/licensing/licensing_test.go
@@ -5,139 +5,60 @@
 package licensing
 
 import (
-	"crypto/ed25519"
-	"encoding/base64"
-	"encoding/hex"
-	"encoding/json"
-	"errors"
-	"fmt"
-	"strings"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func setupTestKeypair(t *testing.T) ed25519.PrivateKey {
-	t.Helper()
-	pub, priv, err := ed25519.GenerateKey(nil)
-	if err != nil {
-		t.Fatal(err)
+func acmeLicense() License {
+	renewal := time.Date(2027, 1, 1, 0, 0, 0, 0, time.UTC)
+	return License{
+		OrgName:               "Acme Corp",
+		PlanCode:              "enterprise",
+		SubscriptionStartAt:   time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		SubscriptionRenewalAt: &renewal,
 	}
-	previous := verifyKeyHex
-	verifyKeyHex = hex.EncodeToString(pub)
-	t.Cleanup(func() {
-		verifyKeyHex = previous
-		Deactivate()
-	})
-	return priv
 }
 
-// signTestKey builds a key in Keygen's ED25519_SIGN format: the signature
-// covers the literal string "key/" + base64url(dataset).
-func signTestKey(t *testing.T, priv ed25519.PrivateKey, expiry *time.Time) string {
-	t.Helper()
-	dataset := keygenDataset{}
-	dataset.Account.ID = "b3195b02-fde3-4cf5-9279-e55751e41005"
-	dataset.Product.ID = "11e753b3-9f14-4f5a-90de-e1962ba62be8"
-	dataset.Policy.ID = "4d9663af-1f29-47f5-9bb2-8905c7cbdba7"
-	dataset.License.ID = "6e5b1b1d-2a11-4b64-8de0-d160b81a0301"
-	dataset.License.Created = time.Now().UTC()
-	dataset.License.Expiry = expiry
-	payload, err := json.Marshal(dataset)
-	if err != nil {
-		t.Fatal(err)
-	}
-	encoded := base64.RawURLEncoding.EncodeToString(payload)
-	sig := ed25519.Sign(priv, []byte("key/"+encoded))
-	return fmt.Sprintf("key/%s.%s", encoded, base64.RawURLEncoding.EncodeToString(sig))
-}
+func TestActivateDeactivateCurrent(t *testing.T) {
+	t.Cleanup(Deactivate)
 
-func in(d time.Duration) *time.Time {
-	at := time.Now().Add(d)
-	return &at
-}
-
-func TestActivateValidKey(t *testing.T) {
-	priv := setupTestKeypair(t)
-	key := signTestKey(t, priv, in(24*time.Hour))
-	l, err := Activate(key)
-	if err != nil {
-		t.Fatalf("expected activation to succeed, got %v", err)
-	}
-	if l.LicenseID != "6e5b1b1d-2a11-4b64-8de0-d160b81a0301" {
-		t.Fatalf("unexpected payload: %+v", l)
-	}
-	if !IsEnterprise() {
-		t.Fatal("expected IsEnterprise to be true after activation")
-	}
 	Deactivate()
-	if IsEnterprise() {
-		t.Fatal("expected IsEnterprise to be false after deactivation")
-	}
+	assert.Nil(t, Current())
+	assert.False(t, IsEnterprise())
+
+	Activate(acmeLicense())
+	require.NotNil(t, Current())
+	assert.Equal(t, "Acme Corp", Current().OrgName)
+	assert.Equal(t, "enterprise", Current().PlanCode)
+	assert.True(t, IsEnterprise())
+
+	Deactivate()
+	assert.Nil(t, Current())
+	assert.False(t, IsEnterprise())
 }
 
-func TestActivatePerpetualKey(t *testing.T) {
-	priv := setupTestKeypair(t)
-	key := signTestKey(t, priv, nil)
-	l, err := Activate(key)
-	if err != nil {
-		t.Fatalf("expected activation to succeed, got %v", err)
-	}
-	if l.Expiry != nil || l.Expired() {
-		t.Fatalf("expected perpetual license, got %+v", l)
-	}
-}
+func TestLicenseStatusGraceWindow(t *testing.T) {
+	license := acmeLicense()
 
-func TestRejectsTamperedKey(t *testing.T) {
-	priv := setupTestKeypair(t)
-	key := signTestKey(t, priv, in(24*time.Hour))
-	other := signTestKey(t, priv, in(48*time.Hour))
-	// Graft other's dataset onto key's signature. Each part is genuine on its
-	// own, the datasets are guaranteed to differ (24h vs 48h expiry), so
-	// only signature verification over the full payload catches the mix.
-	dataset := strings.SplitN(strings.TrimPrefix(other, keyPrefix), ".", 2)[0]
-	signature := strings.SplitN(strings.TrimPrefix(key, keyPrefix), ".", 2)[1]
-	tampered := keyPrefix + dataset + "." + signature
-	if _, err := Activate(tampered); !errors.Is(err, ErrInvalidSignature) {
-		t.Fatalf("expected ErrInvalidSignature for tampered key, got %v", err)
-	}
-	if IsEnterprise() {
-		t.Fatal("expected no active license after rejected activation")
-	}
-}
+	healthy := LicenseStatus{HasKey: true, License: &license}
+	assert.True(t, healthy.Valid())
+	assert.False(t, healthy.Suspended())
+	assert.Nil(t, healthy.GraceDeadline())
 
-func TestRejectsKeyFromWrongSigningKey(t *testing.T) {
-	setupTestKeypair(t)
-	_, otherPriv, err := ed25519.GenerateKey(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	key := signTestKey(t, otherPriv, in(24*time.Hour))
-	if _, err := Activate(key); !errors.Is(err, ErrInvalidSignature) {
-		t.Fatalf("expected ErrInvalidSignature, got %v", err)
-	}
-}
+	failedRecently := time.Now().Add(-time.Hour)
+	inGrace := LicenseStatus{HasKey: true, License: &license, ValidationFailedAt: &failedRecently}
+	assert.True(t, inGrace.Valid(), "a license failing for an hour is still in its grace window")
+	assert.False(t, inGrace.Suspended())
+	require.NotNil(t, inGrace.GraceDeadline())
+	assert.WithinDuration(t, failedRecently.Add(GracePeriod), *inGrace.GraceDeadline(), time.Second)
 
-func TestRejectsExpiredKey(t *testing.T) {
-	priv := setupTestKeypair(t)
-	key := signTestKey(t, priv, in(-time.Hour))
-	if _, err := Activate(key); !errors.Is(err, ErrExpired) {
-		t.Fatalf("expected ErrExpired, got %v", err)
-	}
-}
+	failedLongAgo := time.Now().Add(-GracePeriod - time.Hour)
+	suspended := LicenseStatus{HasKey: true, License: &license, ValidationFailedAt: &failedLongAgo}
+	assert.False(t, suspended.Valid())
+	assert.True(t, suspended.Suspended())
 
-func TestRejectsKeyWithoutPrefix(t *testing.T) {
-	priv := setupTestKeypair(t)
-	key := signTestKey(t, priv, in(24*time.Hour))
-	if _, err := Parse(key[len("key/"):]); !errors.Is(err, ErrMalformedKey) {
-		t.Fatalf("expected ErrMalformedKey, got %v", err)
-	}
-}
-
-func TestNoVerifyKeyConfigured(t *testing.T) {
-	previous := verifyKeyHex
-	verifyKeyHex = ""
-	t.Cleanup(func() { verifyKeyHex = previous })
-	if _, err := Parse("key/whatever.sig"); !errors.Is(err, ErrNoVerifyKey) {
-		t.Fatalf("expected ErrNoVerifyKey, got %v", err)
-	}
+	assert.False(t, LicenseStatus{}.Valid(), "no key means community edition")
 }

--- a/ee/licensing/service.go
+++ b/ee/licensing/service.go
@@ -98,7 +98,7 @@ type LicenseService struct {
 // then answers ErrLicenseRequiresControlPlane.
 func NewLicenseService(repo LicenseRepository, client *Client, instanceId string, baseUrl string) *LicenseService {
 	// The server matches baseUrl by exact string equality.
-	return &LicenseService{repo: repo, client: client, instanceId: instanceId, baseUrl: strings.TrimSuffix(baseUrl, "/")}
+	return &LicenseService{repo: repo, client: client, instanceId: instanceId, baseUrl: strings.TrimRight(baseUrl, "/")}
 }
 
 // SetOnAuditEvent plugs the audit emission seam. Nil-safe.

--- a/ee/licensing/service.go
+++ b/ee/licensing/service.go
@@ -8,58 +8,97 @@ import (
 	"context"
 	"errors"
 	"log"
+	"strings"
 	"time"
 	"xprem/internal/auditlog"
+	"xprem/internal/cache"
 	"xprem/internal/services"
+	"xprem/internal/version"
 )
 
-// StoredLicense is the persisted license key row, plus when it was last
-// written (i.e. when the key was activated on this deployment).
+// GracePeriod is how long a failing license keeps enterprise features on.
+const GracePeriod = 7 * 24 * time.Hour
+
+const (
+	validateInterval = 15 * time.Minute
+	validateLockKey  = "license-validate-lock"
+	// Shorter than the interval so the next tick can always reclaim the lock.
+	validateLockTTLSeconds = 840
+)
+
+// StoredLicense is the persisted activation, without the activation secret
+// (see LicenseRepository.GetActivationSecret).
 type StoredLicense struct {
-	Key       string
-	UpdatedAt time.Time
+	Key                 string
+	License             License
+	ActivatedAt         time.Time
+	LastValidatedAt     *time.Time
+	ValidationFailedAt  *time.Time
+	ValidationErrorCode string
 }
 
 // LicenseRepository is the enterprise_license table, a single row holding the
-// key. It has no bucket implementation on purpose: license activation only
-// exists on the control plane, stateless deployments run community edition.
+// activation.
 type LicenseRepository interface {
-	// GetLicense returns nil (no error) when no key has been stored yet.
+	// GetLicense returns nil (no error) when no license has been attached.
 	GetLicense(ctx context.Context) (*StoredLicense, error)
-	UpsertLicense(ctx context.Context, key string) (StoredLicense, error)
+	GetActivationSecret(ctx context.Context) (string, error)
+	SaveActivation(ctx context.Context, key string, activationSecret string, license License) (StoredLicense, error)
+	MarkValidated(ctx context.Context, license License) (StoredLicense, error)
+	// MarkValidationFailed keeps the first failure timestamp on repeats.
+	MarkValidationFailed(ctx context.Context, errorCode string) (StoredLicense, error)
 	DeleteLicense(ctx context.Context) error
 }
 
 // ErrLicenseRequiresControlPlane is answered by every method when the service
-// was built without a repository (stateless mode), mapped to a 400 by the
-// handler.
+// was built without a repository (stateless mode).
 var ErrLicenseRequiresControlPlane = errors.New("the enterprise license is managed in the database: this deployment runs in stateless mode, which is community edition only")
 
-// LicenseStatus describes the stored key and what it unlocks. License is set
-// whenever the key's signature verifies, including for an expired license, so
-// the dashboard can show *when* it expired. Err carries the reason the key is
-// not usable (malformed, bad signature, expired); a valid active license has
-// License != nil and Err == nil.
+// LicenseStatus describes the stored activation and what it unlocks.
 type LicenseStatus struct {
-	HasKey      bool
-	License     *License
-	ActivatedAt time.Time
-	Err         error
+	HasKey              bool
+	License             *License
+	ActivatedAt         time.Time
+	LastValidatedAt     *time.Time
+	ValidationFailedAt  *time.Time
+	ValidationErrorCode string
 }
 
+// GraceDeadline is when the failing license drops, nil while validation holds.
+func (s LicenseStatus) GraceDeadline() *time.Time {
+	if s.ValidationFailedAt == nil {
+		return nil
+	}
+	deadline := s.ValidationFailedAt.Add(GracePeriod)
+	return &deadline
+}
+
+// Suspended reports whether the grace window is exhausted.
+func (s LicenseStatus) Suspended() bool {
+	deadline := s.GraceDeadline()
+	return deadline != nil && time.Now().After(*deadline)
+}
+
+// Valid reports whether enterprise features are on.
 func (s LicenseStatus) Valid() bool {
-	return s.License != nil && s.Err == nil
+	return s.HasKey && !s.Suspended()
 }
 
-// LicenseService owns the stored enterprise license key: it verifies keys
-// before persisting them and keeps the process-wide activation state
-// (licensing.IsEnterprise) in sync with the database.
+// LicenseService owns the stored activation and keeps the process-wide
+// activation state in sync with the database.
 type LicenseService struct {
-	repo LicenseRepository
-	// onAuditEvent is the audit emission seam; nil means license changes
-	// leave no events. Only the admin-called Activate/Remove emit, the boot
-	// load and the sync poll are state convergence, not actions.
+	repo         LicenseRepository
+	client       *Client
+	instanceId   string
+	baseUrl      string
 	onAuditEvent auditlog.RecordFunc
+}
+
+// NewLicenseService accepts a nil repository (stateless mode); every method
+// then answers ErrLicenseRequiresControlPlane.
+func NewLicenseService(repo LicenseRepository, client *Client, instanceId string, baseUrl string) *LicenseService {
+	// The server matches baseUrl by exact string equality.
+	return &LicenseService{repo: repo, client: client, instanceId: instanceId, baseUrl: strings.TrimSuffix(baseUrl, "/")}
 }
 
 // SetOnAuditEvent plugs the audit emission seam. Nil-safe.
@@ -67,8 +106,6 @@ func (s *LicenseService) SetOnAuditEvent(record auditlog.RecordFunc) {
 	s.onAuditEvent = record
 }
 
-// recordLicenseEvent reports an admin license action, actor = the admin
-// principal on the request context (both routes are admin-gated).
 func (s *LicenseService) recordLicenseEvent(ctx context.Context, action auditlog.Action, metadata map[string]any) {
 	if s.onAuditEvent == nil {
 		return
@@ -92,30 +129,57 @@ func (s *LicenseService) recordLicenseEvent(ctx context.Context, action auditlog
 	})
 }
 
-// NewLicenseService accepts a nil repository (stateless mode); every method
-// then answers ErrLicenseRequiresControlPlane.
-func NewLicenseService(repo LicenseRepository) *LicenseService {
-	return &LicenseService{repo: repo}
+func (s *LicenseService) recordSuspendedEvent(ctx context.Context, errorCode string) {
+	if s.onAuditEvent == nil {
+		return
+	}
+	s.onAuditEvent(ctx, auditlog.Event{
+		ActorType:    auditlog.ActorSystem,
+		ActorID:      "license-validation",
+		ActorDisplay: "license validation",
+		Action:       auditlog.ActionLicenseSuspended,
+		TargetType:   "license",
+		TargetID:     "license",
+		Outcome:      auditlog.OutcomeSuccess,
+		Metadata:     map[string]any{"error_code": errorCode},
+	})
 }
 
 func (s *LicenseService) statusOf(stored *StoredLicense) LicenseStatus {
 	if stored == nil {
 		return LicenseStatus{}
 	}
-	status := LicenseStatus{HasKey: true, ActivatedAt: stored.UpdatedAt}
-	license, err := Parse(stored.Key)
-	if err != nil {
-		status.Err = err
-		return status
+	license := stored.License
+	return LicenseStatus{
+		HasKey:              true,
+		License:             &license,
+		ActivatedAt:         stored.ActivatedAt,
+		LastValidatedAt:     stored.LastValidatedAt,
+		ValidationFailedAt:  stored.ValidationFailedAt,
+		ValidationErrorCode: stored.ValidationErrorCode,
 	}
-	status.License = license
-	if license.Expired() {
-		status.Err = ErrExpired
-	}
-	return status
 }
 
-// Status reports on the stored key without touching the activation state.
+func applyStatus(status LicenseStatus) {
+	if status.Valid() {
+		Activate(*status.License)
+	} else {
+		Deactivate()
+	}
+}
+
+func (s *LicenseService) keyParams(key string) KeyParams {
+	return KeyParams{
+		InstanceId: s.instanceId,
+		LicenseKey: key,
+		BaseUrl:    s.baseUrl,
+		Version:    version.Version,
+	}
+}
+
+var ErrInstanceIdUnavailable = errors.New("licensing: the server instance id is unavailable, see the boot logs")
+
+// Status reports on the stored activation without touching anything.
 func (s *LicenseService) Status(ctx context.Context) (LicenseStatus, error) {
 	if s.repo == nil {
 		return LicenseStatus{}, ErrLicenseRequiresControlPlane
@@ -127,37 +191,63 @@ func (s *LicenseService) Status(ctx context.Context) (LicenseStatus, error) {
 	return s.statusOf(stored), nil
 }
 
-// Activate verifies a key, persists it as the deployment's license and makes
-// it the active license for this process. An invalid or expired key is
-// rejected without overwriting the stored one.
-func (s *LicenseService) Activate(ctx context.Context, key string) (LicenseStatus, error) {
+func planSupported(l License) bool {
+	return strings.EqualFold(l.PlanCode, PlanEnterprise)
+}
+
+// Check asks the license server whether a key is usable, without consuming it.
+func (s *LicenseService) Check(ctx context.Context, key string) (CheckResult, error) {
+	if s.repo == nil {
+		return CheckResult{}, ErrLicenseRequiresControlPlane
+	}
+	if s.instanceId == "" {
+		return CheckResult{}, ErrInstanceIdUnavailable
+	}
+	result, err := s.client.Check(ctx, s.keyParams(key))
+	if err != nil {
+		return CheckResult{}, err
+	}
+	if result.Valid && !planSupported(*result.License) {
+		return CheckResult{ErrorCode: CodePlanNotSupported}, nil
+	}
+	return result, nil
+}
+
+// Attach checks the key, then consumes it on the license server and persists
+// the activation.
+func (s *LicenseService) Attach(ctx context.Context, key string) (LicenseStatus, error) {
 	if s.repo == nil {
 		return LicenseStatus{}, ErrLicenseRequiresControlPlane
 	}
-	license, err := Parse(key)
+	if s.instanceId == "" {
+		return LicenseStatus{}, ErrInstanceIdUnavailable
+	}
+	check, err := s.Check(ctx, key)
 	if err != nil {
 		return LicenseStatus{}, err
 	}
-	if license.Expired() {
-		return LicenseStatus{}, ErrExpired
+	if !check.Valid {
+		return LicenseStatus{}, &DecisionError{Code: check.ErrorCode}
 	}
-	stored, err := s.repo.UpsertLicense(ctx, key)
+	activation, err := s.client.Attach(ctx, s.keyParams(key))
 	if err != nil {
 		return LicenseStatus{}, err
 	}
-	if _, err := Activate(key); err != nil {
-		// Unreachable in practice: the key just parsed and is not expired.
+	// The attach consumed the single-use key server-side; a cancelled request
+	// must not lose the only copy of the activation secret.
+	stored, err := s.repo.SaveActivation(context.WithoutCancel(ctx), key, activation.ActivationSecret, activation.License)
+	if err != nil {
 		return LicenseStatus{}, err
 	}
-	metadata := map[string]any{"license_id": license.LicenseID}
-	if license.Expiry != nil {
-		metadata["expires_at"] = license.Expiry.Format(time.RFC3339)
-	}
-	s.recordLicenseEvent(ctx, auditlog.ActionLicenseActivated, metadata)
-	return LicenseStatus{HasKey: true, License: license, ActivatedAt: stored.UpdatedAt}, nil
+	Activate(stored.License)
+	s.recordLicenseEvent(ctx, auditlog.ActionLicenseActivated, map[string]any{
+		"org":       stored.License.OrgName,
+		"plan_code": stored.License.PlanCode,
+	})
+	return s.statusOf(&stored), nil
 }
 
-// Remove deletes the stored key and drops back to community edition.
+// Remove deletes the stored activation and drops back to community edition.
 func (s *LicenseService) Remove(ctx context.Context) error {
 	if s.repo == nil {
 		return ErrLicenseRequiresControlPlane
@@ -165,17 +255,15 @@ func (s *LicenseService) Remove(ctx context.Context) error {
 	if err := s.repo.DeleteLicense(ctx); err != nil {
 		return err
 	}
-	// Emitted before Deactivate: dropping to community closes the recorder's
-	// license gate, and the removal must be the last entry it lets through.
+	// Emitted before Deactivate, which closes the recorder's license gate.
 	s.recordLicenseEvent(ctx, auditlog.ActionLicenseRemoved, nil)
 	Deactivate()
 	return nil
 }
 
-// ActivateFromStore loads the stored key at boot and activates it when valid.
-// A missing, invalid or expired key means community edition, never a boot
-// failure, so it only returns infrastructure errors (database unreachable).
-// Steady-state changes are picked up by StartSync afterwards.
+// ActivateFromStore loads the stored activation at boot; it only returns
+// infrastructure errors, a missing or suspended activation means community
+// edition.
 func (s *LicenseService) ActivateFromStore(ctx context.Context) error {
 	if s.repo == nil {
 		return nil
@@ -184,30 +272,134 @@ func (s *LicenseService) ActivateFromStore(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	if stored == nil {
-		log.Println("🏘️  [LICENSE] No enterprise license key stored, running community edition")
-		return nil
-	}
-	license, err := Activate(stored.Key)
-	if err != nil {
-		log.Printf("⚠️  [LICENSE] Stored enterprise license key is not usable (%v), running community edition", err)
-		return nil
-	}
-	if license.Expiry != nil {
-		log.Printf("🏢 [LICENSE] Enterprise edition enabled (license %s, expires %s)", license.LicenseID, license.Expiry.UTC().Format(time.RFC3339))
-	} else {
-		log.Printf("🏢 [LICENSE] Enterprise edition enabled (license %s, perpetual)", license.LicenseID)
+	status := s.statusOf(stored)
+	applyStatus(status)
+	switch {
+	case stored == nil:
+		log.Println("🏘️  [LICENSE] No enterprise license attached, running community edition")
+	case status.Suspended():
+		log.Printf("⚠️  [LICENSE] The enterprise license has not been verifiable since %s (%s) and the grace period is over, running community edition. Contact support@xprem.dev.", stored.ValidationFailedAt.UTC().Format(time.RFC3339), stored.ValidationErrorCode)
+	case status.ValidationFailedAt != nil:
+		log.Printf("⚠️  [LICENSE] Enterprise edition enabled, but the license could not be verified since %s (%s); it drops on %s. Contact support@xprem.dev.", stored.ValidationFailedAt.UTC().Format(time.RFC3339), stored.ValidationErrorCode, status.GraceDeadline().UTC().Format(time.RFC3339))
+	default:
+		log.Printf("🏢 [LICENSE] Enterprise edition enabled (%s, %s plan)", stored.License.OrgName, stored.License.PlanCode)
 	}
 	return nil
 }
 
-// StartSync keeps IsEnterprise() honest on replicas that did not serve the
-// dashboard request that changed the license: the in-process activation state
-// is otherwise only written at boot and by the replica handling the
-// activation/removal, so the others would drift until their next restart.
-// The reconciliation is a primary-key read on a one-row table, so a short
-// interval costs nothing. No-op in stateless mode; runs until ctx is
-// cancelled.
+// ValidateNow re-checks the stored activation against the license server and
+// persists the outcome.
+func (s *LicenseService) ValidateNow(ctx context.Context) {
+	if s.repo == nil {
+		return
+	}
+	stored, err := s.repo.GetLicense(ctx)
+	if err != nil {
+		log.Printf("⚠️  [LICENSE] Could not read the enterprise license from the database: %v", err)
+		return
+	}
+	if stored == nil {
+		return
+	}
+	// Local problems must not start the grace window.
+	if s.instanceId == "" {
+		log.Println("⚠️  [LICENSE] Skipping license validation: the server instance id is unavailable, see the boot logs")
+		return
+	}
+	activationSecret, err := s.repo.GetActivationSecret(ctx)
+	if err != nil {
+		log.Printf("⚠️  [LICENSE] Skipping license validation: %v", err)
+		return
+	}
+	wasFailing := stored.ValidationFailedAt != nil
+	license, err := s.client.Validate(ctx, ValidateParams{
+		InstanceId:       s.instanceId,
+		ActivationSecret: activationSecret,
+		BaseUrl:          s.baseUrl,
+	})
+	if err == nil && !planSupported(*license) {
+		err = &DecisionError{Code: CodePlanNotSupported}
+	}
+	if err == nil {
+		updated, repoErr := s.repo.MarkValidated(ctx, *license)
+		if repoErr != nil {
+			log.Printf("⚠️  [LICENSE] Could not persist the license validation: %v", repoErr)
+			return
+		}
+		applyStatus(s.statusOf(&updated))
+		if wasFailing {
+			log.Println("🏢 [LICENSE] Enterprise license verification recovered")
+		}
+		return
+	}
+
+	// A cancelled context is a shutdown, not a license decision.
+	if ctx.Err() != nil {
+		return
+	}
+	code := CodeServerUnreachable
+	if errors.Is(err, ErrServerRejected) {
+		code = CodeServerRejected
+	}
+	var refusal *DecisionError
+	if errors.As(err, &refusal) {
+		code = refusal.Code
+	}
+	updated, repoErr := s.repo.MarkValidationFailed(ctx, code)
+	if repoErr != nil {
+		log.Printf("⚠️  [LICENSE] License validation failed (%v) and the failure could not be persisted: %v", err, repoErr)
+		return
+	}
+	status := s.statusOf(&updated)
+	if status.Suspended() {
+		if IsEnterprise() {
+			log.Printf("🚨 [LICENSE] The enterprise license could not be verified for %d days (%s), dropping to community edition. Contact support@xprem.dev.", int(GracePeriod.Hours()/24), code)
+			// Before Deactivate: the gate must still be open.
+			s.recordSuspendedEvent(ctx, code)
+		}
+		Deactivate()
+		return
+	}
+	if deadline := status.GraceDeadline(); deadline != nil {
+		log.Printf("⚠️  [LICENSE] Could not verify the enterprise license (%s); enterprise features stay on until %s. Contact support@xprem.dev if this persists.", code, deadline.UTC().Format(time.RFC3339))
+	}
+}
+
+// StartValidationLoop re-validates now and then every 15 minutes until ctx is
+// cancelled; the cache lock keeps it to one validation per interval.
+func (s *LicenseService) StartValidationLoop(ctx context.Context) {
+	if s.repo == nil {
+		return
+	}
+	go func() {
+		s.validateWithLock(ctx)
+		ticker := time.NewTicker(validateInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				s.validateWithLock(ctx)
+			}
+		}
+	}()
+}
+
+func (s *LicenseService) validateWithLock(ctx context.Context) {
+	locked, err := cache.GetCache().TryLock(validateLockKey, validateLockTTLSeconds)
+	if err != nil {
+		// A broken lock backend must not silently stop validation; a duplicate
+		// run is harmless.
+		log.Printf("⚠️  [LICENSE] Could not take the validation lock, validating anyway: %v", err)
+	} else if !locked {
+		return
+	}
+	s.ValidateNow(ctx)
+}
+
+// StartSync reconciles the in-process activation state with the stored row
+// until ctx is cancelled.
 func (s *LicenseService) StartSync(ctx context.Context, interval time.Duration) {
 	if s.repo == nil {
 		return
@@ -226,18 +418,6 @@ func (s *LicenseService) StartSync(ctx context.Context, interval time.Duration) 
 	}()
 }
 
-func equalExpiry(a, b *time.Time) bool {
-	if a == nil || b == nil {
-		return a == b
-	}
-	return a.Equal(*b)
-}
-
-// syncFromStore reconciles the process-wide activation state with the stored
-// key. Re-activation is unconditional when the stored key verifies, one
-// Ed25519 check per interval is negligible and it also propagates renewals
-// (same license id, new expiry), but transitions are only logged when the
-// active license actually changed, so the loop stays silent in steady state.
 func (s *LicenseService) syncFromStore(ctx context.Context) {
 	stored, err := s.repo.GetLicense(ctx)
 	if err != nil {
@@ -245,24 +425,22 @@ func (s *LicenseService) syncFromStore(ctx context.Context) {
 		return
 	}
 	previous := Current()
-	if stored == nil {
-		Deactivate()
-		if previous != nil {
+	status := s.statusOf(stored)
+	// Emitted before applyStatus: deactivating closes the recorder's license
+	// gate. The validation loop only observes the deadline every 15 minutes,
+	// so the suspension is usually first seen here.
+	if previous != nil && stored != nil && status.Suspended() {
+		s.recordSuspendedEvent(ctx, stored.ValidationErrorCode)
+	}
+	applyStatus(status)
+	if previous == nil && status.Valid() {
+		log.Printf("🏢 [LICENSE] Enterprise license synced from the database (%s)", status.License.OrgName)
+	}
+	if previous != nil && !status.Valid() {
+		if stored == nil {
 			log.Println("🏘️  [LICENSE] Enterprise license removed from the database, dropping to community edition")
+		} else {
+			log.Printf("🚨 [LICENSE] Enterprise license suspended (%s), dropping to community edition. Contact support@xprem.dev.", stored.ValidationErrorCode)
 		}
-		return
-	}
-	license, err := Activate(stored.Key)
-	if err != nil {
-		// Activate leaves the previous state untouched on failure, so an
-		// unusable stored key must drop the in-memory license explicitly.
-		Deactivate()
-		if previous != nil {
-			log.Printf("⚠️  [LICENSE] Stored enterprise license key is no longer usable (%v), dropping to community edition", err)
-		}
-		return
-	}
-	if previous == nil || previous.LicenseID != license.LicenseID || !equalExpiry(previous.Expiry, license.Expiry) {
-		log.Printf("🏢 [LICENSE] Enterprise license %s synced from the database", license.LicenseID)
 	}
 }

--- a/ee/licensing/service_audit_test.go
+++ b/ee/licensing/service_audit_test.go
@@ -6,6 +6,7 @@ package licensing
 
 import (
 	"context"
+	"net/http"
 	"testing"
 	"time"
 	"xprem/internal/auditlog"
@@ -15,13 +16,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// The recorder mirrors audit.AuditService.Record's license gate (an event
-// emitted after the gate closed is dropped) with a LOCAL func rather than the
-// real AuditService: this package must not import ee/audit, which imports
-// ee/licensing back (the gate lives in EE code by design), so pulling the real
-// service in here would be an import cycle. The behavior under test is
-// licensing's own ordering (emit BEFORE Deactivate), and the local gate
-// reproduces exactly what would drop a mis-ordered event.
+// gatedRecorder mirrors the audit service's license gate locally (importing
+// ee/audit here would be an import cycle).
 func gatedRecorder(recorded *[]auditlog.Event) auditlog.RecordFunc {
 	return func(_ context.Context, event auditlog.Event) {
 		if IsEnterprise() {
@@ -30,16 +26,20 @@ func gatedRecorder(recorded *[]auditlog.Event) auditlog.RecordFunc {
 	}
 }
 
-func TestActivateAndRemoveEmitAuditEvents(t *testing.T) {
-	priv := setupTestKeypair(t)
-	service := NewLicenseService(&fakeLicenseRepo{})
+func TestAttachAndRemoveEmitAuditEvents(t *testing.T) {
+	fake := &fakeLicenseServer{
+		check: checkAnswersValidAcme,
+		attach: func(w http.ResponseWriter, r *http.Request) {
+			writeJSONBody(w, http.StatusOK, `{"isActive": true, "activationSecret": "secret-42", "licenseInformations": `+acmeInformationsJSON+`}`)
+		},
+	}
+	service := newTestService(t, &fakeLicenseRepo{}, fake.client(t))
 	var recorded []auditlog.Event
 	service.SetOnAuditEvent(gatedRecorder(&recorded))
 	ctx := services.WithPrincipal(context.Background(),
 		&services.DashboardPrincipal{UserId: "admin-1", Email: "admin@example.com"})
 
-	expiry := time.Now().Add(365 * 24 * time.Hour).UTC()
-	_, err := service.Activate(ctx, signTestKey(t, priv, &expiry))
+	_, err := service.Attach(ctx, "XPREM-KEY")
 	require.NoError(t, err)
 
 	// The activation itself is recorded through the gate it just opened.
@@ -48,14 +48,61 @@ func TestActivateAndRemoveEmitAuditEvents(t *testing.T) {
 	assert.Equal(t, auditlog.ActionLicenseActivated, activated.Action)
 	assert.Equal(t, "admin-1", activated.ActorID)
 	assert.Equal(t, "admin@example.com", activated.ActorDisplay)
-	assert.NotEmpty(t, activated.Metadata["license_id"])
-	assert.NotEmpty(t, activated.Metadata["expires_at"])
+	assert.Equal(t, "Acme Corp", activated.Metadata["org"])
+	assert.Equal(t, "enterprise", activated.Metadata["plan_code"])
 
 	require.NoError(t, service.Remove(ctx))
 
-	// Emitted before Deactivate: the removal is the last entry the license
-	// gate lets through. A regression emitting after would drop it here.
+	// Emitted before Deactivate, so the gated recorder still sees it.
 	require.Len(t, recorded, 2)
 	assert.Equal(t, auditlog.ActionLicenseRemoved, recorded[1].Action)
 	assert.False(t, IsEnterprise())
+}
+
+func TestSuspensionEmitsSystemAuditEvent(t *testing.T) {
+	repo := repoWithAcme()
+	anchor := time.Now().Add(-GracePeriod - time.Hour).UTC()
+	repo.stored.ValidationFailedAt = &anchor
+
+	fake := &fakeLicenseServer{
+		validate: func(w http.ResponseWriter, r *http.Request) {
+			writeJSONBody(w, http.StatusBadRequest, `{"valid": false, "errorCode": "SUBSCRIPTION_INACTIVE"}`)
+		},
+	}
+	service := newTestService(t, repo, fake.client(t))
+	var recorded []auditlog.Event
+	service.SetOnAuditEvent(gatedRecorder(&recorded))
+	Activate(repo.stored.License)
+
+	service.ValidateNow(context.Background())
+
+	// Emitted before Deactivate, so the gated recorder still sees it.
+	require.Len(t, recorded, 1)
+	suspended := recorded[0]
+	assert.Equal(t, auditlog.ActionLicenseSuspended, suspended.Action)
+	assert.Equal(t, auditlog.ActorSystem, suspended.ActorType)
+	assert.Equal(t, CodeSubscriptionInactive, suspended.Metadata["error_code"])
+	assert.False(t, IsEnterprise())
+}
+
+func TestSyncEmitsSuspensionEventBeforeDroppingTheLicense(t *testing.T) {
+	repo := repoWithAcme()
+	anchor := time.Now().Add(-GracePeriod - time.Hour).UTC()
+	repo.stored.ValidationFailedAt = &anchor
+	repo.stored.ValidationErrorCode = CodeSubscriptionInactive
+	service := newTestService(t, repo, NewClient("http://127.0.0.1:1"))
+	var recorded []auditlog.Event
+	service.SetOnAuditEvent(gatedRecorder(&recorded))
+	Activate(repo.stored.License)
+
+	service.syncFromStore(context.Background())
+
+	// Emitted before applyStatus, so the gated recorder still sees it.
+	require.Len(t, recorded, 1)
+	assert.Equal(t, auditlog.ActionLicenseSuspended, recorded[0].Action)
+	assert.Equal(t, CodeSubscriptionInactive, recorded[0].Metadata["error_code"])
+	assert.False(t, IsEnterprise())
+
+	service.syncFromStore(context.Background())
+	assert.Len(t, recorded, 1, "an already-deactivated process must not re-emit the suspension")
 }

--- a/ee/licensing/service_test.go
+++ b/ee/licensing/service_test.go
@@ -7,29 +7,84 @@ package licensing
 import (
 	"context"
 	"errors"
+	"net/http"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // fakeLicenseRepo is an in-memory LicenseRepository mirroring the singleton
 // row of the enterprise_license table.
 type fakeLicenseRepo struct {
-	stored *StoredLicense
-	err    error
+	stored    *StoredLicense
+	secret    string
+	secretErr error
+	err       error
+	saveHook  func(ctx context.Context)
 }
 
 func (r *fakeLicenseRepo) GetLicense(ctx context.Context) (*StoredLicense, error) {
 	if r.err != nil {
 		return nil, r.err
 	}
-	return r.stored, nil
+	if r.stored == nil {
+		return nil, nil
+	}
+	snapshot := *r.stored
+	return &snapshot, nil
 }
 
-func (r *fakeLicenseRepo) UpsertLicense(ctx context.Context, key string) (StoredLicense, error) {
+func (r *fakeLicenseRepo) GetActivationSecret(ctx context.Context) (string, error) {
+	if r.err != nil {
+		return "", r.err
+	}
+	if r.secretErr != nil {
+		return "", r.secretErr
+	}
+	return r.secret, nil
+}
+
+func (r *fakeLicenseRepo) SaveActivation(ctx context.Context, key string, activationSecret string, license License) (StoredLicense, error) {
+	if r.saveHook != nil {
+		r.saveHook(ctx)
+	}
 	if r.err != nil {
 		return StoredLicense{}, r.err
 	}
-	r.stored = &StoredLicense{Key: key, UpdatedAt: time.Now().UTC()}
+	now := time.Now().UTC()
+	r.secret = activationSecret
+	r.stored = &StoredLicense{
+		Key:             key,
+		License:         license,
+		ActivatedAt:     now,
+		LastValidatedAt: &now,
+	}
+	return *r.stored, nil
+}
+
+func (r *fakeLicenseRepo) MarkValidated(ctx context.Context, license License) (StoredLicense, error) {
+	if r.err != nil {
+		return StoredLicense{}, r.err
+	}
+	now := time.Now().UTC()
+	r.stored.License = license
+	r.stored.LastValidatedAt = &now
+	r.stored.ValidationFailedAt = nil
+	r.stored.ValidationErrorCode = ""
+	return *r.stored, nil
+}
+
+func (r *fakeLicenseRepo) MarkValidationFailed(ctx context.Context, errorCode string) (StoredLicense, error) {
+	if r.err != nil {
+		return StoredLicense{}, r.err
+	}
+	if r.stored.ValidationFailedAt == nil {
+		now := time.Now().UTC()
+		r.stored.ValidationFailedAt = &now
+	}
+	r.stored.ValidationErrorCode = errorCode
 	return *r.stored, nil
 }
 
@@ -41,12 +96,45 @@ func (r *fakeLicenseRepo) DeleteLicense(ctx context.Context) error {
 	return nil
 }
 
+func newTestService(t *testing.T, repo LicenseRepository, client *Client) *LicenseService {
+	t.Helper()
+	Deactivate()
+	t.Cleanup(Deactivate)
+	return NewLicenseService(repo, client, "instance-1", "https://updates.example.com")
+}
+
+const proInformationsJSON = `{
+	"org": {"name": "Acme Corp"},
+	"planCode": "pro",
+	"subscription": {"startAt": "2026-01-01T00:00:00.000Z", "endAt": null, "renewalAt": null}
+}`
+
+func checkAnswersValidAcme(w http.ResponseWriter, r *http.Request) {
+	writeJSONBody(w, http.StatusOK, `{"valid": true, "licenseInformations": `+acmeInformationsJSON+`}`)
+}
+
+func repoWithAcme() *fakeLicenseRepo {
+	now := time.Now().UTC()
+	return &fakeLicenseRepo{
+		secret: "secret-42",
+		stored: &StoredLicense{
+			Key:             "XPREM-KEY",
+			License:         acmeLicense(),
+			ActivatedAt:     now.Add(-24 * time.Hour),
+			LastValidatedAt: &now,
+		},
+	}
+}
+
 func TestServiceStatelessModeAnswersControlPlaneError(t *testing.T) {
-	service := NewLicenseService(nil)
+	service := newTestService(t, nil, NewClient(""))
 	if _, err := service.Status(context.Background()); !errors.Is(err, ErrLicenseRequiresControlPlane) {
 		t.Fatalf("expected ErrLicenseRequiresControlPlane, got %v", err)
 	}
-	if _, err := service.Activate(context.Background(), "key/whatever"); !errors.Is(err, ErrLicenseRequiresControlPlane) {
+	if _, err := service.Check(context.Background(), "XPREM-KEY"); !errors.Is(err, ErrLicenseRequiresControlPlane) {
+		t.Fatalf("expected ErrLicenseRequiresControlPlane, got %v", err)
+	}
+	if _, err := service.Attach(context.Background(), "XPREM-KEY"); !errors.Is(err, ErrLicenseRequiresControlPlane) {
 		t.Fatalf("expected ErrLicenseRequiresControlPlane, got %v", err)
 	}
 	if err := service.Remove(context.Background()); !errors.Is(err, ErrLicenseRequiresControlPlane) {
@@ -55,181 +143,307 @@ func TestServiceStatelessModeAnswersControlPlaneError(t *testing.T) {
 	if err := service.ActivateFromStore(context.Background()); err != nil {
 		t.Fatalf("expected boot activation to be a no-op in stateless mode, got %v", err)
 	}
+	// Must not panic nor call the network.
+	service.ValidateNow(context.Background())
 }
 
-func TestServiceActivatePersistsAndEnablesEnterprise(t *testing.T) {
-	priv := setupTestKeypair(t)
+func TestAttachPersistsActivationAndEnablesEnterprise(t *testing.T) {
 	repo := &fakeLicenseRepo{}
-	service := NewLicenseService(repo)
+	fake := &fakeLicenseServer{
+		check: checkAnswersValidAcme,
+		attach: func(w http.ResponseWriter, r *http.Request) {
+			writeJSONBody(w, http.StatusOK, `{"isActive": true, "activationSecret": "secret-42", "licenseInformations": `+acmeInformationsJSON+`}`)
+		},
+	}
+	service := newTestService(t, repo, fake.client(t))
 
-	status, err := service.Activate(context.Background(), signTestKey(t, priv, in(24*time.Hour)))
-	if err != nil {
-		t.Fatalf("expected activation to succeed, got %v", err)
-	}
-	if !status.Valid() {
-		t.Fatalf("expected a valid status, got %+v", status)
-	}
-	if repo.stored == nil {
-		t.Fatal("expected the key to be persisted")
-	}
-	if !IsEnterprise() {
-		t.Fatal("expected IsEnterprise after activation")
-	}
+	status, err := service.Attach(context.Background(), "XPREM-KEY")
+	require.NoError(t, err)
+	assert.True(t, status.Valid())
+	require.NotNil(t, repo.stored)
+	assert.Equal(t, "XPREM-KEY", repo.stored.Key)
+	assert.Equal(t, "secret-42", repo.secret)
+	assert.Equal(t, "Acme Corp", repo.stored.License.OrgName)
+	assert.True(t, IsEnterprise())
 }
 
-func TestServiceActivateRejectsBadKeysWithoutPersisting(t *testing.T) {
-	priv := setupTestKeypair(t)
+func TestAttachRefusalLeavesStoreAndEditionUntouched(t *testing.T) {
 	repo := &fakeLicenseRepo{}
-	service := NewLicenseService(repo)
+	fake := &fakeLicenseServer{
+		check: func(w http.ResponseWriter, r *http.Request) {
+			writeJSONBody(w, http.StatusOK, `{"valid": false, "errorCode": "LICENSE_KEY_ALREADY_USED"}`)
+		},
+		attach: func(w http.ResponseWriter, r *http.Request) {
+			t.Error("attach must not be called for a key the check refused")
+		},
+	}
+	service := newTestService(t, repo, fake.client(t))
 
-	if _, err := service.Activate(context.Background(), "not-a-key"); !errors.Is(err, ErrMalformedKey) {
-		t.Fatalf("expected ErrMalformedKey, got %v", err)
-	}
-	if _, err := service.Activate(context.Background(), signTestKey(t, priv, in(-time.Hour))); !errors.Is(err, ErrExpired) {
-		t.Fatalf("expected ErrExpired, got %v", err)
-	}
-	if repo.stored != nil {
-		t.Fatal("expected no key to be persisted after rejected activations")
-	}
-	if IsEnterprise() {
-		t.Fatal("expected community edition after rejected activations")
-	}
+	_, err := service.Attach(context.Background(), "XPREM-KEY")
+	var refusal *DecisionError
+	require.ErrorAs(t, err, &refusal)
+	assert.Equal(t, CodeLicenseKeyAlreadyUsed, refusal.Code)
+	assert.Nil(t, repo.stored)
+	assert.False(t, IsEnterprise())
 }
 
-func TestServiceRemoveDropsToCommunity(t *testing.T) {
-	priv := setupTestKeypair(t)
+func TestCheckHasNoSideEffect(t *testing.T) {
 	repo := &fakeLicenseRepo{}
-	service := NewLicenseService(repo)
+	fake := &fakeLicenseServer{
+		check: func(w http.ResponseWriter, r *http.Request) {
+			writeJSONBody(w, http.StatusOK, `{"valid": true, "licenseInformations": `+acmeInformationsJSON+`}`)
+		},
+	}
+	service := newTestService(t, repo, fake.client(t))
 
-	if _, err := service.Activate(context.Background(), signTestKey(t, priv, in(24*time.Hour))); err != nil {
-		t.Fatalf("expected activation to succeed, got %v", err)
+	result, err := service.Check(context.Background(), "XPREM-KEY")
+	require.NoError(t, err)
+	assert.True(t, result.Valid)
+	assert.Nil(t, repo.stored)
+	assert.False(t, IsEnterprise(), "a check must not activate anything")
+}
+
+func TestCheckRefusesUnsupportedPlan(t *testing.T) {
+	repo := &fakeLicenseRepo{}
+	fake := &fakeLicenseServer{
+		check: func(w http.ResponseWriter, r *http.Request) {
+			writeJSONBody(w, http.StatusOK, `{"valid": true, "licenseInformations": `+proInformationsJSON+`}`)
+		},
 	}
-	if err := service.Remove(context.Background()); err != nil {
-		t.Fatalf("expected removal to succeed, got %v", err)
+	service := newTestService(t, repo, fake.client(t))
+
+	result, err := service.Check(context.Background(), "XPREM-KEY")
+	require.NoError(t, err)
+	assert.False(t, result.Valid)
+	assert.Equal(t, CodePlanNotSupported, result.ErrorCode)
+}
+
+func TestAttachRefusesUnsupportedPlanBeforeConsumingKey(t *testing.T) {
+	repo := &fakeLicenseRepo{}
+	fake := &fakeLicenseServer{
+		check: func(w http.ResponseWriter, r *http.Request) {
+			writeJSONBody(w, http.StatusOK, `{"valid": true, "licenseInformations": `+proInformationsJSON+`}`)
+		},
+		attach: func(w http.ResponseWriter, r *http.Request) {
+			t.Error("attach must not consume a key whose plan is unsupported")
+		},
 	}
-	if repo.stored != nil {
-		t.Fatal("expected the stored key to be deleted")
+	service := newTestService(t, repo, fake.client(t))
+
+	_, err := service.Attach(context.Background(), "XPREM-KEY")
+	var refusal *DecisionError
+	require.ErrorAs(t, err, &refusal)
+	assert.Equal(t, CodePlanNotSupported, refusal.Code)
+	assert.Nil(t, repo.stored)
+	assert.False(t, IsEnterprise())
+}
+
+func TestValidateNowPlanDowngradeStartsGrace(t *testing.T) {
+	repo := repoWithAcme()
+	fake := &fakeLicenseServer{
+		validate: func(w http.ResponseWriter, r *http.Request) {
+			writeJSONBody(w, http.StatusOK, `{"isActive": true, "licenseInformations": `+proInformationsJSON+`}`)
+		},
 	}
-	if IsEnterprise() {
-		t.Fatal("expected community edition after removal")
+	service := newTestService(t, repo, fake.client(t))
+	Activate(repo.stored.License)
+
+	service.ValidateNow(context.Background())
+
+	require.NotNil(t, repo.stored.ValidationFailedAt)
+	assert.Equal(t, CodePlanNotSupported, repo.stored.ValidationErrorCode)
+	assert.True(t, IsEnterprise(), "the grace window applies to a plan downgrade too")
+}
+
+func TestValidateNowSuccessClearsFailureAndRefreshesLicense(t *testing.T) {
+	repo := repoWithAcme()
+	failedAt := time.Now().Add(-time.Hour).UTC()
+	repo.stored.ValidationFailedAt = &failedAt
+	repo.stored.ValidationErrorCode = CodeServerUnreachable
+
+	fake := &fakeLicenseServer{
+		validate: func(w http.ResponseWriter, r *http.Request) {
+			refreshed := `{
+				"org": {"name": "Acme Corp"},
+				"planCode": "enterprise",
+				"subscription": {"startAt": "2026-01-01T00:00:00.000Z", "endAt": null, "renewalAt": "2028-01-01T00:00:00.000Z"}
+			}`
+			writeJSONBody(w, http.StatusOK, `{"isActive": true, "licenseInformations": `+refreshed+`}`)
+		},
 	}
+	service := newTestService(t, repo, fake.client(t))
+
+	service.ValidateNow(context.Background())
+
+	assert.Nil(t, repo.stored.ValidationFailedAt)
+	assert.Empty(t, repo.stored.ValidationErrorCode)
+	require.NotNil(t, repo.stored.License.SubscriptionRenewalAt)
+	assert.Equal(t, 2028, repo.stored.License.SubscriptionRenewalAt.Year(), "a successful validation refreshes the descriptor")
+	assert.True(t, IsEnterprise())
+}
+
+func TestValidateNowRefusalStartsGraceAndKeepsEnterpriseOn(t *testing.T) {
+	repo := repoWithAcme()
+	fake := &fakeLicenseServer{
+		validate: func(w http.ResponseWriter, r *http.Request) {
+			writeJSONBody(w, http.StatusBadRequest, `{"valid": false, "errorCode": "SUBSCRIPTION_INACTIVE"}`)
+		},
+	}
+	service := newTestService(t, repo, fake.client(t))
+	Activate(repo.stored.License)
+
+	service.ValidateNow(context.Background())
+
+	require.NotNil(t, repo.stored.ValidationFailedAt)
+	assert.Equal(t, CodeSubscriptionInactive, repo.stored.ValidationErrorCode)
+	assert.True(t, IsEnterprise(), "the grace window keeps enterprise features on")
+}
+
+func TestValidateNowKeepsTheFirstFailureAsGraceAnchor(t *testing.T) {
+	repo := repoWithAcme()
+	anchor := time.Now().Add(-48 * time.Hour).UTC()
+	repo.stored.ValidationFailedAt = &anchor
+	repo.stored.ValidationErrorCode = CodeServerUnreachable
+
+	fake := &fakeLicenseServer{
+		validate: func(w http.ResponseWriter, r *http.Request) {
+			writeJSONBody(w, http.StatusBadRequest, `{"valid": false, "errorCode": "SUBSCRIPTION_INACTIVE"}`)
+		},
+	}
+	service := newTestService(t, repo, fake.client(t))
+	Activate(repo.stored.License)
+
+	service.ValidateNow(context.Background())
+
+	assert.True(t, repo.stored.ValidationFailedAt.Equal(anchor), "repeat failures must not push the grace deadline back")
+	assert.Equal(t, CodeSubscriptionInactive, repo.stored.ValidationErrorCode)
+	assert.True(t, IsEnterprise())
+}
+
+func TestValidateNowSuspendsOnceGraceIsExhausted(t *testing.T) {
+	repo := repoWithAcme()
+	anchor := time.Now().Add(-GracePeriod - time.Hour).UTC()
+	repo.stored.ValidationFailedAt = &anchor
+	repo.stored.ValidationErrorCode = CodeSubscriptionInactive
+
+	fake := &fakeLicenseServer{
+		validate: func(w http.ResponseWriter, r *http.Request) {
+			writeJSONBody(w, http.StatusBadRequest, `{"valid": false, "errorCode": "SUBSCRIPTION_INACTIVE"}`)
+		},
+	}
+	service := newTestService(t, repo, fake.client(t))
+	Activate(repo.stored.License)
+
+	service.ValidateNow(context.Background())
+
+	assert.False(t, IsEnterprise(), "an exhausted grace window drops the license")
+	require.NotNil(t, repo.stored, "the row stays so the dashboard can explain the suspension")
+}
+
+func TestValidateNowUnreachableServerCountsAsFailure(t *testing.T) {
+	repo := repoWithAcme()
+	fake := &fakeLicenseServer{} // no validate handler: 404 answers
+	service := newTestService(t, repo, fake.client(t))
+	Activate(repo.stored.License)
+
+	service.ValidateNow(context.Background())
+
+	require.NotNil(t, repo.stored.ValidationFailedAt)
+	assert.Equal(t, CodeServerUnreachable, repo.stored.ValidationErrorCode)
+	assert.True(t, IsEnterprise())
+}
+
+func TestValidateNowSkipsWithoutInstanceIdInsteadOfBurningGrace(t *testing.T) {
+	repo := repoWithAcme()
+	Deactivate()
+	t.Cleanup(Deactivate)
+	service := NewLicenseService(repo, NewClient("http://127.0.0.1:1"), "", "https://updates.example.com")
+	Activate(repo.stored.License)
+
+	service.ValidateNow(context.Background())
+
+	assert.Nil(t, repo.stored.ValidationFailedAt, "a missing instance id is a local problem, not a license decision")
+	assert.True(t, IsEnterprise())
+}
+
+func TestValidateNowSkipsWhenSecretUnreadableInsteadOfBurningGrace(t *testing.T) {
+	repo := repoWithAcme()
+	repo.secretErr = errors.New("failed to unseal the license activation secret")
+	service := newTestService(t, repo, NewClient("http://127.0.0.1:1"))
+	Activate(repo.stored.License)
+
+	service.ValidateNow(context.Background())
+
+	assert.Nil(t, repo.stored.ValidationFailedAt, "an unreadable secret is a local problem, not a license decision")
+	assert.True(t, IsEnterprise())
+}
+
+func TestValidateNowIgnoresShutdownCancellation(t *testing.T) {
+	repo := repoWithAcme()
+	service := newTestService(t, repo, NewClient("http://127.0.0.1:1"))
+	Activate(repo.stored.License)
+	cancelled, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	service.ValidateNow(cancelled)
+
+	assert.Nil(t, repo.stored.ValidationFailedAt, "a shutdown must not be recorded as a license failure")
+	assert.True(t, IsEnterprise())
+}
+
+func TestActivateFromStoreWithinGrace(t *testing.T) {
+	repo := repoWithAcme()
+	failedAt := time.Now().Add(-time.Hour).UTC()
+	repo.stored.ValidationFailedAt = &failedAt
+	service := newTestService(t, repo, NewClient(""))
+
+	require.NoError(t, service.ActivateFromStore(context.Background()))
+	assert.True(t, IsEnterprise())
+}
+
+func TestActivateFromStoreSuspendedRunsCommunity(t *testing.T) {
+	repo := repoWithAcme()
+	failedAt := time.Now().Add(-GracePeriod - time.Hour).UTC()
+	repo.stored.ValidationFailedAt = &failedAt
+	service := newTestService(t, repo, NewClient(""))
+
+	require.NoError(t, service.ActivateFromStore(context.Background()))
+	assert.False(t, IsEnterprise())
+
 	status, err := service.Status(context.Background())
-	if err != nil {
-		t.Fatalf("expected status to succeed, got %v", err)
-	}
-	if status.HasKey || status.Valid() {
-		t.Fatalf("expected an empty status, got %+v", status)
-	}
+	require.NoError(t, err)
+	assert.True(t, status.HasKey)
+	assert.True(t, status.Suspended())
+	assert.False(t, status.Valid())
 }
 
-func TestServiceActivateFromStore(t *testing.T) {
-	priv := setupTestKeypair(t)
-	repo := &fakeLicenseRepo{stored: &StoredLicense{Key: signTestKey(t, priv, in(24*time.Hour)), UpdatedAt: time.Now()}}
-	service := NewLicenseService(repo)
+func TestRemoveDropsToCommunity(t *testing.T) {
+	repo := repoWithAcme()
+	service := newTestService(t, repo, NewClient(""))
+	Activate(repo.stored.License)
 
-	if err := service.ActivateFromStore(context.Background()); err != nil {
-		t.Fatalf("expected boot activation to succeed, got %v", err)
-	}
-	if !IsEnterprise() {
-		t.Fatal("expected IsEnterprise after boot activation")
-	}
+	require.NoError(t, service.Remove(context.Background()))
+	assert.Nil(t, repo.stored)
+	assert.False(t, IsEnterprise())
 }
 
-func TestServiceActivateFromStoreWithExpiredKeyStaysCommunity(t *testing.T) {
-	priv := setupTestKeypair(t)
-	repo := &fakeLicenseRepo{stored: &StoredLicense{Key: signTestKey(t, priv, in(-time.Hour)), UpdatedAt: time.Now()}}
-	service := NewLicenseService(repo)
-
-	if err := service.ActivateFromStore(context.Background()); err != nil {
-		t.Fatalf("expected an expired stored key to be non-fatal, got %v", err)
+func TestAttachPersistsWhenTheRequestContextIsCancelled(t *testing.T) {
+	fake := &fakeLicenseServer{
+		check: checkAnswersValidAcme,
+		attach: func(w http.ResponseWriter, r *http.Request) {
+			writeJSONBody(w, http.StatusOK, `{"isActive": true, "activationSecret": "secret-42", "licenseInformations": `+acmeInformationsJSON+`}`)
+		},
 	}
-	if IsEnterprise() {
-		t.Fatal("expected community edition with an expired stored key")
-	}
-	// The dashboard still sees the key, the parsed payload and the reason it
-	// is not usable.
-	status, err := service.Status(context.Background())
-	if err != nil {
-		t.Fatalf("expected status to succeed, got %v", err)
-	}
-	if !status.HasKey || status.Valid() || !errors.Is(status.Err, ErrExpired) || status.License == nil {
-		t.Fatalf("expected an expired-key status, got %+v", status)
-	}
-}
-
-func TestServiceActivateFromStoreSurfacesInfrastructureErrors(t *testing.T) {
-	infraErr := errors.New("connection refused")
-	service := NewLicenseService(&fakeLicenseRepo{err: infraErr})
-	if err := service.ActivateFromStore(context.Background()); !errors.Is(err, infraErr) {
-		t.Fatalf("expected the infrastructure error to surface, got %v", err)
-	}
-}
-
-// The sync loop scenarios below call syncFromStore directly: they model what
-// a replica that did NOT serve the dashboard request observes when its
-// reconciliation fires.
-
-func TestSyncFromStorePicksUpActivationFromAnotherReplica(t *testing.T) {
-	priv := setupTestKeypair(t)
 	repo := &fakeLicenseRepo{}
-	service := NewLicenseService(repo)
+	ctx, cancel := context.WithCancel(context.Background())
+	repo.saveHook = func(saveCtx context.Context) {
+		cancel()
+		assert.NoError(t, saveCtx.Err(), "the attach consumed the single-use key; persistence must survive the request context")
+	}
+	service := newTestService(t, repo, fake.client(t))
 
-	service.syncFromStore(context.Background())
-	if IsEnterprise() {
-		t.Fatal("expected community edition while no key is stored")
-	}
-	// Another replica stores a key: only the database row moves.
-	repo.stored = &StoredLicense{Key: signTestKey(t, priv, in(24*time.Hour)), UpdatedAt: time.Now()}
-	service.syncFromStore(context.Background())
-	if !IsEnterprise() {
-		t.Fatal("expected IsEnterprise after the sync picked up the stored key")
-	}
-}
-
-func TestSyncFromStoreDropsRemovalFromAnotherReplica(t *testing.T) {
-	priv := setupTestKeypair(t)
-	repo := &fakeLicenseRepo{}
-	service := NewLicenseService(repo)
-
-	if _, err := service.Activate(context.Background(), signTestKey(t, priv, in(24*time.Hour))); err != nil {
-		t.Fatalf("expected activation to succeed, got %v", err)
-	}
-	// Another replica removes the license: only the database row moves.
-	repo.stored = nil
-	service.syncFromStore(context.Background())
-	if IsEnterprise() {
-		t.Fatal("expected community edition after the sync noticed the removal")
-	}
-}
-
-func TestSyncFromStorePropagatesRenewal(t *testing.T) {
-	priv := setupTestKeypair(t)
-	repo := &fakeLicenseRepo{stored: &StoredLicense{Key: signTestKey(t, priv, in(time.Hour)), UpdatedAt: time.Now()}}
-	service := NewLicenseService(repo)
-	if err := service.ActivateFromStore(context.Background()); err != nil {
-		t.Fatalf("expected boot activation to succeed, got %v", err)
-	}
-	// A renewed key carries the same license id with a later expiry; the sync
-	// must refresh the in-memory expiry, not treat it as the same state.
-	repo.stored = &StoredLicense{Key: signTestKey(t, priv, in(48*time.Hour)), UpdatedAt: time.Now()}
-	service.syncFromStore(context.Background())
-	active := Current()
-	if active == nil || active.Expiry == nil || time.Until(*active.Expiry) < 24*time.Hour {
-		t.Fatalf("expected the renewed expiry to be active, got %+v", active)
-	}
-}
-
-func TestSyncFromStoreKeepsStateOnInfrastructureError(t *testing.T) {
-	priv := setupTestKeypair(t)
-	repo := &fakeLicenseRepo{}
-	service := NewLicenseService(repo)
-	if _, err := service.Activate(context.Background(), signTestKey(t, priv, in(24*time.Hour))); err != nil {
-		t.Fatalf("expected activation to succeed, got %v", err)
-	}
-	// A transient database failure must not drop a valid license.
-	repo.err = errors.New("connection refused")
-	service.syncFromStore(context.Background())
-	if !IsEnterprise() {
-		t.Fatal("expected the active license to survive a transient database error")
-	}
+	_, err := service.Attach(ctx, "XPREM-KEY")
+	require.NoError(t, err)
+	require.NotNil(t, repo.stored)
+	assert.Equal(t, "secret-42", repo.secret)
 }

--- a/ee/licensing/store_postgres.go
+++ b/ee/licensing/store_postgres.go
@@ -7,8 +7,20 @@ package licensing
 import (
 	"context"
 	"fmt"
+	"time"
+	"xprem/internal/crypto"
 	"xprem/internal/database"
+	"xprem/internal/database/postgres/pgdb"
+	"xprem/internal/keyStore"
+
+	"github.com/jackc/pgx/v5/pgtype"
 )
+
+// activationSecretAAD is the AES-GCM AAD binding the sealed secret to this
+// column.
+func activationSecretAAD() []byte {
+	return []byte("enterprise_license|activation_secret")
+}
 
 type PostgresLicenseStore struct {
 	engine *database.Engine
@@ -16,6 +28,41 @@ type PostgresLicenseStore struct {
 
 func NewPostgresLicenseStore(engine *database.Engine) *PostgresLicenseStore {
 	return &PostgresLicenseStore{engine: engine}
+}
+
+func toPgTimestamptz(t *time.Time) pgtype.Timestamptz {
+	if t == nil {
+		return pgtype.Timestamptz{}
+	}
+	return pgtype.Timestamptz{Time: *t, Valid: true}
+}
+
+func fromPgTimestamptz(ts pgtype.Timestamptz) *time.Time {
+	if !ts.Valid {
+		return nil
+	}
+	t := ts.Time
+	return &t
+}
+
+func storedFromRow(row pgdb.EnterpriseLicense) *StoredLicense {
+	stored := &StoredLicense{
+		Key: row.LicenseKey,
+		License: License{
+			OrgName:               row.OrgName,
+			PlanCode:              row.PlanCode,
+			SubscriptionStartAt:   row.SubscriptionStartAt.Time,
+			SubscriptionEndAt:     fromPgTimestamptz(row.SubscriptionEndAt),
+			SubscriptionRenewalAt: fromPgTimestamptz(row.SubscriptionRenewalAt),
+		},
+		ActivatedAt:        row.ActivatedAt.Time,
+		LastValidatedAt:    fromPgTimestamptz(row.LastValidatedAt),
+		ValidationFailedAt: fromPgTimestamptz(row.ValidationFailedAt),
+	}
+	if row.ValidationErrorCode != nil {
+		stored.ValidationErrorCode = *row.ValidationErrorCode
+	}
+	return stored
 }
 
 func (s *PostgresLicenseStore) GetLicense(ctx context.Context) (*StoredLicense, error) {
@@ -26,15 +73,63 @@ func (s *PostgresLicenseStore) GetLicense(ctx context.Context) (*StoredLicense, 
 		}
 		return nil, fmt.Errorf("failed to read enterprise license from database: %w", err)
 	}
-	return &StoredLicense{Key: row.LicenseKey, UpdatedAt: row.UpdatedAt.Time}, nil
+	return storedFromRow(row), nil
 }
 
-func (s *PostgresLicenseStore) UpsertLicense(ctx context.Context, key string) (StoredLicense, error) {
-	row, err := s.engine.Queries.UpsertEnterpriseLicense(ctx, key)
+func (s *PostgresLicenseStore) GetActivationSecret(ctx context.Context) (string, error) {
+	row, err := s.engine.Queries.GetEnterpriseLicense(ctx)
+	if err != nil {
+		return "", fmt.Errorf("failed to read enterprise license from database: %w", err)
+	}
+	secret, err := crypto.UnsealAESGCM(row.SealedActivationSecret, []byte(keyStore.ReadDBKeysMasterKey()), activationSecretAAD())
+	if err != nil {
+		return "", fmt.Errorf("failed to unseal the license activation secret: %w", err)
+	}
+	return string(secret), nil
+}
+
+func (s *PostgresLicenseStore) SaveActivation(ctx context.Context, key string, activationSecret string, license License) (StoredLicense, error) {
+	sealedSecret, err := crypto.SealAESGCM([]byte(activationSecret), []byte(keyStore.ReadDBKeysMasterKey()), activationSecretAAD())
+	if err != nil {
+		return StoredLicense{}, fmt.Errorf("failed to seal the license activation secret: %w", err)
+	}
+	startAt := license.SubscriptionStartAt
+	row, err := s.engine.Queries.UpsertEnterpriseLicense(ctx, pgdb.UpsertEnterpriseLicenseParams{
+		LicenseKey:             key,
+		SealedActivationSecret: sealedSecret,
+		OrgName:                license.OrgName,
+		PlanCode:               license.PlanCode,
+		SubscriptionStartAt:    toPgTimestamptz(&startAt),
+		SubscriptionEndAt:      toPgTimestamptz(license.SubscriptionEndAt),
+		SubscriptionRenewalAt:  toPgTimestamptz(license.SubscriptionRenewalAt),
+	})
 	if err != nil {
 		return StoredLicense{}, fmt.Errorf("failed to store enterprise license in database: %w", err)
 	}
-	return StoredLicense{Key: row.LicenseKey, UpdatedAt: row.UpdatedAt.Time}, nil
+	return *storedFromRow(row), nil
+}
+
+func (s *PostgresLicenseStore) MarkValidated(ctx context.Context, license License) (StoredLicense, error) {
+	startAt := license.SubscriptionStartAt
+	row, err := s.engine.Queries.MarkEnterpriseLicenseValidated(ctx, pgdb.MarkEnterpriseLicenseValidatedParams{
+		OrgName:               license.OrgName,
+		PlanCode:              license.PlanCode,
+		SubscriptionStartAt:   toPgTimestamptz(&startAt),
+		SubscriptionEndAt:     toPgTimestamptz(license.SubscriptionEndAt),
+		SubscriptionRenewalAt: toPgTimestamptz(license.SubscriptionRenewalAt),
+	})
+	if err != nil {
+		return StoredLicense{}, fmt.Errorf("failed to record the license validation in database: %w", err)
+	}
+	return *storedFromRow(row), nil
+}
+
+func (s *PostgresLicenseStore) MarkValidationFailed(ctx context.Context, errorCode string) (StoredLicense, error) {
+	row, err := s.engine.Queries.MarkEnterpriseLicenseValidationFailed(ctx, &errorCode)
+	if err != nil {
+		return StoredLicense{}, fmt.Errorf("failed to record the license validation failure in database: %w", err)
+	}
+	return *storedFromRow(row), nil
 }
 
 func (s *PostgresLicenseStore) DeleteLicense(ctx context.Context) error {

--- a/ee/telemetry/services.go
+++ b/ee/telemetry/services.go
@@ -1,0 +1,198 @@
+// Copyright (c) 2026 Axel Marciano (Mercure Technologies). All rights reserved.
+// This file is governed by the Mercure Technologies Enterprise Edition License
+// (see ee/LICENSE); it is NOT covered by the MIT license of this repository.
+
+package telemetry
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"xprem/config"
+	"xprem/internal/cache"
+	"xprem/internal/cdn"
+	"xprem/internal/services"
+	"xprem/internal/version"
+)
+
+var heartbeatClient = &http.Client{Timeout: 10 * time.Second}
+
+const (
+	heartbeatInterval = time.Hour
+	heartbeatLockKey  = "telemetry-heartbeat-lock"
+	// Shorter than the interval so the next tick can always reclaim the lock.
+	heartbeatLockTTLSeconds = 3300
+)
+
+// Enum values accepted by the heartbeat API's telemetry schema.
+const (
+	TelemetryModeStateless    = "stateless"
+	TelemetryModeControlPlane = "control_plane"
+
+	TelemetryBucketS3    = "s3"
+	TelemetryBucketGCS   = "gcs"
+	TelemetryBucketAzure = "azure"
+	TelemetryBucketLocal = "local"
+
+	TelemetryCDNCloudfront  = "cloudfront"
+	TelemetryCDNAzureDirect = "azure_direct"
+	TelemetryCDNGCSDirect   = "gcs_direct"
+	TelemetryCDNGeneric     = "generic"
+	TelemetryCDNS3Direct    = "s3_direct"
+
+	TelemetryCacheLocal         = "local"
+	TelemetryCacheRedis         = "redis"
+	TelemetryCacheRedisSentinel = "redis-sentinel"
+)
+
+type HeartbeatTelemetry struct {
+	AppsCount  *int    `json:"appsCount,omitempty"`
+	UsersCount *int    `json:"usersCount,omitempty"`
+	Mode       *string `json:"mode,omitempty"`
+	Bucket     *string `json:"bucket,omitempty"`
+	CDN        *string `json:"cdn,omitempty"`
+	Cache      *string `json:"cache,omitempty"`
+	UseObserve *bool   `json:"useObserve,omitempty"`
+}
+
+type HeartbeatParams struct {
+	InstanceId string             `json:"instanceId"`
+	BaseUrl    string             `json:"baseUrl"`
+	Version    string             `json:"version"`
+	Telemetry  HeartbeatTelemetry `json:"telemetry"`
+}
+
+type TelemetryService struct {
+	userRepo   services.UserRepository
+	appRepo    services.AppRepository
+	instanceId string
+}
+
+// NewTelemetryService accepts nil repos: stateless mode has no user store, and
+// the matching count is simply omitted from the payload.
+func NewTelemetryService(userRepo services.UserRepository, appRepo services.AppRepository, instanceId string) *TelemetryService {
+	return &TelemetryService{
+		userRepo:   userRepo,
+		appRepo:    appRepo,
+		instanceId: instanceId,
+	}
+}
+
+// Start sends one heartbeat now and one per hour until ctx is cancelled. The
+// cache lock keeps a multi-replica deployment at one send per interval.
+func (s *TelemetryService) Start(ctx context.Context) {
+	if config.IsServerTelemetryDisabled() || config.IsTestMode() {
+		return
+	}
+	go func() {
+		s.heartbeat(ctx)
+		ticker := time.NewTicker(heartbeatInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				s.heartbeat(ctx)
+			}
+		}
+	}()
+}
+
+func (s *TelemetryService) sendHeartBeatRequest(ctx context.Context, params HeartbeatParams) error {
+	const endpoint = "https://api.xprem.dev/v1/heartbeats"
+	body, err := json.Marshal(params)
+	if err != nil {
+		return fmt.Errorf("marshal heartbeat payload: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("build heartbeat request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := heartbeatClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("send heartbeat: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNoContent {
+		return fmt.Errorf("heartbeat rejected: %s", resp.Status)
+	}
+	return nil
+}
+
+func (s *TelemetryService) buildTelemetryParams(ctx context.Context) *HeartbeatTelemetry {
+	response := &HeartbeatTelemetry{}
+
+	mode := TelemetryModeStateless
+	if config.IsDBMode() {
+		mode = TelemetryModeControlPlane
+	}
+	response.Mode = &mode
+
+	if bucket := config.GetEnv("STORAGE_MODE"); bucket != "" {
+		response.Bucket = &bucket
+	}
+	if cdnType := telemetryCDNType(); cdnType != "" {
+		response.CDN = &cdnType
+	}
+	cacheMode := string(cache.ResolveCacheType())
+	response.Cache = &cacheMode
+
+	useObserve := config.GetClickHouseURL() != ""
+	response.UseObserve = &useObserve
+
+	if s.appRepo != nil {
+		if apps, err := s.appRepo.GetApps(ctx); err == nil {
+			appsCount := len(apps)
+			response.AppsCount = &appsCount
+		}
+	}
+	if s.userRepo != nil {
+		if users, err := s.userRepo.GetUsers(ctx); err == nil {
+			usersCount := len(users)
+			response.UsersCount = &usersCount
+		}
+	}
+	return response
+}
+
+func telemetryCDNType() string {
+	switch cdn.ResolvedType() {
+	case "cloudfront":
+		return TelemetryCDNCloudfront
+	case "azure-direct":
+		return TelemetryCDNAzureDirect
+	case "gcs-direct":
+		return TelemetryCDNGCSDirect
+	case "s3-direct":
+		return TelemetryCDNS3Direct
+	case "generic":
+		return TelemetryCDNGeneric
+	default:
+		return ""
+	}
+}
+
+func (s *TelemetryService) buildParams(ctx context.Context) *HeartbeatParams {
+	telemetry := s.buildTelemetryParams(ctx)
+	return &HeartbeatParams{
+		BaseUrl:    config.GetEnv("BASE_URL"),
+		Version:    version.Version,
+		InstanceId: s.instanceId,
+		Telemetry:  *telemetry,
+	}
+}
+
+func (s *TelemetryService) heartbeat(ctx context.Context) {
+	locked, err := cache.GetCache().TryLock(heartbeatLockKey, heartbeatLockTTLSeconds)
+	if err != nil || !locked {
+		return
+	}
+	params := s.buildParams(ctx)
+	s.sendHeartBeatRequest(ctx, *params)
+}

--- a/internal/auditlog/auditlog.go
+++ b/internal/auditlog/auditlog.go
@@ -64,6 +64,7 @@ const (
 	// Enterprise administration.
 	ActionLicenseActivated Action = "license.activated"
 	ActionLicenseRemoved   Action = "license.removed"
+	ActionLicenseSuspended Action = "license.suspended"
 	ActionSSOConfigSaved   Action = "sso_config.saved"
 	ActionSSOConfigDeleted Action = "sso_config.deleted"
 

--- a/internal/bucket/azureBucket.go
+++ b/internal/bucket/azureBucket.go
@@ -407,6 +407,37 @@ func (b *AzureBucket) CreateUpdateFrom(previousUpdate *types.Update, newUpdateId
 	}, nil
 }
 
+func (b *AzureBucket) GetInstanceID() (string, error) {
+	ctx := context.Background()
+	cc, err := b.containerClient()
+	if err != nil {
+		return "", err
+	}
+	resp, err := cc.NewBlobClient(b.prefixedKey(".instanceid")).DownloadStream(ctx, nil)
+	if err != nil {
+		if bloberror.HasCode(err, bloberror.BlobNotFound) {
+			return "", nil
+		}
+		return "", err
+	}
+	defer resp.Body.Close()
+	buf := new(bytes.Buffer)
+	if _, err := io.Copy(buf, resp.Body); err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(buf.String()), nil
+}
+
+func (b *AzureBucket) PersistInstanceID(id string) error {
+	ctx := context.Background()
+	cc, err := b.containerClient()
+	if err != nil {
+		return err
+	}
+	_, err = cc.NewBlockBlobClient(b.prefixedKey(".instanceid")).UploadBuffer(ctx, []byte(id+"\n"), nil)
+	return err
+}
+
 func (b *AzureBucket) RetrieveMigrationHistory() ([]string, error) {
 	ctx := context.Background()
 	cc, err := b.containerClient()

--- a/internal/bucket/bucket.go
+++ b/internal/bucket/bucket.go
@@ -157,6 +157,8 @@ type Bucket interface {
 	RetrieveMigrationHistory() ([]string, error)
 	ApplyMigration(migrationId string) error
 	RemoveMigrationFromHistory(migrationId string) error
+	GetInstanceID() (string, error)
+	PersistInstanceID(id string) error
 }
 
 type BucketType string

--- a/internal/bucket/gcsBucket.go
+++ b/internal/bucket/gcsBucket.go
@@ -365,6 +365,41 @@ func (b *GCSBucket) CreateUpdateFrom(previousUpdate *types.Update, newUpdateId s
 	}, nil
 }
 
+func (b *GCSBucket) GetInstanceID() (string, error) {
+	ctx := context.Background()
+	bh, err := b.bucketHandle(ctx)
+	if err != nil {
+		return "", err
+	}
+	r, err := bh.Object(b.prefixedKey(".instanceid")).NewReader(ctx)
+	if err != nil {
+		if errors.Is(err, storage.ErrObjectNotExist) {
+			return "", nil
+		}
+		return "", err
+	}
+	defer r.Close()
+	buf := new(bytes.Buffer)
+	if _, err := io.Copy(buf, r); err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(buf.String()), nil
+}
+
+func (b *GCSBucket) PersistInstanceID(id string) error {
+	ctx := context.Background()
+	bh, err := b.bucketHandle(ctx)
+	if err != nil {
+		return err
+	}
+	w := bh.Object(b.prefixedKey(".instanceid")).NewWriter(ctx)
+	if _, err := w.Write([]byte(id + "\n")); err != nil {
+		_ = w.Close()
+		return err
+	}
+	return w.Close()
+}
+
 func (b *GCSBucket) RetrieveMigrationHistory() ([]string, error) {
 	ctx := context.Background()
 	bh, err := b.bucketHandle(ctx)

--- a/internal/bucket/localBucket.go
+++ b/internal/bucket/localBucket.go
@@ -483,6 +483,27 @@ func copyFile(src, dst string) error {
 	return out.Sync()
 }
 
+func (b *LocalBucket) GetInstanceID() (string, error) {
+	if b.BasePath == "" {
+		return "", errors.New("BasePath not set")
+	}
+	content, err := os.ReadFile(filepath.Join(b.rootPath(), ".instanceid"))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+		return "", err
+	}
+	return strings.TrimSpace(string(content)), nil
+}
+
+func (b *LocalBucket) PersistInstanceID(id string) error {
+	if b.BasePath == "" {
+		return errors.New("BasePath not set")
+	}
+	return os.WriteFile(filepath.Join(b.rootPath(), ".instanceid"), []byte(id+"\n"), 0644)
+}
+
 func (b *LocalBucket) RetrieveMigrationHistory() ([]string, error) {
 	if b.BasePath == "" {
 		return nil, errors.New("BasePath not set")

--- a/internal/bucket/s3Bucket.go
+++ b/internal/bucket/s3Bucket.go
@@ -443,6 +443,52 @@ func (b *S3Bucket) CreateUpdateFrom(previousUpdate *types.Update, newUpdateId st
 	}, nil
 }
 
+func (b *S3Bucket) GetInstanceID() (string, error) {
+	if b.BucketName == "" {
+		return "", errors.New("BucketName not set")
+	}
+	s3Client, errS3 := aws.GetS3Client()
+	if errS3 != nil {
+		return "", errS3
+	}
+	resp, err := s3Client.GetObject(context.TODO(), &s3.GetObjectInput{
+		Bucket: awssdk.String(b.BucketName),
+		Key:    awssdk.String(b.prefixedKey(".instanceid")),
+	})
+	if err != nil {
+		var noSuchKey *s3types.NoSuchKey
+		if errors.As(err, &noSuchKey) {
+			return "", nil
+		}
+		return "", fmt.Errorf("GetObject error: %w", err)
+	}
+	defer resp.Body.Close()
+	content, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(content)), nil
+}
+
+func (b *S3Bucket) PersistInstanceID(id string) error {
+	if b.BucketName == "" {
+		return errors.New("BucketName not set")
+	}
+	s3Client, errS3 := aws.GetS3Client()
+	if errS3 != nil {
+		return errS3
+	}
+	_, err := s3Client.PutObject(context.TODO(), &s3.PutObjectInput{
+		Bucket: awssdk.String(b.BucketName),
+		Key:    awssdk.String(b.prefixedKey(".instanceid")),
+		Body:   bytes.NewReader([]byte(id + "\n")),
+	})
+	if err != nil {
+		return fmt.Errorf("PutObject error: %w", err)
+	}
+	return nil
+}
+
 func (b *S3Bucket) RetrieveMigrationHistory() ([]string, error) {
 	if b.BucketName == "" {
 		return nil, errors.New("BucketName not set")

--- a/internal/bucket/validatingBucket.go
+++ b/internal/bucket/validatingBucket.go
@@ -123,6 +123,14 @@ func (v *validatingBucket) CreateUpdateFrom(previousUpdate *types.Update, newUpd
 	return v.Inner.CreateUpdateFrom(previousUpdate, newUpdateId)
 }
 
+func (v *validatingBucket) GetInstanceID() (string, error) {
+	return v.Inner.GetInstanceID()
+}
+
+func (v *validatingBucket) PersistInstanceID(id string) error {
+	return v.Inner.PersistInstanceID(id)
+}
+
 func (v *validatingBucket) RetrieveMigrationHistory() ([]string, error) {
 	return v.Inner.RetrieveMigrationHistory()
 }

--- a/internal/bucket/validatingBucket_test.go
+++ b/internal/bucket/validatingBucket_test.go
@@ -52,6 +52,8 @@ func (s *stubBucket) CreateUpdateFrom(previousUpdate *types.Update, newUpdateId 
 	s.mark()
 	return nil, nil
 }
+func (s *stubBucket) GetInstanceID() (string, error)              { s.mark(); return "", nil }
+func (s *stubBucket) PersistInstanceID(_ string) error            { s.mark(); return nil }
 func (s *stubBucket) RetrieveMigrationHistory() ([]string, error) { s.mark(); return nil, nil }
 func (s *stubBucket) ApplyMigration(migrationId string) error     { s.mark(); return nil }
 func (s *stubBucket) RemoveMigrationFromHistory(id string) error  { s.mark(); return nil }

--- a/internal/bucketmigrations/20260422_v2_scope_data_under_appid/20260422_v2_scope_data_under_appid_test.go
+++ b/internal/bucketmigrations/20260422_v2_scope_data_under_appid/20260422_v2_scope_data_under_appid_test.go
@@ -55,6 +55,14 @@ func (u unreachableBucket) CreateUpdateFrom(*types.Update, string) (*types.Updat
 	u.t.Fatal("migration should have skipped")
 	return nil, nil
 }
+func (u unreachableBucket) GetInstanceID() (string, error) {
+	u.t.Fatal("migration should have skipped")
+	return "", nil
+}
+func (u unreachableBucket) PersistInstanceID(string) error {
+	u.t.Fatal("migration should have skipped")
+	return nil
+}
 func (u unreachableBucket) RetrieveMigrationHistory() ([]string, error) {
 	u.t.Fatal("migration should have skipped")
 	return nil, nil

--- a/internal/database/postgres/migrations/20260815120000_server_instance.sql
+++ b/internal/database/postgres/migrations/20260815120000_server_instance.sql
@@ -1,0 +1,31 @@
+-- +goose Up
+
+-- The deployment's permanent identity, minted once on first boot. The
+-- singleton key caps the table at one row, and the triggers below make that
+-- row append-only for every role short of a superuser dropping the trigger.
+CREATE TABLE server_instance (
+    singleton BOOLEAN PRIMARY KEY DEFAULT TRUE CHECK (singleton),
+    id UUID NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- +goose StatementBegin
+CREATE FUNCTION server_instance_immutable() RETURNS trigger AS $$
+BEGIN
+    RAISE EXCEPTION 'server_instance is immutable';
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+CREATE TRIGGER trg_server_instance_immutable
+BEFORE UPDATE OR DELETE ON server_instance
+FOR EACH ROW EXECUTE FUNCTION server_instance_immutable();
+
+CREATE TRIGGER trg_server_instance_no_truncate
+BEFORE TRUNCATE ON server_instance
+FOR EACH STATEMENT EXECUTE FUNCTION server_instance_immutable();
+
+-- +goose Down
+
+DROP TABLE server_instance;
+DROP FUNCTION server_instance_immutable;

--- a/internal/database/postgres/migrations/20260815130000_enterprise_license_server.sql
+++ b/internal/database/postgres/migrations/20260815130000_enterprise_license_server.sql
@@ -1,0 +1,39 @@
+-- +goose Up
+-- +goose StatementBegin
+
+-- Rebuilds enterprise_license for server-backed licensing; old offline keys
+-- cannot be migrated, deployments re-attach from the dashboard.
+DROP TABLE IF EXISTS enterprise_license;
+
+CREATE TABLE enterprise_license (
+    singleton BOOLEAN PRIMARY KEY DEFAULT TRUE CHECK (singleton),
+    license_key TEXT NOT NULL,
+    sealed_activation_secret TEXT NOT NULL,
+    org_name TEXT NOT NULL,
+    plan_code TEXT NOT NULL,
+    subscription_start_at TIMESTAMP WITH TIME ZONE,
+    subscription_end_at TIMESTAMP WITH TIME ZONE,
+    subscription_renewal_at TIMESTAMP WITH TIME ZONE,
+    activated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    last_validated_at TIMESTAMP WITH TIME ZONE,
+    validation_failed_at TIMESTAMP WITH TIME ZONE,
+    validation_error_code TEXT,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+
+DROP TABLE IF EXISTS enterprise_license;
+
+CREATE TABLE enterprise_license (
+    singleton BOOLEAN PRIMARY KEY DEFAULT TRUE CHECK (singleton),
+    license_key TEXT NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- +goose StatementEnd

--- a/internal/database/postgres/pgdb/models.go
+++ b/internal/database/postgres/pgdb/models.go
@@ -215,6 +215,12 @@ type RuntimeVersion struct {
 	UpdatedAt pgtype.Timestamptz `json:"updated_at"`
 }
 
+type ServerInstance struct {
+	Singleton bool               `json:"singleton"`
+	ID        pgtype.UUID        `json:"id"`
+	CreatedAt pgtype.Timestamptz `json:"created_at"`
+}
+
 type SsoConfig struct {
 	Singleton            bool               `json:"singleton"`
 	Issuer               string             `json:"issuer"`

--- a/internal/database/postgres/pgdb/models.go
+++ b/internal/database/postgres/pgdb/models.go
@@ -148,10 +148,20 @@ type DeviceUpdateRuntimeState struct {
 }
 
 type EnterpriseLicense struct {
-	Singleton  bool               `json:"singleton"`
-	LicenseKey string             `json:"license_key"`
-	CreatedAt  pgtype.Timestamptz `json:"created_at"`
-	UpdatedAt  pgtype.Timestamptz `json:"updated_at"`
+	Singleton              bool               `json:"singleton"`
+	LicenseKey             string             `json:"license_key"`
+	SealedActivationSecret string             `json:"sealed_activation_secret"`
+	OrgName                string             `json:"org_name"`
+	PlanCode               string             `json:"plan_code"`
+	SubscriptionStartAt    pgtype.Timestamptz `json:"subscription_start_at"`
+	SubscriptionEndAt      pgtype.Timestamptz `json:"subscription_end_at"`
+	SubscriptionRenewalAt  pgtype.Timestamptz `json:"subscription_renewal_at"`
+	ActivatedAt            pgtype.Timestamptz `json:"activated_at"`
+	LastValidatedAt        pgtype.Timestamptz `json:"last_validated_at"`
+	ValidationFailedAt     pgtype.Timestamptz `json:"validation_failed_at"`
+	ValidationErrorCode    *string            `json:"validation_error_code"`
+	CreatedAt              pgtype.Timestamptz `json:"created_at"`
+	UpdatedAt              pgtype.Timestamptz `json:"updated_at"`
 }
 
 type IdentitySchema struct {

--- a/internal/database/postgres/pgdb/queries.sql.go
+++ b/internal/database/postgres/pgdb/queries.sql.go
@@ -1509,7 +1509,7 @@ func (q *Queries) GetDeviceIdentityForUpdate(ctx context.Context, arg GetDeviceI
 }
 
 const getEnterpriseLicense = `-- name: GetEnterpriseLicense :one
-SELECT singleton, license_key, created_at, updated_at FROM enterprise_license
+SELECT singleton, license_key, sealed_activation_secret, org_name, plan_code, subscription_start_at, subscription_end_at, subscription_renewal_at, activated_at, last_validated_at, validation_failed_at, validation_error_code, created_at, updated_at FROM enterprise_license
 WHERE singleton
 `
 
@@ -1519,6 +1519,16 @@ func (q *Queries) GetEnterpriseLicense(ctx context.Context) (EnterpriseLicense, 
 	err := row.Scan(
 		&i.Singleton,
 		&i.LicenseKey,
+		&i.SealedActivationSecret,
+		&i.OrgName,
+		&i.PlanCode,
+		&i.SubscriptionStartAt,
+		&i.SubscriptionEndAt,
+		&i.SubscriptionRenewalAt,
+		&i.ActivatedAt,
+		&i.LastValidatedAt,
+		&i.ValidationFailedAt,
+		&i.ValidationErrorCode,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 	)
@@ -4417,6 +4427,88 @@ func (q *Queries) ListUserAppGrants(ctx context.Context, userID pgtype.UUID) ([]
 	return items, nil
 }
 
+const markEnterpriseLicenseValidated = `-- name: MarkEnterpriseLicenseValidated :one
+UPDATE enterprise_license SET
+    org_name = $1,
+    plan_code = $2,
+    subscription_start_at = $3,
+    subscription_end_at = $4,
+    subscription_renewal_at = $5,
+    last_validated_at = CURRENT_TIMESTAMP,
+    validation_failed_at = NULL,
+    validation_error_code = NULL,
+    updated_at = CURRENT_TIMESTAMP
+WHERE singleton
+RETURNING singleton, license_key, sealed_activation_secret, org_name, plan_code, subscription_start_at, subscription_end_at, subscription_renewal_at, activated_at, last_validated_at, validation_failed_at, validation_error_code, created_at, updated_at
+`
+
+type MarkEnterpriseLicenseValidatedParams struct {
+	OrgName               string             `json:"org_name"`
+	PlanCode              string             `json:"plan_code"`
+	SubscriptionStartAt   pgtype.Timestamptz `json:"subscription_start_at"`
+	SubscriptionEndAt     pgtype.Timestamptz `json:"subscription_end_at"`
+	SubscriptionRenewalAt pgtype.Timestamptz `json:"subscription_renewal_at"`
+}
+
+func (q *Queries) MarkEnterpriseLicenseValidated(ctx context.Context, arg MarkEnterpriseLicenseValidatedParams) (EnterpriseLicense, error) {
+	row := q.db.QueryRow(ctx, markEnterpriseLicenseValidated,
+		arg.OrgName,
+		arg.PlanCode,
+		arg.SubscriptionStartAt,
+		arg.SubscriptionEndAt,
+		arg.SubscriptionRenewalAt,
+	)
+	var i EnterpriseLicense
+	err := row.Scan(
+		&i.Singleton,
+		&i.LicenseKey,
+		&i.SealedActivationSecret,
+		&i.OrgName,
+		&i.PlanCode,
+		&i.SubscriptionStartAt,
+		&i.SubscriptionEndAt,
+		&i.SubscriptionRenewalAt,
+		&i.ActivatedAt,
+		&i.LastValidatedAt,
+		&i.ValidationFailedAt,
+		&i.ValidationErrorCode,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
+}
+
+const markEnterpriseLicenseValidationFailed = `-- name: MarkEnterpriseLicenseValidationFailed :one
+UPDATE enterprise_license SET
+    validation_failed_at = COALESCE(validation_failed_at, CURRENT_TIMESTAMP),
+    validation_error_code = $1,
+    updated_at = CURRENT_TIMESTAMP
+WHERE singleton
+RETURNING singleton, license_key, sealed_activation_secret, org_name, plan_code, subscription_start_at, subscription_end_at, subscription_renewal_at, activated_at, last_validated_at, validation_failed_at, validation_error_code, created_at, updated_at
+`
+
+func (q *Queries) MarkEnterpriseLicenseValidationFailed(ctx context.Context, validationErrorCode *string) (EnterpriseLicense, error) {
+	row := q.db.QueryRow(ctx, markEnterpriseLicenseValidationFailed, validationErrorCode)
+	var i EnterpriseLicense
+	err := row.Scan(
+		&i.Singleton,
+		&i.LicenseKey,
+		&i.SealedActivationSecret,
+		&i.OrgName,
+		&i.PlanCode,
+		&i.SubscriptionStartAt,
+		&i.SubscriptionEndAt,
+		&i.SubscriptionRenewalAt,
+		&i.ActivatedAt,
+		&i.LastValidatedAt,
+		&i.ValidationFailedAt,
+		&i.ValidationErrorCode,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
+}
+
 const markUpdateAsChecked = `-- name: MarkUpdateAsChecked :execrows
 WITH target AS (
     SELECT u.id, u.branch_id, u.runtime_version_id, u.platform, u.rollout_percentage, u.created_at
@@ -5892,19 +5984,62 @@ func (q *Queries) UpsertDeviceUpdateFailure(ctx context.Context, arg UpsertDevic
 }
 
 const upsertEnterpriseLicense = `-- name: UpsertEnterpriseLicense :one
-INSERT INTO enterprise_license (singleton, license_key)
-VALUES (TRUE, $1)
-ON CONFLICT (singleton) DO UPDATE
-SET license_key = EXCLUDED.license_key, updated_at = CURRENT_TIMESTAMP
-RETURNING singleton, license_key, created_at, updated_at
+INSERT INTO enterprise_license (
+    singleton, license_key, sealed_activation_secret, org_name, plan_code,
+    subscription_start_at, subscription_end_at, subscription_renewal_at,
+    activated_at, last_validated_at
+)
+VALUES (TRUE, $1, $2, $3, $4, $5, $6, $7, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+ON CONFLICT (singleton) DO UPDATE SET
+    license_key = EXCLUDED.license_key,
+    sealed_activation_secret = EXCLUDED.sealed_activation_secret,
+    org_name = EXCLUDED.org_name,
+    plan_code = EXCLUDED.plan_code,
+    subscription_start_at = EXCLUDED.subscription_start_at,
+    subscription_end_at = EXCLUDED.subscription_end_at,
+    subscription_renewal_at = EXCLUDED.subscription_renewal_at,
+    activated_at = CURRENT_TIMESTAMP,
+    last_validated_at = CURRENT_TIMESTAMP,
+    validation_failed_at = NULL,
+    validation_error_code = NULL,
+    updated_at = CURRENT_TIMESTAMP
+RETURNING singleton, license_key, sealed_activation_secret, org_name, plan_code, subscription_start_at, subscription_end_at, subscription_renewal_at, activated_at, last_validated_at, validation_failed_at, validation_error_code, created_at, updated_at
 `
 
-func (q *Queries) UpsertEnterpriseLicense(ctx context.Context, licenseKey string) (EnterpriseLicense, error) {
-	row := q.db.QueryRow(ctx, upsertEnterpriseLicense, licenseKey)
+type UpsertEnterpriseLicenseParams struct {
+	LicenseKey             string             `json:"license_key"`
+	SealedActivationSecret string             `json:"sealed_activation_secret"`
+	OrgName                string             `json:"org_name"`
+	PlanCode               string             `json:"plan_code"`
+	SubscriptionStartAt    pgtype.Timestamptz `json:"subscription_start_at"`
+	SubscriptionEndAt      pgtype.Timestamptz `json:"subscription_end_at"`
+	SubscriptionRenewalAt  pgtype.Timestamptz `json:"subscription_renewal_at"`
+}
+
+func (q *Queries) UpsertEnterpriseLicense(ctx context.Context, arg UpsertEnterpriseLicenseParams) (EnterpriseLicense, error) {
+	row := q.db.QueryRow(ctx, upsertEnterpriseLicense,
+		arg.LicenseKey,
+		arg.SealedActivationSecret,
+		arg.OrgName,
+		arg.PlanCode,
+		arg.SubscriptionStartAt,
+		arg.SubscriptionEndAt,
+		arg.SubscriptionRenewalAt,
+	)
 	var i EnterpriseLicense
 	err := row.Scan(
 		&i.Singleton,
 		&i.LicenseKey,
+		&i.SealedActivationSecret,
+		&i.OrgName,
+		&i.PlanCode,
+		&i.SubscriptionStartAt,
+		&i.SubscriptionEndAt,
+		&i.SubscriptionRenewalAt,
+		&i.ActivatedAt,
+		&i.LastValidatedAt,
+		&i.ValidationFailedAt,
+		&i.ValidationErrorCode,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 	)

--- a/internal/database/postgres/pgdb/queries.sql.go
+++ b/internal/database/postgres/pgdb/queries.sql.go
@@ -1953,6 +1953,17 @@ func (q *Queries) GetSSOConfig(ctx context.Context) (SsoConfig, error) {
 	return i, err
 }
 
+const getServerInstanceID = `-- name: GetServerInstanceID :one
+SELECT id FROM server_instance
+`
+
+func (q *Queries) GetServerInstanceID(ctx context.Context) (pgtype.UUID, error) {
+	row := q.db.QueryRow(ctx, getServerInstanceID)
+	var id pgtype.UUID
+	err := row.Scan(&id)
+	return id, err
+}
+
 const getSurfableBranches = `-- name: GetSurfableBranches :many
 SELECT b.name AS branch_name, MAX(u.created_at)::timestamptz AS last_update_at
 FROM branches b
@@ -3092,6 +3103,22 @@ func (q *Queries) InsertSSOIdentity(ctx context.Context, arg InsertSSOIdentityPa
 		arg.Email,
 	)
 	return err
+}
+
+const insertServerInstance = `-- name: InsertServerInstance :one
+INSERT INTO server_instance (id)
+VALUES ($1)
+ON CONFLICT (singleton) DO NOTHING
+RETURNING id
+`
+
+// ON CONFLICT DO NOTHING returns no row when another replica minted the id
+// first; the caller falls back to reading the winner's row.
+func (q *Queries) InsertServerInstance(ctx context.Context, id pgtype.UUID) (pgtype.UUID, error) {
+	row := q.db.QueryRow(ctx, insertServerInstance, id)
+	var id_2 pgtype.UUID
+	err := row.Scan(&id_2)
+	return id_2, err
 }
 
 const insertUpdate = `-- name: InsertUpdate :one

--- a/internal/database/postgres/queries/queries.sql
+++ b/internal/database/postgres/queries/queries.sql
@@ -793,10 +793,47 @@ SELECT * FROM enterprise_license
 WHERE singleton;
 
 -- name: UpsertEnterpriseLicense :one
-INSERT INTO enterprise_license (singleton, license_key)
-VALUES (TRUE, $1)
-ON CONFLICT (singleton) DO UPDATE
-SET license_key = EXCLUDED.license_key, updated_at = CURRENT_TIMESTAMP
+INSERT INTO enterprise_license (
+    singleton, license_key, sealed_activation_secret, org_name, plan_code,
+    subscription_start_at, subscription_end_at, subscription_renewal_at,
+    activated_at, last_validated_at
+)
+VALUES (TRUE, $1, $2, $3, $4, $5, $6, $7, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+ON CONFLICT (singleton) DO UPDATE SET
+    license_key = EXCLUDED.license_key,
+    sealed_activation_secret = EXCLUDED.sealed_activation_secret,
+    org_name = EXCLUDED.org_name,
+    plan_code = EXCLUDED.plan_code,
+    subscription_start_at = EXCLUDED.subscription_start_at,
+    subscription_end_at = EXCLUDED.subscription_end_at,
+    subscription_renewal_at = EXCLUDED.subscription_renewal_at,
+    activated_at = CURRENT_TIMESTAMP,
+    last_validated_at = CURRENT_TIMESTAMP,
+    validation_failed_at = NULL,
+    validation_error_code = NULL,
+    updated_at = CURRENT_TIMESTAMP
+RETURNING *;
+
+-- name: MarkEnterpriseLicenseValidated :one
+UPDATE enterprise_license SET
+    org_name = $1,
+    plan_code = $2,
+    subscription_start_at = $3,
+    subscription_end_at = $4,
+    subscription_renewal_at = $5,
+    last_validated_at = CURRENT_TIMESTAMP,
+    validation_failed_at = NULL,
+    validation_error_code = NULL,
+    updated_at = CURRENT_TIMESTAMP
+WHERE singleton
+RETURNING *;
+
+-- name: MarkEnterpriseLicenseValidationFailed :one
+UPDATE enterprise_license SET
+    validation_failed_at = COALESCE(validation_failed_at, CURRENT_TIMESTAMP),
+    validation_error_code = $1,
+    updated_at = CURRENT_TIMESTAMP
+WHERE singleton
 RETURNING *;
 
 -- name: DeleteEnterpriseLicense :exec

--- a/internal/database/postgres/queries/queries.sql
+++ b/internal/database/postgres/queries/queries.sql
@@ -2377,3 +2377,14 @@ JOIN runtime_versions rv ON rv.id = u.runtime_version_id AND rv.app_id = $1
 WHERE b.app_id = $1 AND rv.version = $2 AND u.platform = @platform::text
 GROUP BY b.id, b.name
 ORDER BY MAX(u.created_at) DESC, b.name ASC;
+
+-- name: GetServerInstanceID :one
+SELECT id FROM server_instance;
+
+-- name: InsertServerInstance :one
+-- ON CONFLICT DO NOTHING returns no row when another replica minted the id
+-- first; the caller falls back to reading the winner's row.
+INSERT INTO server_instance (id)
+VALUES ($1)
+ON CONFLICT (singleton) DO NOTHING
+RETURNING id;

--- a/internal/router/routes_account.go
+++ b/internal/router/routes_account.go
@@ -24,6 +24,7 @@ func registerAccountRoutes(
 	accountSubrouter.HandleFunc("/me/password", container.UsersHandler.ChangeMyPasswordHandler).Methods(http.MethodPut)
 
 	accountSubrouter.HandleFunc("/license", container.LicenseHandler.GetLicenseHandler).Methods(http.MethodGet)
+	accountSubrouter.Handle("/license/check", adminOnly(http.HandlerFunc(container.LicenseHandler.CheckLicenseHandler))).Methods(http.MethodPost)
 	accountSubrouter.Handle("/license", adminOnly(http.HandlerFunc(container.LicenseHandler.ActivateLicenseHandler))).Methods(http.MethodPut)
 	accountSubrouter.Handle("/license", adminOnly(http.HandlerFunc(container.LicenseHandler.RemoveLicenseHandler))).Methods(http.MethodDelete)
 

--- a/internal/router/wire.go
+++ b/internal/router/wire.go
@@ -15,6 +15,7 @@ import (
 	"xprem/ee/observe"
 	"xprem/ee/rbac"
 	"xprem/ee/sso"
+	"xprem/ee/telemetry"
 	"xprem/internal/bucket"
 	"xprem/internal/cache"
 	"xprem/internal/database"
@@ -107,6 +108,10 @@ func InitDependencies(ctx context.Context) (*AppContainer, func()) {
 	var explorer *observe.Explorer
 	var checkInRecorder *observe.CheckInRecorder
 
+	telemetryEnabled := !config.IsServerTelemetryDisabled() && !config.IsTestMode()
+	var instanceId string
+	var instanceIdErr error
+
 	cleanup := func() {}
 	// Releases in reverse acquisition order.
 	addCleanup := func(release func()) {
@@ -156,6 +161,11 @@ func InitDependencies(ctx context.Context) (*AppContainer, func()) {
 		updateRepo = pgUpdateStore
 		rolloutRepo = store.NewPostgresRolloutStore(dbEngine)
 
+		if telemetryEnabled {
+			seedInstanceId, _ := resolvedBucket.GetInstanceID()
+			instanceId, instanceIdErr = store.NewPostgresServerInstanceStore(dbEngine).GetOrCreateInstanceID(ctx, seedInstanceId)
+		}
+
 		if config.IsDeviceTelemetryDisabled() {
 			log.Println("🔕 [TELEMETRY] DISABLE_DEVICE_TELEMETRY is set; nothing is recorded about a device: manifest check-ins, identity ops and telemetry batches are all dropped, and no ClickHouse connection is opened. The Observe and Identity dashboards report the feature as unavailable, and CLICKHOUSE_URL is ignored.")
 			addCleanup(observe.StartHealthOutboxDiscarder(ctx, dbEngine))
@@ -193,6 +203,17 @@ func InitDependencies(ctx context.Context) (*AppContainer, func()) {
 		branchRepo = store.NewBucketBranchStore(resolvedBucket)
 		channelRepo = store.NewBucketChannelStore(resolvedBucket)
 		updateRepo = store.NewBucketUpdateStore(resolvedBucket)
+		if telemetryEnabled {
+			instanceId, instanceIdErr = store.NewBucketServerInstanceStore(resolvedBucket, cache.GetCache()).GetOrCreateInstanceID(ctx)
+		}
+	}
+
+	if telemetryEnabled {
+		if instanceIdErr != nil {
+			log.Printf("⚠️  [TELEMETRY] Could not resolve the server instance id, heartbeats stay off for this run: %v", instanceIdErr)
+		} else {
+			telemetry.NewTelemetryService(userRepo, appRepo, instanceId).Start(ctx)
+		}
 	}
 
 	// The router starts the geo resolver in every mode, so its cleanup does

--- a/internal/router/wire.go
+++ b/internal/router/wire.go
@@ -161,9 +161,11 @@ func InitDependencies(ctx context.Context) (*AppContainer, func()) {
 		updateRepo = pgUpdateStore
 		rolloutRepo = store.NewPostgresRolloutStore(dbEngine)
 
-		if telemetryEnabled {
-			seedInstanceId, _ := resolvedBucket.GetInstanceID()
-			instanceId, instanceIdErr = store.NewPostgresServerInstanceStore(dbEngine).GetOrCreateInstanceID(ctx, seedInstanceId)
+		// Resolved even when telemetry is off: licensing needs the instance id.
+		seedInstanceId, _ := resolvedBucket.GetInstanceID()
+		instanceId, instanceIdErr = store.NewPostgresServerInstanceStore(dbEngine).GetOrCreateInstanceID(ctx, seedInstanceId)
+		if instanceIdErr != nil {
+			log.Printf("⚠️  [INSTANCE] Could not resolve the server instance id, license activation and heartbeats are unavailable this run: %v", instanceIdErr)
 		}
 
 		if config.IsDeviceTelemetryDisabled() {
@@ -205,15 +207,14 @@ func InitDependencies(ctx context.Context) (*AppContainer, func()) {
 		updateRepo = store.NewBucketUpdateStore(resolvedBucket)
 		if telemetryEnabled {
 			instanceId, instanceIdErr = store.NewBucketServerInstanceStore(resolvedBucket, cache.GetCache()).GetOrCreateInstanceID(ctx)
+			if instanceIdErr != nil {
+				log.Printf("⚠️  [TELEMETRY] Could not resolve the server instance id, heartbeats stay off for this run: %v", instanceIdErr)
+			}
 		}
 	}
 
-	if telemetryEnabled {
-		if instanceIdErr != nil {
-			log.Printf("⚠️  [TELEMETRY] Could not resolve the server instance id, heartbeats stay off for this run: %v", instanceIdErr)
-		} else {
-			telemetry.NewTelemetryService(userRepo, appRepo, instanceId).Start(ctx)
-		}
+	if telemetryEnabled && instanceIdErr == nil {
+		telemetry.NewTelemetryService(userRepo, appRepo, instanceId).Start(ctx)
 	}
 
 	// The router starts the geo resolver in every mode, so its cleanup does
@@ -222,19 +223,26 @@ func InitDependencies(ctx context.Context) (*AppContainer, func()) {
 
 	logLegacyAppIdFallback()
 
-	licenseService := licensing.NewLicenseService(licenseRepo)
-	if err := licenseService.ActivateFromStore(ctx); err != nil {
-		log.Printf("⚠️  [LICENSE] Could not load the enterprise license from the database: %v", err)
-	}
-	licenseService.StartSync(ctx, 30*time.Second)
-
-	apiKeyAccessService := apikeyrestrictions.NewApiKeyAccessService(apiKeyAccessRepo)
-	branchProtectionService := branchprotection.NewService(branchProtectionRepo)
 	auditService := audit.NewAuditService(auditRepo)
 	if err := auditService.StartArchiveFromEnv(ctx); err != nil {
 		log.Fatalf("🚨 [AUDIT] %v", err)
 	}
 	auditService.StartRetentionPurgeFromEnv(ctx)
+
+	licenseClient := licensing.NewClient(config.GetEnv("LICENSE_API_URL"))
+	licenseService := licensing.NewLicenseService(licenseRepo, licenseClient, instanceId, config.GetEnv("BASE_URL"))
+	// Wired before the loops start: they emit audit events from goroutines.
+	licenseService.SetOnAuditEvent(auditService.Record)
+	if err := licenseService.ActivateFromStore(ctx); err != nil {
+		log.Printf("⚠️  [LICENSE] Could not load the enterprise license from the database: %v", err)
+	}
+	licenseService.StartSync(ctx, 30*time.Second)
+	if !config.IsTestMode() {
+		licenseService.StartValidationLoop(ctx)
+	}
+
+	apiKeyAccessService := apikeyrestrictions.NewApiKeyAccessService(apiKeyAccessRepo)
+	branchProtectionService := branchprotection.NewService(branchProtectionRepo)
 	apiKeyAccessService.SetOnAuditEvent(auditService.Record)
 	branchProtectionService.SetOnAuditEvent(auditService.Record)
 	rbacService := rbac.NewRBACService(rbacRepo, userRepo)
@@ -251,7 +259,6 @@ func InitDependencies(ctx context.Context) (*AppContainer, func()) {
 	dashboardAuthService.SetOnAuditEvent(auditService.Record)
 	ssoService.SetOnAuditEvent(auditService.Record)
 	userService.SetOnAuditEvent(auditService.Record)
-	licenseService.SetOnAuditEvent(auditService.Record)
 	appService := services.NewAppService(appRepo)
 	appService.SetOnAuditEvent(auditService.Record)
 	branchService := services.NewBranchService(branchRepo, channelRepo, updateRepo, rolloutRepo, resolvedBucket)

--- a/internal/router/wire.go
+++ b/internal/router/wire.go
@@ -214,6 +214,7 @@ func InitDependencies(ctx context.Context) (*AppContainer, func()) {
 	}
 
 	if telemetryEnabled && instanceIdErr == nil {
+		log.Println("📡 [TELEMETRY] Hourly usage ping enabled (instance id, base URL, version, configuration shape); set DISABLE_TELEMETRY=true to opt out")
 		telemetry.NewTelemetryService(userRepo, appRepo, instanceId).Start(ctx)
 	}
 

--- a/internal/services/rollout_resolution_test.go
+++ b/internal/services/rollout_resolution_test.go
@@ -590,6 +590,10 @@ func (fakeRolloutBucket) CreateUpdateFrom(previousUpdate *types.Update, newUpdat
 	}, nil
 }
 
+func (fakeRolloutBucket) GetInstanceID() (string, error) { return "", nil }
+
+func (fakeRolloutBucket) PersistInstanceID(_ string) error { return nil }
+
 func (fakeRolloutBucket) RetrieveMigrationHistory() ([]string, error) { return nil, nil }
 
 func (fakeRolloutBucket) ApplyMigration(_ string) error { return nil }

--- a/internal/store/server_instance_bucket.go
+++ b/internal/store/server_instance_bucket.go
@@ -1,0 +1,68 @@
+package store
+
+import (
+	"context"
+	"time"
+	"xprem/internal/bucket"
+	"xprem/internal/cache"
+
+	"github.com/google/uuid"
+)
+
+const (
+	instanceIDLockKey        = "instance-id-lock"
+	instanceIDLockTTLSeconds = 30
+	instanceIDWaitPoll       = 2 * time.Second
+	instanceIDMaxWaits       = 5
+)
+
+// BucketServerInstanceStore is the stateless-mode counterpart of
+// PostgresServerInstanceStore: the deployment id lives in the bucket's
+// .instanceid root file.
+type BucketServerInstanceStore struct {
+	bucket bucket.Bucket
+	cache  cache.Cache
+}
+
+func NewBucketServerInstanceStore(b bucket.Bucket, c cache.Cache) *BucketServerInstanceStore {
+	return &BucketServerInstanceStore{bucket: b, cache: c}
+}
+
+// GetOrCreateInstanceID mints the id on first boot, under the cache lock so
+// concurrent replicas agree on a single one. A replica that cannot get the
+// lock within instanceIDMaxWaits polls mints anyway rather than blocking boot.
+func (s *BucketServerInstanceStore) GetOrCreateInstanceID(ctx context.Context) (string, error) {
+	locked := false
+	for attempt := 0; ; attempt++ {
+		id, err := s.bucket.GetInstanceID()
+		if err != nil {
+			return "", err
+		}
+		if id != "" {
+			return id, nil
+		}
+		locked, err = s.cache.TryLock(instanceIDLockKey, instanceIDLockTTLSeconds)
+		if err != nil {
+			return "", err
+		}
+		if locked || attempt >= instanceIDMaxWaits {
+			break
+		}
+		time.Sleep(instanceIDWaitPoll)
+	}
+	if locked {
+		defer s.cache.Delete(instanceIDLockKey)
+	}
+	id, err := s.bucket.GetInstanceID()
+	if err != nil {
+		return "", err
+	}
+	if id != "" {
+		return id, nil
+	}
+	minted := uuid.New().String()
+	if err := s.bucket.PersistInstanceID(minted); err != nil {
+		return "", err
+	}
+	return minted, nil
+}

--- a/internal/store/server_instance_bucket_test.go
+++ b/internal/store/server_instance_bucket_test.go
@@ -1,0 +1,37 @@
+package store_test
+
+import (
+	"context"
+	"testing"
+	"xprem/internal/bucket"
+	"xprem/internal/cache"
+	"xprem/internal/store"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBucketInstanceIDMintedOnceAndStable(t *testing.T) {
+	b := &bucket.LocalBucket{BasePath: t.TempDir()}
+	s := store.NewBucketServerInstanceStore(b, cache.NewLocalCache())
+
+	first, err := s.GetOrCreateInstanceID(context.Background())
+	require.NoError(t, err)
+	_, err = uuid.Parse(first)
+	require.NoError(t, err)
+
+	second, err := s.GetOrCreateInstanceID(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, first, second)
+}
+
+func TestBucketInstanceIDAdoptsExistingFile(t *testing.T) {
+	b := &bucket.LocalBucket{BasePath: t.TempDir()}
+	existing := uuid.New().String()
+	require.NoError(t, b.PersistInstanceID(existing))
+
+	s := store.NewBucketServerInstanceStore(b, cache.NewLocalCache())
+	got, err := s.GetOrCreateInstanceID(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, existing, got)
+}

--- a/internal/store/server_instance_postgres.go
+++ b/internal/store/server_instance_postgres.go
@@ -1,0 +1,51 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"xprem/internal/database"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+)
+
+// PostgresServerInstanceStore is the server_instance singleton: the
+// deployment's permanent UUID, minted on first boot and immutable after.
+type PostgresServerInstanceStore struct {
+	engine *database.Engine
+}
+
+func NewPostgresServerInstanceStore(engine *database.Engine) *PostgresServerInstanceStore {
+	return &PostgresServerInstanceStore{engine: engine}
+}
+
+// GetOrCreateInstanceID returns the persisted id, minting one first if the
+// table is empty. A valid UUID seed is adopted instead of minting, so a
+// deployment moving from stateless to DB mode keeps its bucket-minted id.
+func (s *PostgresServerInstanceStore) GetOrCreateInstanceID(ctx context.Context, seed string) (string, error) {
+	existing, err := s.engine.Queries.GetServerInstanceID(ctx)
+	if err == nil {
+		return existing.String(), nil
+	}
+	if !errors.Is(err, pgx.ErrNoRows) {
+		return "", fmt.Errorf("read server instance id: %w", err)
+	}
+	candidate := seed
+	if _, parseErr := uuid.Parse(candidate); parseErr != nil {
+		candidate = uuid.New().String()
+	}
+	minted, err := s.engine.Queries.InsertServerInstance(ctx, ToPgUUID(candidate))
+	if err == nil {
+		return minted.String(), nil
+	}
+	if !errors.Is(err, pgx.ErrNoRows) {
+		return "", fmt.Errorf("mint server instance id: %w", err)
+	}
+	// ErrNoRows here means another replica won the first-boot insert race.
+	existing, err = s.engine.Queries.GetServerInstanceID(ctx)
+	if err != nil {
+		return "", fmt.Errorf("read server instance id after lost race: %w", err)
+	}
+	return existing.String(), nil
+}

--- a/test/migrations_test.go
+++ b/test/migrations_test.go
@@ -50,6 +50,10 @@ func (b *dummyMigrationsBucket) CreateUpdateFrom(_ *types.Update, _ string) (*ty
 	b.actionsRecorded = append(b.actionsRecorded, "CreateUpdateFrom")
 	return nil, nil
 }
+func (b *dummyMigrationsBucket) GetInstanceID() (string, error) { return "", nil }
+func (b *dummyMigrationsBucket) PersistInstanceID(_ string) error {
+	return nil
+}
 func (b *dummyMigrationsBucket) RetrieveMigrationHistory() ([]string, error) {
 	return b.migrationsHistory, nil
 }


### PR DESCRIPTION
This pull request introduces major improvements to the Enterprise license management experience in the dashboard. The changes enhance license status visibility, improve error handling and messaging, and introduce a deployment-wide warning banner when license verification fails or the grace period is active. The license activation flow is now safer and clearer, with a verification step before activation. Additionally, license-related UI and audit logging have been updated for better clarity and traceability.

**Enterprise License Management Improvements:**

* Added a deployment-wide `LicenseGraceBanner` component that displays a persistent warning when the license is suspended or in a grace period, ensuring all users are aware of license issues. (`apps/dashboard/src/containers/Layout/index.tsx`, `apps/dashboard/src/ee/components/LicenseGraceBanner.tsx`) [[1]](diffhunk://#diff-03ff5f6ec2639ae15f4f88a178c87480867c9a78bcd387fd6bb4825439c443caR2) [[2]](diffhunk://#diff-03ff5f6ec2639ae15f4f88a178c87480867c9a78bcd387fd6bb4825439c443caR37) [[3]](diffhunk://#diff-df7763267a9f55349ce01907eb300485076076a80a408befb4e6521aeded817eR1-R70)
* Overhauled the License page to:
  - Add a verification step before license activation, with clear error messages and a confirmation dialog. (`apps/dashboard/src/ee/pages/License/index.tsx`, `apps/dashboard/src/ee/lib/licenseErrors.ts`) [[1]](diffhunk://#diff-2b1501a27d7e6dadbca4ede1b3702d73212241ca20d8513e07407820bfcc4f12R46-R53) [[2]](diffhunk://#diff-2b1501a27d7e6dadbca4ede1b3702d73212241ca20d8513e07407820bfcc4f12L49-R99) [[3]](diffhunk://#diff-2b1501a27d7e6dadbca4ede1b3702d73212241ca20d8513e07407820bfcc4f12R111) [[4]](diffhunk://#diff-2b1501a27d7e6dadbca4ede1b3702d73212241ca20d8513e07407820bfcc4f12R147-R171) [[5]](diffhunk://#diff-2b1501a27d7e6dadbca4ede1b3702d73212241ca20d8513e07407820bfcc4f12L141-R192) [[6]](diffhunk://#diff-2b1501a27d7e6dadbca4ede1b3702d73212241ca20d8513e07407820bfcc4f12L156-R257) [[7]](diffhunk://#diff-2b1501a27d7e6dadbca4ede1b3702d73212241ca20d8513e07407820bfcc4f12R267-R311) [[8]](diffhunk://#diff-2b1501a27d7e6dadbca4ede1b3702d73212241ca20d8513e07407820bfcc4f12L218-R333) [[9]](diffhunk://#diff-5608d73596403b4f4b926feb2e4c7d2967a558f845a092536a3bb7d1ba2182abR1-R28)
  - Show detailed, human-friendly messages for license validation errors and status, including grace period and suspension states. [[1]](diffhunk://#diff-2b1501a27d7e6dadbca4ede1b3702d73212241ca20d8513e07407820bfcc4f12L156-R257) [[2]](diffhunk://#diff-2b1501a27d7e6dadbca4ede1b3702d73212241ca20d8513e07407820bfcc4f12R267-R311) [[3]](diffhunk://#diff-2b1501a27d7e6dadbca4ede1b3702d73212241ca20d8513e07407820bfcc4f12L218-R333) [[4]](diffhunk://#diff-5608d73596403b4f4b926feb2e4c7d2967a558f845a092536a3bb7d1ba2182abR1-R28)
  - Improve license details display to show organization, plan, subscription, and verification timestamps.
  - Update descriptions to clarify that license verification is now online and periodic. [[1]](diffhunk://#diff-2b1501a27d7e6dadbca4ede1b3702d73212241ca20d8513e07407820bfcc4f12L141-R192) [[2]](diffhunk://#diff-2b1501a27d7e6dadbca4ede1b3702d73212241ca20d8513e07407820bfcc4f12L218-R333)

**Audit Logging:**

* Added `'license.suspended'` to the list of auditable Enterprise administration actions, improving traceability of license state changes. (`apps/dashboard/src/ee/lib/auditCatalog.ts`)

**UI Improvements:**

* Updated the `EnterpriseBadge` component to display the organization name instead of the license ID for better clarity. (`apps/dashboard/src/ee/components/EnterpriseBadge.tsx`)

**Documentation:**

* Minor update to the `README.md` to clarify MCP server documentation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added server-backed Enterprise license activation, verification, and periodic validation.
  * Added detailed license status, including organization, plan, subscription, suspension, and grace-period information.
  * Added dashboard warnings for suspended licenses and validation grace periods.
  * Added persistent deployment identity and periodic telemetry heartbeats.
  * Added audit events for license suspension.

* **Bug Fixes**
  * Improved license error messages and protected sensitive license data from responses.

* **Documentation**
  * Updated licensing and deployment documentation for the new activation process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->