### PR TITLE
feat: support serving under a URL path prefix (subpath)

### DIFF
--- a/apps/dashboard/src/lib/api.ts
+++ b/apps/dashboard/src/lib/api.ts
@@ -1,4 +1,5 @@
 import { getRefreshToken, getToken, logout, saveReturnTo, setTokens } from '@/lib/auth.ts';
+import { dashboardBasename } from '@/lib/basename.ts';
 
 export type APIProblemPayload = {
   title: string;
@@ -796,7 +797,6 @@ export class ApiClient {
   private appId: string | null = null;
 
   constructor() {
-    // @ts-expect-error window.env is injected at runtime by /env.js
     this.baseUrl = window?.env?.VITE_OTA_API_URL || import.meta.env.VITE_OTA_API_URL;
     if (!this.baseUrl) {
       throw new Error('Missing VITE_OTA_API_URL environment variable');
@@ -941,13 +941,14 @@ export class ApiClient {
       return;
     }
     logout();
-    // Remember where the session died so the next sign-in resumes there; the
-    // stored path is router-relative, so the /dashboard basename is stripped.
-    const currentPath = window.location.pathname.replace(/^\/dashboard/, '');
+    const basename = dashboardBasename();
+    const currentPath = window.location.pathname.startsWith(basename)
+      ? window.location.pathname.slice(basename.length)
+      : window.location.pathname;
     if (currentPath && currentPath !== '/login') {
       saveReturnTo(currentPath + window.location.search);
     }
-    window.location.assign('/dashboard/login');
+    window.location.assign(`${basename}/login`);
   }
 
   public async login(email: string, password: string) {

--- a/apps/dashboard/src/lib/basename.ts
+++ b/apps/dashboard/src/lib/basename.ts
@@ -1,0 +1,3 @@
+export function dashboardBasename(): string {
+  return window.env?.DASHBOARD_BASENAME || '/dashboard';
+}

--- a/apps/dashboard/src/main.tsx
+++ b/apps/dashboard/src/main.tsx
@@ -3,6 +3,7 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { App } from '@/App.tsx';
 import { ThemeProvider } from '@/lib/ThemeProvider';
+import { dashboardBasename } from '@/lib/basename.ts';
 import './index.css';
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
@@ -20,7 +21,7 @@ createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <ThemeProvider>
       <QueryClientProvider client={queryClient}>
-        <BrowserRouter basename="/dashboard">
+        <BrowserRouter basename={dashboardBasename()}>
           <App />
         </BrowserRouter>
       </QueryClientProvider>

--- a/apps/dashboard/src/pages/Account/index.tsx
+++ b/apps/dashboard/src/pages/Account/index.tsx
@@ -11,6 +11,7 @@ import { Label } from '@/components/ui/label';
 import { PageHeader } from '@/components/PageHeader';
 import { PasswordRulesChecklist } from '@/components/ui/password-rules-checklist';
 import { isPasswordValid } from '@/lib/password-policy';
+import { dashboardBasename } from '@/lib/basename.ts';
 
 export const Account = () => {
   const { CONTROL_PLANE_ENABLED } = useSettings();
@@ -41,7 +42,7 @@ export const Account = () => {
         // navigation rather than a router transition, for the reason endSession
         // gives in lib/api.ts: the state held above the router never re-reads
         // the cleared tokens, and would keep issuing unauthenticated requests.
-        window.location.assign('/login');
+        window.location.assign(`${dashboardBasename()}/login`);
         return;
       }
       toast({

--- a/apps/dashboard/src/vite-env.d.ts
+++ b/apps/dashboard/src/vite-env.d.ts
@@ -1,1 +1,9 @@
 /// <reference types="vite/client" />
+
+interface Window {
+  env?: {
+    VITE_OTA_API_URL?: string;
+    DASHBOARD_BASENAME?: string;
+  };
+}
+

--- a/apps/dashboard/vite.config.ts
+++ b/apps/dashboard/vite.config.ts
@@ -3,12 +3,14 @@ import react from '@vitejs/plugin-react-swc';
 import * as path from 'node:path';
 
 // https://vite.dev/config/
-export default defineConfig({
+// Relative base in builds: the server injects <base href> with the real mount
+// path, unknown at build time. Dev keeps the absolute path the router expects.
+export default defineConfig(({ command }) => ({
   plugins: [react()],
-  base: '/dashboard',
+  base: command === 'build' ? './' : '/dashboard',
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),
     },
   },
-});
+}));

--- a/apps/eoas/src/commands/__tests__/republish.test.ts
+++ b/apps/eoas/src/commands/__tests__/republish.test.ts
@@ -27,10 +27,13 @@ vi.mock('../../lib/vcs', () => ({
 vi.mock('../../lib/package', () => ({
   isExpoInstalled: () => true,
 }));
-vi.mock('../../lib/expoConfig', () => ({
-  getPrivateExpoConfigAsync: async () => ({}),
-  resolveServerUrl: async (_config: unknown, customServerUrl?: string) =>
-    new URL(customServerUrl ?? 'https://ota.example.com/manifest').origin,
+// resolveServerUrl stays real; the config below feeds it the same update URL a
+// project would.
+vi.mock('../../lib/expoConfig', async importOriginal => ({
+  ...(await importOriginal<typeof import('../../lib/expoConfig')>()),
+  getPrivateExpoConfigAsync: async () => ({
+    updates: { url: 'https://ota.example.com/manifest' },
+  }),
   requireExpoAppId: () => 'app-1',
 }));
 vi.mock('../../lib/serverUpdates', async importOriginal => {
@@ -314,13 +317,13 @@ describe('republish command flow', () => {
 
     expect(lastPostUrl().origin).toBe('https://publish.example.com');
     expect(vi.mocked(fetchRuntimeVersions).mock.calls[0][0]).toMatchObject({
-      baseUrl: 'https://publish.example.com',
+      baseUrl: 'https://publish.example.com/some/path',
     });
     expect(vi.mocked(fetchPublishGroups).mock.calls[0][0]).toMatchObject({
-      baseUrl: 'https://publish.example.com',
+      baseUrl: 'https://publish.example.com/some/path',
     });
     expect(vi.mocked(fetchUpdates).mock.calls[0][0]).toMatchObject({
-      baseUrl: 'https://publish.example.com',
+      baseUrl: 'https://publish.example.com/some/path',
     });
   });
 });

--- a/apps/eoas/src/commands/doctor.ts
+++ b/apps/eoas/src/commands/doctor.ts
@@ -1,7 +1,7 @@
 import { Env } from '@expo/eas-build-job';
 import { Command, Flags } from '@oclif/core';
 
-import { getExpoAppId, getExpoConfigUpdateUrl, getPrivateExpoConfigAsync } from '../lib/expoConfig';
+import { getExpoAppId, getPrivateExpoConfigAsync, resolveServerUrl } from '../lib/expoConfig';
 import { fetchWithRetries } from '../lib/fetch';
 import Log from '../lib/log';
 import { ora } from '../lib/ora';
@@ -74,20 +74,10 @@ export default class Doctor extends Command {
     const privateConfig = await getPrivateExpoConfigAsync(projectDir, {
       env: process.env as Env,
     });
-    const updateUrl = flags.url ?? getExpoConfigUpdateUrl(privateConfig);
-    if (!updateUrl) {
-      Log.error(
-        "Update url is not setup in your config. Please run 'eoas init' to setup the update url, or pass --url"
-      );
+    const baseUrl = await resolveServerUrl(privateConfig, flags.url).catch(e => {
+      Log.error(e.message);
       process.exit(1);
-    }
-    let baseUrl: string;
-    try {
-      baseUrl = new URL(updateUrl).origin;
-    } catch (e) {
-      Log.error('Invalid URL', e);
-      process.exit(1);
-    }
+    });
 
     const appId = flags.appId ?? getExpoAppId(privateConfig);
 

--- a/apps/eoas/src/commands/init.ts
+++ b/apps/eoas/src/commands/init.ts
@@ -44,7 +44,8 @@ export default class Init extends Command {
       validate: v => !!v,
     });
     const { updateUrl: promptedUrl } = await promptAsync({
-      message: 'Enter the URL of your update server (ex: https://customota.com)',
+      message:
+        'Enter the URL of your update server (ex: https://customota.com or https://api.example.com/ota)',
       name: 'updateUrl',
       type: 'text',
       initial: (getExpoConfigUpdateUrl(config) || '').replace(/\/manifest$/, ''),
@@ -52,7 +53,7 @@ export default class Init extends Command {
         return !!v && isValidUpdateUrl(v);
       },
     });
-    let manifestEndpoint = `${promptedUrl}/manifest`;
+    let manifestEndpoint = `${promptedUrl.replace(/\/+$/, '')}/manifest`;
     const updateUrl = getExpoConfigUpdateUrl(config);
     if (updateUrl && !updateUrl.includes('expo.dev')) {
       const confirmed = await confirmAsync({

--- a/apps/eoas/src/commands/publish.ts
+++ b/apps/eoas/src/commands/publish.ts
@@ -64,7 +64,7 @@ export default class Publish extends Command {
     }),
     serverUrl: Flags.string({
       description:
-        'URL of the self-hosted update server to publish to. Defaults to the origin of updates.url from your Expo config',
+        'URL of the self-hosted update server to publish to. Defaults to updates.url from your Expo config, minus a trailing /manifest',
       required: false,
     }),
     nonInteractive: Flags.boolean({

--- a/apps/eoas/src/commands/republish.ts
+++ b/apps/eoas/src/commands/republish.ts
@@ -42,7 +42,7 @@ export default class Publish extends Command {
     }),
     serverUrl: Flags.string({
       description:
-        'URL of the self-hosted update server to republish on. Defaults to the origin of updates.url from your Expo config',
+        'URL of the self-hosted update server to republish on. Defaults to updates.url from your Expo config, minus a trailing /manifest',
       required: false,
     }),
   };

--- a/apps/eoas/src/commands/rollback.ts
+++ b/apps/eoas/src/commands/rollback.ts
@@ -34,7 +34,7 @@ export default class Publish extends Command {
     }),
     serverUrl: Flags.string({
       description:
-        'URL of the self-hosted update server to roll back on. Defaults to the origin of updates.url from your Expo config',
+        'URL of the self-hosted update server to roll back on. Defaults to updates.url from your Expo config, minus a trailing /manifest',
       required: false,
     }),
     nonInteractive: Flags.boolean({

--- a/apps/eoas/src/commands/server/init.ts
+++ b/apps/eoas/src/commands/server/init.ts
@@ -97,6 +97,18 @@ function isHttpUrl(value: string): boolean {
   }
 }
 
+/** The path of the URL without trailing slash; '' when at the root or invalid. */
+function pathPrefix(baseUrl: string | undefined): string {
+  if (!baseUrl) {
+    return '';
+  }
+  try {
+    return new URL(baseUrl).pathname.replace(/\/+$/, '');
+  } catch {
+    return '';
+  }
+}
+
 function shortPasswordHint(missing: string[]): string {
   const short = missing.map(rule =>
     rule
@@ -156,6 +168,7 @@ const DELIVERY_CHOICES: Record<string, { title: string; description: string }> =
 
 type WizardState = {
   baseUrl?: string;
+  serveFromSubPath?: boolean;
   jwtSecret?: string;
   dbUrl?: string;
   awsAuth?: AwsAuth;
@@ -192,8 +205,21 @@ function summaryLines(state: WizardState): string {
   const storageChoice = STORAGE_CHOICES.find(choice => choice.value === state.storagePick);
   const set = ACCENT;
   const later = chalk.dim('to fill later');
+  const prefix = pathPrefix(state.baseUrl);
   const rows: [string, string][] = [
     ['Base URL', state.baseUrl ? set(state.baseUrl) : later],
+    ...(prefix
+      ? ([
+          [
+            'Path prefix',
+            set(
+              state.serveFromSubPath
+                ? `${prefix} · routed by the server`
+                : `${prefix} · stripped by the proxy`
+            ),
+          ],
+        ] as [string, string][])
+      : []),
     ['JWT secret', state.jwtSecret ? set('generated') : later],
     ['PostgreSQL', state.dbUrl ? set(state.dbUrl) : later],
     ['Master key', set('generated, keep a backup')],
@@ -249,16 +275,43 @@ export default class ServerInit extends Command {
       {
         id: 'base-url',
         run: async () => {
-          const value = await textStep('Public HTTPS URL of the server', {
-            optional: true,
-            initial: state.baseUrl,
-            validate: v => isHttpUrl(v) || 'Must be a valid http(s) URL',
-          });
-          if (value === BACK) {
-            return 'back';
+          while (true) {
+            const value = await textStep('Public HTTPS URL of the server', {
+              optional: true,
+              initial: state.baseUrl,
+              validate: v => isHttpUrl(v) || 'Must be a valid http(s) URL',
+            });
+            if (value === BACK) {
+              return 'back';
+            }
+            state.baseUrl = value;
+            const prefix = pathPrefix(value);
+            if (!prefix) {
+              state.serveFromSubPath = undefined;
+              return 'next';
+            }
+            const passthrough = await selectStep<boolean>(
+              `How does your proxy forward the ${prefix} prefix?`,
+              [
+                {
+                  title: 'It strips it',
+                  value: false,
+                  description: `${prefix}/manifest reaches the server as /manifest`,
+                },
+                {
+                  title: 'It passes it through',
+                  value: true,
+                  description: `the server routes under ${prefix} itself`,
+                },
+              ],
+              { allowBack: true, initial: state.serveFromSubPath ?? false }
+            );
+            if (passthrough === BACK) {
+              continue;
+            }
+            state.serveFromSubPath = passthrough;
+            return 'next';
           }
-          state.baseUrl = value;
-          return 'next';
         },
       },
       {
@@ -672,6 +725,7 @@ export default class ServerInit extends Command {
 
     const choices: ServerChoices = {
       baseUrl: state.baseUrl,
+      serveFromSubPath: state.serveFromSubPath,
       jwtSecret: state.jwtSecret,
       dbUrl: state.dbUrl,
       // The wizard always seals the master key in the env; storing it in AWS

--- a/apps/eoas/src/lib/__tests__/expoConfig.test.ts
+++ b/apps/eoas/src/lib/__tests__/expoConfig.test.ts
@@ -272,13 +272,30 @@ module.exports = makeConfig();
 describe('resolveServerUrl', () => {
   const config = { updates: { url: 'https://ota.example.com/manifest' } } as any;
 
-  it('falls back to the origin of the Expo config update url', async () => {
+  it('strips a trailing /manifest and keeps the origin', async () => {
     await expect(resolveServerUrl(config)).resolves.toBe('https://ota.example.com');
   });
 
-  it('prefers the custom server url and keeps only its origin', async () => {
+  it('keeps a path prefix in front of /manifest', async () => {
+    await expect(
+      resolveServerUrl({ updates: { url: 'https://api.example.com/ota/manifest' } } as any)
+    ).resolves.toBe('https://api.example.com/ota');
+    await expect(
+      resolveServerUrl({
+        updates: { url: 'https://api.example.com/path1/path2/manifest' },
+      } as any)
+    ).resolves.toBe('https://api.example.com/path1/path2');
+  });
+
+  it('prefers the custom server url and keeps its path', async () => {
     await expect(resolveServerUrl(config, 'https://publish.example.com/some/path')).resolves.toBe(
-      'https://publish.example.com'
+      'https://publish.example.com/some/path'
+    );
+  });
+
+  it('strips /manifest from an explicit --serverUrl', async () => {
+    await expect(resolveServerUrl(config, 'https://api.example.com/ota/manifest/')).resolves.toBe(
+      'https://api.example.com/ota'
     );
   });
 

--- a/apps/eoas/src/lib/__tests__/utils.test.ts
+++ b/apps/eoas/src/lib/__tests__/utils.test.ts
@@ -11,10 +11,21 @@ describe('isValidUpdateUrl', () => {
     expect(isValidUpdateUrl('http://localhost:3000')).toBe(true);
   });
 
-  it('rejects URLs with a path or without a scheme', () => {
+  it('accepts a path prefix the server is mounted under', () => {
+    expect(isValidUpdateUrl('https://api.example.com/ota')).toBe(true);
+    expect(isValidUpdateUrl('https://api.example.com/path1/path2')).toBe(true);
+  });
+
+  it('rejects the /manifest device endpoint, a missing scheme, or a non-http scheme', () => {
     expect(isValidUpdateUrl('https://customota.com/manifest')).toBe(false);
+    expect(isValidUpdateUrl('https://api.example.com/ota/manifest')).toBe(false);
     expect(isValidUpdateUrl('customota.com')).toBe(false);
     expect(isValidUpdateUrl('ftp://customota.com')).toBe(false);
+  });
+
+  it('rejects a query string or fragment', () => {
+    expect(isValidUpdateUrl('https://api.example.com/ota?foo=1')).toBe(false);
+    expect(isValidUpdateUrl('https://api.example.com/ota#section')).toBe(false);
   });
 });
 

--- a/apps/eoas/src/lib/expoConfig.ts
+++ b/apps/eoas/src/lib/expoConfig.ts
@@ -410,6 +410,17 @@ function stringifyWithEnv(obj: Record<string, any>): string {
   return json.replace(/"__RAW_EXPR_(\d+)__"/g, (_match, index) => rawExpressions[Number(index)]);
 }
 
+// Strips a trailing /manifest from an Expo updates.url (or --serverUrl) and
+// keeps any path prefix the server is mounted under.
+export function publicServerUrl(raw: string): string {
+  const parsed = new URL(raw);
+  let path = parsed.pathname.replace(/\/+$/, '');
+  if (path.endsWith('/manifest')) {
+    path = path.slice(0, -'/manifest'.length);
+  }
+  return `${parsed.origin}${path}`;
+}
+
 // customServerUrl wins over the Expo config, so a project serving updates and
 // receiving publishes on two different origins can point the CLI at the second
 // one without touching its config.
@@ -424,7 +435,7 @@ export async function resolveServerUrl(
     );
   }
   try {
-    return new URL(updateUrl).origin;
+    return publicServerUrl(updateUrl);
   } catch {
     throw new Error(customServerUrl ? 'Invalid --serverUrl value.' : 'Invalid update URL.');
   }

--- a/apps/eoas/src/lib/serverConfig/__tests__/serverConfig.test.ts
+++ b/apps/eoas/src/lib/serverConfig/__tests__/serverConfig.test.ts
@@ -68,6 +68,20 @@ describe('renderEnvFile', () => {
     expect(content).not.toContain('TRUST_GEOIP_HEADERS');
   });
 
+  it('writes SERVE_FROM_SUB_PATH only when pass-through routing was chosen', () => {
+    expect(renderEnvFile(baseChoices)).not.toContain('SERVE_FROM_SUB_PATH');
+    const env = parseEnvFile(
+      renderEnvFile({
+        ...baseChoices,
+        baseUrl: 'https://api.example.com/ota',
+        serveFromSubPath: true,
+      })
+    );
+    expect(env.SERVE_FROM_SUB_PATH).toBe('true');
+    // Inference keeps the var applicable on re-validation of the same file.
+    expect(validateEnvMap(env)).toEqual([]);
+  });
+
   it('renders optional vars commented out', () => {
     const content = renderEnvFile(baseChoices);
     expect(content).toContain('# PROMETHEUS_ENABLED=true');

--- a/apps/eoas/src/lib/serverConfig/choices.ts
+++ b/apps/eoas/src/lib/serverConfig/choices.ts
@@ -14,6 +14,8 @@ export type GeoipStrategy = 'proxy-headers' | 'maxmind';
 
 export type ServerChoices = {
   baseUrl?: string;
+  /** The server routes under BASE_URL's path itself (SERVE_FROM_SUB_PATH). */
+  serveFromSubPath?: boolean;
   jwtSecret?: string;
   dbUrl?: string;
   masterKeySource: MasterKeySource;

--- a/apps/eoas/src/lib/serverConfig/envCatalog.ts
+++ b/apps/eoas/src/lib/serverConfig/envCatalog.ts
@@ -48,7 +48,16 @@ export const ENV_SECTIONS: EnvSection[] = [
         applies: () => true,
         required: true,
         value: c => or(c.baseUrl, '<https://your-ota-domain>'),
-        comment: 'Public HTTPS URL of the server; manifest and asset URLs are built from it.',
+        comment:
+          'Public HTTPS URL of the server, including a path prefix if the gateway mounts it under one (e.g. https://api.example.com/ota).',
+      },
+      {
+        name: 'SERVE_FROM_SUB_PATH',
+        applies: c => c.serveFromSubPath === true,
+        required: true,
+        value: () => 'true',
+        comment:
+          "Serve every route under the BASE_URL path prefix. Remove when the gateway strips the prefix before forwarding (it only affects routing; links always use BASE_URL's path).",
       },
       {
         name: 'JWT_SECRET',
@@ -521,6 +530,7 @@ export function inferChoicesFromEnv(env: Record<string, string>): ServerChoices 
   const cacheMode = (env.CACHE_MODE ?? 'local') as CacheMode;
   return {
     baseUrl: env.BASE_URL,
+    serveFromSubPath: env.SERVE_FROM_SUB_PATH === 'true',
     jwtSecret: env.JWT_SECRET,
     dbUrl: env.DB_URL,
     masterKeySource,

--- a/apps/eoas/src/lib/utils.ts
+++ b/apps/eoas/src/lib/utils.ts
@@ -4,7 +4,22 @@ import path from 'path';
 import Log from './log';
 
 export function isValidUpdateUrl(updateUrl: string): boolean {
-  return updateUrl.match(/^https?:\/\/[^/]+$/) !== null;
+  try {
+    const parsed = new URL(updateUrl);
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+      return false;
+    }
+    if (!parsed.host) {
+      return false;
+    }
+    // A query or fragment would corrupt the `${url}/manifest` concatenation.
+    if (parsed.search || parsed.hash) {
+      return false;
+    }
+    return !parsed.pathname.replace(/\/+$/, '').endsWith('/manifest');
+  } catch {
+    return false;
+  }
 }
 
 // Appends pattern to the project .gitignore unless an identical rule is already

--- a/config/config.go
+++ b/config/config.go
@@ -118,7 +118,16 @@ func validateBucketParams(storageMode string) bool {
 }
 
 func validateBaseUrl(baseUrl string) bool {
-	return baseUrl != "" && helpers.IsValidURL(baseUrl)
+	if baseUrl == "" || !helpers.IsValidURL(baseUrl) {
+		return false
+	}
+	parsed, err := url.Parse(baseUrl)
+	if err != nil {
+		return false
+	}
+	// Paths are appended to BASE_URL, so a query or fragment would end up
+	// before them.
+	return parsed.RawQuery == "" && !parsed.ForceQuery && parsed.Fragment == ""
 }
 
 // BaseURL is BASE_URL without any trailing slash.

--- a/config/config.go
+++ b/config/config.go
@@ -4,8 +4,10 @@ import (
 	"flag"
 	"fmt"
 	"log"
+	"net/url"
 	"os"
 	"strconv"
+	"strings"
 	"xprem/internal/helpers"
 
 	"github.com/joho/godotenv"
@@ -117,6 +119,44 @@ func validateBucketParams(storageMode string) bool {
 
 func validateBaseUrl(baseUrl string) bool {
 	return baseUrl != "" && helpers.IsValidURL(baseUrl)
+}
+
+// BaseURL is BASE_URL without any trailing slash.
+func BaseURL() string {
+	return strings.TrimRight(GetEnv("BASE_URL"), "/")
+}
+
+// ServeFromSubPath reports whether the server itself serves under BASE_URL's
+// path; when false the reverse proxy is expected to strip the prefix.
+func ServeFromSubPath() bool {
+	return GetEnv("SERVE_FROM_SUB_PATH") == "true"
+}
+
+// PublicPath is the path component of BASE_URL, empty when BASE_URL has none.
+func PublicPath() string {
+	parsed, err := url.Parse(BaseURL())
+	if err != nil {
+		return ""
+	}
+	p := strings.TrimRight(parsed.Path, "/")
+	if p == "" || p == "/" {
+		return ""
+	}
+	if !strings.HasPrefix(p, "/") {
+		return "/" + p
+	}
+	return p
+}
+
+// PublicHref is path as a root-relative URL under BASE_URL.
+func PublicHref(path string) string {
+	if path == "" {
+		path = "/"
+	}
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+	return PublicPath() + path
 }
 
 func IsTestMode() bool {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -95,6 +95,12 @@ func TestValidBaseUrlWithPath(t *testing2.T) {
 	assert.True(t, validateBaseUrl("https://api.example.com/path1/path2"))
 }
 
+func TestNotValidBaseUrlWithQueryOrFragment(t *testing2.T) {
+	assert.False(t, validateBaseUrl("https://api.example.com/ota?foo=bar"))
+	assert.False(t, validateBaseUrl("https://api.example.com/ota#section"))
+	assert.False(t, validateBaseUrl("https://api.example.com?"))
+}
+
 func TestPublicPath(t *testing2.T) {
 	t.Setenv("BASE_URL", "https://ota.example.com")
 	assert.Equal(t, "", PublicPath())

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -90,6 +90,29 @@ func TestValidBaseUrl(t *testing2.T) {
 	assert.True(t, isValid)
 }
 
+func TestValidBaseUrlWithPath(t *testing2.T) {
+	assert.True(t, validateBaseUrl("https://api.example.com/ota"))
+	assert.True(t, validateBaseUrl("https://api.example.com/path1/path2"))
+}
+
+func TestPublicPath(t *testing2.T) {
+	t.Setenv("BASE_URL", "https://ota.example.com")
+	assert.Equal(t, "", PublicPath())
+	assert.Equal(t, "/dashboard/", PublicHref("/dashboard/"))
+
+	t.Setenv("BASE_URL", "https://ota.example.com/")
+	assert.Equal(t, "", PublicPath())
+
+	t.Setenv("BASE_URL", "https://api.example.com/ota")
+	assert.Equal(t, "/ota", PublicPath())
+	assert.Equal(t, "/ota/dashboard/", PublicHref("/dashboard/"))
+	assert.Equal(t, "/ota/manifest", PublicHref("/manifest"))
+
+	t.Setenv("BASE_URL", "https://api.example.com/path1/path2/")
+	assert.Equal(t, "/path1/path2", PublicPath())
+	assert.Equal(t, "/path1/path2/dashboard", PublicHref("/dashboard"))
+}
+
 func TestNotValidConfigStorage(t *testing2.T) {
 	teardown := setup(t)
 	defer teardown()

--- a/ee/licensing/service_test.go
+++ b/ee/licensing/service_test.go
@@ -6,6 +6,7 @@ package licensing
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"testing"
@@ -185,6 +186,35 @@ func TestAttachRefusalLeavesStoreAndEditionUntouched(t *testing.T) {
 	assert.Equal(t, CodeLicenseKeyAlreadyUsed, refusal.Code)
 	assert.Nil(t, repo.stored)
 	assert.False(t, IsEnterprise())
+}
+
+// The license server binds keys to baseUrl by exact string equality, so a
+// BASE_URL with a path prefix must reach it whole, not reduced to its origin.
+func TestLicenseCallsSendTheFullBaseURLPathIncluded(t *testing.T) {
+	requireFullBaseUrl := func(r *http.Request) {
+		var body map[string]string
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		assert.Equal(t, "https://api.example.com/ota", body["baseUrl"])
+	}
+	fake := &fakeLicenseServer{
+		check: func(w http.ResponseWriter, r *http.Request) {
+			requireFullBaseUrl(r)
+			checkAnswersValidAcme(w, r)
+		},
+		validate: func(w http.ResponseWriter, r *http.Request) {
+			requireFullBaseUrl(r)
+			writeJSONBody(w, http.StatusOK, `{"isActive": true, "licenseInformations": `+acmeInformationsJSON+`}`)
+		},
+	}
+	repo := repoWithAcme()
+	Deactivate()
+	t.Cleanup(Deactivate)
+	service := NewLicenseService(repo, fake.client(t), "instance-1", "https://api.example.com/ota/")
+
+	_, err := service.Check(context.Background(), "XPREM-KEY")
+	require.NoError(t, err)
+	service.ValidateNow(context.Background())
+	assert.Nil(t, repo.stored.ValidationFailedAt, "validate must have sent the exact baseUrl the fake expected")
 }
 
 func TestCheckHasNoSideEffect(t *testing.T) {

--- a/ee/sso/handler.go
+++ b/ee/sso/handler.go
@@ -99,7 +99,7 @@ func sanitizeForLog(value string) string {
 // fragment: fragments never reach a server, so neither tokens nor error codes
 // can end up in access logs anywhere.
 func loginPageURL(fragment url.Values) string {
-	return strings.TrimRight(config.GetEnv("BASE_URL"), "/") + "/dashboard/login#" + fragment.Encode()
+	return config.BaseURL() + "/dashboard/login#" + fragment.Encode()
 }
 
 func redirectWithError(w http.ResponseWriter, r *http.Request, code string) {
@@ -115,7 +115,7 @@ func flowCookie(value string, maxAge int) *http.Cookie {
 	return &http.Cookie{
 		Name:     flowCookieName,
 		Value:    value,
-		Path:     "/auth/sso",
+		Path:     config.PublicHref("/auth/sso"),
 		MaxAge:   maxAge,
 		HttpOnly: true,
 		SameSite: http.SameSiteLaxMode,

--- a/ee/sso/handler_test.go
+++ b/ee/sso/handler_test.go
@@ -113,6 +113,34 @@ func TestLoginRedirectHandlerSetsFlowCookie(t *testing.T) {
 	assert.False(t, cookie.Secure)
 }
 
+func TestLoginRedirectHandlerScopesFlowCookieToBasePath(t *testing.T) {
+	idp := newFakeIdP(t)
+	users := newFakeUserRepo()
+	handler, _, _ := newTestHandler(t, newFakeSSORepo(users, testConfigFor(idp)), users)
+	t.Setenv("BASE_URL", "https://api.example.com/ota")
+
+	recorder := httptest.NewRecorder()
+	handler.LoginRedirectHandler(recorder, httptest.NewRequest(http.MethodGet, "/auth/sso/login", nil))
+	cookie := flowCookieFrom(t, recorder.Result())
+	require.NotNil(t, cookie)
+	assert.Equal(t, "/ota/auth/sso", cookie.Path)
+	assert.True(t, cookie.Secure)
+}
+
+func TestLoginRedirectHandlerRedirectsErrorsUnderBasePath(t *testing.T) {
+	idp := newFakeIdP(t)
+	users := newFakeUserRepo()
+	handler, service, _ := newTestHandler(t, newFakeSSORepo(users, testConfigFor(idp)), users)
+	service.licenseValid = func() bool { return false }
+	t.Setenv("BASE_URL", "https://api.example.com/ota")
+
+	recorder := httptest.NewRecorder()
+	handler.LoginRedirectHandler(recorder, httptest.NewRequest(http.MethodGet, "/auth/sso/login", nil))
+	location := recorder.Result().Header.Get("Location")
+	assert.True(t, strings.HasPrefix(location, "https://api.example.com/ota/dashboard/login#"))
+	assert.Equal(t, ssoErrLicense, fragmentValues(t, location).Get("ssoError"))
+}
+
 func TestLoginRedirectHandlerRedirectsErrorsToLoginPage(t *testing.T) {
 	idp := newFakeIdP(t)
 	users := newFakeUserRepo()

--- a/ee/sso/service.go
+++ b/ee/sso/service.go
@@ -269,7 +269,7 @@ func (s *SSOService) PublicConfig(ctx context.Context) PublicConfig {
 // RedirectURI is derived from BASE_URL, never configured: it is displayed
 // read-only in the dashboard for copy-pasting into the IdP's app settings.
 func (s *SSOService) RedirectURI() string {
-	return strings.TrimRight(config.GetEnv("BASE_URL"), "/") + "/auth/sso/callback"
+	return config.BaseURL() + "/auth/sso/callback"
 }
 
 func (s *SSOService) adminView(cfg *SSOConfig) *AdminConfig {

--- a/ee/sso/service_test.go
+++ b/ee/sso/service_test.go
@@ -832,6 +832,14 @@ func TestSaveConfigValidatesDiscoveryBeforePersisting(t *testing.T) {
 	assert.Equal(t, "http://localhost:3000/auth/sso/callback", view.RedirectURI)
 }
 
+func TestRedirectURIFollowsBasePath(t *testing.T) {
+	idp := newFakeIdP(t)
+	users := newFakeUserRepo()
+	service, _ := newTestService(t, newFakeSSORepo(users, testConfigFor(idp)), users)
+	t.Setenv("BASE_URL", "https://api.example.com/ota")
+	assert.Equal(t, "https://api.example.com/ota/auth/sso/callback", service.RedirectURI())
+}
+
 func TestSaveConfigKeepsStoredSecretWhenLeftEmpty(t *testing.T) {
 	idp := newFakeIdP(t)
 	users := newFakeUserRepo()

--- a/internal/middleware/cors_middleware.go
+++ b/internal/middleware/cors_middleware.go
@@ -3,7 +3,6 @@ package middleware
 import (
 	"net/http"
 	"net/url"
-	"strings"
 	"xprem/config"
 
 	"github.com/gorilla/mux"
@@ -46,7 +45,7 @@ func isDashboardOrigin(origin string) bool {
 	if hostname == "localhost" || hostname == "127.0.0.1" || hostname == "::1" {
 		return true
 	}
-	base, err := url.Parse(strings.TrimRight(config.GetEnv("BASE_URL"), "/"))
+	base, err := url.Parse(config.BaseURL())
 	if err != nil {
 		return false
 	}

--- a/internal/oauth/authorize_test.go
+++ b/internal/oauth/authorize_test.go
@@ -66,6 +66,25 @@ func TestAuthorizeRedirectsToConsent(t *testing.T) {
 	}
 }
 
+func TestAuthorizeConsentURLKeepsBasePath(t *testing.T) {
+	handler, clientRepo, _ := newTestHandlerWithCodes(t)
+	t.Setenv("BASE_URL", "https://api.example.com/ota")
+	clientID := seedClient(t, clientRepo, "http://127.0.0.1:53422/callback")
+
+	query := validAuthorizeQuery(clientID)
+	query.Set("resource", "https://api.example.com/ota/mcp")
+	res := httptest.NewRecorder()
+	handler.AuthorizeHandler(res, httptest.NewRequest(http.MethodGet, "/oauth/authorize?"+query.Encode(), nil))
+
+	if res.Code != http.StatusFound {
+		t.Fatalf("expected 302, got %d: %s", res.Code, res.Body.String())
+	}
+	location := res.Header().Get("Location")
+	if !strings.HasPrefix(location, "https://api.example.com/ota/dashboard/oauth/consent?") {
+		t.Fatalf("expected consent under BASE_URL path, got %s", location)
+	}
+}
+
 func TestAuthorizeRejections(t *testing.T) {
 	handler, clientRepo, _ := newTestHandlerWithCodes(t)
 	clientID := seedClient(t, clientRepo, "http://127.0.0.1:53422/callback")

--- a/internal/oauth/handler.go
+++ b/internal/oauth/handler.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"net/http"
 	"net/url"
-	"strings"
 	"time"
 	"xprem/config"
 	"xprem/internal/handlers"
@@ -34,10 +33,6 @@ func NewOAuthHandler(service *OAuthService, limiter *ratelimit.Limiter) *OAuthHa
 	return &OAuthHandler{service: service, limiter: limiter}
 }
 
-func baseURL() string {
-	return strings.TrimRight(config.GetEnv("BASE_URL"), "/")
-}
-
 // WithCORS opens an endpoint to cross-origin callers. The OAuth surface is
 // meant to be reached from other origins (claude.ai and its kind fetch the
 // metadata and token endpoints from their own pages), and nothing on it relies
@@ -61,17 +56,16 @@ func WithCORS(next http.HandlerFunc) http.HandlerFunc {
 func (h *OAuthHandler) ProtectedResourceMetadataHandler(w http.ResponseWriter, r *http.Request) {
 	handlers.RenderJSON(w, http.StatusOK, map[string]interface{}{
 		"resource":                 ResourceURL(),
-		"authorization_servers":    []string{baseURL()},
+		"authorization_servers":    []string{config.BaseURL()},
 		"scopes_supported":         []string{ScopeMCP},
 		"bearer_methods_supported": []string{"header"},
 	})
 }
 
 // AuthorizationServerMetadataHandler serves RFC 8414 metadata. The issuer is
-// the bare BASE_URL, deliberately without a path: path-bearing issuers trigger
-// the well-known path-insertion rules clients disagree on.
+// BASE_URL, including any path the server is mounted under.
 func (h *OAuthHandler) AuthorizationServerMetadataHandler(w http.ResponseWriter, r *http.Request) {
-	base := baseURL()
+	base := config.BaseURL()
 	handlers.RenderJSON(w, http.StatusOK, map[string]interface{}{
 		"issuer":                                base,
 		"authorization_endpoint":                base + "/oauth/authorize",
@@ -181,7 +175,7 @@ func (h *OAuthHandler) AuthorizeHandler(w http.ResponseWriter, r *http.Request) 
 	if req.Resource != "" {
 		consent.Set("resource", req.Resource)
 	}
-	http.Redirect(w, r, baseURL()+consentPath+"?"+consent.Encode(), http.StatusFound)
+	http.Redirect(w, r, config.BaseURL()+consentPath+"?"+consent.Encode(), http.StatusFound)
 }
 
 // ConsentHandler turns an approved consent into an authorization code. It sits

--- a/internal/oauth/token.go
+++ b/internal/oauth/token.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"log"
 	"time"
+	"xprem/config"
 	"xprem/internal/crypto"
 	"xprem/internal/services"
 	"xprem/internal/store"
@@ -38,13 +39,13 @@ var ErrInvalidGrant = errors.New("invalid grant")
 // ResourceURL is the RFC 8707 identifier of the MCP server, carried as the
 // aud claim of every access token and required back at verification.
 func ResourceURL() string {
-	return baseURL() + "/mcp"
+	return config.BaseURL() + "/mcp"
 }
 
 // ResourceMetadataURL is where a 401 sends clients to discover how to
 // authenticate (RFC 9728).
 func ResourceMetadataURL() string {
-	return baseURL() + "/.well-known/oauth-protected-resource/mcp"
+	return config.BaseURL() + "/.well-known/oauth-protected-resource/mcp"
 }
 
 // IssueAccessToken mints the Bearer token the token endpoint hands out.

--- a/internal/router/public_path.go
+++ b/internal/router/public_path.go
@@ -1,0 +1,46 @@
+package infrastructure
+
+import (
+	"net/http"
+	"strings"
+	"xprem/config"
+
+	"github.com/gorilla/mux"
+)
+
+// mountPublicPath serves the app under BASE_URL's path when
+// SERVE_FROM_SUB_PATH is true; by default the reverse proxy is expected to
+// strip the prefix. /hc and /ready stay at the process root either way.
+func mountPublicPath(inner *mux.Router, container *AppContainer) *mux.Router {
+	prefix := config.PublicPath()
+	if prefix == "" || !config.ServeFromSubPath() {
+		return inner
+	}
+	outer := mux.NewRouter()
+	outer.SkipClean(true)
+	registerInfraRoutes(outer)
+	registerOAuthWellKnownInserted(outer, container, prefix)
+	stripped := stripPrefix(prefix, inner)
+	outer.Handle(prefix, stripped)
+	outer.PathPrefix(prefix + "/").Handler(stripped)
+	return outer
+}
+
+func stripPrefix(prefix string, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		p := strings.TrimPrefix(r.URL.Path, prefix)
+		if p == r.URL.Path {
+			http.NotFound(w, r)
+			return
+		}
+		if p == "" {
+			p = "/"
+		}
+		r2 := r.Clone(r.Context())
+		r2.URL.Path = p
+		if r.URL.RawPath != "" {
+			r2.URL.RawPath = strings.TrimPrefix(r.URL.RawPath, prefix)
+		}
+		next.ServeHTTP(w, r2)
+	})
+}

--- a/internal/router/public_path_test.go
+++ b/internal/router/public_path_test.go
@@ -1,0 +1,77 @@
+package infrastructure
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"xprem/internal/oauth"
+
+	"github.com/gorilla/mux"
+)
+
+// The RFC 8414 / 9728 inserted discovery documents live at the host root, so
+// they only exist on the outer router mountPublicPath builds.
+func TestMountPublicPathServesInsertedOAuthDiscovery(t *testing.T) {
+	t.Setenv("BASE_URL", "https://api.example.com/a/b")
+	t.Setenv("SERVE_FROM_SUB_PATH", "true")
+	container := &AppContainer{
+		OAuthHandler: oauth.NewOAuthHandler(oauth.NewOAuthService(nil, nil, nil, nil), nil),
+	}
+	inner := mux.NewRouter()
+	inner.SkipClean(true)
+	registerOAuthRoutes(inner, container)
+	router := mountPublicPath(inner, container)
+
+	get := func(path string) *httptest.ResponseRecorder {
+		res := httptest.NewRecorder()
+		router.ServeHTTP(res, httptest.NewRequest(http.MethodGet, path, nil))
+		return res
+	}
+
+	res := get("/.well-known/oauth-authorization-server/a/b")
+	if res.Code != http.StatusOK {
+		t.Fatalf("expected 200 on the inserted AS metadata, got %d", res.Code)
+	}
+	if res.Header().Get("Access-Control-Allow-Origin") != "*" {
+		t.Error("discovery must stay CORS-readable for browser MCP clients")
+	}
+	var asMeta struct {
+		Issuer                string `json:"issuer"`
+		AuthorizationEndpoint string `json:"authorization_endpoint"`
+	}
+	if err := json.Unmarshal(res.Body.Bytes(), &asMeta); err != nil {
+		t.Fatalf("invalid AS metadata JSON: %v", err)
+	}
+	if asMeta.Issuer != "https://api.example.com/a/b" {
+		t.Errorf("issuer must be BASE_URL, got %q", asMeta.Issuer)
+	}
+	if asMeta.AuthorizationEndpoint != "https://api.example.com/a/b/oauth/authorize" {
+		t.Errorf("authorization_endpoint must live under the prefix, got %q", asMeta.AuthorizationEndpoint)
+	}
+
+	res = get("/.well-known/oauth-protected-resource/a/b/mcp")
+	if res.Code != http.StatusOK {
+		t.Fatalf("expected 200 on the inserted resource metadata, got %d", res.Code)
+	}
+	var prMeta struct {
+		Resource string `json:"resource"`
+	}
+	if err := json.Unmarshal(res.Body.Bytes(), &prMeta); err != nil {
+		t.Fatalf("invalid resource metadata JSON: %v", err)
+	}
+	if prMeta.Resource != "https://api.example.com/a/b/mcp" {
+		t.Errorf("resource must be BASE_URL/mcp, got %q", prMeta.Resource)
+	}
+
+	// The suffixed form non-conforming clients probe, reached through the
+	// prefix strip.
+	if res := get("/a/b/.well-known/oauth-authorization-server"); res.Code != http.StatusOK {
+		t.Fatalf("expected 200 on the suffixed form, got %d", res.Code)
+	}
+
+	// The inserted routes must not leak to other paths.
+	if res := get("/.well-known/oauth-authorization-server/other"); res.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for a foreign inserted path, got %d", res.Code)
+	}
+}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -61,5 +61,5 @@ func NewRouter(container *AppContainer) *mux.Router {
 	registerAccountRoutes(apiSubrouter, container, adminOnly)
 	registerAppRoutes(apiSubrouter, container)
 
-	return r
+	return mountPublicPath(r, container)
 }

--- a/internal/router/routes_dashboard_assets.go
+++ b/internal/router/routes_dashboard_assets.go
@@ -1,7 +1,10 @@
 package infrastructure
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
+	"html"
 	"log"
 	"net/http"
 	"os"
@@ -40,20 +43,24 @@ func registerDashboardAssets(r *mux.Router) {
 	// 302 and not 301: a permanent redirect on "/" would be cached by browsers
 	// even after the dashboard is disabled or the root gains a real purpose.
 	r.Path("/").Methods(http.MethodGet).HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		http.Redirect(w, r, "/dashboard/", http.StatusFound)
+		http.Redirect(w, r, config.PublicHref("/dashboard/"), http.StatusFound)
 	})
 	r.PathPrefix("/dashboard").Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/dashboard/env.js" {
 			w.Header().Set("Content-Type", "application/javascript")
-			baseURL := config.GetEnv("BASE_URL")
+			baseURL := config.BaseURL()
 			if baseURL == "" {
 				baseURL = "http://localhost:3000"
 			}
-			w.Write([]byte(fmt.Sprintf("window.env = { VITE_OTA_API_URL: '%s' };", baseURL)))
+			env, _ := json.Marshal(map[string]string{
+				"VITE_OTA_API_URL":   baseURL,
+				"DASHBOARD_BASENAME": config.PublicHref("/dashboard"),
+			})
+			fmt.Fprintf(w, "window.env = %s;", env)
 			return
 		}
 		if r.URL.Path == "/dashboard" {
-			target := "/dashboard/"
+			target := config.PublicHref("/dashboard/")
 			if r.URL.RawQuery != "" {
 				target += "?" + r.URL.RawQuery
 			}
@@ -74,6 +81,14 @@ func registerDashboardAssets(r *mux.Router) {
 		}
 		filePath := filepath.Join(dashboardPath, "index.html")
 		fmt.Println("Serving file", filePath)
-		http.ServeFile(w, r, filePath)
+		body, err := os.ReadFile(filePath)
+		if err != nil {
+			http.NotFound(w, r)
+			return
+		}
+		href := html.EscapeString(config.PublicHref("/dashboard") + "/")
+		body = bytes.Replace(body, []byte("<head>"), []byte(`<head><base href="`+href+`">`), 1)
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.Write(body)
 	}))
 }

--- a/internal/router/routes_dashboard_assets.go
+++ b/internal/router/routes_dashboard_assets.go
@@ -81,16 +81,23 @@ func registerDashboardAssets(r *mux.Router) {
 				return
 			}
 		}
-		filePath := filepath.Join(dashboardPath, "index.html")
-		fmt.Println("Serving file", filePath)
-		body, err := os.ReadFile(filePath)
-		if err != nil {
-			http.NotFound(w, r)
-			return
-		}
-		href := html.EscapeString(config.PublicHref("/dashboard") + "/")
-		body = bytes.Replace(body, []byte("<head>"), []byte(`<head><base href="`+href+`">`), 1)
-		w.Header().Set("Content-Type", "text/html; charset=utf-8")
-		w.Write(body)
+		serveIndexWithBaseHref(w, r, filepath.Join(dashboardPath, "index.html"))
 	}))
+}
+
+// serveIndexWithBaseHref serves the SPA entry point with a <base href> naming
+// the dashboard's public mount. The build references its assets with relative
+// paths, so this tag is what keeps them resolving on deep-route refreshes.
+func serveIndexWithBaseHref(w http.ResponseWriter, r *http.Request, indexPath string) {
+	body, err := os.ReadFile(indexPath)
+	if err != nil {
+		http.NotFound(w, r)
+		return
+	}
+	// EscapeString: the href lands inside an HTML attribute and BASE_URL is
+	// operator input.
+	href := html.EscapeString(config.PublicHref("/dashboard") + "/")
+	body = bytes.Replace(body, []byte("<head>"), []byte(`<head><base href="`+href+`">`), 1)
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.Write(body)
 }

--- a/internal/router/routes_oauth.go
+++ b/internal/router/routes_oauth.go
@@ -29,6 +29,20 @@ func registerOAuthRoutes(r *mux.Router, container *AppContainer) {
 	r.HandleFunc("/oauth/authorize", h.AuthorizeHandler).Methods(http.MethodGet)
 }
 
+// registerOAuthWellKnownInserted serves RFC 8414 / 9728 path-inserted discovery
+// at the host root when BASE_URL has a path (issuer https://host/ota →
+// /.well-known/oauth-authorization-server/ota). The prefixed copies live on
+// the inner router via stripPrefix.
+func registerOAuthWellKnownInserted(r *mux.Router, container *AppContainer, prefix string) {
+	if container.OAuthHandler == nil || prefix == "" {
+		return
+	}
+	h := container.OAuthHandler
+	r.HandleFunc("/.well-known/oauth-protected-resource"+prefix+"/mcp", oauth.WithCORS(h.ProtectedResourceMetadataHandler)).Methods(http.MethodGet, http.MethodOptions)
+	r.HandleFunc("/.well-known/oauth-protected-resource"+prefix, oauth.WithCORS(h.ProtectedResourceMetadataHandler)).Methods(http.MethodGet, http.MethodOptions)
+	r.HandleFunc("/.well-known/oauth-authorization-server"+prefix, oauth.WithCORS(h.AuthorizationServerMetadataHandler)).Methods(http.MethodGet, http.MethodOptions)
+}
+
 // registerOAuthApiRoutes mounts the consent endpoint behind the dashboard
 // session; api is the authenticated /api subrouter.
 func registerOAuthApiRoutes(api *mux.Router, container *AppContainer) {

--- a/internal/router/wire.go
+++ b/internal/router/wire.go
@@ -231,7 +231,7 @@ func InitDependencies(ctx context.Context) (*AppContainer, func()) {
 	auditService.StartRetentionPurgeFromEnv(ctx)
 
 	licenseClient := licensing.NewClient(config.GetEnv("LICENSE_API_URL"))
-	licenseService := licensing.NewLicenseService(licenseRepo, licenseClient, instanceId, config.GetEnv("BASE_URL"))
+	licenseService := licensing.NewLicenseService(licenseRepo, licenseClient, instanceId, config.BaseURL())
 	// Wired before the loops start: they emit audit events from goroutines.
 	licenseService.SetOnAuditEvent(auditService.Record)
 	if err := licenseService.ActivateFromStore(ctx); err != nil {

--- a/internal/update/updates.go
+++ b/internal/update/updates.go
@@ -186,7 +186,7 @@ func BuildFinalManifestAssetUrlURL(baseURL, assetFilePath, runtimeVersion string
 }
 
 func GetAssetEndpoint() string {
-	return config.GetEnv("BASE_URL") + "/assets"
+	return config.BaseURL() + "/assets"
 }
 
 func shapeManifestAsset(update types.Update, asset *types.Asset, isLaunchAsset bool, platform types.Platform) (types.ManifestAsset, error) {

--- a/test/dashboard_path_traversal_test.go
+++ b/test/dashboard_path_traversal_test.go
@@ -17,6 +17,7 @@ func TestDashboardServesStaticFile(t *testing.T) {
 	router.ServeHTTP(respRec, req)
 	assert.Equal(t, http.StatusOK, respRec.Code)
 	assert.Contains(t, respRec.Body.String(), "window.env")
+	assert.Contains(t, respRec.Body.String(), `"DASHBOARD_BASENAME":"/dashboard"`)
 }
 
 func TestDashboardSPAFallback(t *testing.T) {

--- a/test/public_path_test.go
+++ b/test/public_path_test.go
@@ -1,0 +1,104 @@
+package test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	infrastructure "xprem/internal/router"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPublicPathMountsTheApp(t *testing.T) {
+	teardown := setup(t)
+	defer teardown()
+	t.Setenv("BASE_URL", "http://localhost:3000/ota")
+	t.Setenv("SERVE_FROM_SUB_PATH", "true")
+	router := infrastructure.NewRouter(testContainer())
+
+	hc := httptest.NewRecorder()
+	router.ServeHTTP(hc, httptest.NewRequest(http.MethodGet, "/hc", nil))
+	assert.Equal(t, http.StatusOK, hc.Code)
+
+	prefixedHc := httptest.NewRecorder()
+	router.ServeHTTP(prefixedHc, httptest.NewRequest(http.MethodGet, "/ota/hc", nil))
+	assert.Equal(t, http.StatusOK, prefixedHc.Code)
+
+	unprefixed := httptest.NewRecorder()
+	router.ServeHTTP(unprefixed, httptest.NewRequest(http.MethodGet, "/manifest", nil))
+	assert.Equal(t, http.StatusNotFound, unprefixed.Code)
+
+	manifest := httptest.NewRecorder()
+	router.ServeHTTP(manifest, httptest.NewRequest(http.MethodGet, "/ota/manifest", nil))
+	assert.NotEqual(t, http.StatusNotFound, manifest.Code)
+
+	root := httptest.NewRecorder()
+	router.ServeHTTP(root, httptest.NewRequest(http.MethodGet, "/ota", nil))
+	assert.Equal(t, http.StatusFound, root.Code)
+	assert.Equal(t, "/ota/dashboard/", root.Header().Get("Location"))
+
+	slash := httptest.NewRecorder()
+	router.ServeHTTP(slash, httptest.NewRequest(http.MethodGet, "/ota/", nil))
+	assert.Equal(t, http.StatusFound, slash.Code)
+	assert.Equal(t, "/ota/dashboard/", slash.Header().Get("Location"))
+
+	env := httptest.NewRecorder()
+	router.ServeHTTP(env, httptest.NewRequest(http.MethodGet, "/ota/dashboard/env.js", nil))
+	assert.Equal(t, http.StatusOK, env.Code)
+	assert.Contains(t, env.Body.String(), `"VITE_OTA_API_URL":"http://localhost:3000/ota"`)
+	assert.Contains(t, env.Body.String(), `"DASHBOARD_BASENAME":"/ota/dashboard"`)
+
+	sso := httptest.NewRecorder()
+	router.ServeHTTP(sso, httptest.NewRequest(http.MethodGet, "/ota/auth/sso/config", nil))
+	assert.NotEqual(t, http.StatusNotFound, sso.Code)
+}
+
+func TestNestedPublicPathMountsTheApp(t *testing.T) {
+	teardown := setup(t)
+	defer teardown()
+	t.Setenv("BASE_URL", "https://api.example.com/path1/path2")
+	t.Setenv("SERVE_FROM_SUB_PATH", "true")
+	router := infrastructure.NewRouter(testContainer())
+
+	hc := httptest.NewRecorder()
+	router.ServeHTTP(hc, httptest.NewRequest(http.MethodGet, "/path1/path2/hc", nil))
+	assert.Equal(t, http.StatusOK, hc.Code)
+
+	root := httptest.NewRecorder()
+	router.ServeHTTP(root, httptest.NewRequest(http.MethodGet, "/path1/path2", nil))
+	assert.Equal(t, http.StatusFound, root.Code)
+	assert.Equal(t, "/path1/path2/dashboard/", root.Header().Get("Location"))
+
+	manifest := httptest.NewRecorder()
+	router.ServeHTTP(manifest, httptest.NewRequest(http.MethodGet, "/path1/path2/manifest", nil))
+	assert.NotEqual(t, http.StatusNotFound, manifest.Code)
+
+	env := httptest.NewRecorder()
+	router.ServeHTTP(env, httptest.NewRequest(http.MethodGet, "/path1/path2/dashboard/env.js", nil))
+	require.Equal(t, http.StatusOK, env.Code)
+	assert.Contains(t, env.Body.String(), `"DASHBOARD_BASENAME":"/path1/path2/dashboard"`)
+}
+
+// Default mode: the reverse proxy strips BASE_URL's path, so routes stay at
+// the process root while emitted links still carry the public prefix.
+func TestStripModeKeepsRootRoutesAndPublicLinks(t *testing.T) {
+	teardown := setup(t)
+	defer teardown()
+	t.Setenv("BASE_URL", "https://api.example.com/ota")
+	router := infrastructure.NewRouter(testContainer())
+
+	manifest := httptest.NewRecorder()
+	router.ServeHTTP(manifest, httptest.NewRequest(http.MethodGet, "/manifest", nil))
+	assert.NotEqual(t, http.StatusNotFound, manifest.Code)
+
+	root := httptest.NewRecorder()
+	router.ServeHTTP(root, httptest.NewRequest(http.MethodGet, "/", nil))
+	assert.Equal(t, http.StatusFound, root.Code)
+	assert.Equal(t, "/ota/dashboard/", root.Header().Get("Location"))
+
+	env := httptest.NewRecorder()
+	router.ServeHTTP(env, httptest.NewRequest(http.MethodGet, "/dashboard/env.js", nil))
+	require.Equal(t, http.StatusOK, env.Code)
+	assert.Contains(t, env.Body.String(), `"DASHBOARD_BASENAME":"/ota/dashboard"`)
+}

--- a/test/public_path_test.go
+++ b/test/public_path_test.go
@@ -15,6 +15,7 @@ func TestPublicPathMountsTheApp(t *testing.T) {
 	defer teardown()
 	t.Setenv("BASE_URL", "http://localhost:3000/ota")
 	t.Setenv("SERVE_FROM_SUB_PATH", "true")
+	t.Setenv("DASHBOARD_ROOT_REDIRECT", "true")
 	router := infrastructure.NewRouter(testContainer())
 
 	hc := httptest.NewRecorder()
@@ -59,6 +60,7 @@ func TestNestedPublicPathMountsTheApp(t *testing.T) {
 	defer teardown()
 	t.Setenv("BASE_URL", "https://api.example.com/path1/path2")
 	t.Setenv("SERVE_FROM_SUB_PATH", "true")
+	t.Setenv("DASHBOARD_ROOT_REDIRECT", "true")
 	router := infrastructure.NewRouter(testContainer())
 
 	hc := httptest.NewRecorder()
@@ -86,6 +88,7 @@ func TestStripModeKeepsRootRoutesAndPublicLinks(t *testing.T) {
 	teardown := setup(t)
 	defer teardown()
 	t.Setenv("BASE_URL", "https://api.example.com/ota")
+	t.Setenv("DASHBOARD_ROOT_REDIRECT", "true")
 	router := infrastructure.NewRouter(testContainer())
 
 	manifest := httptest.NewRecorder()


### PR DESCRIPTION
## Summary

This PR introduces **path prefix (subpath) support**: the server can now be deployed under a `BASE_URL` that carries a path, e.g. `https://myorg.com/ota`.

## Two routing modes

A subpath deployment can be wired in two ways, depending on what the reverse proxy forwards. Both are supported:

### 1. The proxy strips the prefix (default)

The server keeps serving its routes at the root (`/manifest`, `/api/...`, `/dashboard/...`) and the proxy rewrites the path before forwarding. Nothing to set besides `BASE_URL`.

```nginx
# nginx: the trailing slash on proxy_pass strips /ota
location /ota/ { proxy_pass http://xprem:3000/; }
```

Same idea with Traefik's `StripPrefix` middleware or an ingress `rewrite-target`.

### 2. The server serves under the prefix (`SERVE_FROM_SUB_PATH=true`)

Every route is served under the full prefix (`/ota/manifest`, `/ota/api/...`) and the proxy forwards paths untouched.

```nginx
# nginx: no trailing slash = the path is forwarded intact
location /ota { proxy_pass http://xprem:3000; }
```

Same idea with an ALB / API Gateway rule that forwards the full path.

In **both** modes, every URL the server emits:  redirects, cookies, OAuth/MCP discovery metadata, dashboard assets, update manifests carries the full `BASE_URL` path.

`SERVE_FROM_SUB_PATH` only changes how incoming requests are routed. Health checks (`/hc`, `/ready`) stay at the process root in every mode.

## What changed

- **Server (Go):** `BASE_URL` may now include a path. New `SERVE_FROM_SUB_PATH` toggle mounts the whole app under the prefix; RFC 8414 / RFC 9728 path-inserted OAuth discovery documents are served at the host root so MCP clients keep discovering auth.
- **Dashboard:** built once with a relative base; the server injects `<base href>` and `window.env.DASHBOARD_BASENAME` at serve time, so a single build works under any prefix (router basename, login redirects and asset URLs follow).
- **eoas CLI:** `server:init` detects a path in the submitted `BASE_URL` and asks which routing mode you use, writing `SERVE_FROM_SUB_PATH=true` when the proxy passes the prefix through; server URL resolution preserves prefixes and strips a trailing `/manifest`.
- **Licensing (EE):** the license is bound to the exact `BASE_URL`, path included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deploy the dashboard and update service under custom, including nested, URL paths.
  * Configure whether proxy prefixes are preserved or stripped during server setup.
  * OAuth, SSO, licensing, health, and asset links honor the configured public path.
* **Bug Fixes**
  * Dashboard redirects, login flows, and return URLs work outside the default path.
  * Update-server URLs preserve path prefixes.
* **Documentation**
  * CLI help and setup prompts clarify server URL behavior and configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->