### PR TITLE
refactor: typed claims for the JWTs we issue ourselves

### DIFF
--- a/ee/sso/service.go
+++ b/ee/sso/service.go
@@ -407,14 +407,16 @@ func (s *SSOService) BeginLogin(ctx context.Context) (*LoginRedirect, error) {
 		return nil, err
 	}
 	verifier := oauth2.GenerateVerifier()
-	flowToken, err := crypto.GenerateJWTToken(s.secret, jwt.MapClaims{
-		"sub":      flowSubject,
-		"type":     flowClaimType,
-		"exp":      time.Now().Add(flowTTL).Unix(),
-		"iat":      time.Now().Unix(),
-		"state":    state,
-		"nonce":    nonce,
-		"verifier": verifier,
+	flowToken, err := crypto.GenerateJWTToken(s.secret, flowClaims{
+		RegisteredClaims: jwt.RegisteredClaims{
+			Subject:   flowSubject,
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(flowTTL)),
+			IssuedAt:  jwt.NewNumericDate(time.Now()),
+		},
+		Type:     flowClaimType,
+		State:    state,
+		Nonce:    nonce,
+		Verifier: verifier,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("error while generating the sso flow token: %w", err)
@@ -582,18 +584,25 @@ type flowState struct {
 	verifier string
 }
 
+// flowClaims is the claim set of the token that carries an SSO login across
+// the redirect to the IdP and back.
+type flowClaims struct {
+	jwt.RegisteredClaims
+	Type     string `json:"type"`
+	State    string `json:"state"`
+	Nonce    string `json:"nonce"`
+	Verifier string `json:"verifier"`
+}
+
 func (s *SSOService) verifyFlowToken(flowToken string) (*flowState, error) {
-	claims := jwt.MapClaims{}
+	claims := flowClaims{}
 	if _, err := crypto.DecodeAndExtractJWTToken(s.secret, flowToken, &claims); err != nil {
 		return nil, err
 	}
-	if claims["type"] != flowClaimType || claims["sub"] != flowSubject {
+	if claims.Type != flowClaimType || claims.Subject != flowSubject {
 		return nil, errors.New("not an sso flow token")
 	}
-	flow := &flowState{}
-	flow.state, _ = claims["state"].(string)
-	flow.nonce, _ = claims["nonce"].(string)
-	flow.verifier, _ = claims["verifier"].(string)
+	flow := &flowState{state: claims.State, nonce: claims.Nonce, verifier: claims.Verifier}
 	if flow.state == "" || flow.nonce == "" || flow.verifier == "" {
 		return nil, errors.New("incomplete sso flow token")
 	}

--- a/internal/bucket/localBucket.go
+++ b/internal/bucket/localBucket.go
@@ -55,16 +55,15 @@ func (b *LocalBucket) RequestUploadUrlForFileUpdate(appId string, branch string,
 	if err != nil {
 		return "", err
 	}
-	token, err := crypto.GenerateJWTToken(config.GetEnv("JWT_SECRET"), jwt.MapClaims{
-		"sub":      GetSubjectForApp(appId),
-		"exp":      time.Now().Add(time.Minute * 10).Unix(),
-		"filePath": filepath.Join(dirPath, fileName),
-		"action":   "uploadLocalFile",
-		"appId":    appId,
-		// The branch this upload belongs to. The route that spends this token
-		// names no branch of its own, so this claim is what lets the router
-		// judge it against the API key's access rules.
-		"branch": branch,
+	token, err := crypto.GenerateJWTToken(config.GetEnv("JWT_SECRET"), uploadClaims{
+		RegisteredClaims: jwt.RegisteredClaims{
+			Subject:   GetSubjectForApp(appId),
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Minute * 10)),
+		},
+		FilePath: filepath.Join(dirPath, fileName),
+		Action:   "uploadLocalFile",
+		AppID:    appId,
+		Branch:   branch,
 	})
 	if err != nil {
 		return "", err
@@ -276,6 +275,17 @@ func GetSubjectForApp(appId string) string {
 	return fmt.Sprintf("app:%s", appId)
 }
 
+// uploadClaims is the claim set of a local upload URL token. Branch is what
+// lets the router judge the upload route, which names no branch of its own,
+// against the API key's access rules.
+type uploadClaims struct {
+	jwt.RegisteredClaims
+	FilePath string `json:"filePath"`
+	Action   string `json:"action"`
+	AppID    string `json:"appId"`
+	Branch   string `json:"branch"`
+}
+
 // ValidateUploadTokenAndResolveFilePath decodes and verifies the JWT emitted
 // by RequestUploadUrlForFileUpdate. It returns the resolved filesystem path
 // plus the appId claim so the caller can confirm the token is scoped to the
@@ -283,23 +293,15 @@ func GetSubjectForApp(appId string) string {
 // token for AppA could PUT into AppB's bucket by hitting
 // /{AppB}/uploadLocalFile?token=<appA_token>.
 func ValidateUploadTokenAndResolveFilePath(token string) (filePath string, appId string, branch string, err error) {
-	claims := jwt.MapClaims{}
-	decodedToken, err := crypto.DecodeAndExtractJWTToken(config.GetEnv("JWT_SECRET"), token, claims)
-	if err != nil {
+	claims := uploadClaims{}
+	if _, err := crypto.DecodeAndExtractJWTToken(config.GetEnv("JWT_SECRET"), token, &claims); err != nil {
 		return "", "", "", err
 	}
-	if !decodedToken.Valid {
-		return "", "", "", errors.New("invalid token")
-	}
-	action, _ := claims["action"].(string)
-	filePath, _ = claims["filePath"].(string)
-	sub, _ := claims["sub"].(string)
-	appId, _ = claims["appId"].(string)
-	branch, _ = claims["branch"].(string)
-	if appId == "" || sub != GetSubjectForApp(appId) {
+	filePath, appId, branch = claims.FilePath, claims.AppID, claims.Branch
+	if appId == "" || claims.Subject != GetSubjectForApp(appId) {
 		return "", "", "", errors.New("invalid token sub")
 	}
-	if action != "uploadLocalFile" {
+	if claims.Action != "uploadLocalFile" {
 		return "", "", "", errors.New("invalid token action")
 	}
 	// The token carries the branch and the file path as two separate claims,

--- a/internal/oauth/token.go
+++ b/internal/oauth/token.go
@@ -47,16 +47,28 @@ func ResourceMetadataURL() string {
 	return baseURL() + "/.well-known/oauth-protected-resource/mcp"
 }
 
+// mcpClaims is the claim set of both MCP OAuth JWTs. Type and ID are only set
+// on the refresh token, Audience and Scope only on the access token.
+type mcpClaims struct {
+	jwt.RegisteredClaims
+	Type           string `json:"type,omitempty"`
+	UserID         string `json:"userId"`
+	SessionVersion int32  `json:"sv"`
+	Scope          string `json:"scope,omitempty"`
+}
+
 // IssueAccessToken mints the Bearer token the token endpoint hands out.
 func (s *OAuthService) IssueAccessToken(principal services.DashboardPrincipal) (string, error) {
-	token, err := crypto.GenerateJWTToken(s.secret, jwt.MapClaims{
-		"sub":    mcpSubject,
-		"aud":    ResourceURL(),
-		"exp":    time.Now().Add(accessTokenTTL).Unix(),
-		"iat":    time.Now().Unix(),
-		"userId": principal.UserId,
-		"sv":     principal.SessionVersion,
-		"scope":  ScopeMCP,
+	token, err := crypto.GenerateJWTToken(s.secret, mcpClaims{
+		RegisteredClaims: jwt.RegisteredClaims{
+			Subject:   mcpSubject,
+			Audience:  jwt.ClaimStrings{ResourceURL()},
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(accessTokenTTL)),
+			IssuedAt:  jwt.NewNumericDate(time.Now()),
+		},
+		UserID:         principal.UserId,
+		SessionVersion: principal.SessionVersion,
+		Scope:          ScopeMCP,
 	})
 	if err != nil {
 		return "", fmt.Errorf("error while generating the mcp access token: %w", err)
@@ -136,25 +148,24 @@ func (s *OAuthService) ExchangeAuthorizationCode(ctx context.Context, req Exchan
 // one; rotation, replay grace and replay revocation mirror the dashboard's
 // RefreshSession over the same ledger.
 func (s *OAuthService) RefreshAccessToken(ctx context.Context, tokenString string) (*TokenResponse, error) {
-	claims := jwt.MapClaims{}
+	claims := mcpClaims{}
 	if _, err := crypto.DecodeAndExtractJWTToken(s.secret, tokenString, &claims); err != nil {
 		return nil, ErrInvalidGrant
 	}
-	if claims["sub"] != mcpSubject || claims["type"] != "refreshToken" {
+	if claims.Subject != mcpSubject || claims.Type != "refreshToken" {
 		return nil, ErrInvalidGrant
 	}
-	userId, _ := claims["userId"].(string)
-	if userId == "" {
+	if claims.UserID == "" {
 		return nil, ErrInvalidGrant
 	}
-	principal, err := s.principalForUser(ctx, userId)
+	principal, err := s.principalForUser(ctx, claims.UserID)
 	if err != nil {
 		return nil, err
 	}
-	if sessionVersion, _ := claims["sv"].(float64); principal.SessionVersion != int32(sessionVersion) {
+	if principal.SessionVersion != claims.SessionVersion {
 		return nil, ErrInvalidGrant
 	}
-	spentId, _ := claims["jti"].(string)
+	spentId := claims.ID
 	if spentId == "" {
 		return nil, ErrInvalidGrant
 	}
@@ -241,14 +252,16 @@ func (s *OAuthService) issueTokenPair(principal services.DashboardPrincipal, tok
 	if err != nil {
 		return nil, err
 	}
-	refreshToken, err := crypto.GenerateJWTToken(s.secret, jwt.MapClaims{
-		"sub":    mcpSubject,
-		"type":   "refreshToken",
-		"exp":    expiresAt.Unix(),
-		"iat":    time.Now().Unix(),
-		"userId": principal.UserId,
-		"sv":     principal.SessionVersion,
-		"jti":    tokenId,
+	refreshToken, err := crypto.GenerateJWTToken(s.secret, mcpClaims{
+		RegisteredClaims: jwt.RegisteredClaims{
+			Subject:   mcpSubject,
+			ExpiresAt: jwt.NewNumericDate(expiresAt),
+			IssuedAt:  jwt.NewNumericDate(time.Now()),
+			ID:        tokenId,
+		},
+		Type:           "refreshToken",
+		UserID:         principal.UserId,
+		SessionVersion: principal.SessionVersion,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("error while generating the mcp refresh token: %w", err)
@@ -266,34 +279,32 @@ func (s *OAuthService) issueTokenPair(principal services.DashboardPrincipal, tok
 // signature proves the token was valid when minted, the user row says whether
 // it still is. The returned time is the token's expiration.
 func (s *OAuthService) AuthenticateMCPToken(ctx context.Context, tokenString string) (*services.DashboardPrincipal, time.Time, error) {
-	claims := jwt.MapClaims{}
+	claims := mcpClaims{}
 	if _, err := crypto.DecodeAndExtractJWTToken(s.secret, tokenString, &claims); err != nil {
 		return nil, time.Time{}, err
 	}
-	if claims["sub"] != mcpSubject {
+	if claims.Subject != mcpSubject {
 		return nil, time.Time{}, errors.New("invalid token subject")
 	}
-	if audience, _ := claims.GetAudience(); len(audience) != 1 || audience[0] != ResourceURL() {
+	if len(claims.Audience) != 1 || claims.Audience[0] != ResourceURL() {
 		return nil, time.Time{}, errors.New("invalid token audience")
 	}
-	expiresAt, err := claims.GetExpirationTime()
-	if err != nil || expiresAt == nil {
+	if claims.ExpiresAt == nil {
 		return nil, time.Time{}, errors.New("invalid token expiration")
 	}
-	userId, _ := claims["userId"].(string)
-	if userId == "" {
+	expiresAt := claims.ExpiresAt
+	if claims.UserID == "" {
 		return nil, time.Time{}, services.ErrSessionRevoked
 	}
-	sessionVersion, _ := claims["sv"].(float64)
 
-	user, err := s.userRepo.GetUserByID(ctx, userId)
+	user, err := s.userRepo.GetUserByID(ctx, claims.UserID)
 	if err != nil {
 		if notFoundErr := (*store.ErrResourceNotFound)(nil); errors.As(err, &notFoundErr) {
 			return nil, time.Time{}, services.ErrSessionRevoked
 		}
 		return nil, time.Time{}, fmt.Errorf("%w: %v", services.ErrAuthUnavailable, err)
 	}
-	if !user.Enabled || user.SessionVersion != int32(sessionVersion) {
+	if !user.Enabled || user.SessionVersion != claims.SessionVersion {
 		return nil, time.Time{}, services.ErrSessionRevoked
 	}
 	return &services.DashboardPrincipal{

--- a/internal/services/dashboard_auth_service.go
+++ b/internal/services/dashboard_auth_service.go
@@ -121,31 +121,50 @@ func statelessPasswordVersion() string {
 	return hex.EncodeToString(sum[:8])
 }
 
+// sessionClaims is the claim set of both dashboard session JWTs. SessionVersion
+// is absent on a token minted before it existed, which reads as generation 0.
+type sessionClaims struct {
+	jwt.RegisteredClaims
+	Type           string `json:"type"`
+	UserID         string `json:"userId"`
+	Email          string `json:"email"`
+	IsAdmin        bool   `json:"isAdmin,omitempty"`
+	SessionVersion int32  `json:"sv"`
+	// PasswordVersion is only set in stateless mode.
+	PasswordVersion string `json:"pv,omitempty"`
+}
+
 // statelessClaimsAreCurrent reports whether a stateless token was minted under
 // the password in force now. Always true outside stateless mode, where the
 // account row carries the session version instead.
-func (a *DashboardAuthService) statelessClaimsAreCurrent(claims jwt.MapClaims) bool {
+func (a *DashboardAuthService) statelessClaimsAreCurrent(claims sessionClaims) bool {
 	if a.userRepo != nil {
 		return true
 	}
-	version, _ := claims["pv"].(string)
-	return version == statelessPasswordVersion()
+	return claims.PasswordVersion == statelessPasswordVersion()
+}
+
+func (a *DashboardAuthService) statelessPasswordVersionClaim() string {
+	if a.userRepo == nil {
+		return statelessPasswordVersion()
+	}
+	return ""
 }
 
 // generateSessionToken mints the access half of a dashboard session.
 func (a *DashboardAuthService) generateSessionToken(principal DashboardPrincipal) (*string, error) {
-	claims := jwt.MapClaims{
-		"sub":     dashboardSubject,
-		"exp":     time.Now().Add(sessionTokenTTL).Unix(),
-		"iat":     time.Now().Unix(),
-		"type":    "token",
-		"userId":  principal.UserId,
-		"email":   principal.Email,
-		"isAdmin": principal.IsAdmin,
-		"sv":      principal.SessionVersion,
-	}
-	if a.userRepo == nil {
-		claims["pv"] = statelessPasswordVersion()
+	claims := sessionClaims{
+		RegisteredClaims: jwt.RegisteredClaims{
+			Subject:   dashboardSubject,
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(sessionTokenTTL)),
+			IssuedAt:  jwt.NewNumericDate(time.Now()),
+		},
+		Type:            "token",
+		UserID:          principal.UserId,
+		Email:           principal.Email,
+		IsAdmin:         principal.IsAdmin,
+		SessionVersion:  principal.SessionVersion,
+		PasswordVersion: a.statelessPasswordVersionClaim(),
 	}
 	token, err := crypto.GenerateJWTToken(a.Secret, claims)
 	if err != nil {
@@ -157,18 +176,18 @@ func (a *DashboardAuthService) generateSessionToken(principal DashboardPrincipal
 // generateRefreshToken mints the refresh half. tokenId names the ledger row
 // that makes it single-use, and is empty in stateless mode.
 func (a *DashboardAuthService) generateRefreshToken(principal DashboardPrincipal, tokenId string, expiresAt time.Time) (*string, error) {
-	claims := jwt.MapClaims{
-		"sub":    dashboardSubject,
-		"exp":    expiresAt.Unix(),
-		"iat":    time.Now().Unix(),
-		"type":   "refreshToken",
-		"userId": principal.UserId,
-		"email":  principal.Email,
-		"sv":     principal.SessionVersion,
-		"jti":    tokenId,
-	}
-	if a.userRepo == nil {
-		claims["pv"] = statelessPasswordVersion()
+	claims := sessionClaims{
+		RegisteredClaims: jwt.RegisteredClaims{
+			Subject:   dashboardSubject,
+			ExpiresAt: jwt.NewNumericDate(expiresAt),
+			IssuedAt:  jwt.NewNumericDate(time.Now()),
+			ID:        tokenId,
+		},
+		Type:            "refreshToken",
+		UserID:          principal.UserId,
+		Email:           principal.Email,
+		SessionVersion:  principal.SessionVersion,
+		PasswordVersion: a.statelessPasswordVersionClaim(),
 	}
 	refreshToken, err := crypto.GenerateJWTToken(a.Secret, claims)
 	if err != nil {
@@ -383,39 +402,26 @@ func (a *DashboardAuthService) IssueSession(ctx context.Context, user store.User
 // minted for, purely from the claims. It does not check the account still
 // exists; AuthenticateSession does.
 func (a *DashboardAuthService) ValidateSession(tokenString string) (*DashboardPrincipal, error) {
-	claims := jwt.MapClaims{}
+	claims := sessionClaims{}
 	_, err := crypto.DecodeAndExtractJWTToken(a.Secret, tokenString, &claims)
 	if err != nil {
 		return nil, err
 	}
-	if claims["type"] != "token" {
+	if claims.Type != "token" {
 		return nil, errors.New("invalid token type")
 	}
-	if claims["sub"] != dashboardSubject {
+	if claims.Subject != dashboardSubject {
 		return nil, errors.New("invalid token subject")
 	}
 	if !a.statelessClaimsAreCurrent(claims) {
 		return nil, ErrSessionRevoked
 	}
-	principal := DashboardPrincipal{}
-	if userId, ok := claims["userId"].(string); ok {
-		principal.UserId = userId
-	}
-	if email, ok := claims["email"].(string); ok {
-		principal.Email = email
-	}
-	if isAdmin, ok := claims["isAdmin"].(bool); ok {
-		principal.IsAdmin = isAdmin
-	}
-	principal.SessionVersion = sessionVersionClaim(claims)
-	return &principal, nil
-}
-
-// sessionVersionClaim reads the sv claim; a token minted before sv existed
-// has none, which reads as generation 0.
-func sessionVersionClaim(claims jwt.MapClaims) int32 {
-	version, _ := claims["sv"].(float64)
-	return int32(version)
+	return &DashboardPrincipal{
+		UserId:         claims.UserID,
+		Email:          claims.Email,
+		IsAdmin:        claims.IsAdmin,
+		SessionVersion: claims.SessionVersion,
+	}, nil
 }
 
 // AuthenticateSession validates the token and re-reads the account behind it,
@@ -454,14 +460,14 @@ func (a *DashboardAuthService) AuthenticateSession(ctx context.Context, tokenStr
 // Step 2 runs before the spend so a database outage leaves the caller's token
 // intact instead of burning a good credential over a blip.
 func (a *DashboardAuthService) RefreshSession(ctx context.Context, tokenString string) (*DashboardSession, error) {
-	claims := jwt.MapClaims{}
+	claims := sessionClaims{}
 	if _, err := crypto.DecodeAndExtractJWTToken(a.Secret, tokenString, &claims); err != nil {
 		return nil, err
 	}
-	if claims["type"] != "refreshToken" {
+	if claims.Type != "refreshToken" {
 		return nil, errors.New("invalid token type")
 	}
-	if claims["sub"] != dashboardSubject {
+	if claims.Subject != dashboardSubject {
 		return nil, errors.New("invalid token subject")
 	}
 
@@ -469,26 +475,24 @@ func (a *DashboardAuthService) RefreshSession(ctx context.Context, tokenString s
 		if !a.statelessClaimsAreCurrent(claims) {
 			return nil, ErrSessionRevoked
 		}
-		email, _ := claims["email"].(string)
-		principal, err := resolveStatelessPrincipal(email, nil)
+		principal, err := resolveStatelessPrincipal(claims.Email, nil)
 		if err != nil {
 			return nil, err
 		}
 		return a.startSession(ctx, *principal)
 	}
 
-	userId, _ := claims["userId"].(string)
-	principal, err := a.resolveRefreshPrincipal(ctx, userId)
+	principal, err := a.resolveRefreshPrincipal(ctx, claims.UserID)
 	if err != nil {
 		return nil, err
 	}
-	if principal.SessionVersion != sessionVersionClaim(claims) {
+	if principal.SessionVersion != claims.SessionVersion {
 		return nil, ErrSessionRevoked
 	}
 	if a.refreshTokens == nil {
 		return a.startSession(ctx, *principal)
 	}
-	spentId, _ := claims["jti"].(string)
+	spentId := claims.ID
 	if spentId == "" {
 		// Minted before rotation existed, or forged: no ledger row names it.
 		return nil, ErrSessionRevoked

--- a/internal/services/dashboard_auth_service_test.go
+++ b/internal/services/dashboard_auth_service_test.go
@@ -3,8 +3,11 @@ package services
 import (
 	"context"
 	"testing"
+	"time"
+	"xprem/internal/crypto"
 	"xprem/internal/store"
 
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -144,4 +147,30 @@ func TestSSOEnforcementOnPasswordLogin(t *testing.T) {
 	ssoActive = false
 	_, err = authService.LoginWithEmailPassword(ctx, "member@example.com", "Sup3rSecret!")
 	assert.NoError(t, err)
+}
+
+// A session minted before claims were typed (jwt.MapClaims, sv as a JSON
+// number) must keep validating: the claim set is the wire contract.
+func TestSessionClaimsStayCompatibleWithMapClaimsTokens(t *testing.T) {
+	t.Setenv("JWT_SECRET", "test-secret")
+	authService := NewDashboardAuthService(newFakeUserRepo(), newFakeRefreshTokenRepo())
+
+	legacy, err := crypto.GenerateJWTToken("test-secret", jwt.MapClaims{
+		"sub":     dashboardSubject,
+		"exp":     time.Now().Add(time.Hour).Unix(),
+		"iat":     time.Now().Unix(),
+		"type":    "token",
+		"userId":  "user-1",
+		"email":   "member@example.com",
+		"isAdmin": true,
+		"sv":      3,
+	})
+	require.NoError(t, err)
+
+	principal, err := authService.ValidateSession(legacy)
+	require.NoError(t, err)
+	assert.Equal(t, "user-1", principal.UserId)
+	assert.Equal(t, "member@example.com", principal.Email)
+	assert.True(t, principal.IsAdmin)
+	assert.Equal(t, int32(3), principal.SessionVersion)
 }


### PR DESCRIPTION
The four token families the server mints and verifies itself (dashboard session, MCP OAuth, local upload URL, SSO flow) were read back through `jwt.MapClaims`: about twenty `claims["x"].(string)` assertions spread over four files, and the session version read as a `float64` and cast to `int32` in three places. Each new claim meant another untyped read at every verification site.

Each family now has one claims struct, used both to mint and to verify, with the same JSON names as before so tokens already in circulation keep validating (covered by a test that verifies a `MapClaims`-minted token).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability and consistency when validating SSO, upload, access, refresh, and dashboard session tokens.
  * Preserved compatibility with existing sessions, including legacy token formats.
  * Continued enforcing token expiration, identity, audience, revocation, and rotation checks.
  * Strengthened handling of token data to reduce validation errors and improve authentication consistency across services.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->