### PR TITLE
fix: clarify rollout device count label

### DIFF
--- a/apps/dashboard/src/ee/components/UpdateHealthHistory.tsx
+++ b/apps/dashboard/src/ee/components/UpdateHealthHistory.tsx
@@ -227,6 +227,7 @@ export const UpdateHealthHistory = ({
   renderAnnotationDetails,
   breakdownLabel,
   onBreakdownSelect,
+  devicesLabel,
 }: {
   series: HealthHistorySeries[];
   from?: string;
@@ -239,6 +240,7 @@ export const UpdateHealthHistory = ({
   // nothing to rank, so it leaves this unset and keeps the legend.
   breakdownLabel?: string;
   onBreakdownSelect?: (key: string) => void;
+  devicesLabel?: string;
 }) => {
   const { selectedAppId } = useSelectedApp();
   const [metric, setMetric] = useState<Metric>('health');
@@ -332,6 +334,7 @@ export const UpdateHealthHistory = ({
         pointsByUpdate={query.data.updates}
         annotations={annotations}
         renderAnnotationDetails={renderAnnotationDetails}
+        devicesLabel={devicesLabel}
       />
     );
   }

--- a/apps/dashboard/src/ee/components/UpdateStateHistory.tsx
+++ b/apps/dashboard/src/ee/components/UpdateStateHistory.tsx
@@ -40,11 +40,13 @@ export const UpdateStateHistory = ({
   pointsByUpdate,
   annotations,
   renderAnnotationDetails,
+  devicesLabel = 'Devices on this update now',
 }: {
   series: HealthHistorySeries[];
   pointsByUpdate: Record<string, UpdateStateHistoryPoint[]>;
   annotations?: TimeSeriesAnnotation[];
   renderAnnotationDetails?: TimeSeriesChartProps['renderAnnotationDetails'];
+  devicesLabel?: string;
 }) => {
   const [metric, setMetric] = useState<Metric>('arrivals');
 
@@ -132,7 +134,7 @@ export const UpdateStateHistory = ({
                 }`}>
                 <span className="flex items-center gap-1.5 text-xs text-muted-foreground">
                   <option.icon className="h-3 w-3" />
-                  {option.key === 'arrivals' ? 'Devices on this update now' : 'Failing now'}
+                  {option.key === 'arrivals' ? devicesLabel : 'Failing now'}
                 </span>
                 <span
                   className={`font-mono text-lg tabular-nums ${

--- a/apps/dashboard/src/pages/Updates/components/UpdateRolloutCard.tsx
+++ b/apps/dashboard/src/pages/Updates/components/UpdateRolloutCard.tsx
@@ -204,6 +204,7 @@ export const UpdateRolloutCard = ({
             <UpdateHealthHistory
               from={updates.map(update => update.createdAt).sort()[0]}
               live
+              devicesLabel="Devices in this rollout now"
               series={[
                 {
                   key: 'candidate',


### PR DESCRIPTION
In the Dashboard rollout card, the “Devices on this update now” label is shown above a count that actually sums devices across both the candidate and control updates.

This pr makes the device-count label configurable and sets it to “Devices in this rollout now” for rollout cards. Other update views keep the existing label.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated rollout health history to display clearer, context-specific device labels.
  * Added customizable device labels for update state history views while preserving existing defaults.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->