### PR TITLE
fix: admin gate and app deletion trust what the request already resolved

### DIFF
--- a/internal/handlers/dashboard/apps_handler.go
+++ b/internal/handlers/dashboard/apps_handler.go
@@ -13,8 +13,6 @@ import (
 	"xprem/internal/services"
 	"xprem/internal/store"
 	"xprem/internal/validation"
-
-	"github.com/gorilla/mux"
 )
 
 // AppVisibilityFilter narrows the dashboard app list to what the requesting
@@ -127,17 +125,12 @@ func (h *AppHandler) GetAppHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *AppHandler) DeleteAppHandler(w http.ResponseWriter, r *http.Request) {
-	appId := mux.Vars(r)["APP_ID"]
-	if err := config.ValidateAppId(appId, "APP_ID"); err != nil {
-		handlers.RenderError(w, http.StatusBadRequest, err.Error())
+	app := services.AppFromContext(r.Context())
+	if app == nil {
+		handlers.RenderError(w, http.StatusInternalServerError, "app not resolved for this route")
 		return
 	}
-	err := h.appService.DeleteApp(r.Context(), appId)
-	if err != nil {
-		if notFoundErr := (*store.ErrResourceNotFound)(nil); errors.As(err, &notFoundErr) {
-			handlers.RenderError(w, http.StatusNotFound, notFoundErr.Error())
-			return
-		}
+	if err := h.appService.DeleteApp(r.Context(), *app); err != nil {
 		handlers.RenderError(w, http.StatusInternalServerError, "An internal error occurred while deleting the app.")
 		return
 	}
@@ -145,7 +138,7 @@ func (h *AppHandler) DeleteAppHandler(w http.ResponseWriter, r *http.Request) {
 
 	cache := cache2.GetCache()
 	appsCacheKey := dashboard.ComputeGetAppsCacheKey()
-	appCacheKey := dashboard.ComputeGetAppCacheKey(appId)
+	appCacheKey := dashboard.ComputeGetAppCacheKey(app.Id)
 	cache.Delete(appCacheKey)
 	cache.Delete(appsCacheKey)
 }

--- a/internal/middleware/auth_middleware.go
+++ b/internal/middleware/auth_middleware.go
@@ -6,7 +6,6 @@ import (
 	"xprem/internal/handlers"
 	"xprem/internal/helpers"
 	"xprem/internal/services"
-	"xprem/internal/store"
 
 	"github.com/gorilla/mux"
 )
@@ -79,31 +78,14 @@ func NewDashboardOnlyMiddleware() mux.MiddlewareFunc {
 }
 
 // NewAdminMiddleware guards a route behind the account-level admin flag.
-// userRepo is nil in stateless mode, where the single ADMIN_EMAIL account is
-// always an admin.
-func NewAdminMiddleware(userRepo services.UserRepository) mux.MiddlewareFunc {
+// NewAdminMiddleware gates a route behind the principal's admin flag, which the
+// auth middleware reads from the users table on every request.
+func NewAdminMiddleware() mux.MiddlewareFunc {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			principal := services.PrincipalFromContext(r.Context())
 			if principal == nil {
 				http.Error(w, "This action requires a dashboard session", http.StatusForbidden)
-				return
-			}
-			if userRepo != nil {
-				user, err := userRepo.GetUserByID(r.Context(), principal.UserId)
-				if err != nil {
-					if notFoundErr := (*store.ErrResourceNotFound)(nil); errors.As(err, &notFoundErr) {
-						http.Error(w, "Invalid token", http.StatusUnauthorized)
-					} else {
-						http.Error(w, "Could not verify the account", http.StatusInternalServerError)
-					}
-					return
-				}
-				if !user.IsAdmin {
-					http.Error(w, "This action requires an admin account", http.StatusForbidden)
-					return
-				}
-				next.ServeHTTP(w, r)
 				return
 			}
 			if !principal.IsAdmin {

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -55,7 +55,7 @@ func NewRouter(container *AppContainer) *mux.Router {
 
 	// adminOnly guards the global administration surface (users, roles,
 	// license, SSO, app creation).
-	adminOnly := middleware.NewAdminMiddleware(container.UserRepo)
+	adminOnly := middleware.NewAdminMiddleware()
 
 	registerOAuthApiRoutes(apiSubrouter, container)
 	registerAccountRoutes(apiSubrouter, container, adminOnly)

--- a/internal/services/app_service.go
+++ b/internal/services/app_service.go
@@ -133,23 +133,20 @@ func (s *AppService) CreateApp(ctx context.Context, displayName string, keysConf
 	return insertedAppId, nil
 }
 
-func (s *AppService) DeleteApp(ctx context.Context, appId string) error {
-	// Read before the delete: afterwards there is no row left to name in the
-	// audit entry. Best-effort, like the entry itself.
-	displayName := appId
-	if app, err := s.appRepo.GetAppByID(ctx, appId); err == nil && app.Name != "" {
-		displayName = app.Name
-	}
-	err := s.appRepo.DeleteAppByID(ctx, appId)
-	if err != nil {
+func (s *AppService) DeleteApp(ctx context.Context, app config.AppConfig) error {
+	if err := s.appRepo.DeleteAppByID(ctx, app.Id); err != nil {
 		return err
+	}
+	displayName := app.Name
+	if displayName == "" {
+		displayName = app.Id
 	}
 	recordManagementEvent(ctx, s.onAuditEvent, auditlog.Event{
 		Action:        auditlog.ActionAppDeleted,
 		TargetType:    "app",
-		TargetID:      appId,
+		TargetID:      app.Id,
 		TargetDisplay: displayName,
-		AppID:         appId,
+		AppID:         app.Id,
 	})
 	return nil
 }

--- a/internal/services/management_audit_test.go
+++ b/internal/services/management_audit_test.go
@@ -140,8 +140,10 @@ func TestAppLifecycleEmitsAuditEvents(t *testing.T) {
 	require.NoError(t, appService.UpdateApp(ctx, app, "Renamed App"))
 	require.Len(t, recorder.events, 2)
 
-	// The deletion entry still names the app: read before the row went away.
-	require.NoError(t, appService.DeleteApp(ctx, appId))
+	// The deletion entry still names the app.
+	app, err = appService.GetAppByID(ctx, appId)
+	require.NoError(t, err)
+	require.NoError(t, appService.DeleteApp(ctx, app))
 	require.Len(t, recorder.events, 3)
 	assert.Equal(t, auditlog.ActionAppDeleted, recorder.events[2].Action)
 	assert.Equal(t, "Renamed App", recorder.events[2].TargetDisplay)


### PR DESCRIPTION
Two leftovers of the same habit fixed in #175. The admin-only middleware on the account routes re-read the user from the database to get an admin flag the principal already carries (the auth middleware reads it from the users table on every request). App deletion re-fetched the app the resolver middleware had just loaded, only to name it in the audit entry.

Both now use what the request context already holds. Stacked on #175, which introduces the app-in-context helper this relies on; merge that one first.