### PR TITLE
refactor: response structs instead of map literals in the API handlers

### DIFF
--- a/ee/audit/handler.go
+++ b/ee/audit/handler.go
@@ -134,6 +134,12 @@ func renderAuditLogsServiceError(w http.ResponseWriter, err error) {
 	}
 }
 
+type listAuditLogsResponse struct {
+	Events     []AuditEventResponse `json:"events"`
+	NextCursor *int64               `json:"nextCursor"`
+	Count      int64                `json:"count"`
+}
+
 func (h *AuditHandler) ListAuditLogsHandler(w http.ResponseWriter, r *http.Request) {
 	query := r.URL.Query()
 	from, to, errRange := checkAndParseRange(
@@ -181,9 +187,5 @@ func (h *AuditHandler) ListAuditLogsHandler(w http.ResponseWriter, r *http.Reque
 	for i, event := range events {
 		responseEvents[i] = auditEventResponseFrom(event)
 	}
-	handlers.RenderJSON(w, http.StatusOK, map[string]interface{}{
-		"events":     responseEvents,
-		"nextCursor": nextCursor,
-		"count":      count,
-	})
+	handlers.RenderJSON(w, http.StatusOK, listAuditLogsResponse{Events: responseEvents, NextCursor: nextCursor, Count: count})
 }

--- a/ee/identity/handler.go
+++ b/ee/identity/handler.go
@@ -53,6 +53,28 @@ func renderIdentityServiceError(w http.ResponseWriter, err error) {
 }
 
 // schemaKeyResponse is the wire shape of a KeySpec (camelCase; timestamps RFC3339 UTC).
+type schemaResponse struct {
+	Keys []schemaKeyResponse `json:"keys"`
+}
+
+type valuesResponse struct {
+	Values []ValueCount `json:"values"`
+}
+
+type devicesPageResponse struct {
+	Devices    []deviceResponse `json:"devices"`
+	NextCursor *string          `json:"nextCursor"`
+}
+
+type onlineDevicesResponse struct {
+	Online        int64 `json:"online"`
+	WindowMinutes int   `json:"windowMinutes"`
+}
+
+type updatesHealthResponse struct {
+	Updates map[string]updateHealthResponse `json:"updates"`
+}
+
 type schemaKeyResponse struct {
 	Key       string `json:"key"`
 	Type      string `json:"type"`
@@ -125,7 +147,7 @@ func (h *IdentityHandler) GetSchemaHandler(w http.ResponseWriter, r *http.Reques
 		keys = append(keys, schemaKeyResponseFrom(spec))
 	}
 	sortSchemaKeys(keys)
-	handlers.RenderJSON(w, http.StatusOK, map[string]any{"keys": keys})
+	handlers.RenderJSON(w, http.StatusOK, schemaResponse{Keys: keys})
 }
 
 func (h *IdentityHandler) UpsertSchemaKeyHandler(w http.ResponseWriter, r *http.Request) {
@@ -200,7 +222,7 @@ func (h *IdentityHandler) SearchValuesHandler(w http.ResponseWriter, r *http.Req
 	}
 	out := make([]ValueCount, 0, len(values))
 	out = append(out, values...) // To init with [] instead of nil for the renderJSON
-	handlers.RenderJSON(w, http.StatusOK, map[string]any{"values": out})
+	handlers.RenderJSON(w, http.StatusOK, valuesResponse{Values: out})
 }
 
 // parseDeviceQuery reads the filter parameters shared by the inventory page and the online
@@ -303,10 +325,7 @@ func (h *IdentityHandler) ListDevicesHandler(w http.ResponseWriter, r *http.Requ
 	for _, d := range devices {
 		items = append(items, deviceResponseFrom(d))
 	}
-	handlers.RenderJSON(w, http.StatusOK, map[string]any{
-		"devices":    items,
-		"nextCursor": encodeDeviceCursor(next),
-	})
+	handlers.RenderJSON(w, http.StatusOK, devicesPageResponse{Devices: items, NextCursor: encodeDeviceCursor(next)})
 }
 
 // OnlineDevicesHandler answers "how many devices are live right now", taking the same
@@ -339,10 +358,7 @@ func (h *IdentityHandler) OnlineDevicesHandler(w http.ResponseWriter, r *http.Re
 		renderIdentityServiceError(w, err)
 		return
 	}
-	handlers.RenderJSON(w, http.StatusOK, map[string]any{
-		"online":        count,
-		"windowMinutes": int(min(window, MaxOnlineWindow).Minutes()),
-	})
+	handlers.RenderJSON(w, http.StatusOK, onlineDevicesResponse{Online: count, WindowMinutes: int(min(window, MaxOnlineWindow).Minutes())})
 }
 
 func (h *IdentityHandler) GetDeviceHandler(w http.ResponseWriter, r *http.Request) {
@@ -470,5 +486,5 @@ func (h *IdentityHandler) UpdateHealthHandler(w http.ResponseWriter, r *http.Req
 		}
 		out[parsed.String()] = response
 	}
-	handlers.RenderJSON(w, http.StatusOK, map[string]any{"updates": out})
+	handlers.RenderJSON(w, http.StatusOK, updatesHealthResponse{Updates: out})
 }

