### PR TITLE
fix: requests error on dashboard with disabled device telemetry

### DIFF
--- a/ee/identity/handler.go
+++ b/ee/identity/handler.go
@@ -28,12 +28,10 @@ func NewIdentityHandler(service *Service) *IdentityHandler {
 	return &IdentityHandler{service: service}
 }
 
-// requireService short-circuits with a 400 when identity has no storage
-// (stateless mode). Returns the service and true when it is available.
 func (h *IdentityHandler) requireService(w http.ResponseWriter, throw bool) (*Service, bool) {
 	if h.service == nil {
 		if throw {
-			handlers.RenderError(w, http.StatusBadRequest, "Device identity requires a control plane (database).")
+			handlers.RenderError(w, http.StatusBadRequest, "Device identity requires a control plane (database) and to enable DEVICE_TELEMETRY")
 		}
 		return nil, false
 	}

--- a/ee/identity/handler.go
+++ b/ee/identity/handler.go
@@ -206,6 +206,7 @@ func (h *IdentityHandler) DeleteSchemaKeyHandler(w http.ResponseWriter, r *http.
 func (h *IdentityHandler) SearchValuesHandler(w http.ResponseWriter, r *http.Request) {
 	service, ok := h.requireService(w, false)
 	if !ok {
+		handlers.RenderJSON(w, http.StatusOK, valuesResponse{Values: []ValueCount{}})
 		return
 	}
 	appID := mux.Vars(r)["APP_ID"]

--- a/ee/identity/handler.go
+++ b/ee/identity/handler.go
@@ -30,9 +30,11 @@ func NewIdentityHandler(service *Service) *IdentityHandler {
 
 // requireService short-circuits with a 400 when identity has no storage
 // (stateless mode). Returns the service and true when it is available.
-func (h *IdentityHandler) requireService(w http.ResponseWriter) (*Service, bool) {
+func (h *IdentityHandler) requireService(w http.ResponseWriter, throw bool) (*Service, bool) {
 	if h.service == nil {
-		handlers.RenderError(w, http.StatusBadRequest, "Device identity requires a control plane (database).")
+		if throw {
+			handlers.RenderError(w, http.StatusBadRequest, "Device identity requires a control plane (database).")
+		}
 		return nil, false
 	}
 	return h.service, true
@@ -131,8 +133,9 @@ func deviceResponseFrom(d Device) deviceResponse {
 }
 
 func (h *IdentityHandler) GetSchemaHandler(w http.ResponseWriter, r *http.Request) {
-	service, ok := h.requireService(w)
+	service, ok := h.requireService(w, false)
 	if !ok {
+		handlers.RenderJSON(w, http.StatusOK, schemaResponse{Keys: []schemaKeyResponse{}})
 		return
 	}
 	appID := mux.Vars(r)["APP_ID"]
@@ -151,7 +154,7 @@ func (h *IdentityHandler) GetSchemaHandler(w http.ResponseWriter, r *http.Reques
 }
 
 func (h *IdentityHandler) UpsertSchemaKeyHandler(w http.ResponseWriter, r *http.Request) {
-	service, ok := h.requireService(w)
+	service, ok := h.requireService(w, true)
 	if !ok {
 		return
 	}
@@ -184,7 +187,7 @@ func (h *IdentityHandler) UpsertSchemaKeyHandler(w http.ResponseWriter, r *http.
 }
 
 func (h *IdentityHandler) DeleteSchemaKeyHandler(w http.ResponseWriter, r *http.Request) {
-	service, ok := h.requireService(w)
+	service, ok := h.requireService(w, true)
 	if !ok {
 		return
 	}
@@ -203,7 +206,7 @@ func (h *IdentityHandler) DeleteSchemaKeyHandler(w http.ResponseWriter, r *http.
 }
 
 func (h *IdentityHandler) SearchValuesHandler(w http.ResponseWriter, r *http.Request) {
-	service, ok := h.requireService(w)
+	service, ok := h.requireService(w, false)
 	if !ok {
 		return
 	}
@@ -297,8 +300,9 @@ func parseDeviceQuery(w http.ResponseWriter, r *http.Request, service *Service, 
 }
 
 func (h *IdentityHandler) ListDevicesHandler(w http.ResponseWriter, r *http.Request) {
-	service, ok := h.requireService(w)
+	service, ok := h.requireService(w, false)
 	if !ok {
+		handlers.RenderJSON(w, http.StatusOK, devicesPageResponse{Devices: []deviceResponse{}, NextCursor: nil})
 		return
 	}
 	appID := mux.Vars(r)["APP_ID"]
@@ -331,8 +335,9 @@ func (h *IdentityHandler) ListDevicesHandler(w http.ResponseWriter, r *http.Requ
 // OnlineDevicesHandler answers "how many devices are live right now", taking the same
 // filters as the inventory.
 func (h *IdentityHandler) OnlineDevicesHandler(w http.ResponseWriter, r *http.Request) {
-	service, ok := h.requireService(w)
+	service, ok := h.requireService(w, false)
 	if !ok {
+		handlers.RenderJSON(w, http.StatusOK, onlineDevicesResponse{Online: 0, WindowMinutes: int(DefaultOnlineWindow.Minutes())})
 		return
 	}
 	appID := mux.Vars(r)["APP_ID"]
@@ -362,7 +367,7 @@ func (h *IdentityHandler) OnlineDevicesHandler(w http.ResponseWriter, r *http.Re
 }
 
 func (h *IdentityHandler) GetDeviceHandler(w http.ResponseWriter, r *http.Request) {
-	service, ok := h.requireService(w)
+	service, ok := h.requireService(w, true)
 	if !ok {
 		return
 	}
@@ -436,8 +441,9 @@ type updateHealthResponse struct {
 // UpdateHealthHandler serves GET .../identity/update-health?ids=uuid,uuid. Every id gets an
 // entry, zeroes when nothing was recorded for it.
 func (h *IdentityHandler) UpdateHealthHandler(w http.ResponseWriter, r *http.Request) {
-	service, ok := h.requireService(w)
+	service, ok := h.requireService(w, false)
 	if !ok {
+		handlers.RenderJSON(w, http.StatusOK, updatesHealthResponse{Updates: map[string]updateHealthResponse{}})
 		return
 	}
 	appID := mux.Vars(r)["APP_ID"]

--- a/ee/identity/handler_test.go
+++ b/ee/identity/handler_test.go
@@ -112,17 +112,34 @@ func serve(handler *IdentityHandler, method, path, body string) *httptest.Respon
 
 const appPath = "/api/apps/app-1/identity"
 
-func TestNilStoreAnswers400(t *testing.T) {
+// A nil service (stateless mode or DISABLE_DEVICE_TELEMETRY) answers the
+// dashboard's polled reads with empty payloads instead of a 400.
+func TestNilServiceAnswersEmptyReads(t *testing.T) {
 	h := NewIdentityHandler(nil)
-	for _, path := range []string{
-		appPath + "/schema",
-		appPath + "/values?key=userId",
-		appPath + "/devices",
-		appPath + "/devices/abc",
-		appPath + "/update-health?ids=9b3b89b6-5a0d-4a57-b1f5-6e1d5b7c2a10",
+	for path, body := range map[string]string{
+		appPath + "/schema":            `{"keys":[]}`,
+		appPath + "/values?key=userId": `{"values":[]}`,
+		appPath + "/devices":           `{"devices":[],"nextCursor":null}`,
+		appPath + "/online":            `{"online":0,"windowMinutes":20}`,
+		appPath + "/update-health?ids=9b3b89b6-5a0d-4a57-b1f5-6e1d5b7c2a10": `{"updates":{}}`,
 	} {
 		rec := serve(h, http.MethodGet, path, "")
-		require.Equal(t, http.StatusBadRequest, rec.Code, path)
+		require.Equal(t, http.StatusOK, rec.Code, path)
+		require.JSONEq(t, body, rec.Body.String(), path)
+	}
+}
+
+// Schema writes and the device detail keep the hard 400: they are reached by
+// explicit action, never by background polling.
+func TestNilServiceAnswers400(t *testing.T) {
+	h := NewIdentityHandler(nil)
+	for _, request := range []struct{ method, path, body string }{
+		{http.MethodPut, appPath + "/schema/userId", `{"type":"string"}`},
+		{http.MethodDelete, appPath + "/schema/userId", ""},
+		{http.MethodGet, appPath + "/devices/abc", ""},
+	} {
+		rec := serve(h, request.method, request.path, request.body)
+		require.Equal(t, http.StatusBadRequest, rec.Code, request.path)
 	}
 }
 

--- a/internal/router/wire.go
+++ b/internal/router/wire.go
@@ -169,7 +169,7 @@ func InitDependencies(ctx context.Context) (*AppContainer, func()) {
 		}
 
 		if config.IsDeviceTelemetryDisabled() {
-			log.Println("🔕 [TELEMETRY] DISABLE_DEVICE_TELEMETRY is set; nothing is recorded about a device: manifest check-ins, identity ops and telemetry batches are all dropped, and no ClickHouse connection is opened. The Observe and Identity dashboards report the feature as unavailable, and CLICKHOUSE_URL is ignored.")
+			log.Println("🔕 [TELEMETRY] DISABLE_DEVICE_TELEMETRY is set; nothing is recorded about a device: manifest check-ins, identity ops and telemetry batches are all dropped, and no ClickHouse connection is opened.(CLICKHOUSE_URL is ignored.)")
 			addCleanup(observe.StartHealthOutboxDiscarder(ctx, dbEngine))
 		} else {
 			stateHistory = observe.NewStateHistory(dbEngine)


### PR DESCRIPTION
When DISABLE_DEVICE_TELEMETRY is set, the update-health requests polled by the dashboard all failed: the `requireService` guard short-circuits every identity handler with a 400 "Device identity requires a control plane (database)".

The short-circuit is now optional. The reads the dashboard polls (schema, values, devices, online, update-health) answer 200 with an empty payload instead.

Schema writes and the device detail keep the hard 400 as they are only reached by explicit action.