### PR TITLE
refactor: keep sqlc types out of the service interfaces

### DIFF
--- a/internal/handlers/branch_list_handler_test.go
+++ b/internal/handlers/branch_list_handler_test.go
@@ -8,7 +8,6 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
-	"xprem/internal/providers/expo"
 	"xprem/internal/services"
 	"xprem/internal/types"
 
@@ -32,7 +31,7 @@ func (r *stubChannelRepo) GetChannelNameByBranchName(_ context.Context, _, _ str
 func (r *stubChannelRepo) GetChannels(_ context.Context, _ string) ([]types.ChannelMapping, error) {
 	return nil, nil
 }
-func (r *stubChannelRepo) GetChannelBranchMapping(_ context.Context, _, _ string) (*expo.ChannelResolution, error) {
+func (r *stubChannelRepo) GetChannelBranchMapping(_ context.Context, _, _ string) (*types.ChannelResolution, error) {
 	return nil, nil
 }
 func (r *stubChannelRepo) GetBranchSurfing(_ context.Context, _, channelName string) (*types.BranchSurfing, error) {

--- a/internal/handlers/branch_list_handler_test.go
+++ b/internal/handlers/branch_list_handler_test.go
@@ -51,7 +51,7 @@ func (r *stubBranchRepo) InsertBranch(_ context.Context, _, _ string) (int64, er
 func (r *stubBranchRepo) UpsertBranchAndRuntimeVersion(_ context.Context, _, _, _ string) error {
 	return nil
 }
-func (r *stubBranchRepo) GetUpdatedMetadataByBranchName(_ context.Context, _, _ string) ([]types.UpdateRef, error) {
+func (r *stubBranchRepo) GetUpdateRefsByBranchName(_ context.Context, _, _ string) ([]types.UpdateRef, error) {
 	return nil, nil
 }
 func (r *stubBranchRepo) DeleteBranchByName(_ context.Context, _, _ string) error { return nil }

--- a/internal/handlers/branch_list_handler_test.go
+++ b/internal/handlers/branch_list_handler_test.go
@@ -8,7 +8,6 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
-	"xprem/internal/database/postgres/pgdb"
 	"xprem/internal/providers/expo"
 	"xprem/internal/services"
 	"xprem/internal/types"
@@ -33,7 +32,7 @@ func (r *stubChannelRepo) GetChannelNameByBranchName(_ context.Context, _, _ str
 func (r *stubChannelRepo) GetChannels(_ context.Context, _ string) ([]types.ChannelMapping, error) {
 	return nil, nil
 }
-func (r *stubChannelRepo) GetChannelBranchMapping(_ context.Context, _, _ string) (*expo.ChannelMapping, error) {
+func (r *stubChannelRepo) GetChannelBranchMapping(_ context.Context, _, _ string) (*expo.ChannelResolution, error) {
 	return nil, nil
 }
 func (r *stubChannelRepo) GetBranchSurfing(_ context.Context, _, channelName string) (*types.BranchSurfing, error) {
@@ -47,13 +46,13 @@ type stubBranchRepo struct {
 	surfable map[string][]types.SurfableBranch
 }
 
-func (r *stubBranchRepo) InsertBranch(_ context.Context, _ pgdb.InsertBranchParams) (int64, error) {
+func (r *stubBranchRepo) InsertBranch(_ context.Context, _, _ string) (int64, error) {
 	return 0, nil
 }
 func (r *stubBranchRepo) UpsertBranchAndRuntimeVersion(_ context.Context, _, _, _ string) error {
 	return nil
 }
-func (r *stubBranchRepo) GetUpdatedMetadataByBranchName(_ context.Context, _, _ string) ([]pgdb.GetUpdatesMetadataByBranchNameRow, error) {
+func (r *stubBranchRepo) GetUpdatedMetadataByBranchName(_ context.Context, _, _ string) ([]types.UpdateRef, error) {
 	return nil, nil
 }
 func (r *stubBranchRepo) DeleteBranchByName(_ context.Context, _, _ string) error { return nil }

--- a/internal/handlers/dashboard/channels_branch_surfing_test.go
+++ b/internal/handlers/dashboard/channels_branch_surfing_test.go
@@ -6,7 +6,6 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
-	"xprem/internal/providers/expo"
 	"xprem/internal/services"
 	"xprem/internal/types"
 
@@ -29,7 +28,7 @@ func (r *surfingChannelRepo) GetChannelNameByBranchName(_ context.Context, _, _ 
 func (r *surfingChannelRepo) GetChannels(_ context.Context, _ string) ([]types.ChannelMapping, error) {
 	return nil, nil
 }
-func (r *surfingChannelRepo) GetChannelBranchMapping(_ context.Context, _, _ string) (*expo.ChannelResolution, error) {
+func (r *surfingChannelRepo) GetChannelBranchMapping(_ context.Context, _, _ string) (*types.ChannelResolution, error) {
 	return nil, nil
 }
 func (r *surfingChannelRepo) GetBranchSurfing(_ context.Context, _, _ string) (*types.BranchSurfing, error) {

--- a/internal/handlers/dashboard/channels_branch_surfing_test.go
+++ b/internal/handlers/dashboard/channels_branch_surfing_test.go
@@ -6,7 +6,6 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
-	"xprem/internal/database/postgres/pgdb"
 	"xprem/internal/providers/expo"
 	"xprem/internal/services"
 	"xprem/internal/types"
@@ -30,7 +29,7 @@ func (r *surfingChannelRepo) GetChannelNameByBranchName(_ context.Context, _, _ 
 func (r *surfingChannelRepo) GetChannels(_ context.Context, _ string) ([]types.ChannelMapping, error) {
 	return nil, nil
 }
-func (r *surfingChannelRepo) GetChannelBranchMapping(_ context.Context, _, _ string) (*expo.ChannelMapping, error) {
+func (r *surfingChannelRepo) GetChannelBranchMapping(_ context.Context, _, _ string) (*expo.ChannelResolution, error) {
 	return nil, nil
 }
 func (r *surfingChannelRepo) GetBranchSurfing(_ context.Context, _, _ string) (*types.BranchSurfing, error) {
@@ -43,13 +42,13 @@ func (r *surfingChannelRepo) SetBranchSurfing(_ context.Context, _, _ string, su
 
 type surfingBranchRepo struct{}
 
-func (surfingBranchRepo) InsertBranch(_ context.Context, _ pgdb.InsertBranchParams) (int64, error) {
+func (surfingBranchRepo) InsertBranch(_ context.Context, _, _ string) (int64, error) {
 	return 0, nil
 }
 func (surfingBranchRepo) UpsertBranchAndRuntimeVersion(_ context.Context, _, _, _ string) error {
 	return nil
 }
-func (surfingBranchRepo) GetUpdatedMetadataByBranchName(_ context.Context, _, _ string) ([]pgdb.GetUpdatesMetadataByBranchNameRow, error) {
+func (surfingBranchRepo) GetUpdatedMetadataByBranchName(_ context.Context, _, _ string) ([]types.UpdateRef, error) {
 	return nil, nil
 }
 func (surfingBranchRepo) DeleteBranchByName(_ context.Context, _, _ string) error { return nil }

--- a/internal/handlers/dashboard/channels_branch_surfing_test.go
+++ b/internal/handlers/dashboard/channels_branch_surfing_test.go
@@ -47,7 +47,7 @@ func (surfingBranchRepo) InsertBranch(_ context.Context, _, _ string) (int64, er
 func (surfingBranchRepo) UpsertBranchAndRuntimeVersion(_ context.Context, _, _, _ string) error {
 	return nil
 }
-func (surfingBranchRepo) GetUpdatedMetadataByBranchName(_ context.Context, _, _ string) ([]types.UpdateRef, error) {
+func (surfingBranchRepo) GetUpdateRefsByBranchName(_ context.Context, _, _ string) ([]types.UpdateRef, error) {
 	return nil, nil
 }
 func (surfingBranchRepo) DeleteBranchByName(_ context.Context, _, _ string) error { return nil }

--- a/internal/middleware/auth_middleware_test.go
+++ b/internal/middleware/auth_middleware_test.go
@@ -7,7 +7,6 @@ import (
 	"strconv"
 	"testing"
 
-	"xprem/internal/database/postgres/pgdb"
 	"xprem/internal/services"
 	"xprem/internal/types"
 
@@ -102,7 +101,7 @@ func (fakeCliAuthRepo) GetApiKeyNameByID(_ context.Context, _ string, _ int64) (
 	return "", nil
 }
 
-func (fakeCliAuthRepo) GetApiKeysMetadataByAppID(_ context.Context, _ string) ([]pgdb.GetApiKeysMetadataByAppIDRow, error) {
+func (fakeCliAuthRepo) GetApiKeysMetadataByAppID(_ context.Context, _ string) ([]types.ApiKeyMetadata, error) {
 	return nil, nil
 }
 func (fakeCliAuthRepo) RevokeApiKeyByID(_ context.Context, _ int64, _ string) (string, error) {

--- a/internal/providers/expo/expo.go
+++ b/internal/providers/expo/expo.go
@@ -25,8 +25,6 @@ type UserAccount struct {
 	Email    string `json:"email"`
 }
 
-
-
 type BranchMapping struct {
 	BranchName  string  `json:"branchName"`
 	BranchId    string  `json:"branchId"`

--- a/internal/providers/expo/expo.go
+++ b/internal/providers/expo/expo.go
@@ -25,23 +25,7 @@ type UserAccount struct {
 	Email    string `json:"email"`
 }
 
-// ChannelRolloutInfo is the active channel rollout folded into a ChannelResolution in
-// control-plane mode. ID doubles as the bucketing salt. The stateless (Expo) provider
-// never sets it, so rollouts stay a control-plane-only feature.
-type ChannelRolloutInfo struct {
-	ID         string `json:"id"`
-	BranchName string `json:"branchName"`
-	Percentage int    `json:"percentage"`
-}
 
-// ChannelResolution is the branch a channel serves to devices, with its active
-// rollout; the dashboard listing shape is types.ChannelMapping.
-type ChannelResolution struct {
-	Id         string `json:"id"`
-	BranchName string `json:"branchName"`
-	// Set only by the Postgres channel store when the channel has an active rollout.
-	Rollout *ChannelRolloutInfo `json:"rollout,omitempty"`
-}
 
 type BranchMapping struct {
 	BranchName  string  `json:"branchName"`
@@ -358,10 +342,10 @@ func FetchAppName(ctx context.Context, appId string) string {
 	return name
 }
 
-func FetchChannelMapping(appId, channelName string) (*ChannelResolution, error) {
+func FetchChannelMapping(appId, channelName string) (*types.ChannelResolution, error) {
 	mappingCache := cache2.GetCache()
 	cacheKey := channelMappingCacheKey(appId, channelName)
-	if mapping, ok := cache2.GetJSON[ChannelResolution](mappingCache, cacheKey); ok {
+	if mapping, ok := cache2.GetJSON[types.ChannelResolution](mappingCache, cacheKey); ok {
 		return &mapping, nil
 	}
 
@@ -444,7 +428,7 @@ func FetchChannelMapping(appId, channelName string) (*ChannelResolution, error) 
 		return nil, nil
 	}
 
-	result := &ChannelResolution{
+	result := &types.ChannelResolution{
 		Id:         resp.Data.App.ById.UpdateChannelByName.ID,
 		BranchName: branchName,
 	}

--- a/internal/providers/expo/expo.go
+++ b/internal/providers/expo/expo.go
@@ -25,7 +25,7 @@ type UserAccount struct {
 	Email    string `json:"email"`
 }
 
-// ChannelRolloutInfo is the active channel rollout folded into a ChannelMapping in
+// ChannelRolloutInfo is the active channel rollout folded into a ChannelResolution in
 // control-plane mode. ID doubles as the bucketing salt. The stateless (Expo) provider
 // never sets it, so rollouts stay a control-plane-only feature.
 type ChannelRolloutInfo struct {
@@ -34,7 +34,9 @@ type ChannelRolloutInfo struct {
 	Percentage int    `json:"percentage"`
 }
 
-type ChannelMapping struct {
+// ChannelResolution is the branch a channel serves to devices, with its active
+// rollout; the dashboard listing shape is types.ChannelMapping.
+type ChannelResolution struct {
 	Id         string `json:"id"`
 	BranchName string `json:"branchName"`
 	// Set only by the Postgres channel store when the channel has an active rollout.
@@ -356,10 +358,10 @@ func FetchAppName(ctx context.Context, appId string) string {
 	return name
 }
 
-func FetchChannelMapping(appId, channelName string) (*ChannelMapping, error) {
+func FetchChannelMapping(appId, channelName string) (*ChannelResolution, error) {
 	mappingCache := cache2.GetCache()
 	cacheKey := channelMappingCacheKey(appId, channelName)
-	if mapping, ok := cache2.GetJSON[ChannelMapping](mappingCache, cacheKey); ok {
+	if mapping, ok := cache2.GetJSON[ChannelResolution](mappingCache, cacheKey); ok {
 		return &mapping, nil
 	}
 
@@ -442,7 +444,7 @@ func FetchChannelMapping(appId, channelName string) (*ChannelMapping, error) {
 		return nil, nil
 	}
 
-	result := &ChannelMapping{
+	result := &ChannelResolution{
 		Id:         resp.Data.App.ById.UpdateChannelByName.ID,
 		BranchName: branchName,
 	}

--- a/internal/router/routes_publish_test.go
+++ b/internal/router/routes_publish_test.go
@@ -10,7 +10,6 @@ import (
 
 	"xprem/ee/apikeyrestrictions"
 	"xprem/internal/bucket"
-	"xprem/internal/database/postgres/pgdb"
 	"xprem/internal/services"
 	"xprem/internal/types"
 
@@ -208,7 +207,7 @@ func (acceptingCliRepo) GetApiKeyNameByID(context.Context, string, int64) (strin
 func (acceptingCliRepo) InsertApiKey(context.Context, string, string, string, string) (int64, error) {
 	return 0, nil
 }
-func (acceptingCliRepo) GetApiKeysMetadataByAppID(context.Context, string) ([]pgdb.GetApiKeysMetadataByAppIDRow, error) {
+func (acceptingCliRepo) GetApiKeysMetadataByAppID(context.Context, string) ([]types.ApiKeyMetadata, error) {
 	return nil, nil
 }
 func (acceptingCliRepo) RevokeApiKeyByID(context.Context, int64, string) (string, error) {

--- a/internal/services/asset_branch_guard_test.go
+++ b/internal/services/asset_branch_guard_test.go
@@ -26,8 +26,8 @@ func guardService(t *testing.T, surfing *types.BranchSurfing) *ExpoProtocolServi
 }
 
 func TestAssetBranchGuardMirrorsTheManifest(t *testing.T) {
-	mapped := &expo.ChannelMapping{Id: "1", BranchName: "staging"}
-	withRollout := &expo.ChannelMapping{
+	mapped := &expo.ChannelResolution{Id: "1", BranchName: "staging"}
+	withRollout := &expo.ChannelResolution{
 		Id: "1", BranchName: "staging",
 		Rollout: &expo.ChannelRolloutInfo{ID: "r1", BranchName: "canary", Percentage: 50},
 	}
@@ -35,7 +35,7 @@ func TestAssetBranchGuardMirrorsTheManifest(t *testing.T) {
 	cases := []struct {
 		name    string
 		surfing *types.BranchSurfing
-		mapping *expo.ChannelMapping
+		mapping *expo.ChannelResolution
 		branch  string
 		want    bool
 	}{
@@ -59,7 +59,7 @@ func TestAssetBranchGuardMirrorsTheManifest(t *testing.T) {
 // branch it has no claim to.
 func TestAssetBranchGuardDeniesOnUnknownChannel(t *testing.T) {
 	service := guardService(t, nil)
-	mapped := &expo.ChannelMapping{Id: "1", BranchName: "staging"}
+	mapped := &expo.ChannelResolution{Id: "1", BranchName: "staging"}
 
 	assert.False(t, service.isAssetBranchAllowed(context.Background(), guardAppID, "qa", "pr-482", mapped))
 }

--- a/internal/services/asset_branch_guard_test.go
+++ b/internal/services/asset_branch_guard_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 	"xprem/internal/cache"
-	"xprem/internal/providers/expo"
 	"xprem/internal/types"
 
 	"github.com/stretchr/testify/assert"
@@ -26,16 +25,16 @@ func guardService(t *testing.T, surfing *types.BranchSurfing) *ExpoProtocolServi
 }
 
 func TestAssetBranchGuardMirrorsTheManifest(t *testing.T) {
-	mapped := &expo.ChannelResolution{Id: "1", BranchName: "staging"}
-	withRollout := &expo.ChannelResolution{
+	mapped := &types.ChannelResolution{Id: "1", BranchName: "staging"}
+	withRollout := &types.ChannelResolution{
 		Id: "1", BranchName: "staging",
-		Rollout: &expo.ChannelRolloutInfo{ID: "r1", BranchName: "canary", Percentage: 50},
+		Rollout: &types.ChannelRolloutInfo{ID: "r1", BranchName: "canary", Percentage: 50},
 	}
 
 	cases := []struct {
 		name    string
 		surfing *types.BranchSurfing
-		mapping *expo.ChannelResolution
+		mapping *types.ChannelResolution
 		branch  string
 		want    bool
 	}{
@@ -59,7 +58,7 @@ func TestAssetBranchGuardMirrorsTheManifest(t *testing.T) {
 // branch it has no claim to.
 func TestAssetBranchGuardDeniesOnUnknownChannel(t *testing.T) {
 	service := guardService(t, nil)
-	mapped := &expo.ChannelResolution{Id: "1", BranchName: "staging"}
+	mapped := &types.ChannelResolution{Id: "1", BranchName: "staging"}
 
 	assert.False(t, service.isAssetBranchAllowed(context.Background(), guardAppID, "qa", "pr-482", mapped))
 }

--- a/internal/services/branch_rules.go
+++ b/internal/services/branch_rules.go
@@ -3,7 +3,6 @@ package services
 import (
 	"context"
 	"xprem/internal/branch"
-	"xprem/internal/providers/expo"
 	"xprem/internal/rollout"
 	"xprem/internal/types"
 )
@@ -17,7 +16,7 @@ type BranchResolutionRequest struct {
 	ClientID       string
 	Platform       string
 	RuntimeVersion string
-	Mapping        *expo.ChannelResolution
+	Mapping        *types.ChannelResolution
 	// RequestedBranch is the xprem-branch header, empty when the device asks for
 	// nothing in particular. Surfing is the channel's setting for it.
 	RequestedBranch string

--- a/internal/services/branch_rules.go
+++ b/internal/services/branch_rules.go
@@ -17,7 +17,7 @@ type BranchResolutionRequest struct {
 	ClientID       string
 	Platform       string
 	RuntimeVersion string
-	Mapping        *expo.ChannelMapping
+	Mapping        *expo.ChannelResolution
 	// RequestedBranch is the xprem-branch header, empty when the device asks for
 	// nothing in particular. Surfing is the channel's setting for it.
 	RequestedBranch string

--- a/internal/services/branch_service.go
+++ b/internal/services/branch_service.go
@@ -29,7 +29,7 @@ type BranchService struct {
 type BranchRepository interface {
 	InsertBranch(ctx context.Context, appId string, branchName string) (int64, error)
 	UpsertBranchAndRuntimeVersion(ctx context.Context, appId string, branchName string, runtimeVersion string) error
-	GetUpdatedMetadataByBranchName(ctx context.Context, appId string, branchName string) ([]types.UpdateRef, error)
+	GetUpdateRefsByBranchName(ctx context.Context, appId string, branchName string) ([]types.UpdateRef, error)
 	DeleteBranchByName(ctx context.Context, appId string, branchName string) error
 	GetBranches(ctx context.Context, appId string) ([]types.BranchMapping, error)
 	GetSurfableBranches(ctx context.Context, appId string, runtimeVersion string, platform string) ([]types.SurfableBranch, error)
@@ -106,7 +106,7 @@ func (s *BranchService) DeleteBranch(ctx context.Context, branchName string, app
 			}
 		}
 	}
-	rows, err := s.branchRepo.GetUpdatedMetadataByBranchName(ctx, appId, branchName)
+	rows, err := s.branchRepo.GetUpdateRefsByBranchName(ctx, appId, branchName)
 	if err != nil {
 		return fmt.Errorf("failed to retrieve updates linked to the branch from database: %w", err)
 	}

--- a/internal/services/branch_service.go
+++ b/internal/services/branch_service.go
@@ -9,7 +9,6 @@ import (
 	"xprem/internal/bucket"
 	"xprem/internal/cache"
 	"xprem/internal/dashboard"
-	"xprem/internal/database/postgres/pgdb"
 	"xprem/internal/store"
 	"xprem/internal/types"
 	"xprem/internal/validation"
@@ -28,9 +27,9 @@ type BranchService struct {
 }
 
 type BranchRepository interface {
-	InsertBranch(ctx context.Context, branch pgdb.InsertBranchParams) (int64, error)
+	InsertBranch(ctx context.Context, appId string, branchName string) (int64, error)
 	UpsertBranchAndRuntimeVersion(ctx context.Context, appId string, branchName string, runtimeVersion string) error
-	GetUpdatedMetadataByBranchName(ctx context.Context, appId string, branchName string) ([]pgdb.GetUpdatesMetadataByBranchNameRow, error)
+	GetUpdatedMetadataByBranchName(ctx context.Context, appId string, branchName string) ([]types.UpdateRef, error)
 	DeleteBranchByName(ctx context.Context, appId string, branchName string) error
 	GetBranches(ctx context.Context, appId string) ([]types.BranchMapping, error)
 	GetSurfableBranches(ctx context.Context, appId string, runtimeVersion string, platform string) ([]types.SurfableBranch, error)
@@ -60,11 +59,7 @@ func (s *BranchService) CreateBranch(ctx context.Context, appId string, branchNa
 	if err := validation.Name("branchName", branchName); err != nil {
 		return 0, err
 	}
-	pgAppID := store.ToPgUUID(appId)
-	branchId, err := s.branchRepo.InsertBranch(ctx, pgdb.InsertBranchParams{
-		AppID: pgAppID,
-		Name:  branchName,
-	})
+	branchId, err := s.branchRepo.InsertBranch(ctx, appId, branchName)
 	if err != nil {
 		return 0, err
 	}
@@ -129,7 +124,7 @@ func (s *BranchService) DeleteBranch(ctx context.Context, branchName string, app
 	appCache := cache.GetCache()
 	appCache.Delete(dashboard.ComputeGetBranchesCacheKey(appId))
 	appCache.Delete(dashboard.ComputeGetRuntimeVersionsCacheKey(appId, branchName))
-	go func(bucketRows []pgdb.GetUpdatesMetadataByBranchNameRow) {
+	go func(bucketRows []types.UpdateRef) {
 		for _, row := range bucketRows {
 			err := s.bucket.DeleteUpdateFolder(appId, branchName, row.RuntimeVersion, strconv.FormatInt(row.ID, 10))
 			if err != nil {

--- a/internal/services/branch_surf_block_test.go
+++ b/internal/services/branch_surf_block_test.go
@@ -5,7 +5,6 @@ import (
 	"reflect"
 	"strings"
 	"testing"
-	"xprem/internal/providers/expo"
 	"xprem/internal/types"
 
 	"github.com/google/uuid"
@@ -19,7 +18,7 @@ func newBlockHarness(t *testing.T) *rolloutTestHarness {
 	t.Helper()
 	t.Setenv("DB_URL", "postgres://stub")
 	h := newRolloutTestHarness(t)
-	h.channelRepo.mappings["qa"] = &expo.ChannelResolution{Id: "1", BranchName: "staging"}
+	h.channelRepo.mappings["qa"] = &types.ChannelResolution{Id: "1", BranchName: "staging"}
 	h.channelRepo.surfing = map[string]*types.BranchSurfing{"qa": {Enabled: true, Pattern: "pr-*"}}
 	h.seed(seedRow{branch: "staging", rtv: "1", platform: "ios", id: 100, checked: true})
 	return h

--- a/internal/services/branch_surf_block_test.go
+++ b/internal/services/branch_surf_block_test.go
@@ -19,7 +19,7 @@ func newBlockHarness(t *testing.T) *rolloutTestHarness {
 	t.Helper()
 	t.Setenv("DB_URL", "postgres://stub")
 	h := newRolloutTestHarness(t)
-	h.channelRepo.mappings["qa"] = &expo.ChannelMapping{Id: "1", BranchName: "staging"}
+	h.channelRepo.mappings["qa"] = &expo.ChannelResolution{Id: "1", BranchName: "staging"}
 	h.channelRepo.surfing = map[string]*types.BranchSurfing{"qa": {Enabled: true, Pattern: "pr-*"}}
 	h.seed(seedRow{branch: "staging", rtv: "1", platform: "ios", id: 100, checked: true})
 	return h

--- a/internal/services/branch_surf_resolution_test.go
+++ b/internal/services/branch_surf_resolution_test.go
@@ -3,7 +3,6 @@ package services
 import (
 	"context"
 	"testing"
-	"xprem/internal/providers/expo"
 	"xprem/internal/types"
 
 	"github.com/stretchr/testify/assert"
@@ -13,11 +12,11 @@ import (
 // These cover the wiring the unit tests cannot see: ManifestRequestParams.XpremBranch
 // reaching the rule chain and changing which branch is served. Drop any link of that
 // chain and only these fail.
-func newSurfHarness(t *testing.T, surfing *types.BranchSurfing, rollout *expo.ChannelRolloutInfo) *rolloutTestHarness {
+func newSurfHarness(t *testing.T, surfing *types.BranchSurfing, rollout *types.ChannelRolloutInfo) *rolloutTestHarness {
 	t.Helper()
 	t.Setenv("DB_URL", "postgres://stub")
 	h := newRolloutTestHarness(t)
-	h.channelRepo.mappings["qa"] = &expo.ChannelResolution{Id: "1", BranchName: "staging", Rollout: rollout}
+	h.channelRepo.mappings["qa"] = &types.ChannelResolution{Id: "1", BranchName: "staging", Rollout: rollout}
 	h.channelRepo.surfing = map[string]*types.BranchSurfing{"qa": surfing}
 	h.seed(seedRow{branch: "staging", rtv: "1", platform: "ios", id: 100, checked: true})
 	return h
@@ -89,7 +88,7 @@ func TestResolveManifestBundleSurfOutranksAnActiveRollout(t *testing.T) {
 	const salt = "surf-vs-rollout-salt"
 	h := newSurfHarness(t,
 		&types.BranchSurfing{Enabled: true, Pattern: "pr-*"},
-		&expo.ChannelRolloutInfo{ID: salt, BranchName: "canary", Percentage: 100},
+		&types.ChannelRolloutInfo{ID: salt, BranchName: "canary", Percentage: 100},
 	)
 	h.seed(seedRow{branch: "canary", rtv: "1", platform: "ios", id: 200, checked: true})
 	h.seed(seedRow{branch: "pr-482", rtv: "1", platform: "ios", id: 300, checked: true})

--- a/internal/services/branch_surf_resolution_test.go
+++ b/internal/services/branch_surf_resolution_test.go
@@ -17,7 +17,7 @@ func newSurfHarness(t *testing.T, surfing *types.BranchSurfing, rollout *expo.Ch
 	t.Helper()
 	t.Setenv("DB_URL", "postgres://stub")
 	h := newRolloutTestHarness(t)
-	h.channelRepo.mappings["qa"] = &expo.ChannelMapping{Id: "1", BranchName: "staging", Rollout: rollout}
+	h.channelRepo.mappings["qa"] = &expo.ChannelResolution{Id: "1", BranchName: "staging", Rollout: rollout}
 	h.channelRepo.surfing = map[string]*types.BranchSurfing{"qa": surfing}
 	h.seed(seedRow{branch: "staging", rtv: "1", platform: "ios", id: 100, checked: true})
 	return h

--- a/internal/services/branch_surf_rule_test.go
+++ b/internal/services/branch_surf_rule_test.go
@@ -3,21 +3,20 @@ package services
 import (
 	"context"
 	"testing"
-	"xprem/internal/providers/expo"
 	"xprem/internal/types"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func surfRequest(requested string, surfing types.BranchSurfing, rollout *expo.ChannelRolloutInfo) *BranchResolutionRequest {
+func surfRequest(requested string, surfing types.BranchSurfing, rollout *types.ChannelRolloutInfo) *BranchResolutionRequest {
 	return &BranchResolutionRequest{
 		AppID:           "app-1",
 		ChannelName:     "qa",
 		ClientID:        "device-1",
 		Platform:        "ios",
 		RuntimeVersion:  "3.0.0",
-		Mapping:         &expo.ChannelResolution{Id: "1", BranchName: "staging", Rollout: rollout},
+		Mapping:         &types.ChannelResolution{Id: "1", BranchName: "staging", Rollout: rollout},
 		RequestedBranch: requested,
 		Surfing:         surfing,
 	}
@@ -56,7 +55,7 @@ func TestBranchSurfRuleDeclines(t *testing.T) {
 // Asking for the branch the channel already maps to is not a surf, so the chain
 // carries on to the rollout rule instead of pinning the device out of its bucket.
 func TestBranchSurfRuleKeepsTheRolloutWhenAskedForTheMappedBranch(t *testing.T) {
-	rollout := &expo.ChannelRolloutInfo{ID: "r1", BranchName: "canary", Percentage: 100}
+	rollout := &types.ChannelRolloutInfo{ID: "r1", BranchName: "canary", Percentage: 100}
 	req := surfRequest("staging", types.BranchSurfing{Enabled: true, Pattern: "*"}, rollout)
 
 	candidates, err := ResolveBranchCandidates(context.Background(), DefaultBranchRules(), req)
@@ -67,7 +66,7 @@ func TestBranchSurfRuleKeepsTheRolloutWhenAskedForTheMappedBranch(t *testing.T) 
 
 // A surf wins over an active rollout: it is an explicit choice, not a draw.
 func TestBranchSurfRuleOutranksTheRollout(t *testing.T) {
-	rollout := &expo.ChannelRolloutInfo{ID: "r1", BranchName: "canary", Percentage: 100}
+	rollout := &types.ChannelRolloutInfo{ID: "r1", BranchName: "canary", Percentage: 100}
 	req := surfRequest("pr-482", types.BranchSurfing{Enabled: true, Pattern: "pr-*"}, rollout)
 
 	candidates, err := ResolveBranchCandidates(context.Background(), DefaultBranchRules(), req)
@@ -77,7 +76,7 @@ func TestBranchSurfRuleOutranksTheRollout(t *testing.T) {
 }
 
 func TestBranchSurfRuleIsInertWithoutARequestedBranch(t *testing.T) {
-	rollout := &expo.ChannelRolloutInfo{ID: "r1", BranchName: "canary", Percentage: 100}
+	rollout := &types.ChannelRolloutInfo{ID: "r1", BranchName: "canary", Percentage: 100}
 	req := surfRequest("", types.BranchSurfing{}, rollout)
 
 	candidates, err := ResolveBranchCandidates(context.Background(), DefaultBranchRules(), req)
@@ -99,7 +98,7 @@ func TestBranchSurfRuleIsInertWithoutARequestedBranch(t *testing.T) {
 // having been selected into the rollout. Reverse this and the rule below must
 // exclude Rollout.BranchName, and ListSurfableBranches must stop listing it.
 func TestSurfingOntoTheRolloutTargetIsHonoured(t *testing.T) {
-	rollout := &expo.ChannelRolloutInfo{BranchName: "canary", Percentage: 5}
+	rollout := &types.ChannelRolloutInfo{BranchName: "canary", Percentage: 5}
 	on := types.BranchSurfing{Enabled: true, Pattern: "*"}
 
 	assert.True(t, HonoursSurf(surfRequest("canary", on, rollout)),

--- a/internal/services/branch_surf_rule_test.go
+++ b/internal/services/branch_surf_rule_test.go
@@ -17,7 +17,7 @@ func surfRequest(requested string, surfing types.BranchSurfing, rollout *expo.Ch
 		ClientID:        "device-1",
 		Platform:        "ios",
 		RuntimeVersion:  "3.0.0",
-		Mapping:         &expo.ChannelMapping{Id: "1", BranchName: "staging", Rollout: rollout},
+		Mapping:         &expo.ChannelResolution{Id: "1", BranchName: "staging", Rollout: rollout},
 		RequestedBranch: requested,
 		Surfing:         surfing,
 	}

--- a/internal/services/branch_surfing_test.go
+++ b/internal/services/branch_surfing_test.go
@@ -272,7 +272,7 @@ func TestTheChannelsOwnBranchIsNotOfferedAsASwitch(t *testing.T) {
 			{Name: "pr-1", LastUpdateAt: "2026-08-02T10:00:00Z"},
 			{Name: "staging", LastUpdateAt: "2026-08-01T10:00:00Z"},
 		}})
-	channelRepo.mappings = map[string]*expo.ChannelMapping{
+	channelRepo.mappings = map[string]*expo.ChannelResolution{
 		"qa": {BranchName: "staging"},
 	}
 
@@ -357,6 +357,6 @@ func TestAMappingReadFailureIsNotSwallowed(t *testing.T) {
 
 type mappingErrorChannelRepo struct{ *fakeChannelRepo }
 
-func (mappingErrorChannelRepo) GetChannelBranchMapping(_ context.Context, _, _ string) (*expo.ChannelMapping, error) {
+func (mappingErrorChannelRepo) GetChannelBranchMapping(_ context.Context, _, _ string) (*expo.ChannelResolution, error) {
 	return nil, assert.AnError
 }

--- a/internal/services/branch_surfing_test.go
+++ b/internal/services/branch_surfing_test.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"testing"
 	cache2 "xprem/internal/cache"
-	"xprem/internal/providers/expo"
 	"xprem/internal/types"
 	"xprem/internal/validation"
 
@@ -272,7 +271,7 @@ func TestTheChannelsOwnBranchIsNotOfferedAsASwitch(t *testing.T) {
 			{Name: "pr-1", LastUpdateAt: "2026-08-02T10:00:00Z"},
 			{Name: "staging", LastUpdateAt: "2026-08-01T10:00:00Z"},
 		}})
-	channelRepo.mappings = map[string]*expo.ChannelResolution{
+	channelRepo.mappings = map[string]*types.ChannelResolution{
 		"qa": {BranchName: "staging"},
 	}
 
@@ -357,6 +356,6 @@ func TestAMappingReadFailureIsNotSwallowed(t *testing.T) {
 
 type mappingErrorChannelRepo struct{ *fakeChannelRepo }
 
-func (mappingErrorChannelRepo) GetChannelBranchMapping(_ context.Context, _, _ string) (*expo.ChannelResolution, error) {
+func (mappingErrorChannelRepo) GetChannelBranchMapping(_ context.Context, _, _ string) (*types.ChannelResolution, error) {
 	return nil, assert.AnError
 }

--- a/internal/services/channel_service.go
+++ b/internal/services/channel_service.go
@@ -35,7 +35,7 @@ type ChannelRepository interface {
 	DeleteChannel(ctx context.Context, channelName string, appId string) error
 	GetChannelNameByBranchName(ctx context.Context, appId string, branchName string) ([]string, error)
 	GetChannels(ctx context.Context, appId string) ([]types.ChannelMapping, error)
-	GetChannelBranchMapping(ctx context.Context, appId string, channelName string) (*expo.ChannelMapping, error)
+	GetChannelBranchMapping(ctx context.Context, appId string, channelName string) (*expo.ChannelResolution, error)
 	// GetBranchSurfing returns nil, nil when the channel does not exist.
 	GetBranchSurfing(ctx context.Context, appId string, channelName string) (*types.BranchSurfing, error)
 	SetBranchSurfing(ctx context.Context, appId string, channelName string, surfing types.BranchSurfing) error

--- a/internal/services/channel_service.go
+++ b/internal/services/channel_service.go
@@ -9,7 +9,6 @@ import (
 	"xprem/internal/branch"
 	"xprem/internal/cache"
 	"xprem/internal/dashboard"
-	"xprem/internal/providers/expo"
 	"xprem/internal/types"
 	"xprem/internal/validation"
 )
@@ -35,7 +34,7 @@ type ChannelRepository interface {
 	DeleteChannel(ctx context.Context, channelName string, appId string) error
 	GetChannelNameByBranchName(ctx context.Context, appId string, branchName string) ([]string, error)
 	GetChannels(ctx context.Context, appId string) ([]types.ChannelMapping, error)
-	GetChannelBranchMapping(ctx context.Context, appId string, channelName string) (*expo.ChannelResolution, error)
+	GetChannelBranchMapping(ctx context.Context, appId string, channelName string) (*types.ChannelResolution, error)
 	// GetBranchSurfing returns nil, nil when the channel does not exist.
 	GetBranchSurfing(ctx context.Context, appId string, channelName string) (*types.BranchSurfing, error)
 	SetBranchSurfing(ctx context.Context, appId string, channelName string, surfing types.BranchSurfing) error

--- a/internal/services/cli_auth_service.go
+++ b/internal/services/cli_auth_service.go
@@ -4,10 +4,8 @@ import (
 	"context"
 	"fmt"
 	"strconv"
-	"time"
 	"xprem/internal/auditlog"
 	"xprem/internal/crypto"
-	"xprem/internal/database/postgres/pgdb"
 	"xprem/internal/types"
 	"xprem/internal/validation"
 )
@@ -38,7 +36,7 @@ var ErrCliAuthUnavailable = fmt.Errorf("could not verify this credential")
 type CliAuthRepository interface {
 	ValidateCliCredential(ctx context.Context, appId string, auth types.Auth) (int64, error)
 	InsertApiKey(ctx context.Context, appId string, name string, hint string, hashedKey string) (int64, error)
-	GetApiKeysMetadataByAppID(ctx context.Context, appId string) ([]pgdb.GetApiKeysMetadataByAppIDRow, error)
+	GetApiKeysMetadataByAppID(ctx context.Context, appId string) ([]types.ApiKeyMetadata, error)
 	// GetApiKeyNameByID feeds the audit actor display; RevokeApiKeyByID
 	// returns the revoked key's name so the audit entry needs no second read.
 	GetApiKeyNameByID(ctx context.Context, appId string, apiKeyId int64) (string, error)
@@ -134,24 +132,9 @@ func (s *CliAuthService) GenerateAPIKey(ctx context.Context, appId string, name 
 }
 
 func (s *CliAuthService) GetApiKeysMetadata(ctx context.Context, appId string) ([]types.ApiKeyMetadata, error) {
-	rows, err := s.authRepo.GetApiKeysMetadataByAppID(ctx, appId)
+	apiKeysMetadata, err := s.authRepo.GetApiKeysMetadataByAppID(ctx, appId)
 	if err != nil {
 		return nil, fmt.Errorf("failed to retrieve API keys metadata from database: %w", err)
-	}
-	apiKeysMetadata := make([]types.ApiKeyMetadata, len(rows))
-	for i, row := range rows {
-		var lastUsedAtStr *string
-		if row.LastUsedAt.Valid {
-			timeStr := row.LastUsedAt.Time.Format(time.RFC3339)
-			lastUsedAtStr = &timeStr
-		}
-		apiKeysMetadata[i] = types.ApiKeyMetadata{
-			ID:         strconv.FormatInt(row.ID, 10),
-			Name:       row.Name,
-			Hint:       row.Hint,
-			CreatedAt:  row.CreatedAt.Time.Format(time.RFC3339),
-			LastUsedAt: lastUsedAtStr,
-		}
 	}
 	return apiKeysMetadata, nil
 }

--- a/internal/services/cli_auth_service_test.go
+++ b/internal/services/cli_auth_service_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"testing"
 	"xprem/internal/auditlog"
-	"xprem/internal/database/postgres/pgdb"
 	"xprem/internal/types"
 
 	"github.com/stretchr/testify/assert"
@@ -24,10 +23,10 @@ func (f *fakeCliAuthRepo) ValidateCliCredential(_ context.Context, _ string, _ t
 func (f *fakeCliAuthRepo) InsertApiKey(_ context.Context, _ string, _ string, _ string, _ string) (int64, error) {
 	return 43, nil
 }
-func (f *fakeCliAuthRepo) GetApiKeysMetadataByAppID(_ context.Context, _ string) ([]pgdb.GetApiKeysMetadataByAppIDRow, error) {
-	return []pgdb.GetApiKeysMetadataByAppIDRow{
-		{ID: 41, Name: "other-key"},
-		{ID: 42, Name: "ci-production"},
+func (f *fakeCliAuthRepo) GetApiKeysMetadataByAppID(_ context.Context, _ string) ([]types.ApiKeyMetadata, error) {
+	return []types.ApiKeyMetadata{
+		{ID: "41", Name: "other-key"},
+		{ID: "42", Name: "ci-production"},
 	}, nil
 }
 func (f *fakeCliAuthRepo) GetApiKeyNameByID(_ context.Context, _ string, apiKeyId int64) (string, error) {

--- a/internal/services/expo_protocol_service.go
+++ b/internal/services/expo_protocol_service.go
@@ -18,7 +18,6 @@ import (
 	"xprem/internal/crypto"
 	"xprem/internal/keyStore"
 	"xprem/internal/metrics"
-	"xprem/internal/providers/expo"
 	"xprem/internal/types"
 	update2 "xprem/internal/update"
 )
@@ -328,7 +327,7 @@ func (s *ExpoProtocolService) ResolveManifestBundle(ctx context.Context, params 
 // nil (out-of-bucket with no control => noUpdateAvailable, deliberately no fallback to
 // the next candidate). Shared by manifest and asset resolution so the two paths take
 // the same rollout decision for a device.
-func (s *ExpoProtocolService) resolveUpdateForDevice(ctx context.Context, requestID string, appId string, channelName string, clientID string, platform string, runtimeVersion string, requestedBranch string, surfBlockTokens string, failedUpdateIDsRaw string, branchMap *expo.ChannelResolution) (servedBranchName string, lastUpdate *types.Update, blocked *BlockedSurf, err error) {
+func (s *ExpoProtocolService) resolveUpdateForDevice(ctx context.Context, requestID string, appId string, channelName string, clientID string, platform string, runtimeVersion string, requestedBranch string, surfBlockTokens string, failedUpdateIDsRaw string, branchMap *types.ChannelResolution) (servedBranchName string, lastUpdate *types.Update, blocked *BlockedSurf, err error) {
 	req := &BranchResolutionRequest{
 		AppID:           appId,
 		ChannelName:     channelName,
@@ -465,7 +464,7 @@ func (s *ExpoProtocolService) ResolveAssetBundle(ctx context.Context, params Ass
 // Tiers 1 and 2 only exist on the control plane; in stateless mode resolution goes
 // straight to tier 3, which with no rollout state degrades to exactly today's
 // latest-update behavior.
-func (s *ExpoProtocolService) resolveAssetUpdate(ctx context.Context, params AssetResolutionParams, branchMap *expo.ChannelResolution) (string, *types.Update, error) {
+func (s *ExpoProtocolService) resolveAssetUpdate(ctx context.Context, params AssetResolutionParams, branchMap *types.ChannelResolution) (string, *types.Update, error) {
 	if config.IsDBMode() {
 		if params.UpdateID != "" && params.Branch != "" && s.isAssetBranchAllowed(ctx, params.AppID, params.ChannelName, params.Branch, branchMap) {
 			pinnedUpdate, err := s.updateRepo.GetUpdate(ctx, params.AppID, params.Branch, params.RuntimeVersion, params.UpdateID)
@@ -503,7 +502,7 @@ func (s *ExpoProtocolService) resolveAssetUpdate(ctx context.Context, params Ass
 // permissive as that resolution. Wider and the branch query param becomes a
 // cross-branch read primitive; narrower and the assets of a legitimately surfed
 // branch 404.
-func (s *ExpoProtocolService) isAssetBranchAllowed(ctx context.Context, appId string, channelName string, branchName string, branchMap *expo.ChannelResolution) bool {
+func (s *ExpoProtocolService) isAssetBranchAllowed(ctx context.Context, appId string, channelName string, branchName string, branchMap *types.ChannelResolution) bool {
 	if branchName == branchMap.BranchName {
 		return true
 	}

--- a/internal/services/expo_protocol_service.go
+++ b/internal/services/expo_protocol_service.go
@@ -328,7 +328,7 @@ func (s *ExpoProtocolService) ResolveManifestBundle(ctx context.Context, params 
 // nil (out-of-bucket with no control => noUpdateAvailable, deliberately no fallback to
 // the next candidate). Shared by manifest and asset resolution so the two paths take
 // the same rollout decision for a device.
-func (s *ExpoProtocolService) resolveUpdateForDevice(ctx context.Context, requestID string, appId string, channelName string, clientID string, platform string, runtimeVersion string, requestedBranch string, surfBlockTokens string, failedUpdateIDsRaw string, branchMap *expo.ChannelMapping) (servedBranchName string, lastUpdate *types.Update, blocked *BlockedSurf, err error) {
+func (s *ExpoProtocolService) resolveUpdateForDevice(ctx context.Context, requestID string, appId string, channelName string, clientID string, platform string, runtimeVersion string, requestedBranch string, surfBlockTokens string, failedUpdateIDsRaw string, branchMap *expo.ChannelResolution) (servedBranchName string, lastUpdate *types.Update, blocked *BlockedSurf, err error) {
 	req := &BranchResolutionRequest{
 		AppID:           appId,
 		ChannelName:     channelName,
@@ -465,7 +465,7 @@ func (s *ExpoProtocolService) ResolveAssetBundle(ctx context.Context, params Ass
 // Tiers 1 and 2 only exist on the control plane; in stateless mode resolution goes
 // straight to tier 3, which with no rollout state degrades to exactly today's
 // latest-update behavior.
-func (s *ExpoProtocolService) resolveAssetUpdate(ctx context.Context, params AssetResolutionParams, branchMap *expo.ChannelMapping) (string, *types.Update, error) {
+func (s *ExpoProtocolService) resolveAssetUpdate(ctx context.Context, params AssetResolutionParams, branchMap *expo.ChannelResolution) (string, *types.Update, error) {
 	if config.IsDBMode() {
 		if params.UpdateID != "" && params.Branch != "" && s.isAssetBranchAllowed(ctx, params.AppID, params.ChannelName, params.Branch, branchMap) {
 			pinnedUpdate, err := s.updateRepo.GetUpdate(ctx, params.AppID, params.Branch, params.RuntimeVersion, params.UpdateID)
@@ -503,7 +503,7 @@ func (s *ExpoProtocolService) resolveAssetUpdate(ctx context.Context, params Ass
 // permissive as that resolution. Wider and the branch query param becomes a
 // cross-branch read primitive; narrower and the assets of a legitimately surfed
 // branch 404.
-func (s *ExpoProtocolService) isAssetBranchAllowed(ctx context.Context, appId string, channelName string, branchName string, branchMap *expo.ChannelMapping) bool {
+func (s *ExpoProtocolService) isAssetBranchAllowed(ctx context.Context, appId string, channelName string, branchName string, branchMap *expo.ChannelResolution) bool {
 	if branchName == branchMap.BranchName {
 		return true
 	}

--- a/internal/services/management_audit_test.go
+++ b/internal/services/management_audit_test.go
@@ -76,7 +76,7 @@ func (f *fakeMgmtBranchRepo) InsertBranch(_ context.Context, _, _ string) (int64
 func (f *fakeMgmtBranchRepo) UpsertBranchAndRuntimeVersion(_ context.Context, _ string, _ string, _ string) error {
 	return nil
 }
-func (f *fakeMgmtBranchRepo) GetUpdatedMetadataByBranchName(_ context.Context, _ string, _ string) ([]types.UpdateRef, error) {
+func (f *fakeMgmtBranchRepo) GetUpdateRefsByBranchName(_ context.Context, _ string, _ string) ([]types.UpdateRef, error) {
 	return nil, nil
 }
 func (f *fakeMgmtBranchRepo) DeleteBranchByName(_ context.Context, _ string, _ string) error {

--- a/internal/services/management_audit_test.go
+++ b/internal/services/management_audit_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"xprem/config"
 	"xprem/internal/auditlog"
-	"xprem/internal/providers/expo"
 	"xprem/internal/store"
 	"xprem/internal/types"
 
@@ -55,7 +54,7 @@ func (f *fakeMgmtChannelRepo) GetChannelNameByBranchName(_ context.Context, _ st
 func (f *fakeMgmtChannelRepo) GetChannels(_ context.Context, _ string) ([]types.ChannelMapping, error) {
 	return nil, nil
 }
-func (f *fakeMgmtChannelRepo) GetChannelBranchMapping(_ context.Context, _ string, _ string) (*expo.ChannelResolution, error) {
+func (f *fakeMgmtChannelRepo) GetChannelBranchMapping(_ context.Context, _ string, _ string) (*types.ChannelResolution, error) {
 	return nil, nil
 }
 func (f *fakeMgmtChannelRepo) GetBranchSurfing(_ context.Context, _ string, _ string) (*types.BranchSurfing, error) {

--- a/internal/services/management_audit_test.go
+++ b/internal/services/management_audit_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"xprem/config"
 	"xprem/internal/auditlog"
-	"xprem/internal/database/postgres/pgdb"
 	"xprem/internal/providers/expo"
 	"xprem/internal/store"
 	"xprem/internal/types"
@@ -56,7 +55,7 @@ func (f *fakeMgmtChannelRepo) GetChannelNameByBranchName(_ context.Context, _ st
 func (f *fakeMgmtChannelRepo) GetChannels(_ context.Context, _ string) ([]types.ChannelMapping, error) {
 	return nil, nil
 }
-func (f *fakeMgmtChannelRepo) GetChannelBranchMapping(_ context.Context, _ string, _ string) (*expo.ChannelMapping, error) {
+func (f *fakeMgmtChannelRepo) GetChannelBranchMapping(_ context.Context, _ string, _ string) (*expo.ChannelResolution, error) {
 	return nil, nil
 }
 func (f *fakeMgmtChannelRepo) GetBranchSurfing(_ context.Context, _ string, _ string) (*types.BranchSurfing, error) {
@@ -72,13 +71,13 @@ func (f *fakeMgmtBranchRepo) GetSurfableBranches(_ context.Context, _ string, _ 
 	return nil, nil
 }
 
-func (f *fakeMgmtBranchRepo) InsertBranch(_ context.Context, _ pgdb.InsertBranchParams) (int64, error) {
+func (f *fakeMgmtBranchRepo) InsertBranch(_ context.Context, _, _ string) (int64, error) {
 	return 7, nil
 }
 func (f *fakeMgmtBranchRepo) UpsertBranchAndRuntimeVersion(_ context.Context, _ string, _ string, _ string) error {
 	return nil
 }
-func (f *fakeMgmtBranchRepo) GetUpdatedMetadataByBranchName(_ context.Context, _ string, _ string) ([]pgdb.GetUpdatesMetadataByBranchNameRow, error) {
+func (f *fakeMgmtBranchRepo) GetUpdatedMetadataByBranchName(_ context.Context, _ string, _ string) ([]types.UpdateRef, error) {
 	return nil, nil
 }
 func (f *fakeMgmtBranchRepo) DeleteBranchByName(_ context.Context, _ string, _ string) error {

--- a/internal/services/protocol_cache.go
+++ b/internal/services/protocol_cache.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"xprem/config"
 	cache2 "xprem/internal/cache"
-	"xprem/internal/providers/expo"
 	"xprem/internal/types"
 	"xprem/internal/version"
 )
@@ -132,16 +131,16 @@ func (s *ExpoProtocolService) cachedUpdateType(ctx context.Context, update types
 // made outside the dashboard can take the provider's TTL plus this one to
 // reach devices.
 // An unknown or unmapped channel (nil) is never cached.
-func (s *ExpoProtocolService) channelBranchMapping(ctx context.Context, appId string, channelName string) (*expo.ChannelResolution, error) {
+func (s *ExpoProtocolService) channelBranchMapping(ctx context.Context, appId string, channelName string) (*types.ChannelResolution, error) {
 	return cachedChannelMapping(ctx, s.channelRepo, appId, channelName)
 }
 
 // cachedChannelMapping is channelBranchMapping without the service, so the
 // branch list can read the same entry the delivery path already fills.
-func cachedChannelMapping(ctx context.Context, channelRepo ChannelRepository, appId string, channelName string) (*expo.ChannelResolution, error) {
+func cachedChannelMapping(ctx context.Context, channelRepo ChannelRepository, appId string, channelName string) (*types.ChannelResolution, error) {
 	mappingCache := cache2.GetCache()
 	cacheKey := channelMappingCacheKey(appId, channelName)
-	if mapping, ok := cache2.GetJSON[expo.ChannelResolution](mappingCache, cacheKey); ok {
+	if mapping, ok := cache2.GetJSON[types.ChannelResolution](mappingCache, cacheKey); ok {
 		return &mapping, nil
 	}
 	mapping, err := channelRepo.GetChannelBranchMapping(ctx, appId, channelName)

--- a/internal/services/protocol_cache.go
+++ b/internal/services/protocol_cache.go
@@ -132,16 +132,16 @@ func (s *ExpoProtocolService) cachedUpdateType(ctx context.Context, update types
 // made outside the dashboard can take the provider's TTL plus this one to
 // reach devices.
 // An unknown or unmapped channel (nil) is never cached.
-func (s *ExpoProtocolService) channelBranchMapping(ctx context.Context, appId string, channelName string) (*expo.ChannelMapping, error) {
+func (s *ExpoProtocolService) channelBranchMapping(ctx context.Context, appId string, channelName string) (*expo.ChannelResolution, error) {
 	return cachedChannelMapping(ctx, s.channelRepo, appId, channelName)
 }
 
 // cachedChannelMapping is channelBranchMapping without the service, so the
 // branch list can read the same entry the delivery path already fills.
-func cachedChannelMapping(ctx context.Context, channelRepo ChannelRepository, appId string, channelName string) (*expo.ChannelMapping, error) {
+func cachedChannelMapping(ctx context.Context, channelRepo ChannelRepository, appId string, channelName string) (*expo.ChannelResolution, error) {
 	mappingCache := cache2.GetCache()
 	cacheKey := channelMappingCacheKey(appId, channelName)
-	if mapping, ok := cache2.GetJSON[expo.ChannelMapping](mappingCache, cacheKey); ok {
+	if mapping, ok := cache2.GetJSON[expo.ChannelResolution](mappingCache, cacheKey); ok {
 		return &mapping, nil
 	}
 	mapping, err := channelRepo.GetChannelBranchMapping(ctx, appId, channelName)

--- a/internal/services/protocol_cache_test.go
+++ b/internal/services/protocol_cache_test.go
@@ -39,7 +39,7 @@ type countingChannelRepo struct {
 	surfingErr   error
 }
 
-func (r *countingChannelRepo) GetChannelBranchMapping(ctx context.Context, appId, channelName string) (*expo.ChannelMapping, error) {
+func (r *countingChannelRepo) GetChannelBranchMapping(ctx context.Context, appId, channelName string) (*expo.ChannelResolution, error) {
 	r.calls++
 	return r.fakeChannelRepo.GetChannelBranchMapping(ctx, appId, channelName)
 }
@@ -53,7 +53,7 @@ func (r *countingChannelRepo) GetBranchSurfing(ctx context.Context, appId, chann
 }
 
 func TestChannelBranchMappingCache(t *testing.T) {
-	repo := &countingChannelRepo{fakeChannelRepo: &fakeChannelRepo{mappings: map[string]*expo.ChannelMapping{
+	repo := &countingChannelRepo{fakeChannelRepo: &fakeChannelRepo{mappings: map[string]*expo.ChannelResolution{
 		"production": {Id: "1", BranchName: "main", Rollout: &expo.ChannelRolloutInfo{ID: "r1", BranchName: "canary", Percentage: 30}},
 	}}}
 	protocolService := NewExpoProtocolService(fakeAppRepo{}, repo, nil, nil, nil)
@@ -94,7 +94,7 @@ func TestChannelBranchMappingCache(t *testing.T) {
 }
 
 func TestChannelBranchMappingNilNeverCached(t *testing.T) {
-	repo := &countingChannelRepo{fakeChannelRepo: &fakeChannelRepo{mappings: map[string]*expo.ChannelMapping{}}}
+	repo := &countingChannelRepo{fakeChannelRepo: &fakeChannelRepo{mappings: map[string]*expo.ChannelResolution{}}}
 	protocolService := NewExpoProtocolService(fakeAppRepo{}, repo, nil, nil, nil)
 	ctx := context.Background()
 	appId := "channel-mapping-nil-test"

--- a/internal/services/protocol_cache_test.go
+++ b/internal/services/protocol_cache_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"xprem/config"
 	cache2 "xprem/internal/cache"
-	"xprem/internal/providers/expo"
 	"xprem/internal/types"
 	"xprem/internal/version"
 )
@@ -39,7 +38,7 @@ type countingChannelRepo struct {
 	surfingErr   error
 }
 
-func (r *countingChannelRepo) GetChannelBranchMapping(ctx context.Context, appId, channelName string) (*expo.ChannelResolution, error) {
+func (r *countingChannelRepo) GetChannelBranchMapping(ctx context.Context, appId, channelName string) (*types.ChannelResolution, error) {
 	r.calls++
 	return r.fakeChannelRepo.GetChannelBranchMapping(ctx, appId, channelName)
 }
@@ -53,8 +52,8 @@ func (r *countingChannelRepo) GetBranchSurfing(ctx context.Context, appId, chann
 }
 
 func TestChannelBranchMappingCache(t *testing.T) {
-	repo := &countingChannelRepo{fakeChannelRepo: &fakeChannelRepo{mappings: map[string]*expo.ChannelResolution{
-		"production": {Id: "1", BranchName: "main", Rollout: &expo.ChannelRolloutInfo{ID: "r1", BranchName: "canary", Percentage: 30}},
+	repo := &countingChannelRepo{fakeChannelRepo: &fakeChannelRepo{mappings: map[string]*types.ChannelResolution{
+		"production": {Id: "1", BranchName: "main", Rollout: &types.ChannelRolloutInfo{ID: "r1", BranchName: "canary", Percentage: 30}},
 	}}}
 	protocolService := NewExpoProtocolService(fakeAppRepo{}, repo, nil, nil, nil)
 	ctx := context.Background()
@@ -94,7 +93,7 @@ func TestChannelBranchMappingCache(t *testing.T) {
 }
 
 func TestChannelBranchMappingNilNeverCached(t *testing.T) {
-	repo := &countingChannelRepo{fakeChannelRepo: &fakeChannelRepo{mappings: map[string]*expo.ChannelResolution{}}}
+	repo := &countingChannelRepo{fakeChannelRepo: &fakeChannelRepo{mappings: map[string]*types.ChannelResolution{}}}
 	protocolService := NewExpoProtocolService(fakeAppRepo{}, repo, nil, nil, nil)
 	ctx := context.Background()
 	appId := "channel-mapping-nil-test"

--- a/internal/services/rollout_resolution_test.go
+++ b/internal/services/rollout_resolution_test.go
@@ -522,7 +522,7 @@ func (fakeBranchRepo) UpsertBranchAndRuntimeVersion(_ context.Context, _, _, _ s
 	return nil
 }
 
-func (fakeBranchRepo) GetUpdatedMetadataByBranchName(_ context.Context, _, _ string) ([]types.UpdateRef, error) {
+func (fakeBranchRepo) GetUpdateRefsByBranchName(_ context.Context, _, _ string) ([]types.UpdateRef, error) {
 	return nil, nil
 }
 

--- a/internal/services/rollout_resolution_test.go
+++ b/internal/services/rollout_resolution_test.go
@@ -15,7 +15,6 @@ import (
 	"time"
 
 	"xprem/config"
-	"xprem/internal/database/postgres/pgdb"
 	"xprem/internal/providers/expo"
 	"xprem/internal/rollout"
 	"xprem/internal/store"
@@ -286,10 +285,6 @@ func (r *fakeUpdateRepo) CreateRollback(_ context.Context, appId string, updateI
 	return &updateCopy, nil
 }
 
-func (r *fakeUpdateRepo) GetUpdateByBranchNameAndRuntime(_ context.Context, _ string, _ int64, _, _ string) (pgdb.GetUpdateByBranchNameAndRuntimeRow, error) {
-	return pgdb.GetUpdateByBranchNameAndRuntimeRow{}, nil
-}
-
 func (r *fakeUpdateRepo) GetUpdatesByRunTimeVersionAndBranchName(_ context.Context, _, _, _ string, _ *int64, _ int) (types.UpdatesPage, error) {
 	return types.UpdatesPage{}, nil
 }
@@ -443,7 +438,7 @@ func (r *fakeRolloutRepo) ClearUpdateRollout(_ context.Context, appId, branchNam
 }
 
 type fakeChannelRepo struct {
-	mappings map[string]*expo.ChannelMapping
+	mappings map[string]*expo.ChannelResolution
 	// surfing is the branch-surfing setting GetBranchSurfing answers with, per
 	// channel name. A channel absent from the map does not exist.
 	surfing map[string]*types.BranchSurfing
@@ -482,7 +477,7 @@ func (r *fakeChannelRepo) GetChannels(_ context.Context, _ string) ([]types.Chan
 	return nil, nil
 }
 
-func (r *fakeChannelRepo) GetChannelBranchMapping(_ context.Context, _, channelName string) (*expo.ChannelMapping, error) {
+func (r *fakeChannelRepo) GetChannelBranchMapping(_ context.Context, _, channelName string) (*expo.ChannelResolution, error) {
 	mapping, ok := r.mappings[channelName]
 	if !ok {
 		return nil, nil
@@ -520,7 +515,7 @@ func (r fakeBranchRepo) GetSurfableBranches(_ context.Context, _, runtimeVersion
 	return r.surfable[runtimeVersion], nil
 }
 
-func (fakeBranchRepo) InsertBranch(_ context.Context, _ pgdb.InsertBranchParams) (int64, error) {
+func (fakeBranchRepo) InsertBranch(_ context.Context, _, _ string) (int64, error) {
 	return 0, nil
 }
 
@@ -528,7 +523,7 @@ func (fakeBranchRepo) UpsertBranchAndRuntimeVersion(_ context.Context, _, _, _ s
 	return nil
 }
 
-func (fakeBranchRepo) GetUpdatedMetadataByBranchName(_ context.Context, _, _ string) ([]pgdb.GetUpdatesMetadataByBranchNameRow, error) {
+func (fakeBranchRepo) GetUpdatedMetadataByBranchName(_ context.Context, _, _ string) ([]types.UpdateRef, error) {
 	return nil, nil
 }
 
@@ -616,7 +611,7 @@ func newRolloutTestHarness(t *testing.T) *rolloutTestHarness {
 	t.Helper()
 	events := &eventLog{}
 	updateRepo := &fakeUpdateRepo{events: events}
-	channelRepo := &fakeChannelRepo{mappings: map[string]*expo.ChannelMapping{}}
+	channelRepo := &fakeChannelRepo{mappings: map[string]*expo.ChannelResolution{}}
 	rolloutRepo := &fakeRolloutRepo{updateRepo: updateRepo, events: events}
 	updateService := NewUpdateService(updateRepo, nil)
 	branchService := NewBranchService(fakeBranchRepo{}, channelRepo, updateRepo, rolloutRepo, fakeRolloutBucket{})
@@ -764,7 +759,7 @@ func TestGetLatestUpdateForClientDecisionTree(t *testing.T) {
 func TestResolveManifestBundleServesRollbackControl(t *testing.T) {
 	ctx := context.Background()
 	h := newRolloutTestHarness(t)
-	h.channelRepo.mappings["production"] = &expo.ChannelMapping{Id: "1", BranchName: "main"}
+	h.channelRepo.mappings["production"] = &expo.ChannelResolution{Id: "1", BranchName: "main"}
 	// A rollout published on top of a rollback (the progressive hotfix case): the
 	// out-of-bucket cohort must receive the rollback directive, so the update type
 	// dispatch has to run on the served update, not on the latest row.
@@ -803,7 +798,7 @@ func TestResolveManifestBundleChannelRollout(t *testing.T) {
 
 	newChannelRolloutHarness := func(t *testing.T) *rolloutTestHarness {
 		h := newRolloutTestHarness(t)
-		h.channelRepo.mappings["production"] = &expo.ChannelMapping{
+		h.channelRepo.mappings["production"] = &expo.ChannelResolution{
 			Id:         "1",
 			BranchName: "main",
 			Rollout:    &expo.ChannelRolloutInfo{ID: channelSalt, BranchName: "beta", Percentage: 30},
@@ -1129,9 +1124,9 @@ func TestRolloutServiceRequiresControlPlane(t *testing.T) {
 func TestResolveAssetUpdateTiers(t *testing.T) {
 	ctx := context.Background()
 
-	newAssetHarness := func(t *testing.T) (*rolloutTestHarness, *expo.ChannelMapping, string, string) {
+	newAssetHarness := func(t *testing.T) (*rolloutTestHarness, *expo.ChannelResolution, string, string) {
 		h := newRolloutTestHarness(t)
-		h.channelRepo.mappings["production"] = &expo.ChannelMapping{Id: "1", BranchName: "main"}
+		h.channelRepo.mappings["production"] = &expo.ChannelResolution{Id: "1", BranchName: "main"}
 		h.seed(seedRow{branch: "main", rtv: "1", platform: "ios", id: 100, checked: true, uuid: "11111111-1111-1111-1111-111111111111"})
 		h.seed(seedRow{branch: "main", rtv: "1", platform: "ios", id: 200, checked: true, percentage: 40, controlId: 100, uuid: "22222222-2222-2222-2222-222222222222"})
 		branchMap, err := h.channelRepo.GetChannelBranchMapping(ctx, h.appId, "production")

--- a/internal/services/rollout_resolution_test.go
+++ b/internal/services/rollout_resolution_test.go
@@ -15,7 +15,6 @@ import (
 	"time"
 
 	"xprem/config"
-	"xprem/internal/providers/expo"
 	"xprem/internal/rollout"
 	"xprem/internal/store"
 	"xprem/internal/types"
@@ -438,7 +437,7 @@ func (r *fakeRolloutRepo) ClearUpdateRollout(_ context.Context, appId, branchNam
 }
 
 type fakeChannelRepo struct {
-	mappings map[string]*expo.ChannelResolution
+	mappings map[string]*types.ChannelResolution
 	// surfing is the branch-surfing setting GetBranchSurfing answers with, per
 	// channel name. A channel absent from the map does not exist.
 	surfing map[string]*types.BranchSurfing
@@ -477,7 +476,7 @@ func (r *fakeChannelRepo) GetChannels(_ context.Context, _ string) ([]types.Chan
 	return nil, nil
 }
 
-func (r *fakeChannelRepo) GetChannelBranchMapping(_ context.Context, _, channelName string) (*expo.ChannelResolution, error) {
+func (r *fakeChannelRepo) GetChannelBranchMapping(_ context.Context, _, channelName string) (*types.ChannelResolution, error) {
 	mapping, ok := r.mappings[channelName]
 	if !ok {
 		return nil, nil
@@ -611,7 +610,7 @@ func newRolloutTestHarness(t *testing.T) *rolloutTestHarness {
 	t.Helper()
 	events := &eventLog{}
 	updateRepo := &fakeUpdateRepo{events: events}
-	channelRepo := &fakeChannelRepo{mappings: map[string]*expo.ChannelResolution{}}
+	channelRepo := &fakeChannelRepo{mappings: map[string]*types.ChannelResolution{}}
 	rolloutRepo := &fakeRolloutRepo{updateRepo: updateRepo, events: events}
 	updateService := NewUpdateService(updateRepo, nil)
 	branchService := NewBranchService(fakeBranchRepo{}, channelRepo, updateRepo, rolloutRepo, fakeRolloutBucket{})
@@ -759,7 +758,7 @@ func TestGetLatestUpdateForClientDecisionTree(t *testing.T) {
 func TestResolveManifestBundleServesRollbackControl(t *testing.T) {
 	ctx := context.Background()
 	h := newRolloutTestHarness(t)
-	h.channelRepo.mappings["production"] = &expo.ChannelResolution{Id: "1", BranchName: "main"}
+	h.channelRepo.mappings["production"] = &types.ChannelResolution{Id: "1", BranchName: "main"}
 	// A rollout published on top of a rollback (the progressive hotfix case): the
 	// out-of-bucket cohort must receive the rollback directive, so the update type
 	// dispatch has to run on the served update, not on the latest row.
@@ -798,10 +797,10 @@ func TestResolveManifestBundleChannelRollout(t *testing.T) {
 
 	newChannelRolloutHarness := func(t *testing.T) *rolloutTestHarness {
 		h := newRolloutTestHarness(t)
-		h.channelRepo.mappings["production"] = &expo.ChannelResolution{
+		h.channelRepo.mappings["production"] = &types.ChannelResolution{
 			Id:         "1",
 			BranchName: "main",
-			Rollout:    &expo.ChannelRolloutInfo{ID: channelSalt, BranchName: "beta", Percentage: 30},
+			Rollout:    &types.ChannelRolloutInfo{ID: channelSalt, BranchName: "beta", Percentage: 30},
 		}
 		h.seed(seedRow{branch: "main", rtv: "1", platform: "ios", id: 100, checked: true})
 		return h
@@ -1124,9 +1123,9 @@ func TestRolloutServiceRequiresControlPlane(t *testing.T) {
 func TestResolveAssetUpdateTiers(t *testing.T) {
 	ctx := context.Background()
 
-	newAssetHarness := func(t *testing.T) (*rolloutTestHarness, *expo.ChannelResolution, string, string) {
+	newAssetHarness := func(t *testing.T) (*rolloutTestHarness, *types.ChannelResolution, string, string) {
 		h := newRolloutTestHarness(t)
-		h.channelRepo.mappings["production"] = &expo.ChannelResolution{Id: "1", BranchName: "main"}
+		h.channelRepo.mappings["production"] = &types.ChannelResolution{Id: "1", BranchName: "main"}
 		h.seed(seedRow{branch: "main", rtv: "1", platform: "ios", id: 100, checked: true, uuid: "11111111-1111-1111-1111-111111111111"})
 		h.seed(seedRow{branch: "main", rtv: "1", platform: "ios", id: 200, checked: true, percentage: 40, controlId: 100, uuid: "22222222-2222-2222-2222-222222222222"})
 		branchMap, err := h.channelRepo.GetChannelBranchMapping(ctx, h.appId, "production")

--- a/internal/services/update_service.go
+++ b/internal/services/update_service.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"xprem/internal/bucket"
 	"xprem/internal/cache"
-	"xprem/internal/database/postgres/pgdb"
 	"xprem/internal/rollout"
 	"xprem/internal/types"
 	update2 "xprem/internal/update"
@@ -38,7 +37,6 @@ type UpdateRepository interface {
 	// Control-plane only: the bucket store answers ErrNotSupportedInStatelessMode.
 	GetUpdatesByPublishGroup(ctx context.Context, appId string, branchName string, runtimeVersion string, publishGroup string) ([]types.PublishGroupMember, error)
 	GetPublishGroupsPage(ctx context.Context, appId string, branchName string, runtimeVersion string, cursor *int64, limit int) (types.PublishGroupsPage, error)
-	GetUpdateByBranchNameAndRuntime(ctx context.Context, appId string, updateId int64, branchName string, runtimeVersion string) (pgdb.GetUpdateByBranchNameAndRuntimeRow, error)
 	GetUpdatesByRunTimeVersionAndBranchName(ctx context.Context, appId string, runtimeVersion string, branchName string, cursor *int64, limit int) (types.UpdatesPage, error)
 	GetUpdateFeed(ctx context.Context, appId string, query types.UpdateFeedQuery) ([]types.UpdateFeedItem, error)
 	RetrieveUpdateStoredMetadata(ctx context.Context, update types.Update) (*types.UpdateStoredMetadata, error)

--- a/internal/store/auth_bucket.go
+++ b/internal/store/auth_bucket.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"xprem/internal/bucket"
-	"xprem/internal/database/postgres/pgdb"
 	"xprem/internal/providers/expo"
 	"xprem/internal/types"
 )
@@ -35,8 +34,8 @@ func (s *BucketAuthStore) InsertApiKey(ctx context.Context, appId string, name s
 	return 0, ErrNotSupportedInStatelessMode
 }
 
-func (s *BucketAuthStore) GetApiKeysMetadataByAppID(ctx context.Context, appId string) ([]pgdb.GetApiKeysMetadataByAppIDRow, error) {
-	return []pgdb.GetApiKeysMetadataByAppIDRow{}, ErrNotSupportedInStatelessMode
+func (s *BucketAuthStore) GetApiKeysMetadataByAppID(ctx context.Context, appId string) ([]types.ApiKeyMetadata, error) {
+	return []types.ApiKeyMetadata{}, ErrNotSupportedInStatelessMode
 }
 
 func (s *BucketAuthStore) GetApiKeyNameByID(ctx context.Context, appId string, apiKeyId int64) (string, error) {

--- a/internal/store/auth_postgres.go
+++ b/internal/store/auth_postgres.go
@@ -3,6 +3,8 @@ package store
 import (
 	"context"
 	"fmt"
+	"strconv"
+	"time"
 	"xprem/internal/crypto"
 	"xprem/internal/database"
 	"xprem/internal/database/postgres/pgdb"
@@ -52,9 +54,27 @@ func (s *PostgresAuthStore) InsertApiKey(ctx context.Context, appId string, name
 	})
 }
 
-func (s *PostgresAuthStore) GetApiKeysMetadataByAppID(ctx context.Context, appId string) ([]pgdb.GetApiKeysMetadataByAppIDRow, error) {
-	pgAppID := ToPgUUID(appId)
-	return s.engine.Queries.GetApiKeysMetadataByAppID(ctx, pgAppID)
+func (s *PostgresAuthStore) GetApiKeysMetadataByAppID(ctx context.Context, appId string) ([]types.ApiKeyMetadata, error) {
+	rows, err := s.engine.Queries.GetApiKeysMetadataByAppID(ctx, ToPgUUID(appId))
+	if err != nil {
+		return nil, err
+	}
+	apiKeysMetadata := make([]types.ApiKeyMetadata, len(rows))
+	for i, row := range rows {
+		var lastUsedAt *string
+		if row.LastUsedAt.Valid {
+			formatted := row.LastUsedAt.Time.Format(time.RFC3339)
+			lastUsedAt = &formatted
+		}
+		apiKeysMetadata[i] = types.ApiKeyMetadata{
+			ID:         strconv.FormatInt(row.ID, 10),
+			Name:       row.Name,
+			Hint:       row.Hint,
+			CreatedAt:  row.CreatedAt.Time.Format(time.RFC3339),
+			LastUsedAt: lastUsedAt,
+		}
+	}
+	return apiKeysMetadata, nil
 }
 
 func (s *PostgresAuthStore) RevokeApiKeyByID(ctx context.Context, apiKeyId int64, appId string) (string, error) {

--- a/internal/store/branch_bucket.go
+++ b/internal/store/branch_bucket.go
@@ -9,7 +9,6 @@ import (
 	"xprem/config"
 	"xprem/internal/branch"
 	bucket2 "xprem/internal/bucket"
-	"xprem/internal/database/postgres/pgdb"
 	"xprem/internal/providers/expo"
 	"xprem/internal/types"
 )
@@ -24,11 +23,11 @@ func NewBucketBranchStore(bucket bucket2.Bucket) *BucketBranchStore {
 	}
 }
 
-func (s *BucketBranchStore) InsertBranch(ctx context.Context, branch pgdb.InsertBranchParams) (int64, error) {
+func (s *BucketBranchStore) InsertBranch(ctx context.Context, appId string, branchName string) (int64, error) {
 	return 0, fmt.Errorf("branch creation is only supported in db mode")
 }
 
-func (s *BucketBranchStore) GetUpdatedMetadataByBranchName(ctx context.Context, appId string, branchName string) ([]pgdb.GetUpdatesMetadataByBranchNameRow, error) {
+func (s *BucketBranchStore) GetUpdatedMetadataByBranchName(ctx context.Context, appId string, branchName string) ([]types.UpdateRef, error) {
 	return nil, fmt.Errorf("getting updated metadata by branch name is only supported in db mode")
 }
 

--- a/internal/store/branch_bucket.go
+++ b/internal/store/branch_bucket.go
@@ -27,8 +27,8 @@ func (s *BucketBranchStore) InsertBranch(ctx context.Context, appId string, bran
 	return 0, fmt.Errorf("branch creation is only supported in db mode")
 }
 
-func (s *BucketBranchStore) GetUpdatedMetadataByBranchName(ctx context.Context, appId string, branchName string) ([]types.UpdateRef, error) {
-	return nil, fmt.Errorf("getting updated metadata by branch name is only supported in db mode")
+func (s *BucketBranchStore) GetUpdateRefsByBranchName(ctx context.Context, appId string, branchName string) ([]types.UpdateRef, error) {
+	return nil, fmt.Errorf("getting update refs by branch name is only supported in db mode")
 }
 
 func (s *BucketBranchStore) DeleteBranchByName(ctx context.Context, appId string, branchName string) error {

--- a/internal/store/branch_postgres.go
+++ b/internal/store/branch_postgres.go
@@ -22,23 +22,30 @@ func NewPostgresBranchStore(engine *database.Engine) *PostgresBranchStore {
 	}
 }
 
-func (s *PostgresBranchStore) InsertBranch(ctx context.Context, branch pgdb.InsertBranchParams) (int64, error) {
-	insertedId, err := s.engine.Queries.InsertBranch(ctx, branch)
+func (s *PostgresBranchStore) InsertBranch(ctx context.Context, appId string, branchName string) (int64, error) {
+	insertedId, err := s.engine.Queries.InsertBranch(ctx, pgdb.InsertBranchParams{AppID: ToPgUUID(appId), Name: branchName})
 	if err != nil {
 		if database.IsUniqueViolation(err) {
-			return 0, &ErrResourceAlreadyExists{Resource: "branch", Identifier: branch.Name}
+			return 0, &ErrResourceAlreadyExists{Resource: "branch", Identifier: branchName}
 		}
 		return 0, err
 	}
 	return insertedId, nil
 }
 
-func (s *PostgresBranchStore) GetUpdatedMetadataByBranchName(ctx context.Context, appId string, branchName string) ([]pgdb.GetUpdatesMetadataByBranchNameRow, error) {
-	pgAppID := ToPgUUID(appId)
-	return s.engine.Queries.GetUpdatesMetadataByBranchName(ctx, pgdb.GetUpdatesMetadataByBranchNameParams{
+func (s *PostgresBranchStore) GetUpdatedMetadataByBranchName(ctx context.Context, appId string, branchName string) ([]types.UpdateRef, error) {
+	rows, err := s.engine.Queries.GetUpdatesMetadataByBranchName(ctx, pgdb.GetUpdatesMetadataByBranchNameParams{
 		Name:  branchName,
-		AppID: pgAppID,
+		AppID: ToPgUUID(appId),
 	})
+	if err != nil {
+		return nil, err
+	}
+	refs := make([]types.UpdateRef, len(rows))
+	for i, row := range rows {
+		refs[i] = types.UpdateRef{ID: row.ID, RuntimeVersion: row.RuntimeVersion}
+	}
+	return refs, nil
 }
 
 func (s *PostgresBranchStore) DeleteBranchByName(ctx context.Context, appId string, branchName string) error {
@@ -140,11 +147,7 @@ func branchUpdateState(runtimeVersion *string, commitHash *string, createdAt pgt
 }
 
 func (s *PostgresBranchStore) UpsertBranchAndRuntimeVersion(ctx context.Context, appId string, branchName string, runtimeVersion string) error {
-	pgAppID := ToPgUUID(appId)
-	_, err := s.InsertBranch(ctx, pgdb.InsertBranchParams{
-		AppID: pgAppID,
-		Name:  branchName,
-	})
+	_, err := s.InsertBranch(ctx, appId, branchName)
 	if err != nil {
 		if _, ok := err.(*ErrResourceAlreadyExists); ok {
 			err = nil

--- a/internal/store/branch_postgres.go
+++ b/internal/store/branch_postgres.go
@@ -33,7 +33,7 @@ func (s *PostgresBranchStore) InsertBranch(ctx context.Context, appId string, br
 	return insertedId, nil
 }
 
-func (s *PostgresBranchStore) GetUpdatedMetadataByBranchName(ctx context.Context, appId string, branchName string) ([]types.UpdateRef, error) {
+func (s *PostgresBranchStore) GetUpdateRefsByBranchName(ctx context.Context, appId string, branchName string) ([]types.UpdateRef, error) {
 	rows, err := s.engine.Queries.GetUpdatesMetadataByBranchName(ctx, pgdb.GetUpdatesMetadataByBranchNameParams{
 		Name:  branchName,
 		AppID: ToPgUUID(appId),

--- a/internal/store/channel_bucket.go
+++ b/internal/store/channel_bucket.go
@@ -60,7 +60,7 @@ func (s *BucketChannelStore) GetChannels(ctx context.Context, appId string) ([]t
 	return channels, nil
 }
 
-func (s *BucketChannelStore) GetChannelBranchMapping(ctx context.Context, appId string, channelName string) (*expo.ChannelMapping, error) {
+func (s *BucketChannelStore) GetChannelBranchMapping(ctx context.Context, appId string, channelName string) (*expo.ChannelResolution, error) {
 	return expo.FetchChannelMapping(appId, channelName)
 }
 

--- a/internal/store/channel_bucket.go
+++ b/internal/store/channel_bucket.go
@@ -60,7 +60,7 @@ func (s *BucketChannelStore) GetChannels(ctx context.Context, appId string) ([]t
 	return channels, nil
 }
 
-func (s *BucketChannelStore) GetChannelBranchMapping(ctx context.Context, appId string, channelName string) (*expo.ChannelResolution, error) {
+func (s *BucketChannelStore) GetChannelBranchMapping(ctx context.Context, appId string, channelName string) (*types.ChannelResolution, error) {
 	return expo.FetchChannelMapping(appId, channelName)
 }
 

--- a/internal/store/channel_postgres.go
+++ b/internal/store/channel_postgres.go
@@ -166,7 +166,7 @@ func (s *PostgresChannelStore) GetUpdatesByRunTimeVersionAndBranchName(ctx conte
 	})
 }
 
-func (s *PostgresChannelStore) GetChannelBranchMapping(ctx context.Context, appId string, channelName string) (*expo.ChannelMapping, error) {
+func (s *PostgresChannelStore) GetChannelBranchMapping(ctx context.Context, appId string, channelName string) (*expo.ChannelResolution, error) {
 	pgAppID := ToPgUUID(appId)
 	mapping, err := s.engine.Queries.GetChannelBranchMapping(ctx, pgdb.GetChannelBranchMappingParams{
 		AppID: pgAppID,
@@ -182,7 +182,7 @@ func (s *PostgresChannelStore) GetChannelBranchMapping(ctx context.Context, appI
 		return nil, fmt.Errorf("failed to retrieve channel mapping from database: %w", err)
 	}
 	mappingStr := strconv.FormatInt(mapping.ID, 10)
-	result := &expo.ChannelMapping{
+	result := &expo.ChannelResolution{
 		Id:         mappingStr,
 		BranchName: mapping.BranchName,
 	}

--- a/internal/store/channel_postgres.go
+++ b/internal/store/channel_postgres.go
@@ -8,7 +8,6 @@ import (
 	"time"
 	"xprem/internal/database"
 	"xprem/internal/database/postgres/pgdb"
-	"xprem/internal/providers/expo"
 	"xprem/internal/types"
 
 	"github.com/jackc/pgx/v5"
@@ -166,7 +165,7 @@ func (s *PostgresChannelStore) GetUpdatesByRunTimeVersionAndBranchName(ctx conte
 	})
 }
 
-func (s *PostgresChannelStore) GetChannelBranchMapping(ctx context.Context, appId string, channelName string) (*expo.ChannelResolution, error) {
+func (s *PostgresChannelStore) GetChannelBranchMapping(ctx context.Context, appId string, channelName string) (*types.ChannelResolution, error) {
 	pgAppID := ToPgUUID(appId)
 	mapping, err := s.engine.Queries.GetChannelBranchMapping(ctx, pgdb.GetChannelBranchMappingParams{
 		AppID: pgAppID,
@@ -182,12 +181,12 @@ func (s *PostgresChannelStore) GetChannelBranchMapping(ctx context.Context, appI
 		return nil, fmt.Errorf("failed to retrieve channel mapping from database: %w", err)
 	}
 	mappingStr := strconv.FormatInt(mapping.ID, 10)
-	result := &expo.ChannelResolution{
+	result := &types.ChannelResolution{
 		Id:         mappingStr,
 		BranchName: mapping.BranchName,
 	}
 	if mapping.RolloutID.Valid && mapping.RolloutBranchName != nil && mapping.RolloutPercentage != nil {
-		result.Rollout = &expo.ChannelRolloutInfo{
+		result.Rollout = &types.ChannelRolloutInfo{
 			ID:         mapping.RolloutID.String(),
 			BranchName: *mapping.RolloutBranchName,
 			Percentage: int(*mapping.RolloutPercentage),

--- a/internal/store/rollout_postgres_test.go
+++ b/internal/store/rollout_postgres_test.go
@@ -78,9 +78,9 @@ func newRolloutFixture(t *testing.T) *rolloutFixture {
 	}
 	_, err = pool.Exec(ctx, "INSERT INTO apps (id, name) VALUES ($1, $2)", fixture.appId, "rollout-store-test")
 	require.NoError(t, err)
-	fixture.defaultBranchId, err = fixture.branches.InsertBranch(ctx, pgdb.InsertBranchParams{AppID: store.ToPgUUID(fixture.appId), Name: rolloutTestDefaultBranch})
+	fixture.defaultBranchId, err = fixture.branches.InsertBranch(ctx, fixture.appId, rolloutTestDefaultBranch)
 	require.NoError(t, err)
-	fixture.rolloutBranchId, err = fixture.branches.InsertBranch(ctx, pgdb.InsertBranchParams{AppID: store.ToPgUUID(fixture.appId), Name: rolloutTestRolloutBranch})
+	fixture.rolloutBranchId, err = fixture.branches.InsertBranch(ctx, fixture.appId, rolloutTestRolloutBranch)
 	require.NoError(t, err)
 	_, err = fixture.branches.CreateRuntimeVersion(ctx, fixture.appId, rolloutTestRuntime)
 	require.NoError(t, err)

--- a/internal/store/update_bucket.go
+++ b/internal/store/update_bucket.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	bucket2 "xprem/internal/bucket"
 	"xprem/internal/crypto"
-	"xprem/internal/database/postgres/pgdb"
 	"xprem/internal/helpers"
 	"xprem/internal/types"
 
@@ -298,10 +297,6 @@ func (s *BucketUpdateStore) CreateRollback(ctx context.Context, appId string, up
 		return nil, err
 	}
 	return &update, nil
-}
-
-func (s *BucketUpdateStore) GetUpdateByBranchNameAndRuntime(ctx context.Context, appId string, updateId int64, branchName string, runtimeVersion string) (pgdb.GetUpdateByBranchNameAndRuntimeRow, error) {
-	return pgdb.GetUpdateByBranchNameAndRuntimeRow{}, ErrNotSupportedInStatelessMode
 }
 
 // GetLatestUpdateWithRollout wraps GetLatestUpdate with an empty rollout

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -149,6 +149,12 @@ type UpdateDetails struct {
 	ControlUpdateId   *string `json:"controlUpdateId,omitempty"`
 }
 
+// UpdateRef locates one update's files on a branch.
+type UpdateRef struct {
+	ID             int64
+	RuntimeVersion string
+}
+
 type ApiKeyMetadata struct {
 	ID         string  `json:"id"`
 	Name       string  `json:"name"`

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -149,7 +149,8 @@ type UpdateDetails struct {
 	ControlUpdateId   *string `json:"controlUpdateId,omitempty"`
 }
 
-// UpdateRef locates one update's files on a branch.
+// UpdateRef is the (update id, runtime version) pair that, with a branch,
+// locates an update's folder in the bucket.
 type UpdateRef struct {
 	ID             int64
 	RuntimeVersion string
@@ -330,7 +331,7 @@ type ChannelRolloutInfo struct {
 }
 
 // ChannelResolution is the branch a channel serves to devices, with its active
-// rollout; the dashboard listing shape is types.ChannelMapping.
+// rollout; the dashboard listing shape is ChannelMapping.
 type ChannelResolution struct {
 	Id         string `json:"id"`
 	BranchName string `json:"branchName"`

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -319,3 +319,21 @@ type Auth struct {
 	Token         *string
 	SessionSecret *string
 }
+
+// ChannelRolloutInfo is the active channel rollout folded into a ChannelResolution in
+// control-plane mode. ID doubles as the bucketing salt. The stateless (Expo) provider
+// never sets it, so rollouts stay a control-plane-only feature.
+type ChannelRolloutInfo struct {
+	ID         string `json:"id"`
+	BranchName string `json:"branchName"`
+	Percentage int    `json:"percentage"`
+}
+
+// ChannelResolution is the branch a channel serves to devices, with its active
+// rollout; the dashboard listing shape is types.ChannelMapping.
+type ChannelResolution struct {
+	Id         string `json:"id"`
+	BranchName string `json:"branchName"`
+	// Set only by the Postgres channel store when the channel has an active rollout.
+	Rollout *ChannelRolloutInfo `json:"rollout,omitempty"`
+}


### PR DESCRIPTION
The repository interfaces the services depend on are meant to hide whether the data lives in Postgres or in a bucket, but four of their members took or returned sqlc-generated `pgdb` types, so every caller (and every test fake) had to build Postgres row structs by hand, and the bucket implementations returned empty `pgdb` rows they have no business knowing about. One of the four had no caller at all.

This replaces those members with the plain domain shapes the callers actually use, moves the row-to-domain conversion into the Postgres store where it belongs, and drops the dead member. While in there, the device-facing channel shape `expo.ChannelMapping` is renamed `ChannelResolution`: it shared its name with the unrelated dashboard listing shape `types.ChannelMapping`, and both came out of the same repository interface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved consistency in branch, channel, rollout, and API key handling across services.
  * Standardized channel resolution and rollout information, including active rollout details.
  * Simplified branch creation and update-reference handling while preserving existing behavior.
  * Removed obsolete update lookup paths that are no longer supported.

* **Tests**
  * Updated automated tests and scenarios for branch, channel, authentication, and rollout workflows.
  * Improved test coverage alignment with current service behavior and data handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->