--- a/ee/observe/health_history_handler.go
+++ b/ee/observe/health_history_handler.go
@@ -51,6 +51,27 @@ type HealthHistoryHandler struct {
 	state  *StateHistory
 }
 
+// healthHistoryResponse and stateHistoryResponse are the two shapes of the
+// health history endpoint, told apart by Source; the dashboard reads them as a
+// discriminated union.
+type healthHistoryResponse struct {
+	Available bool                            `json:"available"`
+	Source    string                          `json:"source"`
+	Updates   map[string][]HealthHistoryPoint `json:"updates"`
+}
+
+type stateHistoryResponse struct {
+	Available bool                           `json:"available"`
+	Source    string                         `json:"source"`
+	Updates   map[string][]StateHistoryPoint `json:"updates"`
+}
+
+type healthSegmentsResponse struct {
+	Available bool                            `json:"available"`
+	Dimension string                          `json:"dimension"`
+	Segments  map[string][]HealthSegmentPoint `json:"segments"`
+}
+
 func NewHealthHistoryHandler(reader HealthHistoryReader, state *StateHistory) *HealthHistoryHandler {
 	// A nil *HealthHistory stored in an interface is itself non-nil. Wiring
 	// does exactly that when ClickHouse is disabled, so normalize it here
@@ -125,11 +146,7 @@ func (h *HealthHistoryHandler) GetUpdateHealthHistoryHandler(w http.ResponseWrit
 	// forgets to branch fails to read the payload rather than mislabelling it.
 	if h.reader == nil {
 		if h.state == nil {
-			handlers.RenderJSON(w, http.StatusOK, map[string]any{
-				"available": false,
-				"source":    "none",
-				"updates":   map[string][]HealthHistoryPoint{},
-			})
+			handlers.RenderJSON(w, http.StatusOK, healthHistoryResponse{Source: "none", Updates: map[string][]HealthHistoryPoint{}})
 			return
 		}
 		points, err := h.state.Read(readContext, mux.Vars(r)["APP_ID"], query.updateIDs, query.from, query.to)
@@ -137,11 +154,7 @@ func (h *HealthHistoryHandler) GetUpdateHealthHistoryHandler(w http.ResponseWrit
 			handlers.RenderError(w, http.StatusInternalServerError, "An internal error occurred.")
 			return
 		}
-		handlers.RenderJSON(w, http.StatusOK, map[string]any{
-			"available": true,
-			"source":    "state",
-			"updates":   points,
-		})
+		handlers.RenderJSON(w, http.StatusOK, stateHistoryResponse{Available: true, Source: "state", Updates: points})
 		return
 	}
 
@@ -150,11 +163,7 @@ func (h *HealthHistoryHandler) GetUpdateHealthHistoryHandler(w http.ResponseWrit
 		handlers.RenderError(w, http.StatusInternalServerError, "An internal error occurred.")
 		return
 	}
-	handlers.RenderJSON(w, http.StatusOK, map[string]any{
-		"available": true,
-		"source":    "projected",
-		"updates":   points,
-	})
+	handlers.RenderJSON(w, http.StatusOK, healthHistoryResponse{Available: true, Source: "projected", Updates: points})
 }
 
 // GetUpdateHealthSegmentsHandler answers the same window split by a device
@@ -186,11 +195,7 @@ func (h *HealthHistoryHandler) GetUpdateHealthSegmentsHandler(w http.ResponseWri
 	// reads `segments`, and finding the key missing entirely is a different
 	// failure from finding it empty.
 	if h.reader == nil {
-		handlers.RenderJSON(w, http.StatusOK, map[string]any{
-			"available": false,
-			"dimension": dimension,
-			"segments":  map[string][]HealthSegmentPoint{},
-		})
+		handlers.RenderJSON(w, http.StatusOK, healthSegmentsResponse{Dimension: dimension, Segments: map[string][]HealthSegmentPoint{}})
 		return
 	}
 
@@ -204,11 +209,7 @@ func (h *HealthHistoryHandler) GetUpdateHealthSegmentsHandler(w http.ResponseWri
 		handlers.RenderError(w, http.StatusInternalServerError, "An internal error occurred.")
 		return
 	}
-	handlers.RenderJSON(w, http.StatusOK, map[string]any{
-		"available": true,
-		"dimension": dimension,
-		"segments":  TrimSegments(segments, maxHealthSegments),
-	})
+	handlers.RenderJSON(w, http.StatusOK, healthSegmentsResponse{Available: true, Dimension: dimension, Segments: TrimSegments(segments, maxHealthSegments)})
 }
 
 func parseHealthHistoryUpdateIDs(raw string) ([]string, bool) {

--- a/internal/handlers/dashboard/api_keys_handler.go
+++ b/internal/handlers/dashboard/api_keys_handler.go
@@ -48,9 +48,7 @@ func (h *ApiKeyHandler) CreateApiKeyHandler(w http.ResponseWriter, r *http.Reque
 		handlers.RenderError(w, http.StatusInternalServerError, "An internal error occurred while generating the API key.")
 		return
 	}
-	marshaledResponse, _ := json.Marshal(map[string]interface{}{
-		"apiKey": apiKey,
-	})
+	marshaledResponse, _ := json.Marshal(createApiKeyResponse{ApiKey: apiKey})
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusCreated)
 	w.Write(marshaledResponse)

--- a/internal/handlers/dashboard/apps_handler.go
+++ b/internal/handlers/dashboard/apps_handler.go
@@ -90,9 +90,7 @@ func (h *AppHandler) CreateAppHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	marshaledResponse, _ := json.Marshal(map[string]interface{}{
-		"appId": appId,
-	})
+	marshaledResponse, _ := json.Marshal(createAppResponse{AppId: appId})
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusCreated)
 	w.Write(marshaledResponse)

