### PR TITLE
add backward compatibility for republish endpoints between 3.1.1 & 3.1.2

### DIFF
--- a/apps/eoas/src/lib/__tests__/serverUpdates.test.ts
+++ b/apps/eoas/src/lib/__tests__/serverUpdates.test.ts
@@ -136,6 +136,23 @@ describe('fetchUpdates and fetchRuntimeVersions', () => {
     expect((options?.headers as Record<string, string>)['use-cli-auth']).toBe('true');
   });
 
+  it('wraps the bare-array response of pre-pagination servers into a page', async () => {
+    const legacyBody = [update({ updateId: '10' }), update({ updateId: '9', platform: 'android' })];
+    vi.mocked(fetchWithRetries).mockResolvedValueOnce({
+      ok: true,
+      json: async () => legacyBody,
+    } as Response);
+
+    const page = await fetchUpdates({
+      baseUrl: 'https://ota.example.com',
+      appId: 'app-1',
+      branch: 'main',
+      runtimeVersion: '1.0.0',
+      credentials,
+    });
+    expect(page).toEqual({ items: legacyBody, nextCursor: null });
+  });
+
   it('fetches publish groups from their group-level cursor endpoint', async () => {
     const payload = {
       items: [],

--- a/apps/eoas/src/lib/serverUpdates.ts
+++ b/apps/eoas/src/lib/serverUpdates.ts
@@ -109,7 +109,12 @@ export async function fetchUpdates({
   if (!response.ok) {
     throw new Error(`Failed to fetch updates: ${await response.text()}`);
   }
-  return (await response.json()) as ServerUpdatesPage;
+  const body = (await response.json()) as ServerUpdatesPage | ServerUpdateItem[];
+  // Servers older than v3.1.2 return a bare array instead of a page.
+  if (Array.isArray(body)) {
+    return { items: body, nextCursor: null };
+  }
+  return body;
 }
 
 // Publish groups only exist in control-plane mode. A 404 marks group mode as


### PR DESCRIPTION
**Legacy server compatibility:**

* Updated `fetchUpdates` in `serverUpdates.ts` to detect and wrap bare-array responses from pre-pagination servers into a paginated format, ensuring backward compatibility.

**Testing:**

* Added a test case in `serverUpdates.test.ts` to verify that bare-array responses are correctly wrapped into a paginated object.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with legacy server responses when retrieving updates.
  * Legacy update lists are now handled consistently with paginated responses.

* **Tests**
  * Added coverage for converting legacy update lists into the standard paginated format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->