### PR TITLE
feat: make the root → /dashboard redirect opt-in

### DIFF
--- a/apps/eoas/src/lib/serverConfig/envCatalog.ts
+++ b/apps/eoas/src/lib/serverConfig/envCatalog.ts
@@ -314,6 +314,14 @@ export const ENV_SECTIONS: EnvSection[] = [
         comment:
           'Policy: 8+ characters, an uppercase, a lowercase, a digit and a special character.',
       },
+      {
+        name: 'DASHBOARD_ROOT_REDIRECT',
+        applies: c => c.dashboard !== false,
+        required: false,
+        value: () => 'true',
+        comment:
+          'Sends / to the dashboard login. Off by default: the root stays a 404 rather than pointing every visitor at the admin UI.',
+      },
     ],
   },
   {

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -88,6 +88,14 @@ environment:
     required:
       - key: "useDashboard"
         is: "true"
+  # "true" redirects / to the dashboard login instead of returning 404. Off by
+  # default so the root of a public OTA domain does not point at the admin UI.
+  - name: "DASHBOARD_ROOT_REDIRECT"
+    value: ""
+    enabled:
+      - key: "useDashboard"
+        is: "true"
+    required: false
   - name: "CACHE_MODE"
     key: "cacheMode"
     required: true

--- a/internal/router/routes_dashboard_assets.go
+++ b/internal/router/routes_dashboard_assets.go
@@ -37,11 +37,13 @@ func registerDashboardAssets(r *mux.Router) {
 	if !dashutils.IsDashboardEnabled() {
 		return
 	}
-	// 302 and not 301: a permanent redirect on "/" would be cached by browsers
-	// even after the dashboard is disabled or the root gains a real purpose.
-	r.Path("/").Methods(http.MethodGet).HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		http.Redirect(w, r, "/dashboard/", http.StatusFound)
-	})
+	if config.GetEnv("DASHBOARD_ROOT_REDIRECT") == "true" {
+		// 302 and not 301: a permanent redirect on "/" would be cached by browsers
+		// even after the dashboard is disabled or the root gains a real purpose.
+		r.Path("/").Methods(http.MethodGet).HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Redirect(w, r, "/dashboard/", http.StatusFound)
+		})
+	}
 	r.PathPrefix("/dashboard").Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/dashboard/env.js" {
 			w.Header().Set("Content-Type", "application/javascript")

--- a/test/dashboard_test.go
+++ b/test/dashboard_test.go
@@ -45,6 +45,7 @@ func TestRootRedirectsToDashboard(t *testing.T) {
 func TestRootNotFoundByDefault(t *testing.T) {
 	teardown := setup(t)
 	defer teardown()
+	t.Setenv("DASHBOARD_ROOT_REDIRECT", "")
 	router := infrastructure.NewRouter(testContainer())
 	respRec := httptest.NewRecorder()
 	req, _ := http.NewRequest("GET", "/", nil)

--- a/test/dashboard_test.go
+++ b/test/dashboard_test.go
@@ -33,6 +33,7 @@ func TestLoginDashboardNotEnabled(t *testing.T) {
 func TestRootRedirectsToDashboard(t *testing.T) {
 	teardown := setup(t)
 	defer teardown()
+	t.Setenv("DASHBOARD_ROOT_REDIRECT", "true")
 	router := infrastructure.NewRouter(testContainer())
 	respRec := httptest.NewRecorder()
 	req, _ := http.NewRequest("GET", "/", nil)
@@ -41,10 +42,21 @@ func TestRootRedirectsToDashboard(t *testing.T) {
 	assert.Equal(t, "/dashboard/", respRec.Header().Get("Location"))
 }
 
+func TestRootNotFoundByDefault(t *testing.T) {
+	teardown := setup(t)
+	defer teardown()
+	router := infrastructure.NewRouter(testContainer())
+	respRec := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/", nil)
+	router.ServeHTTP(respRec, req)
+	assert.Equal(t, http.StatusNotFound, respRec.Code)
+}
+
 func TestRootNotFoundWhenDashboardDisabled(t *testing.T) {
 	teardown := setup(t)
 	defer teardown()
 	os.Setenv("USE_DASHBOARD", "false")
+	t.Setenv("DASHBOARD_ROOT_REDIRECT", "true")
 	router := infrastructure.NewRouter(testContainer())
 	respRec := httptest.NewRecorder()
 	req, _ := http.NewRequest("GET", "/", nil)
@@ -55,6 +67,7 @@ func TestRootNotFoundWhenDashboardDisabled(t *testing.T) {
 func TestRootPostNotRedirected(t *testing.T) {
 	teardown := setup(t)
 	defer teardown()
+	t.Setenv("DASHBOARD_ROOT_REDIRECT", "true")
 	router := infrastructure.NewRouter(testContainer())
 	respRec := httptest.NewRecorder()
 	req, _ := http.NewRequest("POST", "/", nil)


### PR DESCRIPTION
`GET /` redirected to `/dashboard/` unconditionally as soon as `USE_DASHBOARD=true`.

That points the root of every OTA domain at the admin UI, which is not something a self-hosted deployment should get without asking for it (WAF rules, exposure of the login page at the apex URL).

The redirect is now behind `DASHBOARD_ROOT_REDIRECT`, off by default: `/` goes back to a 404 unless you set it to `true`.

- `internal/router/routes_dashboard_assets.go`: route registered only when the var is `"true"`
- `apps/eoas/src/lib/serverConfig/envCatalog.ts`: optional var in the Dashboard section, so `eoas server:init` writes it commented out
- `helm/values.yaml`: optional entry, enabled only when `useDashboard: "true"`

The redirect was added in 083db69 and never released, so no deployment is relying on it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional setting to control whether the site root redirects to the dashboard login.
  * When enabled, visiting `/` redirects to `/dashboard/`.
  * The setting is available through environment configuration and Helm deployment values.

* **Bug Fixes**
  * The site root now returns a 404 by default when the redirect setting is not enabled.
  * Non-GET requests to the root are not redirected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->