### PR TITLE
refactor: one set of pgtype helpers instead of three

### DIFF
--- a/ee/audit/store_postgres.go
+++ b/ee/audit/store_postgres.go
@@ -13,6 +13,7 @@ import (
 	"xprem/internal/database"
 	"xprem/internal/database/postgres"
 	"xprem/internal/database/postgres/pgdb"
+	"xprem/internal/store"
 
 	"github.com/jackc/pgx/v5/pgtype"
 )
@@ -66,13 +67,6 @@ func eventFromRow(row pgdb.AuditLogEvent) Event {
 	return event
 }
 
-func toPgTimestamptz(t *time.Time) pgtype.Timestamptz {
-	if t == nil {
-		return pgtype.Timestamptz{}
-	}
-	return pgtype.Timestamptz{Time: *t, Valid: true}
-}
-
 func (s *PostgresAuditStore) Insert(ctx context.Context, event Event) (Event, error) {
 	var appID *string
 	if event.AppID != "" {
@@ -104,8 +98,8 @@ func (s *PostgresAuditStore) List(ctx context.Context, params ListParams) ([]Eve
 		Action:       params.Action,
 		AppID:        params.AppID,
 		Outcome:      params.Outcome,
-		OccurredFrom: toPgTimestamptz(params.From),
-		OccurredTo:   toPgTimestamptz(params.To),
+		OccurredFrom: store.ToPgTimestamptz(params.From),
+		OccurredTo:   store.ToPgTimestamptz(params.To),
 		BeforeID:     params.BeforeID,
 		RowLimit:     int32(params.Limit),
 	})
@@ -183,8 +177,8 @@ func (s *PostgresAuditStore) Count(ctx context.Context, filters ListFilters) (in
 		Action:       filters.Action,
 		AppID:        filters.AppID,
 		Outcome:      filters.Outcome,
-		OccurredFrom: toPgTimestamptz(filters.From),
-		OccurredTo:   toPgTimestamptz(filters.To),
+		OccurredFrom: store.ToPgTimestamptz(filters.From),
+		OccurredTo:   store.ToPgTimestamptz(filters.To),
 	})
 	if err != nil {
 		return 0, fmt.Errorf("failed to count audit events in database: %w", err)

--- a/ee/identity/store_postgres.go
+++ b/ee/identity/store_postgres.go
@@ -13,6 +13,7 @@ import (
 	"time"
 	"xprem/internal/database"
 	"xprem/internal/database/postgres/pgdb"
+	"xprem/internal/store"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgtype"
@@ -24,15 +25,6 @@ type PostgresIdentityStore struct {
 
 func NewPostgresIdentityStore(engine *database.Engine) *PostgresIdentityStore {
 	return &PostgresIdentityStore{engine: engine}
-}
-
-// toPgUUID surfaces a parse failure as an error, never a zero UUID silently written to the database.
-func toPgUUID(id string) (pgtype.UUID, error) {
-	parsed, err := uuid.Parse(id)
-	if err != nil {
-		return pgtype.UUID{}, fmt.Errorf("invalid uuid %q: %w", id, err)
-	}
-	return pgtype.UUID{Bytes: parsed, Valid: true}, nil
 }
 
 func specFromRow(row pgdb.IdentitySchema) KeySpec {
@@ -87,7 +79,7 @@ func deviceFromRow(row pgdb.DeviceIdentity) (Device, error) {
 
 // GetSchema returns the app's allowlist; an app with no declared keys gets an empty schema.
 func (s *PostgresIdentityStore) GetSchema(ctx context.Context, appID string) (Schema, error) {
-	appUUID, err := toPgUUID(appID)
+	appUUID, err := store.ParsePgUUID(appID)
 	if err != nil {
 		return nil, err
 	}
@@ -105,7 +97,7 @@ func (s *PostgresIdentityStore) UpsertSchemaKey(ctx context.Context, appID strin
 	if err := ValidateKeySpec(spec); err != nil {
 		return KeySpec{}, err
 	}
-	appUUID, err := toPgUUID(appID)
+	appUUID, err := store.ParsePgUUID(appID)
 	if err != nil {
 		return KeySpec{}, err
 	}
@@ -142,7 +134,7 @@ func (s *PostgresIdentityStore) UpsertSchemaKey(ctx context.Context, appID strin
 // DeleteSchemaKey removes a key from the allowlist and wipes its autocomplete stats in the
 // same transaction. Values already merged into device metadata are left in place.
 func (s *PostgresIdentityStore) DeleteSchemaKey(ctx context.Context, appID string, key string) (bool, error) {
-	appUUID, err := toPgUUID(appID)
+	appUUID, err := store.ParsePgUUID(appID)
 	if err != nil {
 		return false, err
 	}
@@ -244,11 +236,11 @@ func applyStatOps(ctx context.Context, q *pgdb.Queries, appUUID pgtype.UUID, ops
 }
 
 func (s *PostgresIdentityStore) mutate(ctx context.Context, appID string, easClientID string, kind mutationKind, raw map[string]any, unsetKeys []string, geo *Geo) (ApplyResult, error) {
-	appUUID, err := toPgUUID(appID)
+	appUUID, err := store.ParsePgUUID(appID)
 	if err != nil {
 		return ApplyResult{}, err
 	}
-	clientUUID, err := toPgUUID(easClientID)
+	clientUUID, err := store.ParsePgUUID(easClientID)
 	if err != nil {
 		return ApplyResult{}, err
 	}
@@ -355,11 +347,11 @@ func (s *PostgresIdentityStore) mutate(ctx context.Context, appID string, easCli
 
 // GetDevice returns nil when the install was never seen.
 func (s *PostgresIdentityStore) GetDevice(ctx context.Context, appID string, easClientID string) (*Device, error) {
-	appUUID, err := toPgUUID(appID)
+	appUUID, err := store.ParsePgUUID(appID)
 	if err != nil {
 		return nil, err
 	}
-	clientUUID, err := toPgUUID(easClientID)
+	clientUUID, err := store.ParsePgUUID(easClientID)
 	if err != nil {
 		return nil, err
 	}
@@ -392,15 +384,15 @@ func deviceFilterParams(query DeviceQuery) (convertedDeviceFilters, error) {
 	if err != nil {
 		return convertedDeviceFilters{}, fmt.Errorf("marshalling device filter: %w", err)
 	}
-	clientIDs, err := toPgUUIDs(query.EASClientIDs)
+	clientIDs, err := store.ParsePgUUIDs(query.EASClientIDs)
 	if err != nil {
 		return convertedDeviceFilters{}, err
 	}
-	updateIDs, err := toPgUUIDs(query.CurrentUpdateIDs)
+	updateIDs, err := store.ParsePgUUIDs(query.CurrentUpdateIDs)
 	if err != nil {
 		return convertedDeviceFilters{}, err
 	}
-	publishGroups, err := toPgUUIDs(query.UpdateGroupIDs)
+	publishGroups, err := store.ParsePgUUIDs(query.UpdateGroupIDs)
 	if err != nil {
 		return convertedDeviceFilters{}, err
 	}
@@ -415,7 +407,7 @@ func deviceFilterParams(query DeviceQuery) (convertedDeviceFilters, error) {
 // ListDevices returns one page of the device inventory, newest-seen first, keyset-paginated.
 // A nil cursor starts at the first page; the returned cursor is nil on the last page.
 func (s *PostgresIdentityStore) ListDevices(ctx context.Context, appID string, query DeviceQuery, limit int, cursor *DeviceCursor) ([]Device, *DeviceCursor, error) {
-	appUUID, err := toPgUUID(appID)
+	appUUID, err := store.ParsePgUUID(appID)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -448,7 +440,7 @@ func (s *PostgresIdentityStore) ListDevices(ctx context.Context, appID string, q
 	}
 	if cursor != nil {
 		params.BeforeLastSeen = pgtype.Timestamptz{Time: cursor.LastSeenAt, Valid: true}
-		cursorUUID, err := toPgUUID(cursor.EASClientID)
+		cursorUUID, err := store.ParsePgUUID(cursor.EASClientID)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -481,7 +473,7 @@ func (s *PostgresIdentityStore) ListDevices(ctx context.Context, appID string, q
 }
 
 func (s *PostgresIdentityStore) CountOnlineDevices(ctx context.Context, appID string, since time.Time, query DeviceQuery) (int64, error) {
-	appUUID, err := toPgUUID(appID)
+	appUUID, err := store.ParsePgUUID(appID)
 	if err != nil {
 		return 0, err
 	}
@@ -513,7 +505,7 @@ func (s *PostgresIdentityStore) CountOnlineDevices(ctx context.Context, appID st
 // SearchMetadataValues returns top values of one key ranked by device count, optionally
 // narrowed by a substring.
 func (s *PostgresIdentityStore) SearchMetadataValues(ctx context.Context, appID string, key string, search string, limit int) ([]ValueCount, error) {
-	appUUID, err := toPgUUID(appID)
+	appUUID, err := store.ParsePgUUID(appID)
 	if err != nil {
 		return nil, err
 	}
@@ -557,20 +549,6 @@ func (s *PostgresIdentityStore) SearchMetadataValues(ctx context.Context, appID 
 }
 
 // toPgUUIDs surfaces an unparseable id as an error, not a silently empty result set.
-func toPgUUIDs(values []string) ([]pgtype.UUID, error) {
-	if len(values) == 0 {
-		return nil, nil
-	}
-	parsed := make([]pgtype.UUID, 0, len(values))
-	for _, value := range values {
-		id, err := toPgUUID(value)
-		if err != nil {
-			return nil, err
-		}
-		parsed = append(parsed, id)
-	}
-	return parsed, nil
-}
 
 // maxHardwareTextRunes bounds the hardware strings before they reach the registry, since
 // Model, OSName and OSVersion are unauthenticated client input into unbounded TEXT columns.
@@ -598,11 +576,11 @@ func optionalText(value string) *string {
 // last_seen (and geo/current update) for a known device or registering a new one. A nil
 // current means this check-in does not know the update and leaves that column alone.
 func (s *PostgresIdentityStore) TouchDevice(ctx context.Context, appID string, easClientID string, geo *Geo, current *CurrentUpdate, device DeviceInfo) error {
-	appUUID, err := toPgUUID(appID)
+	appUUID, err := store.ParsePgUUID(appID)
 	if err != nil {
 		return err
 	}
-	clientUUID, err := toPgUUID(easClientID)
+	clientUUID, err := store.ParsePgUUID(easClientID)
 	if err != nil {
 		return err
 	}
@@ -610,7 +588,7 @@ func (s *PostgresIdentityStore) TouchDevice(ctx context.Context, appID string, e
 	// pgx binds every parameter, so observedAt still needs a valid value even when unused.
 	observedAt := pgtype.Timestamptz{Time: time.Now().UTC(), Valid: true}
 	if current != nil {
-		if currentUpdate, err = toPgUUID(current.ID); err != nil {
+		if currentUpdate, err = store.ParsePgUUID(current.ID); err != nil {
 			return err
 		}
 		if !current.ObservedAt.IsZero() {
@@ -701,16 +679,16 @@ func (s *PostgresIdentityStore) resolveUpdateFailures(
 // failureType are capture-once: the first record of a (device, update) failure names them,
 // and sticky re-sends never overwrite it.
 func (s *PostgresIdentityStore) RecordUpdateFailures(ctx context.Context, appID string, easClientID string, updateIDs []string, fatalError string, failureType FailureType) error {
-	appUUID, err := toPgUUID(appID)
+	appUUID, err := store.ParsePgUUID(appID)
 	if err != nil {
 		return err
 	}
-	clientUUID, err := toPgUUID(easClientID)
+	clientUUID, err := store.ParsePgUUID(easClientID)
 	if err != nil {
 		return err
 	}
 	for _, updateID := range updateIDs {
-		updateUUID, err := toPgUUID(updateID)
+		updateUUID, err := store.ParsePgUUID(updateID)
 		if err != nil {
 			continue // forged id in the header: skip, never fail the batch
 		}
@@ -731,15 +709,15 @@ func (s *PostgresIdentityStore) RecordUpdateFailures(ctx context.Context, appID 
 // RecordRuntimeFailure persists one JS crash using the device event timestamp.
 // That timestamp is bounded by the OTLP decoder before reaching this method.
 func (s *PostgresIdentityStore) RecordRuntimeFailure(ctx context.Context, appID string, easClientID string, updateID string, fatalError string, occurredAt time.Time) error {
-	appUUID, err := toPgUUID(appID)
+	appUUID, err := store.ParsePgUUID(appID)
 	if err != nil {
 		return err
 	}
-	clientUUID, err := toPgUUID(easClientID)
+	clientUUID, err := store.ParsePgUUID(easClientID)
 	if err != nil {
 		return err
 	}
-	updateUUID, err := toPgUUID(updateID)
+	updateUUID, err := store.ParsePgUUID(updateID)
 	if err != nil {
 		return err
 	}
@@ -759,15 +737,15 @@ func (s *PostgresIdentityStore) RecordRuntimeFailure(ctx context.Context, appID 
 // strictly newer than the latest crash. Native update_issue rows are never
 // resolved by JS activity.
 func (s *PostgresIdentityStore) ResolveRuntimeFailure(ctx context.Context, appID string, easClientID string, updateID string, occurredAt time.Time) error {
-	appUUID, err := toPgUUID(appID)
+	appUUID, err := store.ParsePgUUID(appID)
 	if err != nil {
 		return err
 	}
-	clientUUID, err := toPgUUID(easClientID)
+	clientUUID, err := store.ParsePgUUID(easClientID)
 	if err != nil {
 		return err
 	}
-	updateUUID, err := toPgUUID(updateID)
+	updateUUID, err := store.ParsePgUUID(updateID)
 	if err != nil {
 		return err
 	}
@@ -801,13 +779,13 @@ type UpdateHealth struct {
 
 // UpdateHealthByIDs returns health per update uuid, skipping non-UUID ids.
 func (s *PostgresIdentityStore) UpdateHealthByIDs(ctx context.Context, appID string, updateIDs []string) (map[string]UpdateHealth, error) {
-	appUUID, err := toPgUUID(appID)
+	appUUID, err := store.ParsePgUUID(appID)
 	if err != nil {
 		return nil, err
 	}
 	ids := make([]pgtype.UUID, 0, len(updateIDs))
 	for _, raw := range updateIDs {
-		if parsed, err := toPgUUID(raw); err == nil {
+		if parsed, err := store.ParsePgUUID(raw); err == nil {
 			ids = append(ids, parsed)
 		}
 	}
@@ -818,7 +796,7 @@ func (s *PostgresIdentityStore) UpdateHealthByIDs(ctx context.Context, appID str
 	// Every id asked about gets an entry, even zero, so a caller can't confuse "no data" with
 	// "not measured" (both queries below are GROUP BYs that answer nothing for an unused update).
 	for _, raw := range updateIDs {
-		if _, err := toPgUUID(raw); err == nil {
+		if _, err := store.ParsePgUUID(raw); err == nil {
 			health[raw] = UpdateHealth{}
 		}
 	}

--- a/ee/identity/store_postgres_test.go
+++ b/ee/identity/store_postgres_test.go
@@ -25,6 +25,7 @@ import (
 	"xprem/internal/database"
 	"xprem/internal/database/postgres"
 	"xprem/internal/database/postgres/pgdb"
+	pgstore "xprem/internal/store"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -1145,11 +1146,11 @@ func TestUpdateHealthCounts(t *testing.T) {
 	require.NoError(t, store.TouchDevice(ctx, appID, d4, nil, nil, DeviceInfo{}))
 	require.NoError(t, store.RecordUpdateFailures(ctx, appID, d4, []string{updateB}, "crashed at launch", FailureTypeUpdate))
 
-	appUUID, err := toPgUUID(appID)
+	appUUID, err := pgstore.ParsePgUUID(appID)
 	require.NoError(t, err)
-	updateAUUID, err := toPgUUID(updateA)
+	updateAUUID, err := pgstore.ParsePgUUID(updateA)
 	require.NoError(t, err)
-	updateBUUID, err := toPgUUID(updateB)
+	updateBUUID, err := pgstore.ParsePgUUID(updateB)
 	require.NoError(t, err)
 
 	onA, err := store.engine.CountDevicesOnUpdate(ctx, pgdb.CountDevicesOnUpdateParams{AppID: appUUID, CurrentUpdateID: updateAUUID})

--- a/ee/licensing/store_postgres.go
+++ b/ee/licensing/store_postgres.go
@@ -7,13 +7,11 @@ package licensing
 import (
 	"context"
 	"fmt"
-	"time"
 	"xprem/internal/crypto"
 	"xprem/internal/database"
 	"xprem/internal/database/postgres/pgdb"
 	"xprem/internal/keyStore"
-
-	"github.com/jackc/pgx/v5/pgtype"
+	"xprem/internal/store"
 )
 
 // activationSecretAAD is the AES-GCM AAD binding the sealed secret to this
@@ -30,21 +28,6 @@ func NewPostgresLicenseStore(engine *database.Engine) *PostgresLicenseStore {
 	return &PostgresLicenseStore{engine: engine}
 }
 
-func toPgTimestamptz(t *time.Time) pgtype.Timestamptz {
-	if t == nil {
-		return pgtype.Timestamptz{}
-	}
-	return pgtype.Timestamptz{Time: *t, Valid: true}
-}
-
-func fromPgTimestamptz(ts pgtype.Timestamptz) *time.Time {
-	if !ts.Valid {
-		return nil
-	}
-	t := ts.Time
-	return &t
-}
-
 func storedFromRow(row pgdb.EnterpriseLicense) *StoredLicense {
 	stored := &StoredLicense{
 		Key: row.LicenseKey,
@@ -52,12 +35,12 @@ func storedFromRow(row pgdb.EnterpriseLicense) *StoredLicense {
 			OrgName:               row.OrgName,
 			PlanCode:              row.PlanCode,
 			SubscriptionStartAt:   row.SubscriptionStartAt.Time,
-			SubscriptionEndAt:     fromPgTimestamptz(row.SubscriptionEndAt),
-			SubscriptionRenewalAt: fromPgTimestamptz(row.SubscriptionRenewalAt),
+			SubscriptionEndAt:     store.FromPgTimestamptz(row.SubscriptionEndAt),
+			SubscriptionRenewalAt: store.FromPgTimestamptz(row.SubscriptionRenewalAt),
 		},
 		ActivatedAt:        row.ActivatedAt.Time,
-		LastValidatedAt:    fromPgTimestamptz(row.LastValidatedAt),
-		ValidationFailedAt: fromPgTimestamptz(row.ValidationFailedAt),
+		LastValidatedAt:    store.FromPgTimestamptz(row.LastValidatedAt),
+		ValidationFailedAt: store.FromPgTimestamptz(row.ValidationFailedAt),
 	}
 	if row.ValidationErrorCode != nil {
 		stored.ValidationErrorCode = *row.ValidationErrorCode
@@ -99,9 +82,9 @@ func (s *PostgresLicenseStore) SaveActivation(ctx context.Context, key string, a
 		SealedActivationSecret: sealedSecret,
 		OrgName:                license.OrgName,
 		PlanCode:               license.PlanCode,
-		SubscriptionStartAt:    toPgTimestamptz(&startAt),
-		SubscriptionEndAt:      toPgTimestamptz(license.SubscriptionEndAt),
-		SubscriptionRenewalAt:  toPgTimestamptz(license.SubscriptionRenewalAt),
+		SubscriptionStartAt:    store.ToPgTimestamptz(&startAt),
+		SubscriptionEndAt:      store.ToPgTimestamptz(license.SubscriptionEndAt),
+		SubscriptionRenewalAt:  store.ToPgTimestamptz(license.SubscriptionRenewalAt),
 	})
 	if err != nil {
 		return StoredLicense{}, fmt.Errorf("failed to store enterprise license in database: %w", err)
@@ -114,9 +97,9 @@ func (s *PostgresLicenseStore) MarkValidated(ctx context.Context, license Licens
 	row, err := s.engine.Queries.MarkEnterpriseLicenseValidated(ctx, pgdb.MarkEnterpriseLicenseValidatedParams{
 		OrgName:               license.OrgName,
 		PlanCode:              license.PlanCode,
-		SubscriptionStartAt:   toPgTimestamptz(&startAt),
-		SubscriptionEndAt:     toPgTimestamptz(license.SubscriptionEndAt),
-		SubscriptionRenewalAt: toPgTimestamptz(license.SubscriptionRenewalAt),
+		SubscriptionStartAt:   store.ToPgTimestamptz(&startAt),
+		SubscriptionEndAt:     store.ToPgTimestamptz(license.SubscriptionEndAt),
+		SubscriptionRenewalAt: store.ToPgTimestamptz(license.SubscriptionRenewalAt),
 	})
 	if err != nil {
 		return StoredLicense{}, fmt.Errorf("failed to record the license validation in database: %w", err)

--- a/ee/observe/explorer.go
+++ b/ee/observe/explorer.go
@@ -19,6 +19,7 @@ import (
 	"xprem/internal/database"
 	"xprem/internal/database/clickhouse"
 	"xprem/internal/database/postgres/pgdb"
+	"xprem/internal/store"
 )
 
 const embeddedUpdateID = "00000000-0000-0000-0000-000000000000"
@@ -195,31 +196,11 @@ func NewExplorer(postgres *database.Engine, clickhouse *clickhouse.Engine) *Expl
 	return &Explorer{postgres: postgres, clickhouse: clickhouse}
 }
 
-func toPGUUID(value string) (pgtype.UUID, error) {
-	parsed, err := uuid.Parse(value)
-	if err != nil {
-		return pgtype.UUID{}, err
-	}
-	return pgtype.UUID{Bytes: parsed, Valid: true}, nil
-}
-
-func toPGUUIDs(values []string) ([]pgtype.UUID, error) {
-	out := make([]pgtype.UUID, 0, len(values))
-	for _, value := range values {
-		parsed, err := toPGUUID(value)
-		if err != nil {
-			return nil, err
-		}
-		out = append(out, parsed)
-	}
-	return out, nil
-}
-
 func (e *Explorer) cohortContext(ctx context.Context, appID string, activeSince time.Time, filters [][]byte) (context.Context, bool, error) {
 	if len(filters) == 0 {
 		return ctx, false, nil
 	}
-	appUUID, err := toPGUUID(appID)
+	appUUID, err := store.ParsePgUUID(appID)
 	if err != nil {
 		return ctx, false, err
 	}
@@ -278,13 +259,13 @@ func (e *Explorer) resolveUpdateGroup(ctx context.Context, appID string, query E
 	if len(query.UpdateGroupIDs) == 0 {
 		return query, false, nil
 	}
-	appUUID, err := toPGUUID(appID)
+	appUUID, err := store.ParsePgUUID(appID)
 	if err != nil {
 		return query, false, err
 	}
 	members := make([]string, 0, 2*len(query.UpdateGroupIDs))
 	for _, group := range query.UpdateGroupIDs {
-		groupUUID, err := toPGUUID(group)
+		groupUUID, err := store.ParsePgUUID(group)
 		if err != nil {
 			return query, false, err
 		}

--- a/ee/observe/locations.go
+++ b/ee/observe/locations.go
@@ -14,6 +14,7 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 
 	"xprem/internal/database/postgres/pgdb"
+	"xprem/internal/store"
 )
 
 // CheckInQuery narrows a check-in read; unlike ExplorerQuery it carries no telemetry dimensions.
@@ -53,19 +54,19 @@ func (e *Explorer) locationParams(
 	activeSince time.Time,
 	query ExplorerQuery,
 ) (pgdb.ListObserveLocationsParams, error) {
-	appUUID, err := toPGUUID(appID)
+	appUUID, err := store.ParsePgUUID(appID)
 	if err != nil {
 		return pgdb.ListObserveLocationsParams{}, err
 	}
-	clientIDs, err := toPGUUIDs(query.EASClientIDs)
+	clientIDs, err := store.ParsePgUUIDs(query.EASClientIDs)
 	if err != nil {
 		return pgdb.ListObserveLocationsParams{}, err
 	}
-	updateIDs, err := toPGUUIDs(query.UpdateIDs)
+	updateIDs, err := store.ParsePgUUIDs(query.UpdateIDs)
 	if err != nil {
 		return pgdb.ListObserveLocationsParams{}, err
 	}
-	publishGroups, err := toPGUUIDs(query.UpdateGroupIDs)
+	publishGroups, err := store.ParsePgUUIDs(query.UpdateGroupIDs)
 	if err != nil {
 		return pgdb.ListObserveLocationsParams{}, err
 	}
@@ -165,19 +166,19 @@ func (e *Explorer) ReadCheckIns(ctx context.Context, appID string, query CheckIn
 }
 
 func (e *Explorer) activeUsers(ctx context.Context, appID string, query ExplorerQuery) (uint64, error) {
-	appUUID, err := toPGUUID(appID)
+	appUUID, err := store.ParsePgUUID(appID)
 	if err != nil {
 		return 0, err
 	}
-	clientIDs, err := toPGUUIDs(query.EASClientIDs)
+	clientIDs, err := store.ParsePgUUIDs(query.EASClientIDs)
 	if err != nil {
 		return 0, err
 	}
-	updateIDs, err := toPGUUIDs(query.UpdateIDs)
+	updateIDs, err := store.ParsePgUUIDs(query.UpdateIDs)
 	if err != nil {
 		return 0, err
 	}
-	publishGroups, err := toPGUUIDs(query.UpdateGroupIDs)
+	publishGroups, err := store.ParsePgUUIDs(query.UpdateGroupIDs)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/store/app_postgres.go
+++ b/internal/store/app_postgres.go
@@ -7,9 +7,6 @@ import (
 	"xprem/config"
 	"xprem/internal/database"
 	"xprem/internal/database/postgres/pgdb"
-
-	"github.com/google/uuid"
-	"github.com/jackc/pgx/v5/pgtype"
 )
 
 type PostgresAppStore struct {
@@ -20,27 +17,6 @@ func NewPostgresAppStore(engine *database.Engine) *PostgresAppStore {
 	return &PostgresAppStore{
 		engine: engine,
 	}
-}
-
-func ToPgUUID(id string) pgtype.UUID {
-	goUUID, err := uuid.Parse(id)
-	if err != nil {
-		return pgtype.UUID{
-			Valid: false,
-		}
-	}
-	return pgtype.UUID{
-		Bytes: [16]byte(goUUID),
-		Valid: true,
-	}
-}
-
-// ToPgUUIDPtr maps a nil pointer to the SQL NULL uuid.
-func ToPgUUIDPtr(id *string) pgtype.UUID {
-	if id == nil {
-		return pgtype.UUID{}
-	}
-	return ToPgUUID(*id)
 }
 
 type InsertAppParameters struct {

--- a/internal/store/pgtypes.go
+++ b/internal/store/pgtypes.go
@@ -1,0 +1,70 @@
+package store
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+// ParsePgUUID parses id, refusing a malformed one rather than handing the
+// database a NULL.
+func ParsePgUUID(id string) (pgtype.UUID, error) {
+	parsed, err := uuid.Parse(id)
+	if err != nil {
+		return pgtype.UUID{}, fmt.Errorf("invalid uuid %q: %w", id, err)
+	}
+	return pgtype.UUID{Bytes: parsed, Valid: true}, nil
+}
+
+// ParsePgUUIDs parses every id; nil for an empty input.
+func ParsePgUUIDs(ids []string) ([]pgtype.UUID, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+	parsed := make([]pgtype.UUID, 0, len(ids))
+	for _, id := range ids {
+		pgID, err := ParsePgUUID(id)
+		if err != nil {
+			return nil, err
+		}
+		parsed = append(parsed, pgID)
+	}
+	return parsed, nil
+}
+
+// ToPgUUID maps a malformed id to the SQL NULL uuid; callers whose input is
+// not validated upstream should use ParsePgUUID.
+func ToPgUUID(id string) pgtype.UUID {
+	pgID, err := ParsePgUUID(id)
+	if err != nil {
+		return pgtype.UUID{}
+	}
+	return pgID
+}
+
+// ToPgUUIDPtr maps a nil pointer to the SQL NULL uuid.
+func ToPgUUIDPtr(id *string) pgtype.UUID {
+	if id == nil {
+		return pgtype.UUID{}
+	}
+	return ToPgUUID(*id)
+}
+
+// ToPgTimestamptz maps a nil pointer to the SQL NULL timestamptz.
+func ToPgTimestamptz(t *time.Time) pgtype.Timestamptz {
+	if t == nil {
+		return pgtype.Timestamptz{}
+	}
+	return pgtype.Timestamptz{Time: *t, Valid: true}
+}
+
+// FromPgTimestamptz maps the SQL NULL timestamptz to a nil pointer.
+func FromPgTimestamptz(ts pgtype.Timestamptz) *time.Time {
+	if !ts.Valid {
+		return nil
+	}
+	t := ts.Time
+	return &t
+}

--- a/internal/store/refresh_token_postgres.go
+++ b/internal/store/refresh_token_postgres.go
@@ -148,7 +148,7 @@ func refreshTokenFromRow(row pgdb.RefreshToken) RefreshToken {
 		UserId:    row.UserID.String(),
 		FamilyId:  row.FamilyID.String(),
 		ExpiresAt: row.ExpiresAt.Time,
-		UsedAt:    timestamptzToPtr(row.UsedAt),
+		UsedAt:    FromPgTimestamptz(row.UsedAt),
 	}
 	if row.ReplacedBy.Valid {
 		successor := row.ReplacedBy.String()

--- a/internal/store/user_postgres.go
+++ b/internal/store/user_postgres.go
@@ -7,8 +7,6 @@ import (
 	"time"
 	"xprem/internal/database"
 	"xprem/internal/database/postgres/pgdb"
-
-	"github.com/jackc/pgx/v5/pgtype"
 )
 
 // User is a dashboard user account. PasswordHash is only populated by the
@@ -117,7 +115,7 @@ func (s *PostgresUserStore) GetUsers(ctx context.Context) ([]User, error) {
 			IsAdmin:         row.IsAdmin,
 			Enabled:         row.Enabled,
 			CreatedAt:       row.CreatedAt.Time,
-			LastConnectedAt: timestamptzToPtr(row.LastConnectedAt),
+			LastConnectedAt: FromPgTimestamptz(row.LastConnectedAt),
 		}
 	}
 	return users, nil
@@ -220,15 +218,7 @@ func userFromRow(row pgdb.User) User {
 		IsAdmin:         row.IsAdmin,
 		Enabled:         row.Enabled,
 		CreatedAt:       row.CreatedAt.Time,
-		LastConnectedAt: timestamptzToPtr(row.LastConnectedAt),
+		LastConnectedAt: FromPgTimestamptz(row.LastConnectedAt),
 		SessionVersion:  row.SessionVersion,
 	}
-}
-
-func timestamptzToPtr(ts pgtype.Timestamptz) *time.Time {
-	if !ts.Valid {
-		return nil
-	}
-	t := ts.Time
-	return &t
 }


### PR DESCRIPTION
The string-to-uuid and timestamptz conversions for pgx existed in three copies across `internal/store`, `ee/identity` and `ee/observe` (plus two more for timestamps in `ee/audit` and `ee/licensing`), with different failure contracts: one copy swallowed a malformed uuid into a SQL NULL, the other two returned an error. Whoever writes the next store picks whichever they find first.

This keeps a single implementation in `internal/store/pgtypes.go`. `ToPgUUID` keeps its lenient signature for its existing callers; `ParsePgUUID` is the strict one for input that has not been validated upstream.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized database handling for UUIDs and timestamps across audit, identity, licensing, observability, user, and session data.
  * Improved consistency of UUID validation and nullable timestamp conversion.
  * Preserved existing application behavior and public interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->