--- a/internal/handlers/dashboard/branches_handler.go
+++ b/internal/handlers/dashboard/branches_handler.go
@@ -55,9 +55,7 @@ func (h *BranchHandler) CreateBranchHandler(w http.ResponseWriter, r *http.Reque
 		handlers.RenderError(w, http.StatusInternalServerError, "An internal error occurred while creating the branch.")
 		return
 	}
-	marshaledResponse, _ := json.Marshal(map[string]interface{}{
-		"branchId": strconv.FormatInt(branchId, 10),
-	})
+	marshaledResponse, _ := json.Marshal(createBranchResponse{BranchId: strconv.FormatInt(branchId, 10)})
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 	w.Write(marshaledResponse)

--- a/internal/handlers/dashboard/channels_handler.go
+++ b/internal/handlers/dashboard/channels_handler.go
@@ -60,9 +60,7 @@ func (h *ChannelHandler) CreateChannelHandler(w http.ResponseWriter, r *http.Req
 		handlers.RenderError(w, http.StatusInternalServerError, "An internal error occurred while creating the channel.")
 		return
 	}
-	marshaledResponse, _ := json.Marshal(map[string]interface{}{
-		"channelId": strconv.FormatInt(channelId, 10),
-	})
+	marshaledResponse, _ := json.Marshal(createChannelResponse{ChannelId: strconv.FormatInt(channelId, 10)})
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 	w.Write(marshaledResponse)

--- a/internal/handlers/dashboard/responses.go
+++ b/internal/handlers/dashboard/responses.go
@@ -1,0 +1,24 @@
+package handlers
+
+import "xprem/internal/types"
+
+type createAppResponse struct {
+	AppId string `json:"appId"`
+}
+
+type createBranchResponse struct {
+	BranchId string `json:"branchId"`
+}
+
+type createChannelResponse struct {
+	ChannelId string `json:"channelId"`
+}
+
+type createApiKeyResponse struct {
+	ApiKey string `json:"apiKey"`
+}
+
+type updateRolloutResponse struct {
+	Active  bool                  `json:"active"`
+	Updates []types.RolloutUpdate `json:"updates"`
+}

