### PR TITLE
fix: map channels to branches created in dialog

### DIFF
--- a/apps/dashboard/src/components/branch-creation-modal.tsx
+++ b/apps/dashboard/src/components/branch-creation-modal.tsx
@@ -18,7 +18,7 @@ type CreateBranchModalProps = {
   onClose: () => void;
   // Called once the branch exists so the caller can use it straight away:
   // map it to a channel, prefill a form, ...
-  onBranchCreated?: (branch: { branchId: string; branchName: string }) => void;
+  onBranchCreated?: (branch: { branchId: string; branchName: string }) => void | Promise<void>;
 };
 
 export const CreateBranchModal = ({ isOpen, onClose, onBranchCreated }: CreateBranchModalProps) => {
@@ -42,7 +42,7 @@ export const CreateBranchModal = ({ isOpen, onClose, onBranchCreated }: CreateBr
         title: 'Branch created',
         description: `"${branchName}" is ready to receive updates.`,
       });
-      onBranchCreated?.({ branchId, branchName });
+      await onBranchCreated?.({ branchId, branchName });
       handleClose();
     } catch (error) {
       let errorTitle = 'Error creating branch';

--- a/apps/dashboard/src/components/branch-creation-modal.tsx
+++ b/apps/dashboard/src/components/branch-creation-modal.tsx
@@ -33,6 +33,7 @@ export const CreateBranchModal = ({ isOpen, onClose, onBranchCreated }: CreateBr
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    e.stopPropagation();
     const branchName = name.trim();
     if (!branchName || isSubmitting) return;
     setIsSubmitting(true);

--- a/apps/dashboard/src/components/branch-creation-modal.tsx
+++ b/apps/dashboard/src/components/branch-creation-modal.tsx
@@ -38,11 +38,23 @@ export const CreateBranchModal = ({ isOpen, onClose, onBranchCreated }: CreateBr
     setIsSubmitting(true);
     try {
       const { branchId } = await api.createBranch(branchName);
-      toast({
-        title: 'Branch created',
-        description: `"${branchName}" is ready to receive updates.`,
-      });
-      await onBranchCreated?.({ branchId, branchName });
+      try {
+        await onBranchCreated?.({ branchId, branchName });
+        toast({
+          title: 'Branch created',
+          description: `"${branchName}" is ready to receive updates.`,
+        });
+      } catch (error) {
+        const errorMessage =
+          error instanceof Error
+            ? error.message
+            : 'Refresh the page to use the newly created branch.';
+        toast({
+          title: 'Branch created, but the page could not be updated',
+          description: errorMessage,
+          variant: 'destructive',
+        });
+      }
       handleClose();
     } catch (error) {
       let errorTitle = 'Error creating branch';

--- a/apps/dashboard/src/pages/Channels/components/SelectBranch/index.tsx
+++ b/apps/dashboard/src/pages/Channels/components/SelectBranch/index.tsx
@@ -82,10 +82,10 @@ export const SelectBranch = ({
         isOpen={isCreateOpen}
         onClose={() => setIsCreateOpen(false)}
         onBranchCreated={async ({ branchId, branchName }) => {
-          // Pull the new branch into the list, then select it so it is mapped
-          // right away instead of making the user pick it again.
-          await refetch();
+          // Select the new branch before refreshing so the parent form cannot
+          // be submitted without its mapping if the refetch is slow.
           onChange(branchId, branchName);
+          await refetch();
         }}
       />
     </>


### PR DESCRIPTION
## Problem

When creating a channel, a user can create a branch from the nested branch picker and then submit the channel form. The newly created channel may not be mapped to that branch.

### Steps to reproduce

1. Open the Dashboard and go to **Channels**.
2. Start creating a channel.
3. From the branch picker, create a new branch.
4. Submit the channel as soon as the nested branch dialog closes.
5. The channel can be created without a branch mapping.

Expected: the newly created branch is selected immediately and the channel is mapped to it.

Actual: the branch selection waits for the branch-list refetch, so the channel form can be submitted before `branchName` is set.

## Root cause

The nested Create Branch dialog closed without awaiting its callback, while the Channel branch picker awaited a branch-list refetch before updating the parent form. That left a timing window where the form submitted without `branchName`.

## Fix

- update the parent channel form immediately after branch creation, before refreshing the branch list
- allow the branch-created callback to be asynchronous and await it before closing the nested dialog

## Testing

- `tsc -b`
- `eslint .` (0 errors; 12 existing warnings)
- Prettier check for the changed files
- Vite production build

Fixes #188

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the branch creation flow by completing follow-up actions before closing the dialog.
  - Added clearer success and error feedback when the branch list cannot be updated after a branch is created.
  - Newly created branches are selected immediately, providing a smoother experience while the branch list refreshes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->