### PR TITLE
refactor: streamline RBAC subject resolution and app handling

### DIFF
--- a/ee/rbac/handler.go
+++ b/ee/rbac/handler.go
@@ -234,7 +234,7 @@ type MyPermissionsResponse struct {
 // GetMyPermissionsHandler is display support only: the server re-checks every
 // mutation through the middlewares regardless of what the UI shows.
 func (h *RBACHandler) GetMyPermissionsHandler(w http.ResponseWriter, r *http.Request) {
-	subject, ok := h.service.resolveSubject(w, r)
+	subject, ok := resolveSubject(w, r)
 	if !ok {
 		return
 	}

--- a/ee/rbac/handler_test.go
+++ b/ee/rbac/handler_test.go
@@ -143,7 +143,7 @@ func TestMyPermissionsHandler(t *testing.T) {
 	require.Equal(t, map[string][]string{"app-1": {"branch:create"}}, response.Apps)
 
 	// Admin: flagged as such, no map needed.
-	recorder = run(t, http.MethodGet, "/me/permissions", "", &services.DashboardPrincipal{UserId: "admin-1"})
+	recorder = run(t, http.MethodGet, "/me/permissions", "", &services.DashboardPrincipal{UserId: "admin-1", IsAdmin: true})
 	response = decode(recorder)
 	require.True(t, response.IsAdmin)
 	require.Nil(t, response.Apps)

--- a/ee/rbac/mcptools.go
+++ b/ee/rbac/mcptools.go
@@ -71,10 +71,6 @@ func MCPAccess(perm Permission) mcptools.Access {
 	return access
 }
 
-func subjectFor(principal *services.DashboardPrincipal) Subject {
-	return Subject{UserID: principal.UserId, IsAdmin: principal.IsAdmin}
-}
-
 // fallbackFor maps the MIT tool vocabulary onto this package's.
 func fallbackFor(fallback mcptools.Fallback) Fallback {
 	if fallback == mcptools.FallbackAnyMember {

--- a/ee/rbac/middleware.go
+++ b/ee/rbac/middleware.go
@@ -16,38 +16,35 @@ import (
 	"github.com/gorilla/mux"
 )
 
-// UserLookup is the one read the middlewares need from the users store. It is
-// nil in stateless mode, where the session claim (the single ADMIN_EMAIL
-// account) is authoritative.
+// UserLookup resolves a user id to its row; nil in stateless mode.
 type UserLookup interface {
 	GetUserByID(ctx context.Context, id string) (store.User, error)
 }
 
-// resolveSubject authenticates the request as a dashboard account and
-// resolves its admin flag from a fresh users-table read. On failure it writes
-// the response and returns ok=false.
-func (s *RBACService) resolveSubject(w http.ResponseWriter, r *http.Request) (Subject, bool) {
+// resolveSubject reads the dashboard account the auth middleware resolved. On
+// failure it writes the response and returns ok=false.
+func resolveSubject(w http.ResponseWriter, r *http.Request) (Subject, bool) {
 	principal := services.PrincipalFromContext(r.Context())
 	if principal == nil {
 		handlers.RenderError(w, http.StatusForbidden, "This action requires a dashboard session")
 		return Subject{}, false
 	}
-	if s.userLookup == nil {
-		// Stateless mode: the single ADMIN_EMAIL account is always an admin
-		return Subject{UserID: principal.UserId, IsAdmin: principal.IsAdmin}, true
-	}
-	user, err := s.userLookup.GetUserByID(r.Context(), principal.UserId)
-	if err != nil {
-		// Only a missing row means the account is gone; an infrastructure
-		// failure must not read as a dead session.
-		if notFoundErr := (*store.ErrResourceNotFound)(nil); errors.As(err, &notFoundErr) {
-			handlers.RenderError(w, http.StatusUnauthorized, "Invalid token")
-		} else {
-			handlers.RenderError(w, http.StatusInternalServerError, "Could not verify the account")
-		}
-		return Subject{}, false
-	}
-	return Subject{UserID: principal.UserId, IsAdmin: user.IsAdmin}, true
+	return subjectFor(principal), true
+}
+
+// grantContextKey carries the grant RequireAppVisible loaded so that
+// RequirePermission judges the same row instead of reading it again.
+type grantContextKey struct{}
+
+func withGrant(ctx context.Context, grant *AppGrant) context.Context {
+	return context.WithValue(ctx, grantContextKey{}, grant)
+}
+
+// grantFromContext returns the grant loaded earlier in the request; loaded is
+// false when no middleware stored one (admins and the community fallback).
+func grantFromContext(ctx context.Context) (grant *AppGrant, loaded bool) {
+	grant, loaded = ctx.Value(grantContextKey{}).(*AppGrant)
+	return grant, loaded
 }
 
 // RequirePermission guards one app-scoped dashboard action: admins pass,
@@ -72,7 +69,7 @@ func authorizeRequest(
 	perm Permission,
 	fallback Fallback,
 ) bool {
-	subject, ok := service.resolveSubject(w, r)
+	subject, ok := resolveSubject(w, r)
 	if !ok {
 		return false
 	}
@@ -81,7 +78,13 @@ func authorizeRequest(
 		handlers.RenderError(w, http.StatusBadRequest, "invalid app id")
 		return false
 	}
-	if err := service.Authorize(r.Context(), subject, appId, perm, fallback); err != nil {
+	var err error
+	if grant, loaded := grantFromContext(r.Context()); loaded {
+		err = grantAllows(grant, perm)
+	} else {
+		err = service.Authorize(r.Context(), subject, appId, perm, fallback)
+	}
+	if err != nil {
 		service.recordDenied(r, subject, appId, err, map[string]any{"permission": string(perm)})
 		renderAuthorizeError(w, err)
 		return false
@@ -157,19 +160,23 @@ func RequireAppVisible(service *RBACService) mux.MiddlewareFunc {
 				handlers.RenderError(w, http.StatusForbidden, "This action requires a dashboard session")
 				return
 			}
-			subject, ok := service.resolveSubject(w, r)
+			subject, ok := resolveSubject(w, r)
 			if !ok {
 				return
 			}
-			visible, err := service.CanSeeApp(r.Context(), subject, mux.Vars(r)["APP_ID"])
+			appId := mux.Vars(r)["APP_ID"]
+			visible, grant, err := service.VisibleGrant(r.Context(), subject, appId)
 			if err != nil {
 				handlers.RenderError(w, http.StatusInternalServerError, "Could not verify permissions")
 				return
 			}
 			if !visible {
-				service.recordDenied(r, subject, mux.Vars(r)["APP_ID"], ErrNoAppAccess, map[string]any{})
+				service.recordDenied(r, subject, appId, ErrNoAppAccess, map[string]any{})
 				handlers.RenderError(w, http.StatusNotFound, "app not found")
 				return
+			}
+			if grant != nil {
+				r = r.WithContext(withGrant(r.Context(), grant))
 			}
 			next.ServeHTTP(w, r)
 		})

--- a/ee/rbac/middleware_test.go
+++ b/ee/rbac/middleware_test.go
@@ -120,25 +120,59 @@ func TestRequirePermissionEnforcedMember(t *testing.T) {
 	require.Contains(t, recorder.Body.String(), "app not found")
 }
 
-func TestRequirePermissionReadsAdminFlagFresh(t *testing.T) {
-	// The JWT claims admin but the row says member (revoked since the token
-	// was minted): the fresh read wins, and with no grant the app 404s.
+func TestRequirePermissionTrustsPrincipalAdminFlag(t *testing.T) {
+	// The auth layer reads IsAdmin from the users table on every request, so
+	// the middleware judges the principal as is: no second read, and the
+	// lookup is never consulted.
 	lookup := &fakeUserLookup{users: map[string]store.User{"user-1": {Id: "user-1", IsAdmin: false}}}
 	service := withLookup(licensedService(newFakeRepo()), lookup)
-	staleAdmin := &services.DashboardPrincipal{UserId: "user-1", IsAdmin: true}
-	require.Equal(t, http.StatusNotFound,
-		performAppRequest(t, RequirePermission(service, PermBranchCreate, FallbackAdminOnly), staleAdmin).Code)
-
-	// The reverse promotion applies immediately too.
-	lookup.users["user-1"] = store.User{Id: "user-1", IsAdmin: true}
-	freshAdmin := &services.DashboardPrincipal{UserId: "user-1", IsAdmin: false}
 	require.Equal(t, http.StatusOK,
-		performAppRequest(t, RequirePermission(service, PermBranchCreate, FallbackAdminOnly), freshAdmin).Code)
+		performAppRequest(t, RequirePermission(service, PermBranchCreate, FallbackAdminOnly),
+			&services.DashboardPrincipal{UserId: "user-1", IsAdmin: true}).Code)
+	require.Equal(t, http.StatusNotFound,
+		performAppRequest(t, RequirePermission(service, PermBranchCreate, FallbackAdminOnly),
+			&services.DashboardPrincipal{UserId: "user-1", IsAdmin: false}).Code)
+}
 
-	// A deleted account is a dead session, not a 403.
-	recorder := performAppRequest(t, RequirePermission(service, PermBranchCreate, FallbackAdminOnly),
-		&services.DashboardPrincipal{UserId: "ghost"})
-	require.Equal(t, http.StatusUnauthorized, recorder.Code)
+// countingRepo counts grant reads so a test can assert the middlewares share one.
+type countingRepo struct {
+	RBACRepository
+	grantReads int
+}
+
+func (c *countingRepo) GetUserAppGrant(ctx context.Context, userID string, appID string) (*AppGrant, error) {
+	c.grantReads++
+	return c.RBACRepository.GetUserAppGrant(ctx, userID, appID)
+}
+
+func TestRequirePermissionReusesGrantLoadedByRequireAppVisible(t *testing.T) {
+	inner := newFakeRepo()
+	inner.grants["member-1"] = []AppGrant{{AppID: "app-1", ExtraPermissions: []Permission{PermBranchCreate}}}
+	repo := &countingRepo{RBACRepository: inner}
+	service := licensedService(repo)
+	member := &services.DashboardPrincipal{UserId: "member-1"}
+
+	chain := func(next http.Handler) http.Handler {
+		return RequireAppVisible(service)(RequirePermission(service, PermBranchCreate, FallbackAdminOnly)(next))
+	}
+	require.Equal(t, http.StatusOK, performAppRequest(t, chain, member).Code)
+	require.Equal(t, 1, repo.grantReads)
+
+	// The shared grant still decides: a missing permission is a 403.
+	repo.grantReads = 0
+	denied := func(next http.Handler) http.Handler {
+		return RequireAppVisible(service)(RequirePermission(service, PermBranchDelete, FallbackAdminOnly)(next))
+	}
+	recorder := performAppRequest(t, denied, member)
+	require.Equal(t, http.StatusForbidden, recorder.Code)
+	require.Contains(t, recorder.Body.String(), string(PermBranchDelete))
+	require.Equal(t, 1, repo.grantReads)
+
+	// RequirePermission mounted alone still reads the grant itself.
+	repo.grantReads = 0
+	require.Equal(t, http.StatusOK,
+		performAppRequest(t, RequirePermission(service, PermBranchCreate, FallbackAdminOnly), member).Code)
+	require.Equal(t, 1, repo.grantReads)
 }
 
 func TestRequireAppVisible(t *testing.T) {
@@ -160,7 +194,7 @@ func TestRequireAppVisible(t *testing.T) {
 	member := &services.DashboardPrincipal{UserId: "member-1"}
 	require.Equal(t, http.StatusOK, performAppRequest(t, enforced, member).Code)
 	require.Equal(t, http.StatusOK,
-		performAppRequest(t, enforced, &services.DashboardPrincipal{UserId: "admin-1"}).Code)
+		performAppRequest(t, enforced, &services.DashboardPrincipal{UserId: "admin-1", IsAdmin: true}).Code)
 
 	// A grant on another app does not help: this one does not exist for them.
 	repo.grants["member-1"] = []AppGrant{{AppID: "app-2"}}

--- a/ee/rbac/service.go
+++ b/ee/rbac/service.go
@@ -75,11 +75,16 @@ type GrantInput struct {
 }
 
 // Subject is the authenticated account an authorization decision is made for.
-// IsAdmin must come from a fresh users-table read, never the JWT claim alone,
-// so a revoked admin loses access immediately.
+// IsAdmin is the principal's, which the auth layer reads from the users table
+// on every request (services.DashboardAuthService.AuthenticateSession,
+// oauth.OAuthService.AuthenticateMCPToken), never from the JWT claim alone.
 type Subject struct {
 	UserID  string
 	IsAdmin bool
+}
+
+func subjectFor(principal *services.DashboardPrincipal) Subject {
+	return Subject{UserID: principal.UserId, IsAdmin: principal.IsAdmin}
 }
 
 // RBACRepository persists roles and grants. A nil GetUserAppGrant result
@@ -132,7 +137,7 @@ func (e *ValidationError) Error() string {
 // is only consulted while Enabled() is true.
 type RBACService struct {
 	repo RBACRepository
-	// userLookup resolves the fresh admin flag and the grants-endpoint target;
+	// userLookup resolves the grants-endpoint target and audit display names;
 	// nil in stateless mode.
 	userLookup UserLookup
 	// licenseValid reports whether the enterprise license is active.
@@ -374,6 +379,11 @@ func (s *RBACService) Authorize(ctx context.Context, subject Subject, appID stri
 	if err != nil {
 		return err
 	}
+	return grantAllows(grant, perm)
+}
+
+// grantAllows is the member half of Authorize, for a grant already loaded.
+func grantAllows(grant *AppGrant, perm Permission) error {
 	if grant == nil {
 		return ErrNoAppAccess
 	}
@@ -486,17 +496,19 @@ func (s *RBACService) HasPermissionSomewhere(ctx context.Context, subject Subjec
 	return false, nil
 }
 
-// CanSeeApp is the read-path sibling of Authorize: any grant on the app makes
-// it visible to a member; admins see everything.
-func (s *RBACService) CanSeeApp(ctx context.Context, subject Subject, appID string) (bool, error) {
+// VisibleGrant is the read-path sibling of Authorize: any grant on the app
+// makes it visible to a member; admins see everything. The grant is returned
+// so the caller can judge permissions on it without a second read; it is nil
+// whenever visibility did not depend on one.
+func (s *RBACService) VisibleGrant(ctx context.Context, subject Subject, appID string) (visible bool, grant *AppGrant, err error) {
 	if subject.IsAdmin || !s.Enabled() {
-		return true, nil
+		return true, nil, nil
 	}
-	grant, err := s.repo.GetUserAppGrant(ctx, subject.UserID, appID)
+	grant, err = s.repo.GetUserAppGrant(ctx, subject.UserID, appID)
 	if err != nil {
-		return false, err
+		return false, nil, err
 	}
-	return grant != nil, nil
+	return grant != nil, grant, nil
 }
 
 // VisibleApps returns the subject's app scope for list filtering.

--- a/ee/rbac/service_test.go
+++ b/ee/rbac/service_test.go
@@ -238,7 +238,7 @@ func TestAuthorizeAdminBypassesEverything(t *testing.T) {
 	// allowed and always sees everything.
 	for _, service := range []*RBACService{licensedService(newFakeRepo()), unlicensedService(newFakeRepo()), unlicensedService(nil)} {
 		require.NoError(t, service.Authorize(ctx, admin, "any-app", PermAppDelete, FallbackAdminOnly))
-		visible, err := service.CanSeeApp(ctx, admin, "any-app")
+		visible, _, err := service.VisibleGrant(ctx, admin, "any-app")
 		require.NoError(t, err)
 		require.True(t, visible)
 		restricted, _, err := service.VisibleApps(ctx, admin)
@@ -305,7 +305,7 @@ func TestMemberVisibility(t *testing.T) {
 	restricted, _, err := unlicensedService(repo).VisibleApps(ctx, member)
 	require.NoError(t, err)
 	require.False(t, restricted)
-	visible, err := unlicensedService(repo).CanSeeApp(ctx, member, "app-3")
+	visible, _, err := unlicensedService(repo).VisibleGrant(ctx, member, "app-3")
 	require.NoError(t, err)
 	require.True(t, visible)
 
@@ -321,12 +321,14 @@ func TestMemberVisibility(t *testing.T) {
 	require.True(t, restricted)
 	require.Empty(t, ids)
 
-	visible, err = service.CanSeeApp(ctx, member, "app-2")
+	visible, grant, err := service.VisibleGrant(ctx, member, "app-2")
 	require.NoError(t, err)
 	require.True(t, visible)
-	visible, err = service.CanSeeApp(ctx, member, "app-3")
+	require.Equal(t, "app-2", grant.AppID)
+	visible, grant, err = service.VisibleGrant(ctx, member, "app-3")
 	require.NoError(t, err)
 	require.False(t, visible)
+	require.Nil(t, grant)
 }
 
 func TestVisibleAppsForPrincipal(t *testing.T) {

--- a/internal/handlers/dashboard/apps_handler.go
+++ b/internal/handlers/dashboard/apps_handler.go
@@ -132,7 +132,7 @@ func (h *AppHandler) DeleteAppHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	if err := h.appService.DeleteApp(r.Context(), *app); err != nil {
 		notFoundErr := (*store.ErrResourceNotFound)(nil)
-		if !errors.As(err, &notFoundErr) {
+		if errors.As(err, &notFoundErr) {
 			w.WriteHeader(http.StatusNoContent)
 			return
 		}

--- a/internal/handlers/dashboard/apps_handler.go
+++ b/internal/handlers/dashboard/apps_handler.go
@@ -103,13 +103,13 @@ func (h *AppHandler) CreateAppHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *AppHandler) GetAppHandler(w http.ResponseWriter, r *http.Request) {
-	appId := mux.Vars(r)["APP_ID"]
-	if err := config.ValidateAppId(appId, "APP_ID"); err != nil {
-		handlers.RenderError(w, http.StatusBadRequest, err.Error())
+	app := services.AppFromContext(r.Context())
+	if app == nil {
+		handlers.RenderError(w, http.StatusInternalServerError, "app not resolved for this route")
 		return
 	}
 	cache := cache2.GetCache()
-	cacheKey := dashboard.ComputeGetAppCacheKey(appId)
+	cacheKey := dashboard.ComputeGetAppCacheKey(app.Id)
 	if cacheValue := cache.Get(cacheKey); cacheValue != "" {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
@@ -117,17 +117,7 @@ func (h *AppHandler) GetAppHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	app, err := h.appService.GetAppByID(r.Context(), appId)
-	if err != nil {
-		if notFoundErr := (*store.ErrResourceNotFound)(nil); errors.As(err, &notFoundErr) {
-			handlers.RenderError(w, http.StatusNotFound, notFoundErr.Error())
-			return
-		}
-		handlers.RenderError(w, http.StatusInternalServerError, "An internal error occurred while fetching the app.")
-		return
-	}
-
-	marshaledResponse, _ := json.Marshal(app)
+	marshaledResponse, _ := json.Marshal(h.appService.PresentApp(r.Context(), *app))
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 	w.Write(marshaledResponse)
@@ -192,11 +182,9 @@ func (h *AppHandler) GetAppsHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *AppHandler) UpdateAppHandler(w http.ResponseWriter, r *http.Request) {
-	vars := mux.Vars(r)
-	appId := vars["APP_ID"]
-
-	if err := config.ValidateAppId(appId, "APP_ID"); err != nil {
-		handlers.RenderError(w, http.StatusBadRequest, err.Error())
+	app := services.AppFromContext(r.Context())
+	if app == nil {
+		handlers.RenderError(w, http.StatusInternalServerError, "app not resolved for this route")
 		return
 	}
 
@@ -213,15 +201,11 @@ func (h *AppHandler) UpdateAppHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err := h.appService.UpdateApp(r.Context(), appId, requestBody.Name)
+	err := h.appService.UpdateApp(r.Context(), *app, requestBody.Name)
 	if err != nil {
 		var valErr *validation.Error
 		if errors.As(err, &valErr) {
 			handlers.RenderError(w, http.StatusBadRequest, valErr.Error())
-			return
-		}
-		if notFoundErr := (*store.ErrResourceNotFound)(nil); errors.As(err, &notFoundErr) {
-			handlers.RenderError(w, http.StatusNotFound, notFoundErr.Error())
 			return
 		}
 		handlers.RenderError(w, http.StatusInternalServerError, "An internal error occurred while updating the app.")
@@ -230,7 +214,7 @@ func (h *AppHandler) UpdateAppHandler(w http.ResponseWriter, r *http.Request) {
 
 	cache := cache2.GetCache()
 	appsCacheKey := dashboard.ComputeGetAppsCacheKey()
-	appCacheKey := dashboard.ComputeGetAppCacheKey(appId)
+	appCacheKey := dashboard.ComputeGetAppCacheKey(app.Id)
 	cache.Delete(appsCacheKey)
 	cache.Delete(appCacheKey)
 
@@ -238,20 +222,14 @@ func (h *AppHandler) UpdateAppHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *AppHandler) DownloadAppCertificateHandler(w http.ResponseWriter, r *http.Request) {
-	vars := mux.Vars(r)
-	appId := vars["APP_ID"]
-
-	if err := config.ValidateAppId(appId, "APP_ID"); err != nil {
-		handlers.RenderError(w, http.StatusBadRequest, err.Error())
+	app := services.AppFromContext(r.Context())
+	if app == nil {
+		handlers.RenderError(w, http.StatusInternalServerError, "app not resolved for this route")
 		return
 	}
 
-	pemCertificateString, err := h.appService.RetrieveAppCertificate(r.Context(), appId)
+	pemCertificateString, err := h.appService.CertificateFor(r.Context(), *app)
 	if err != nil {
-		if notFoundErr := (*store.ErrResourceNotFound)(nil); errors.As(err, &notFoundErr) {
-			handlers.RenderError(w, http.StatusNotFound, notFoundErr.Error())
-			return
-		}
 		handlers.RenderError(w, http.StatusInternalServerError, "An internal error occurred while downloading the app certificate.")
 		return
 	}

--- a/internal/handlers/dashboard/apps_handler.go
+++ b/internal/handlers/dashboard/apps_handler.go
@@ -133,7 +133,7 @@ func (h *AppHandler) DeleteAppHandler(w http.ResponseWriter, r *http.Request) {
 	if err := h.appService.DeleteApp(r.Context(), *app); err != nil {
 		notFoundErr := (*store.ErrResourceNotFound)(nil)
 		if errors.As(err, &notFoundErr) {
-			w.WriteHeader(http.StatusNoContent)
+			handlers.RenderError(w, http.StatusNotFound, notFoundErr.Error())
 			return
 		}
 		handlers.RenderError(w, http.StatusInternalServerError, "An internal error occurred while deleting the app.")

--- a/internal/handlers/dashboard/apps_handler.go
+++ b/internal/handlers/dashboard/apps_handler.go
@@ -13,8 +13,6 @@ import (
 	"xprem/internal/services"
 	"xprem/internal/store"
 	"xprem/internal/validation"
-
-	"github.com/gorilla/mux"
 )
 
 // AppVisibilityFilter narrows the dashboard app list to what the requesting
@@ -127,17 +125,12 @@ func (h *AppHandler) GetAppHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *AppHandler) DeleteAppHandler(w http.ResponseWriter, r *http.Request) {
-	appId := mux.Vars(r)["APP_ID"]
-	if err := config.ValidateAppId(appId, "APP_ID"); err != nil {
-		handlers.RenderError(w, http.StatusBadRequest, err.Error())
+	app := services.AppFromContext(r.Context())
+	if app == nil {
+		handlers.RenderError(w, http.StatusInternalServerError, "app not resolved for this route")
 		return
 	}
-	err := h.appService.DeleteApp(r.Context(), appId)
-	if err != nil {
-		if notFoundErr := (*store.ErrResourceNotFound)(nil); errors.As(err, &notFoundErr) {
-			handlers.RenderError(w, http.StatusNotFound, notFoundErr.Error())
-			return
-		}
+	if err := h.appService.DeleteApp(r.Context(), *app); err != nil {
 		handlers.RenderError(w, http.StatusInternalServerError, "An internal error occurred while deleting the app.")
 		return
 	}
@@ -145,7 +138,7 @@ func (h *AppHandler) DeleteAppHandler(w http.ResponseWriter, r *http.Request) {
 
 	cache := cache2.GetCache()
 	appsCacheKey := dashboard.ComputeGetAppsCacheKey()
-	appCacheKey := dashboard.ComputeGetAppCacheKey(appId)
+	appCacheKey := dashboard.ComputeGetAppCacheKey(app.Id)
 	cache.Delete(appCacheKey)
 	cache.Delete(appsCacheKey)
 }

--- a/internal/handlers/dashboard/apps_handler.go
+++ b/internal/handlers/dashboard/apps_handler.go
@@ -131,6 +131,11 @@ func (h *AppHandler) DeleteAppHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err := h.appService.DeleteApp(r.Context(), *app); err != nil {
+		notFoundErr := (*store.ErrResourceNotFound)(nil)
+		if !errors.As(err, &notFoundErr) {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
 		handlers.RenderError(w, http.StatusInternalServerError, "An internal error occurred while deleting the app.")
 		return
 	}

--- a/internal/middleware/app_middleware.go
+++ b/internal/middleware/app_middleware.go
@@ -9,8 +9,9 @@ import (
 	"github.com/gorilla/mux"
 )
 
-// AppResolverMiddleware extracts APP_ID from the path vars and short-circuits
-// a malformed or unregistered id with a 4xx before the handler runs.
+// AppResolverMiddleware extracts APP_ID from the path vars, short-circuits a
+// malformed or unregistered id with a 4xx, and hands the loaded app to the
+// handler through the context.
 func AppResolverMiddleware(appRepository services.AppRepository) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -19,11 +20,12 @@ func AppResolverMiddleware(appRepository services.AppRepository) func(http.Handl
 				handlers.RenderError(w, http.StatusBadRequest, "invalid app id")
 				return
 			}
-			if _, err := appRepository.GetAppByID(r.Context(), appId); err != nil {
+			app, err := appRepository.GetAppByID(r.Context(), appId)
+			if err != nil {
 				handlers.RenderError(w, http.StatusNotFound, "app not found")
 				return
 			}
-			next.ServeHTTP(w, r)
+			next.ServeHTTP(w, r.WithContext(services.WithApp(r.Context(), app)))
 		})
 	}
 }

--- a/internal/middleware/auth_middleware.go
+++ b/internal/middleware/auth_middleware.go
@@ -6,7 +6,6 @@ import (
 	"xprem/internal/handlers"
 	"xprem/internal/helpers"
 	"xprem/internal/services"
-	"xprem/internal/store"
 
 	"github.com/gorilla/mux"
 )
@@ -79,31 +78,14 @@ func NewDashboardOnlyMiddleware() mux.MiddlewareFunc {
 }
 
 // NewAdminMiddleware guards a route behind the account-level admin flag.
-// userRepo is nil in stateless mode, where the single ADMIN_EMAIL account is
-// always an admin.
-func NewAdminMiddleware(userRepo services.UserRepository) mux.MiddlewareFunc {
+// NewAdminMiddleware gates a route behind the principal's admin flag, which the
+// auth middleware reads from the users table on every request.
+func NewAdminMiddleware() mux.MiddlewareFunc {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			principal := services.PrincipalFromContext(r.Context())
 			if principal == nil {
 				http.Error(w, "This action requires a dashboard session", http.StatusForbidden)
-				return
-			}
-			if userRepo != nil {
-				user, err := userRepo.GetUserByID(r.Context(), principal.UserId)
-				if err != nil {
-					if notFoundErr := (*store.ErrResourceNotFound)(nil); errors.As(err, &notFoundErr) {
-						http.Error(w, "Invalid token", http.StatusUnauthorized)
-					} else {
-						http.Error(w, "Could not verify the account", http.StatusInternalServerError)
-					}
-					return
-				}
-				if !user.IsAdmin {
-					http.Error(w, "This action requires an admin account", http.StatusForbidden)
-					return
-				}
-				next.ServeHTTP(w, r)
 				return
 			}
 			if !principal.IsAdmin {

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -55,7 +55,7 @@ func NewRouter(container *AppContainer) *mux.Router {
 
 	// adminOnly guards the global administration surface (users, roles,
 	// license, SSO, app creation).
-	adminOnly := middleware.NewAdminMiddleware(container.UserRepo)
+	adminOnly := middleware.NewAdminMiddleware()
 
 	registerOAuthApiRoutes(apiSubrouter, container)
 	registerAccountRoutes(apiSubrouter, container, adminOnly)

--- a/internal/services/app_service.go
+++ b/internal/services/app_service.go
@@ -163,6 +163,12 @@ func (s *AppService) GetAppByID(ctx context.Context, appId string) (config.AppCo
 	if err != nil {
 		return config.AppConfig{}, err
 	}
+	return s.PresentApp(ctx, app), nil
+}
+
+// PresentApp is the dashboard view of an app: secrets stripped, key paths
+// masked, display name resolved.
+func (s *AppService) PresentApp(ctx context.Context, app config.AppConfig) config.AppConfig {
 	app.AccessToken = ""
 	app.Keys.SealedPrivateKey = ""
 	app.Keys.SealedPublicKey = ""
@@ -179,34 +185,27 @@ func (s *AppService) GetAppByID(ctx context.Context, appId string) (config.AppCo
 		// device-facing OTA path never pays the Expo round-trip.
 		app.Name = expo.FetchAppName(ctx, app.Id)
 	}
-	return app, nil
+	return app
 }
 
-func (s *AppService) UpdateApp(ctx context.Context, appId string, newName string) error {
+func (s *AppService) UpdateApp(ctx context.Context, app config.AppConfig, newName string) error {
 	if err := validation.DisplayName("name", newName); err != nil {
 		return err
 	}
-	previous, previousErr := s.appRepo.GetAppByID(ctx, appId)
-	err := s.appRepo.UpdateAppNameByID(ctx, appId, newName)
-	if err != nil {
+	if err := s.appRepo.UpdateAppNameByID(ctx, app.Id, newName); err != nil {
 		return err
 	}
-	// An idempotent rename is not a change: no event. Unknown previous state
-	// records anyway, without the previous_name annotation.
-	if previousErr == nil && previous.Name == newName {
+	// An idempotent rename is not a change: no event.
+	if app.Name == newName {
 		return nil
-	}
-	metadata := map[string]any{"name": newName}
-	if previousErr == nil {
-		metadata["previous_name"] = previous.Name
 	}
 	recordManagementEvent(ctx, s.onAuditEvent, auditlog.Event{
 		Action:        auditlog.ActionAppRenamed,
 		TargetType:    "app",
-		TargetID:      appId,
+		TargetID:      app.Id,
 		TargetDisplay: newName,
-		AppID:         appId,
-		Metadata:      metadata,
+		AppID:         app.Id,
+		Metadata:      map[string]any{"name": newName, "previous_name": app.Name},
 	})
 	return nil
 }
@@ -216,8 +215,14 @@ func (s *AppService) RetrieveAppCertificate(ctx context.Context, appId string) (
 	if err != nil {
 		return "", err
 	}
+	return s.CertificateFor(ctx, app)
+}
+
+// CertificateFor wraps the app's public key in a self-signed code-signing
+// certificate.
+func (s *AppService) CertificateFor(ctx context.Context, app config.AppConfig) (string, error) {
 	if app.Keys.Mode != config.KeysModeDatabase {
-		return "", fmt.Errorf("app with id %s does not use database keys mode", appId)
+		return "", fmt.Errorf("app with id %s does not use database keys mode", app.Id)
 	}
 	publicKey := keyStore.GetPublicExpoKey(app)
 	privateKey := keyStore.GetPrivateExpoKey(app)
@@ -236,9 +241,9 @@ func (s *AppService) RetrieveAppCertificate(ctx context.Context, appId string) (
 	recordManagementEvent(ctx, s.onAuditEvent, auditlog.Event{
 		Action:        auditlog.ActionCertificateDownloaded,
 		TargetType:    "app",
-		TargetID:      appId,
+		TargetID:      app.Id,
 		TargetDisplay: app.Name,
-		AppID:         appId,
+		AppID:         app.Id,
 	})
 	return pemCertificateString, nil
 }

--- a/internal/services/app_service.go
+++ b/internal/services/app_service.go
@@ -133,23 +133,20 @@ func (s *AppService) CreateApp(ctx context.Context, displayName string, keysConf
 	return insertedAppId, nil
 }
 
-func (s *AppService) DeleteApp(ctx context.Context, appId string) error {
-	// Read before the delete: afterwards there is no row left to name in the
-	// audit entry. Best-effort, like the entry itself.
-	displayName := appId
-	if app, err := s.appRepo.GetAppByID(ctx, appId); err == nil && app.Name != "" {
-		displayName = app.Name
-	}
-	err := s.appRepo.DeleteAppByID(ctx, appId)
-	if err != nil {
+func (s *AppService) DeleteApp(ctx context.Context, app config.AppConfig) error {
+	if err := s.appRepo.DeleteAppByID(ctx, app.Id); err != nil {
 		return err
+	}
+	displayName := app.Name
+	if displayName == "" {
+		displayName = app.Id
 	}
 	recordManagementEvent(ctx, s.onAuditEvent, auditlog.Event{
 		Action:        auditlog.ActionAppDeleted,
 		TargetType:    "app",
-		TargetID:      appId,
+		TargetID:      app.Id,
 		TargetDisplay: displayName,
-		AppID:         appId,
+		AppID:         app.Id,
 	})
 	return nil
 }

--- a/internal/services/management_audit_test.go
+++ b/internal/services/management_audit_test.go
@@ -140,8 +140,10 @@ func TestAppLifecycleEmitsAuditEvents(t *testing.T) {
 	require.NoError(t, appService.UpdateApp(ctx, app, "Renamed App"))
 	require.Len(t, recorder.events, 2)
 
-	// The deletion entry still names the app: read before the row went away.
-	require.NoError(t, appService.DeleteApp(ctx, appId))
+	// The deletion entry still names the app.
+	app, err = appService.GetAppByID(ctx, appId)
+	require.NoError(t, err)
+	require.NoError(t, appService.DeleteApp(ctx, app))
 	require.Len(t, recorder.events, 3)
 	assert.Equal(t, auditlog.ActionAppDeleted, recorder.events[2].Action)
 	assert.Equal(t, "Renamed App", recorder.events[2].TargetDisplay)

--- a/internal/services/management_audit_test.go
+++ b/internal/services/management_audit_test.go
@@ -127,13 +127,17 @@ func TestAppLifecycleEmitsAuditEvents(t *testing.T) {
 	assert.Equal(t, map[string]any{"keys_mode": "database"}, created.Metadata)
 
 	// The rename carries both names; an idempotent rename emits nothing.
-	require.NoError(t, appService.UpdateApp(ctx, appId, "Renamed App"))
+	app, err := appService.GetAppByID(ctx, appId)
+	require.NoError(t, err)
+	require.NoError(t, appService.UpdateApp(ctx, app, "Renamed App"))
 	require.Len(t, recorder.events, 2)
 	renamed := recorder.events[1]
 	assert.Equal(t, auditlog.ActionAppRenamed, renamed.Action)
 	assert.Equal(t, map[string]any{"name": "Renamed App", "previous_name": "My App"}, renamed.Metadata)
 
-	require.NoError(t, appService.UpdateApp(ctx, appId, "Renamed App"))
+	app, err = appService.GetAppByID(ctx, appId)
+	require.NoError(t, err)
+	require.NoError(t, appService.UpdateApp(ctx, app, "Renamed App"))
 	require.Len(t, recorder.events, 2)
 
 	// The deletion entry still names the app: read before the row went away.

--- a/internal/services/request_context.go
+++ b/internal/services/request_context.go
@@ -1,6 +1,9 @@
 package services
 
-import "context"
+import (
+	"context"
+	"xprem/config"
+)
 
 // The request-identity context keys live here, next to the types and services
 // that produce them, not in the HTTP middleware that stamps them: the
@@ -82,4 +85,22 @@ const PrincipalExtraKey = "principal"
 func PrincipalFromExtra(extra map[string]any) *DashboardPrincipal {
 	principal, _ := extra[PrincipalExtraKey].(*DashboardPrincipal)
 	return principal
+}
+
+type appContextKey struct{}
+
+// WithApp stores the app the app-resolver middleware loaded for the route's
+// APP_ID.
+func WithApp(ctx context.Context, app config.AppConfig) context.Context {
+	return context.WithValue(ctx, appContextKey{}, app)
+}
+
+// AppFromContext returns the app stored by WithApp, or nil off an app-scoped
+// route.
+func AppFromContext(ctx context.Context) *config.AppConfig {
+	app, ok := ctx.Value(appContextKey{}).(config.AppConfig)
+	if !ok {
+		return nil
+	}
+	return &app
 }


### PR DESCRIPTION
On an app-scoped dashboard request, each middleware re-read from the database what the previous one had already established: the auth middleware loads the user, then the RBAC middlewares load it again (twice) to get an admin flag the principal already carries; the visibility check loads the grant, then the permission check loads the same grant again; the app resolver loads the app, discards it, and the service loads it again. A non-admin member paid 7 reads for 3 facts on every request.

This makes each fact resolved once, by the layer responsible for it, and passed down through the request context: the RBAC layer trusts the principal's admin flag (it is read from the users table on every request by the auth layer, which the MCP path already relied on), the grant loaded by the visibility check is reused by the permission check, and the app loaded by the resolver is handed to the handlers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved app handling by loading app details once and reusing them for viewing, editing, deletion, and certificate downloads.
  * Standardized administrator permission checks using the authenticated principal.
  * Improved permission checks by reusing app access grants already loaded during visibility checks.
  * Improved missing-app handling with clearer not-found responses.
  * Ensured app updates and deletions use the currently resolved app details for more consistent behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->