--- a/internal/handlers/dashboard/rollouts_handler.go
+++ b/internal/handlers/dashboard/rollouts_handler.go
@@ -178,11 +178,7 @@ func (h *RolloutHandler) GetUpdateRolloutHandler(w http.ResponseWriter, r *http.
 	if activeRollouts == nil {
 		activeRollouts = []types.RolloutUpdate{}
 	}
-	response := map[string]interface{}{
-		"active":  len(activeRollouts) > 0,
-		"updates": activeRollouts,
-	}
-	marshaledResponse, _ := json.Marshal(response)
+	marshaledResponse, _ := json.Marshal(updateRolloutResponse{Active: len(activeRollouts) > 0, Updates: activeRollouts})
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 	w.Write(marshaledResponse)

--- a/internal/handlers/republish_handler.go
+++ b/internal/handlers/republish_handler.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"net/http"
 	"xprem/internal/services"
+	"xprem/internal/types"
 	types2 "xprem/internal/types"
 
 	"github.com/google/uuid"
@@ -27,6 +28,11 @@ func NewRepublishHandler(deploymentService *services.DeploymentService) *Republi
 // (historical behavior), ?publishGroup=<uuid> republishes every member of that
 // publish group on its own platform, the new rows sharing a new server-minted
 // group returned in the response.
+type republishGroupResponse struct {
+	PublishGroup string         `json:"publishGroup"`
+	Updates      []types.Update `json:"updates"`
+}
+
 func (h *RepublishHandler) HandleRepublish(w http.ResponseWriter, r *http.Request) {
 	requestID := uuid.New().String()
 	vars := mux.Vars(r)
@@ -91,10 +97,7 @@ func (h *RepublishHandler) HandleRepublish(w http.ResponseWriter, r *http.Reques
 		w.Header().Set("expo-publish-group", result.PublishGroup)
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		json.NewEncoder(w).Encode(map[string]interface{}{
-			"publishGroup": result.PublishGroup,
-			"updates":      result.Updates,
-		})
+		json.NewEncoder(w).Encode(republishGroupResponse{PublishGroup: result.PublishGroup, Updates: result.Updates})
 		return
 	}
 

--- a/internal/handlers/upload_handler.go
+++ b/internal/handlers/upload_handler.go
@@ -205,6 +205,17 @@ func (h *UploadHandler) RequestUploadLocalFileHandler(w http.ResponseWriter, r *
 	w.WriteHeader(http.StatusOK)
 }
 
+// requestUploadUrlsResponse echoes RolloutPercentage and PublishGroup only when
+// the server honoured them: the CLI reads their absence as a server too old to
+// know the parameter (or stateless mode for the group) and warns instead of
+// publishing to every device or pretending the rows are grouped.
+type requestUploadUrlsResponse struct {
+	UpdateID          int64                      `json:"updateId"`
+	UploadRequests    []bucket.FileUploadRequest `json:"uploadRequests"`
+	RolloutPercentage *int                       `json:"rolloutPercentage,omitempty"`
+	PublishGroup      *string                    `json:"publishGroup,omitempty"`
+}
+
 func (h *UploadHandler) RequestUploadUrlHandler(w http.ResponseWriter, r *http.Request) {
 	requestID := uuid.New().String()
 	vars := mux.Vars(r)
@@ -299,20 +310,11 @@ func (h *UploadHandler) RequestUploadUrlHandler(w http.ResponseWriter, r *http.R
 		return
 	}
 
-	response := map[string]interface{}{
-		"updateId":       result.UpdateID,
-		"uploadRequests": result.UploadRequests,
-	}
-	// Echoed back so the CLI can detect a server too old to know the parameter (an
-	// old server silently ignores it and would publish to every device).
-	if rolloutPercentage != nil {
-		response["rolloutPercentage"] = *rolloutPercentage
-	}
-	// Same detection contract for grouping: no echo means the group was not
-	// stored (old server or stateless mode) and the CLI warns instead of
-	// pretending the rows are grouped.
-	if publishGroup != nil {
-		response["publishGroup"] = *publishGroup
+	response := requestUploadUrlsResponse{
+		UpdateID:          result.UpdateID,
+		UploadRequests:    result.UploadRequests,
+		RolloutPercentage: rolloutPercentage,
+		PublishGroup:      publishGroup,
 	}
 
 	w.Header().Set("Content-Type", "application/json")


### PR DESCRIPTION
Nineteen API responses were written as inline `map[string]interface{}` literals, so the shape of those endpoints existed nowhere in Go: the only definition was the hand-written TypeScript in the dashboard's `api.ts`, with nothing tying the two together. One of them (the health history endpoint) was quietly returning two different shapes under the same key depending on the data source; the dashboard already modelled that as a union, the server side had no way to show it.

Each of those responses now has a named struct with the same JSON keys, so the wire contract is declared next to the handler that produces it. No response changes on the wire.