### PR TITLE
feat: add root redirect to dashboard

### DIFF
--- a/internal/router/routes_dashboard_assets.go
+++ b/internal/router/routes_dashboard_assets.go
@@ -37,6 +37,11 @@ func registerDashboardAssets(r *mux.Router) {
 	if !dashutils.IsDashboardEnabled() {
 		return
 	}
+	// 302 and not 301: a permanent redirect on "/" would be cached by browsers
+	// even after the dashboard is disabled or the root gains a real purpose.
+	r.Path("/").Methods(http.MethodGet).HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "/dashboard/", http.StatusFound)
+	})
 	r.PathPrefix("/dashboard").Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/dashboard/env.js" {
 			w.Header().Set("Content-Type", "application/javascript")

--- a/test/dashboard_test.go
+++ b/test/dashboard_test.go
@@ -30,6 +30,38 @@ func TestLoginDashboardNotEnabled(t *testing.T) {
 
 }
 
+func TestRootRedirectsToDashboard(t *testing.T) {
+	teardown := setup(t)
+	defer teardown()
+	router := infrastructure.NewRouter(testContainer())
+	respRec := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/", nil)
+	router.ServeHTTP(respRec, req)
+	assert.Equal(t, http.StatusFound, respRec.Code)
+	assert.Equal(t, "/dashboard/", respRec.Header().Get("Location"))
+}
+
+func TestRootNotFoundWhenDashboardDisabled(t *testing.T) {
+	teardown := setup(t)
+	defer teardown()
+	os.Setenv("USE_DASHBOARD", "false")
+	router := infrastructure.NewRouter(testContainer())
+	respRec := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/", nil)
+	router.ServeHTTP(respRec, req)
+	assert.Equal(t, http.StatusNotFound, respRec.Code)
+}
+
+func TestRootPostNotRedirected(t *testing.T) {
+	teardown := setup(t)
+	defer teardown()
+	router := infrastructure.NewRouter(testContainer())
+	respRec := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/", nil)
+	router.ServeHTTP(respRec, req)
+	assert.Equal(t, http.StatusMethodNotAllowed, respRec.Code)
+}
+
 func loginRequest(email string, password string) *http.Request {
 	formData := url.Values{}
 	formData.Set("email", email)


### PR DESCRIPTION
This pull request improves the routing behavior for the application root path `/` when the dashboard is enabled, and adds comprehensive tests to ensure correct behavior in various scenarios. The main change is introducing a temporary redirect from `/` to `/dashboard/` (using HTTP 302) when the dashboard is enabled, and verifying that this does not interfere with other HTTP methods or when the dashboard is disabled.

Routing improvements:

* Added a GET route for `/` that issues a 302 redirect to `/dashboard/` when the dashboard is enabled, to avoid browsers caching a permanent redirect and to ensure flexibility if the dashboard is later disabled or the root path is repurposed. (`internal/router/routes_dashboard_assets.go`)

Testing enhancements:

* Added tests to verify that:
  - A GET request to `/` redirects to `/dashboard/` when the dashboard is enabled.
  - A GET request to `/` returns a 404 Not Found when the dashboard is disabled.
  - A POST request to `/` returns a 405 Method Not Allowed, confirming only GET is redirected. (`test/dashboard_test.go`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dashboard root URL that redirects visitors to the dashboard.

* **Bug Fixes**
  * Dashboard access now returns the appropriate responses when disabled or accessed with unsupported request methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->