### PR TITLE
feat(auth): add hint for missing EOO_TOKEN on 401 errors

### DIFF
--- a/apps/eoas/src/lib/__tests__/assets.test.ts
+++ b/apps/eoas/src/lib/__tests__/assets.test.ts
@@ -1,6 +1,6 @@
 // node-fetch's Response, not the DOM one: that is what fetchWithRetries resolves to.
 import type { Response } from 'node-fetch';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { activeRolloutConflictMessage, requestUploadUrls } from '../assets';
 import { fetchWithRetries } from '../fetch';
@@ -169,5 +169,50 @@ describe('requestUploadUrls rollout guardrails', () => {
     await expect(requestUploadUrls(baseParams())).rejects.toThrow(
       activeRolloutConflictMessage('main')
     );
+  });
+});
+
+describe('requestUploadUrls auth failures', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  function respondWithStatus(status: number): void {
+    vi.mocked(fetchWithRetries).mockResolvedValueOnce({
+      ok: false,
+      status,
+      text: async () => 'Error validating auth',
+    } as Response);
+  }
+
+  async function captureError(promise: Promise<unknown>): Promise<Error> {
+    try {
+      await promise;
+    } catch (error) {
+      return error as Error;
+    }
+    throw new Error('expected the call to reject');
+  }
+
+  it('hints at EOO_TOKEN on a 401 when publishing with Expo credentials', async () => {
+    vi.stubEnv('EOO_TOKEN', '');
+    respondWithStatus(401);
+    await expect(requestUploadUrls(baseParams())).rejects.toThrow(/set EOO_TOKEN/);
+  });
+
+  it('does not hint when the publish already used a dashboard token', async () => {
+    vi.stubEnv('EOO_TOKEN', 'eoo_test');
+    respondWithStatus(401);
+    const error = await captureError(requestUploadUrls(baseParams()));
+    expect(error.message).toContain('Failed to request upload URL: Error validating auth');
+    expect(error.message).not.toContain('EOO_TOKEN');
+  });
+
+  it('does not hint on non-401 failures', async () => {
+    vi.stubEnv('EOO_TOKEN', '');
+    respondWithStatus(403);
+    const error = await captureError(requestUploadUrls(baseParams()));
+    expect(error.message).toContain('Failed to request upload URL');
+    expect(error.message).not.toContain('EOO_TOKEN');
   });
 });

--- a/apps/eoas/src/lib/assets.ts
+++ b/apps/eoas/src/lib/assets.ts
@@ -4,7 +4,7 @@ import fs from 'fs-extra';
 import Joi from 'joi';
 import path from 'path';
 
-import { Credentials, getAuthHeaders } from './auth';
+import { Credentials, getAuthHeaders, missingEooTokenHint } from './auth';
 import { RequestedPlatform } from './expoConfig';
 import { fetchWithRetries } from './fetch';
 import Log from './log';
@@ -349,7 +349,7 @@ export async function requestUploadUrls({
   }
   if (!response.ok) {
     const text = await response.text();
-    throw new Error(`Failed to request upload URL: ${text}`);
+    throw new Error(`Failed to request upload URL: ${text}${missingEooTokenHint(response.status)}`);
   }
   const json = await response.json();
   // Joi's sanitized value, not the raw payload: it is the object the schema

--- a/apps/eoas/src/lib/auth.ts
+++ b/apps/eoas/src/lib/auth.ts
@@ -11,6 +11,15 @@ export function detectServerImplementation(): ServerImplementation {
   return process.env.EOO_TOKEN ? 'eoo' : 'expo';
 }
 
+// A 401 in expo mode may mean the server only accepts its own dashboard
+// tokens; the CLI cannot know the server's mode, so it can only hint.
+export function missingEooTokenHint(status: number): string {
+  if (status !== 401 || detectServerImplementation() !== 'expo') {
+    return '';
+  }
+  return '\nHint: servers running with a database control plane (DB_URL set) issue their own CLI tokens and do not accept EXPO_TOKEN — generate a token in the dashboard and set EOO_TOKEN.';
+}
+
 export function retrieveCredentials(): Credentials {
   const serverImplementation = detectServerImplementation();
   if (serverImplementation === 'eoo') {


### PR DESCRIPTION
This pull request enhances error handling and user guidance when authentication failures occur during asset upload URL requests. It adds logic to provide helpful hints to users about token requirements and includes new tests to ensure correct behavior in various authentication scenarios.

**Error handling and user guidance improvements:**

* [`apps/eoas/src/lib/auth.ts`](diffhunk://#diff-cee1aabec471953804b1fee16fe1697c3c4aa8e30d2bdc51a7e9e25392f8eb2cR14-R22): Added the `missingEooTokenHint` function, which appends a hint to error messages when a 401 Unauthorized response is received and the server expects a different authentication token (EOO_TOKEN).
* [`apps/eoas/src/lib/assets.ts`](diffhunk://#diff-838759c2d9753887bf32acd506c397087b0c007570aab89459601820adcca938L352-R352): Updated the `requestUploadUrls` function to include the hint from `missingEooTokenHint` in error messages when appropriate. [[1]](diffhunk://#diff-838759c2d9753887bf32acd506c397087b0c007570aab89459601820adcca938L352-R352) [[2]](diffhunk://#diff-838759c2d9753887bf32acd506c397087b0c007570aab89459601820adcca938L7-R7)

**Testing enhancements:**

* [`apps/eoas/src/lib/__tests__/assets.test.ts`](diffhunk://#diff-b2d1cb4e441539037b3afbc8e7459e2ab0c9b76c556056ae69d9ef0976debe78R174-R218): Added a new test suite for authentication failures, covering scenarios for missing tokens, use of the wrong token, and different HTTP status codes to ensure the hint is only provided when relevant. [[1]](diffhunk://#diff-b2d1cb4e441539037b3afbc8e7459e2ab0c9b76c556056ae69d9ef0976debe78R174-R218) [[2]](diffhunk://#diff-b2d1cb4e441539037b3afbc8e7459e2ab0c9b76c556056ae69d9ef0976debe78L3-R3)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved upload error messages for authentication failures.
  * When Expo credentials are missing or invalid, errors now provide guidance about the required dashboard token.
  * Guidance is limited to relevant unauthorized responses and is omitted when a dashboard token is already available or for other failure types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->