### PR TITLE
Add official Cursor plugin (docs MCP + 4 skills)

### DIFF
--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,0 +1,23 @@
+{
+  "name": "xprem",
+  "description": "Self-hosted Expo OTA updates. Docs MCP plus optional connection to your own xprem /mcp.",
+  "version": "1.0.0",
+  "author": {
+    "name": "Mercure Technologies",
+    "url": "https://xprem.dev"
+  },
+  "homepage": "https://xprem.dev",
+  "repository": "https://github.com/mercuretechnologies/xprem",
+  "license": "MIT",
+  "keywords": ["expo", "ota", "self-hosted", "updates", "mcp"],
+  "variables": {
+    "type": "object",
+    "properties": {
+      "XPREM_MCP_URL": {
+        "type": "string",
+        "title": "xprem instance MCP URL",
+        "description": "Full MCP endpoint of YOUR self-hosted control plane, e.g. https://xprem.example.com/mcp. Leave empty to use docs only."
+      }
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -172,6 +172,10 @@ claude mcp add --transport http xprem-docs https://mercure-technologies.gitbook.
 
 Any other MCP-compatible client (ChatGPT connectors included) can be pointed at the same URL.
 
+### Cursor / Grok Bot plugin
+
+This repository includes the official Cursor / Grok Bot plugin (`.cursor-plugin/plugin.json`, `mcp.json`, and four skills). It always connects the docs MCP at `https://mercure-technologies.gitbook.io/xprem/~gitbook/mcp` (no auth). Instance MCP is **your own** deployed control plane at `https://<your-host>/mcp` — set `XPREM_MCP_URL` in Cursor under **Plugins → Configure**. There is no Mercure-hosted control plane. Marketplace listing is a later submit at [cursor.com/marketplace/publish](https://cursor.com/marketplace/publish).
+
 ## Why self-host
 
 EAS Update is the fastest way to get OTA updates running on a small app. These are the reasons teams move to self-hosted infrastructure instead.

--- a/mcp.json
+++ b/mcp.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "xprem-docs": {
+      "type": "http",
+      "url": "https://mercure-technologies.gitbook.io/xprem/~gitbook/mcp"
+    },
+    "xprem": {
+      "type": "http",
+      "url": "${XPREM_MCP_URL}"
+    }
+  }
+}

--- a/skills/xprem-configure-expo/SKILL.md
+++ b/skills/xprem-configure-expo/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: xprem-configure-expo
+description: Wire an Expo app to a running xprem server. Use when the user needs the signing certificate (certs/certificate.pem), App ID, npx eoas init, updates.url / request headers, or a release channel on a native build. Not for publishing an update (use xprem-publish).
+---
+
+# xprem-configure-expo
+
+## Before you start
+
+Read the live docs. Do not invent config keys, header names, or CLI prompts.
+
+1. Query the **xprem-docs** MCP (`https://mercure-technologies.gitbook.io/xprem/~gitbook/mcp`), or
+2. Fetch [Configure your application](https://mercure-technologies.gitbook.io/xprem/installation-guide/configure-your-application.md) and Quickstart steps 5–8 at [quickstart.md](https://mercure-technologies.gitbook.io/xprem/quickstart.md).
+
+xprem is **not** affiliated with Expo. Use `eoas`, not EAS Update.
+
+## When to use
+
+- A control-plane server is already running (see **xprem-quickstart**) and the Expo project is not wired yet
+- Missing `certs/certificate.pem`
+- Need the dashboard App ID, `updates.url` (server `BASE_URL`), channel, or `npx eoas init`
+
+## Steps (confirm every prompt on the live pages)
+
+### 1. Create the app and copy the App ID
+
+Open `{SERVER_URL}/dashboard`, create the app, then **App Info** and copy the App ID (UUID).
+
+### 2. Download the signing certificate
+
+App Info → **Download certificate**. Save it in the Expo project as `certs/certificate.pem`:
+
+```bash
+mkdir -p certs
+mv ~/Downloads/app-<your-app-id>-certificate.txt certs/certificate.pem
+```
+
+Commit the certificate. The app uses it to verify that updates came from this server.
+
+### 3. Create an API key
+
+Dashboard → **API tokens**. Copy it now; it cannot be shown again. **xprem-publish** uses it as `EOO_TOKEN`.
+
+### 4. `npx eoas init`
+
+From the Expo project root:
+
+```bash
+npx eoas init
+```
+
+Prompts on the live docs:
+
+| Prompt | Answer |
+| --- | --- |
+| Project id (sent as expo-app-id the in the header) | Dashboard app UUID |
+| URL of your update server | Server `BASE_URL` — this is `updates.url` |
+| Do you have already generated your certificates | **Yes** (downloaded above) |
+
+`eoas init` also adds three keys to `updates.requestHeaders`: `expo-channel-name`, `expo-app-id`, and `xprem-branch`. Keep all three — `expo-updates` only sends headers declared at build time, and `xprem-branch` is what makes branch surfing possible. Keep `expo-channel-name` as a **literal string**, not `process.env`; the config is evaluated at export time and an unset variable silently drops the key.
+
+### 5. Channel
+
+Each native build is bound to a release channel. After the first publish, create a channel in the dashboard and attach it to the branch. Use the channel name that will be baked into the Expo build. Confirm on the live pages rather than assuming `production`.
+
+### 6. Native rebuild
+
+Server URL and signing certificate are embedded at **build time**. Existing binaries keep the old configuration. A new native build is required after this wiring.
+
+Do not walk through publish here — hand off to **xprem-publish**.

--- a/skills/xprem-connect-mcp/SKILL.md
+++ b/skills/xprem-connect-mcp/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: xprem-connect-mcp
+description: Connect Cursor or another MCP client to a deployed xprem control plane at https://<host>/mcp. Use when the user wants an agent to list apps, branches, channels or updates, or to rollback/republish on their own server. Not for the public docs MCP (already bundled).
+---
+
+# xprem-connect-mcp
+
+## Before you start
+
+Read the live docs. Do not invent endpoints, OAuth paths, or a Mercure-hosted control plane.
+
+1. Query the **xprem-docs** MCP (`https://mercure-technologies.gitbook.io/xprem/~gitbook/mcp`), or
+2. Fetch [MCP server](https://mercure-technologies.gitbook.io/xprem/ai/mcp-server.md).
+
+There is **no** Mercure-hosted instance MCP. The user brings their own host.
+
+## When to use
+
+- Connect Cursor / Grok Bot / Claude Code / VS Code to a running xprem
+- The user has a public URL and wants `/mcp`
+- Docs MCP works but instance tools (apps, branches, rollback) do not
+
+## Requirements
+
+- **Control plane (database).** `/mcp` exists only when the server runs with a database. A stateless deployment does **not** expose `/mcp`.
+- `BASE_URL` must be the exact **public** URL clients use. It is the OAuth issuer and token audience. An internal hostname or missing path breaks discovery.
+- Reverse proxy must forward `/mcp`, `/oauth/`, and `/.well-known/` on that same public host.
+- Several replicas: route `/mcp` with session affinity (the MCP session lives in memory on the replica that created it).
+- `JWT_SECRET` signs MCP access tokens the same way it signs dashboard sessions.
+
+## Endpoint
+
+```
+https://<their-host>/mcp
+```
+
+Streamable HTTP. OAuth 2.1 as the **dashboard account**. The first connect opens the consent page; the user logs in and approves. After that the client stores and refreshes tokens. Sessions idle more than 30 minutes are dropped server-side; the client re-initializes.
+
+## Configure Cursor (this plugin)
+
+The plugin already declares an `xprem` HTTP MCP server whose URL is the user variable `XPREM_MCP_URL` (optional, not required).
+
+1. Ask for the public control-plane URL. Do not guess a host.
+2. Set **Plugins → Configure → xprem instance MCP URL** to `https://<host>/mcp` (full endpoint, including `/mcp`).
+3. If they are testing a local copy of this plugin, you may also write the same URL into their Cursor MCP config:
+
+```json
+{
+  "mcpServers": {
+    "xprem": {
+      "type": "http",
+      "url": "https://updates.example.com/mcp"
+    }
+  }
+}
+```
+
+Replace the example host with **theirs**. Never write a Mercure-owned host. Never hardcode a token.
+
+Claude Code (from the live docs):
+
+```bash
+claude mcp add --transport http xprem https://updates.example.com/mcp
+```
+
+The **docs** MCP stays at `https://mercure-technologies.gitbook.io/xprem/~gitbook/mcp` and needs no auth. Do not replace it with the instance URL.
+
+## Permissions
+
+The agent acts as the connected dashboard account and cannot do more than that account.
+
+- Community default (no Enterprise RBAC): members can use **read** tools on apps they see. Certificate download and every **write** (create/delete branches and channels, rollback, republish) is **admin** only.
+- Enterprise RBAC: per-app permissions; writes can be granted app by app. The audit-log tool stays admin-only.
+
+Destructive tools (`delete_branch`, `delete_channel`, `rollback_branch`) declare the MCP destructive annotation. **Always ask for explicit confirmation** before calling them.
+
+Core MIT tools (confirm the current list on the live page) include `whoami`, `get_apps`, `get_branches`, `get_channels`, `get_updates`, `create_branch`, `create_channel`, `rollback_branch`, `republish_update`, and related read/write tools. Enterprise / Observe tools (`query_logs`, `get_observe_overview`, device search, audit) are **not** MIT — do not treat them as available on every deploy.
+
+After connect, start with `whoami`.

--- a/skills/xprem-publish/SKILL.md
+++ b/skills/xprem-publish/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: xprem-publish
+description: Publish an OTA update with eoas (not EAS). Use when the user has EOO_TOKEN, needs `npx eoas publish --branch …`, or must map a dashboard channel to that branch.
+---
+
+# xprem-publish
+
+## Before you start
+
+Read the live docs. Do not invent flags and do not confuse this with `eas update`.
+
+1. Query the **xprem-docs** MCP (`https://mercure-technologies.gitbook.io/xprem/~gitbook/mcp`), or
+2. Fetch [Publish an update](https://mercure-technologies.gitbook.io/xprem/eoas/publish-an-update.md).
+
+Use **eoas** only. Never run `eas update` / EAS Update unless the user explicitly wants Expo's hosted service instead of xprem.
+
+## When to use
+
+- The Expo app is already wired (certificate, App ID, `eoas init`) — otherwise **xprem-configure-expo**
+- The user wants to publish, set `EOO_TOKEN`, pick a branch, or point a channel at that branch
+
+## Auth
+
+`EOO_TOKEN` is the app-scoped API key created in the dashboard. Set it in the **process environment**. EOAS does **not** load `.env` files (`expo export` runs with `EXPO_NO_DOTENV=1`).
+
+Without `EOO_TOKEN`, EOAS silently falls back to Expo authentication and the xprem server rejects the publish.
+
+## Publish
+
+From the Expo project (example from the live quickstart / publish page):
+
+```bash
+export RELEASE_CHANNEL=production
+export EOO_TOKEN=eoo_your_api_key
+npx eoas publish --branch production
+```
+
+- `--branch` is required and is the **only** thing that selects the branch.
+- `RELEASE_CHANNEL` does not select the branch; it is passed into app config / `expo export` so the JS bundle is built for that channel.
+- Runtime version must match the native build exactly or the update is silently not delivered. Prefer a fixed `runtimeVersion` in app config. Re-read the live page before recommending Expo's fingerprint policy.
+
+Useful flags documented on the live page (re-read before using): `--platform`, `--message` / `-m`, `--rollout-percentage`, `--nonInteractive` (required in CI), `--dumpSourcemap`.
+
+CI shape from the docs:
+
+```bash
+EOO_TOKEN=$EOO_TOKEN RELEASE_CHANNEL=production \
+  npx eoas publish --branch production --nonInteractive
+```
+
+`eoas publish` refuses a dirty git tree (untracked files count). `--nonInteractive` aborts with `Commit all changes. Aborting...`. Escape hatches on the live page: `--disableRepositoryCheck` or `EAS_NO_VCS`.
+
+## Map channel → branch
+
+A build is bound to a **channel**; an update is published to a **branch**. In the dashboard: Channels → Create Channel and attach it to the branch you just published. A fresh channel serves that one branch. Use the channel baked into the Expo build, not a guessed default.
+
+Do **not** invent auto-rollback. Progressive rollouts use `--rollout-percentage` plus dashboard controls; if asked, read [Progressive rollouts](https://mercure-technologies.gitbook.io/xprem/eoas/progressive-rollouts.md).

--- a/skills/xprem-quickstart/SKILL.md
+++ b/skills/xprem-quickstart/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: xprem-quickstart
+description: Stand up a working xprem server in minutes. Use when the user wants a first Railway or local Docker+Postgres deploy, dashboard login, or the first admin account. Not for Helm, S3/CDN, Observe, or production hardening.
+---
+
+# xprem-quickstart
+
+## Before you start
+
+Read the live docs. Do not invent image tags, env vars, ports, or commands.
+
+1. Query the always-on **xprem-docs** MCP (`https://mercure-technologies.gitbook.io/xprem/~gitbook/mcp`), or
+2. Fetch [Quickstart](https://mercure-technologies.gitbook.io/xprem/quickstart.md).
+
+xprem is a self-hosted Expo OTA updates server. It is **not** affiliated with Expo. Prefer `eoas` over EAS Update.
+
+## When to use
+
+- First-time "get a server running"
+- Railway 2-click template
+- Local Docker + Postgres
+- Opening the dashboard and seeding the first admin
+
+Out of scope here: Helm, S3/CDN, Observe, Enterprise RBAC/SSO, production topology. Those belong in the [Installation guide](https://mercure-technologies.gitbook.io/xprem/installation-guide/overview.md).
+
+## Railway (2-click)
+
+The Railway template provisions PostgreSQL and an S3-compatible bucket. The only values the user sets are `ADMIN_EMAIL` and `ADMIN_PASSWORD` (they secure the dashboard).
+
+Use the **Deploy on Railway** button on the live quickstart page (do not invent the template URL).
+
+After deploy, open `/dashboard` on the Railway hostname:
+
+`https://your-app.up.railway.app/dashboard`
+
+Sign in with that email and password, then continue from "Create your app" (quickstart local step 5 / Railway "step 7"). App creation, certificate, `eoas init`, and publish are **xprem-configure-expo** and **xprem-publish**.
+
+## Local Docker + Postgres
+
+Prerequisites from the live page: Docker, and an Expo project using `expo-updates` if they will publish afterwards.
+
+### 1. Generate secrets
+
+```bash
+openssl rand -base64 32   # JWT_SECRET
+openssl rand -base64 32   # DB_KEYS_MASTER_KEY_B64
+```
+
+### 2. Start Postgres
+
+Official docs still use a Docker network named `eoo`:
+
+```bash
+docker network create eoo;
+docker run -d --name eoo-db --network eoo \
+  -e POSTGRES_PASSWORD=secret \
+  -e POSTGRES_DB=expo_open_ota \
+  postgres:16;
+```
+
+No host port is published, so this will not collide with a local Postgres on 5432. The server reaches the DB as `eoo-db` on that network.
+
+### 3. Start the server
+
+Image: `ghcr.io/mercuretechnologies/xprem:latest`
+
+Copy the exact `docker run` from the live quickstart. The documented shape is:
+
+- `--network eoo -p 3000:3000`
+- `BASE_URL=http://localhost:3000`
+- `DB_URL=postgres://postgres:secret@eoo-db:5432/expo_open_ota?sslmode=disable` — `DB_URL` is what selects the control plane; the server runs migrations on boot
+- `DB_KEYS_MASTER_KEY_B64` and `JWT_SECRET` from step 1
+- `STORAGE_MODE=local`, `LOCAL_BUCKET_BASE_PATH=/updates`, `CACHE_MODE=local`
+- `USE_DASHBOARD=true`
+- `ADMIN_EMAIL` / `ADMIN_PASSWORD`
+- volume `$(pwd)/updates:/updates`
+
+Look for this log line:
+
+```
+⚙️  [CONTROL] Initializing Control Plane (DB Mode)..
+```
+
+Health check:
+
+```bash
+curl http://localhost:3000/hc
+```
+
+### 4. Dashboard and first admin
+
+Open [http://localhost:3000/dashboard](http://localhost:3000/dashboard) and log in with the `ADMIN_EMAIL` / `ADMIN_PASSWORD` you set.
+
+That pair seeds the **first admin account** into Postgres on boot. After that the two variables are never read again.
+
+## Next
+
+Creating an app, downloading `certs/certificate.pem`, `npx eoas init`, and publishing are **xprem-configure-expo** and **xprem-publish**.
+
+Teardown (from the live quickstart):
+
+```bash
+docker rm -f eoo-db && docker network rm eoo
+```


### PR DESCRIPTION
## Summary

Adds the official Cursor / Grok Bot plugin V1 for xprem: docs MCP (always on, no auth) plus an optional connection to the user's own control-plane `/mcp`, and four skills that tell the agent to read live GitBook instead of inventing steps.

This is a single-plugin repo (`.cursor-plugin/plugin.json` at the root). No `marketplace.json`. Not affiliated with Expo. Marketplace listing is a later submit to [cursor.com/marketplace/publish](https://cursor.com/marketplace/publish) — not a PR on Cursor. Do not merge until reviewed.

## What landed

- `.cursor-plugin/plugin.json` — Cursor plugin manifest (name `xprem`, homepage https://xprem.dev, repo https://github.com/mercuretechnologies/xprem).
- `mcp.json`
  - **xprem-docs** (always-on, no auth): `https://mercure-technologies.gitbook.io/xprem/~gitbook/mcp`
  - **xprem** (instance): `${XPREM_MCP_URL}` — the user's own `https://<host>/mcp`. Not required. Never a Mercure-hosted control plane.
- Skills (each `SKILL.md` has a when-to-use description and points at live docs):
  - `xprem-quickstart` — Railway 2-click (`ADMIN_EMAIL` / `ADMIN_PASSWORD`) or Docker + Postgres (`ghcr.io/mercuretechnologies/xprem:latest`), dashboard, first admin. Docs: [quickstart.md](https://mercure-technologies.gitbook.io/xprem/quickstart.md).
  - `xprem-configure-expo` — `certs/certificate.pem`, `npx eoas init`, App ID, `updates.url`, channel. Docs: [configure-your-application](https://mercure-technologies.gitbook.io/xprem/installation-guide/configure-your-application.md) + quickstart steps 5–8.
  - `xprem-publish` — `EOO_TOKEN`, `npx eoas publish --branch …`, map channel → branch. Not EAS. Docs: [publish-an-update.md](https://mercure-technologies.gitbook.io/xprem/eoas/publish-an-update.md).
  - `xprem-connect-mcp` — connect an agent to a deployed control plane at `https://<host>/mcp` (OAuth 2.1 as the dashboard account). Docs: [mcp-server.md](https://mercure-technologies.gitbook.io/xprem/ai/mcp-server.md).
- README: short **Cursor / Grok Bot plugin** blurb under Quick start (docs MCP URL + instance MCP is the user's own `/mcp`).

## Instance MCP caveat

Cursor plugins **can** express a user-supplied URL via `variables` + `${XPREM_MCP_URL}` (set under **Plugins → Configure**). That is how instance MCP is shipped. The variable is **not** required; leave it empty to use docs only.

Caveat: an empty `${XPREM_MCP_URL}` still declares an `xprem` HTTP server. Clients may show a broken/empty instance connector until the user sets the URL or the **xprem-connect-mcp** skill writes `https://<their-host>/mcp` into their MCP config. Stateless deploys have no `/mcp` (control plane / DB required). `BASE_URL` must be the public URL; proxies must forward `/mcp`, `/oauth/`, and `/.well-known/`.

## How to test locally

Copy the plugin files into the local plugins path, then reload:

```bash
mkdir -p ~/.cursor/plugins/local/xprem
cp -R .cursor-plugin mcp.json skills ~/.cursor/plugins/local/xprem/
```

In Cursor: **Developer: Reload Window**.

Expected:

1. Docs MCP (`xprem-docs`) connects with no auth and can answer from GitBook.
2. Instance MCP stays unset until **Plugins → Configure → xprem instance MCP URL** is `https://<your-host>/mcp` (or the connect-mcp skill writes it).
3. Asking to "stand up xprem", "wire my Expo app", "publish an update", or "connect MCP to my server" loads the matching skill.
4. Skills tell the agent to read live docs first.

## Out of scope (V1)

Helm, S3/CDN, Observe, Enterprise RBAC, SSO, audit, auto-rollback, license/pricing, leftover expo-open-ota names (except the official docs Docker network still named `eoo`).

## Test plan

- [ ] Manifest loads as a Cursor plugin from `~/.cursor/plugins/local/xprem`
- [ ] Docs MCP answers a question from GitBook
- [ ] Setting `XPREM_MCP_URL` to a real control-plane `/mcp` starts OAuth as a dashboard user
- [ ] Leaving `XPREM_MCP_URL` empty still leaves docs MCP usable
- [ ] Four skills appear with when-to-use descriptions
- [ ] No secrets or Mercure-hosted instance URL in the tree


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Cursor/Grok Bot plugin with metadata, skills, and configurable MCP connectivity.
  * Added support for connecting to public documentation and self-hosted MCP endpoints.
  * Added guided skills for quickstart setup, Expo configuration, publishing, and MCP connection.

* **Documentation**
  * Added setup guidance covering deployment, authentication, releases, configuration, troubleshooting, and progressive rollouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->