### PR TITLE
fix(dashboard): un-crowd the updates feed

### DIFF
--- a/apps/dashboard/src/components/ui/timestamp-cell.tsx
+++ b/apps/dashboard/src/components/ui/timestamp-cell.tsx
@@ -5,8 +5,6 @@ import { formatCompactTimestamp, formatTimestamp } from '@/lib/utils';
 type TimestampCellProps = {
   dateString: string | null | undefined;
   showSeconds?: boolean;
-  // For tables read against the present, where the spelled-out date costs a column and
-  // tells you nothing you did not know. The full timestamp stays on hover.
   compact?: boolean;
 };
 

--- a/apps/dashboard/src/components/ui/timestamp-cell.tsx
+++ b/apps/dashboard/src/components/ui/timestamp-cell.tsx
@@ -1,23 +1,31 @@
 import React from 'react';
 import { Calendar } from 'lucide-react';
-import { formatTimestamp } from '@/lib/utils';
+import { formatCompactTimestamp, formatTimestamp } from '@/lib/utils';
 
 type TimestampCellProps = {
   dateString: string | null | undefined;
   showSeconds?: boolean;
+  // For tables read against the present, where the spelled-out date costs a column and
+  // tells you nothing you did not know. The full timestamp stays on hover.
+  compact?: boolean;
 };
 
 export const TimestampCell: React.FC<TimestampCellProps> = ({
   dateString,
   showSeconds = false,
+  compact = false,
 }) => {
-  const formattedDate = formatTimestamp(dateString, showSeconds);
+  const formattedDate = compact
+    ? formatCompactTimestamp(dateString, showSeconds)
+    : formatTimestamp(dateString, showSeconds);
 
   return (
     <span className="flex items-center gap-1.5 whitespace-nowrap text-muted-foreground">
       <Calendar className="h-3.5 w-3.5 text-muted-foreground/70" />
       {formattedDate ? (
-        formattedDate
+        <span title={compact ? (formatTimestamp(dateString, true) ?? undefined) : undefined}>
+          {formattedDate}
+        </span>
       ) : (
         <span className="italic text-muted-foreground/60">Legacy record</span>
       )}

--- a/apps/dashboard/src/lib/update-format.ts
+++ b/apps/dashboard/src/lib/update-format.ts
@@ -1,7 +1,6 @@
-// CI often publishes with `git log --oneline`, so the subject arrives behind the short
-// hash the Commit column already shows. Drop it only when that leading token really is
-// this update's commit: a message that legitimately opens with a hex-looking word is
-// something someone wrote, and a table cell is the wrong place to second-guess it.
+// CI publishes with `git log --oneline`, so the message arrives prefixed with the short
+// hash the Commit column already shows. Drop that prefix only when it really is this
+// update's commit, so a message that happens to start with a hex word is left alone.
 export const updateTitle = (message: string | undefined, commitHash: string) => {
   const raw = message ?? '';
   // A dashboard rollback stores no commit hash, so there is nothing to match against.
@@ -12,9 +11,7 @@ export const updateTitle = (message: string | undefined, commitHash: string) => 
   return commitHash.toLowerCase().startsWith(token.toLowerCase()) ? rest : raw;
 };
 
-// A fingerprint runtime version is the forty-hex hash `expo-updates
-// runtimeversion:resolve` returns, and it says nothing at a glance; the full value stays
-// one hover away. Anything else — a named version ("1.0.0", "exposdk:52.0.0"), or a hex
-// string of another length — is left exactly as it was set.
+// Forty hex characters is the fingerprint `expo-updates runtimeversion:resolve` returns;
+// named versions ("1.0.0", "exposdk:52.0.0") are left as they were set.
 export const shortRuntimeVersion = (value: string) =>
   /^[0-9a-f]{40}$/i.test(value) ? value.slice(0, 8) : value;

--- a/apps/dashboard/src/lib/update-format.ts
+++ b/apps/dashboard/src/lib/update-format.ts
@@ -12,8 +12,9 @@ export const updateTitle = (message: string | undefined, commitHash: string) => 
   return commitHash.toLowerCase().startsWith(token.toLowerCase()) ? rest : raw;
 };
 
-// A fingerprint runtime version is forty hex characters that say nothing at a glance,
-// and the full value stays one hover away. A named one ("1.0.0", "exposdk:52.0.0") is
-// already short and must survive intact.
+// A fingerprint runtime version is the forty-hex hash `expo-updates
+// runtimeversion:resolve` returns, and it says nothing at a glance; the full value stays
+// one hover away. Anything else — a named version ("1.0.0", "exposdk:52.0.0"), or a hex
+// string of another length — is left exactly as it was set.
 export const shortRuntimeVersion = (value: string) =>
-  /^[0-9a-f]{16,}$/i.test(value) ? value.slice(0, 8) : value;
+  /^[0-9a-f]{40}$/i.test(value) ? value.slice(0, 8) : value;

--- a/apps/dashboard/src/lib/update-format.ts
+++ b/apps/dashboard/src/lib/update-format.ts
@@ -1,0 +1,19 @@
+// CI often publishes with `git log --oneline`, so the subject arrives behind the short
+// hash the Commit column already shows. Drop it only when that leading token really is
+// this update's commit: a message that legitimately opens with a hex-looking word is
+// something someone wrote, and a table cell is the wrong place to second-guess it.
+export const updateTitle = (message: string | undefined, commitHash: string) => {
+  const raw = message ?? '';
+  // A dashboard rollback stores no commit hash, so there is nothing to match against.
+  if (commitHash.length < 7) return raw;
+  const match = /^([0-9a-f]{7,40})\s+(\S.*)$/is.exec(raw);
+  if (!match) return raw;
+  const [, token, rest] = match;
+  return commitHash.toLowerCase().startsWith(token.toLowerCase()) ? rest : raw;
+};
+
+// A fingerprint runtime version is forty hex characters that say nothing at a glance,
+// and the full value stays one hover away. A named one ("1.0.0", "exposdk:52.0.0") is
+// already short and must survive intact.
+export const shortRuntimeVersion = (value: string) =>
+  /^[0-9a-f]{16,}$/i.test(value) ? value.slice(0, 8) : value;

--- a/apps/dashboard/src/lib/utils.ts
+++ b/apps/dashboard/src/lib/utils.ts
@@ -24,3 +24,27 @@ export function formatTimestamp(
   });
   return `${dateStr} at ${timeStr}`;
 }
+
+// A feed is read against now: on the day something shipped, the date says nothing that
+// "Today" does not. Older rows get a fixed dd/mm/yyyy, hand-formatted rather than
+// localised, because toLocaleDateString hands a US browser mm/dd/yyyy instead.
+export function formatCompactTimestamp(
+  dateString: string | null | undefined,
+  showSeconds: boolean = false
+): string | null {
+  if (!dateString) return null;
+  const d = new Date(dateString);
+  if (isNaN(d.getTime())) return null;
+  const pad = (n: number) => String(n).padStart(2, '0');
+  const time = `${pad(d.getHours())}:${pad(d.getMinutes())}${
+    showSeconds ? `:${pad(d.getSeconds())}` : ''
+  }`;
+  const now = new Date();
+  const isToday =
+    d.getDate() === now.getDate() &&
+    d.getMonth() === now.getMonth() &&
+    d.getFullYear() === now.getFullYear();
+  return isToday
+    ? `Today ${time}`
+    : `${pad(d.getDate())}/${pad(d.getMonth() + 1)}/${d.getFullYear()} ${time}`;
+}

--- a/apps/dashboard/src/lib/utils.ts
+++ b/apps/dashboard/src/lib/utils.ts
@@ -26,8 +26,8 @@ export function formatTimestamp(
 }
 
 // A feed is read against now: on the day something shipped, the date says nothing that
-// "Today" does not. Older rows get a fixed dd/mm/yyyy, hand-formatted rather than
-// localised, because toLocaleDateString hands a US browser mm/dd/yyyy instead.
+// "Today" does not. Older rows get the numeric date, in whatever order the reader's
+// locale puts it.
 export function formatCompactTimestamp(
   dateString: string | null | undefined,
   showSeconds: boolean = false
@@ -35,16 +35,21 @@ export function formatCompactTimestamp(
   if (!dateString) return null;
   const d = new Date(dateString);
   if (isNaN(d.getTime())) return null;
-  const pad = (n: number) => String(n).padStart(2, '0');
-  const time = `${pad(d.getHours())}:${pad(d.getMinutes())}${
-    showSeconds ? `:${pad(d.getSeconds())}` : ''
-  }`;
+  const timeStr = d.toLocaleTimeString(undefined, {
+    hour: '2-digit',
+    minute: '2-digit',
+    ...(showSeconds && { second: '2-digit' }),
+  });
   const now = new Date();
   const isToday =
     d.getDate() === now.getDate() &&
     d.getMonth() === now.getMonth() &&
     d.getFullYear() === now.getFullYear();
-  return isToday
-    ? `Today ${time}`
-    : `${pad(d.getDate())}/${pad(d.getMonth() + 1)}/${d.getFullYear()} ${time}`;
+  if (isToday) return `Today ${timeStr}`;
+  const dateStr = d.toLocaleDateString(undefined, {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+  });
+  return `${dateStr} ${timeStr}`;
 }

--- a/apps/dashboard/src/lib/utils.ts
+++ b/apps/dashboard/src/lib/utils.ts
@@ -25,9 +25,6 @@ export function formatTimestamp(
   return `${dateStr} at ${timeStr}`;
 }
 
-// A feed is read against now: on the day something shipped, the date says nothing that
-// "Today" does not. Older rows get the numeric date, in whatever order the reader's
-// locale puts it.
 export function formatCompactTimestamp(
   dateString: string | null | undefined,
   showSeconds: boolean = false

--- a/apps/dashboard/src/pages/Updates/components/UpdatesTable/index.tsx
+++ b/apps/dashboard/src/pages/Updates/components/UpdatesTable/index.tsx
@@ -15,6 +15,7 @@ import { UpdatesBreadcrumb } from '@/pages/Updates/components/UpdatesBreadcrumb'
 import { UpdateRolloutCard } from '@/pages/Updates/components/UpdateRolloutCard';
 import { aggregateUpdateHealth } from '@/pages/Updates/components/updateHealth';
 import { Button } from '@/components/ui/button';
+import { updateTitle } from '@/lib/update-format';
 
 const UPDATES_PAGE_SIZE = 20;
 
@@ -144,7 +145,7 @@ export const UpdatesTable = ({
             header: 'Message',
             accessorKey: 'message',
             cell: ({ row }) => {
-              const msg = row.original.message;
+              const msg = updateTitle(row.original.message, row.original.commitHash);
               return msg ? (
                 <span className="block max-w-[200px] truncate text-sm text-muted-foreground">
                   {msg}

--- a/apps/dashboard/src/pages/Updates/index.tsx
+++ b/apps/dashboard/src/pages/Updates/index.tsx
@@ -49,6 +49,7 @@ import apple from '@/assets/apple.svg';
 import android from '@/assets/android.svg';
 import { HealthBadge } from '@/pages/Updates/components/HealthBadge';
 import { aggregateUpdateHealth } from '@/pages/Updates/components/updateHealth';
+import { shortRuntimeVersion, updateTitle } from '@/lib/update-format';
 
 type FeedGroup = {
   key: string;
@@ -147,7 +148,7 @@ const RuntimeLabel = ({ value }: { value: string }) => (
     className="inline-flex max-w-full items-center gap-1.5 rounded-md border border-amber-400/25 bg-amber-400/[0.08] px-2 py-1 text-xs font-medium text-amber-800 dark:border-amber-300/20 dark:bg-amber-300/[0.07] dark:text-amber-100"
     title={value}>
     <Box className="h-3 w-3 shrink-0 text-amber-600 dark:text-amber-300/80" />
-    <span className="truncate">{value}</span>
+    <span className="truncate">{shortRuntimeVersion(value)}</span>
   </span>
 );
 
@@ -627,17 +628,17 @@ export const Updates = () => {
       )}
 
       <div className="overflow-hidden rounded-lg border bg-card shadow-card">
-        <Table className="min-w-[1250px] table-fixed">
+        <Table className="min-w-[1150px] table-fixed">
           <TableHeader>
             <TableRow>
-              <TableHead className={canPublishUpdate ? 'w-[26%]' : 'w-[30%]'}>Update</TableHead>
+              <TableHead className={canPublishUpdate ? 'w-[32%]' : 'w-[36%]'}>Update</TableHead>
               <TableHead className="w-[11%]">Branch</TableHead>
-              <TableHead className="w-[12%]">Runtime</TableHead>
+              <TableHead className="w-[8%]">Runtime</TableHead>
               <TableHead className="w-[7%]">Platform</TableHead>
               <TableHead className="w-[8%] text-right">Devices</TableHead>
               <TableHead className="w-[9%]">Health</TableHead>
               <TableHead className="w-[9%]">Commit</TableHead>
-              <TableHead className={canPublishUpdate ? 'w-[12%]' : 'w-[14%]'}>Published</TableHead>
+              <TableHead className={canPublishUpdate ? 'w-[10%]' : 'w-[12%]'}>Published</TableHead>
               {canPublishUpdate && <TableHead className="w-[6%]" />}
             </TableRow>
           </TableHeader>
@@ -692,7 +693,8 @@ export const Updates = () => {
                             <p
                               className="block max-w-full truncate font-medium text-foreground"
                               title={primary.message || `Update ${primary.updateId}`}>
-                              {primary.message || `Update ${primary.updateId}`}
+                              {updateTitle(primary.message, primary.commitHash) ||
+                                `Update ${primary.updateId}`}
                             </p>
                             <div className="mt-1 flex min-w-0 items-center gap-2 text-xs text-muted-foreground">
                               {isGroup && (
@@ -736,7 +738,7 @@ export const Updates = () => {
                         <CommitLabel value={primary.commitHash} />
                       </TableCell>
                       <TableCell>
-                        <TimestampCell dateString={primary.createdAt} />
+                        <TimestampCell dateString={primary.createdAt} compact />
                       </TableCell>
                       {canPublishUpdate && (
                         <TableCell className="text-right">
@@ -754,7 +756,9 @@ export const Updates = () => {
                                 setRepublishTarget({
                                   branch: primary.branch,
                                   runtimeVersion: primary.runtimeVersion,
-                                  label: primary.message || `Update ${primary.updateId}`,
+                                  label:
+                                    updateTitle(primary.message, primary.commitHash) ||
+                                    `Update ${primary.updateId}`,
                                   platforms,
                                   ...(isGroup
                                     ? { publishGroup: group.publishGroup as string }
@@ -821,7 +825,7 @@ export const Updates = () => {
                             <CommitLabel value={update.commitHash} />
                           </TableCell>
                           <TableCell>
-                            <TimestampCell dateString={update.createdAt} />
+                            <TimestampCell dateString={update.createdAt} compact />
                           </TableCell>
                           {/* No per-member republish: see the group row. */}
                           {canPublishUpdate && <TableCell />}

--- a/apps/dashboard/src/pages/Updates/index.tsx
+++ b/apps/dashboard/src/pages/Updates/index.tsx
@@ -601,7 +601,9 @@ export const Updates = () => {
                     </span>
                     <span>{rollout.branch}</span>
                     <span aria-hidden="true">·</span>
-                    <span>{rollout.runtimeVersion}</span>
+                    <span title={rollout.runtimeVersion}>
+                      {shortRuntimeVersion(rollout.runtimeVersion)}
+                    </span>
                     <span aria-hidden="true">·</span>
                     <span>{shortId(rollout.commitHash)}</span>
                   </div>


### PR DESCRIPTION
The updates feed is hard to scan: three of its columns spend more width than they earn.

Our CI publishes with `git log --oneline`, so every row opens with the same short hash the Commit column shows two columns later. This drops that prefix, but only when the leading token really is that update's commit hash — a message that legitimately starts with a hex-looking word is left alone. The full message stays in the tooltip and in the details sheet.

Runtime versions are 40-character fingerprints for us; they now show 8 characters with the full value on hover, while named ones ("1.0.0", "exposdk:52.0.0") are untouched. Published reads "Today 15:03" for today and "31/08/2026 09:12" otherwise, with the spelled-out timestamp on hover. That one is opt-in per table through a `compact` prop on TimestampCell, so the audit log, users and API token tables render exactly as before. The width this frees goes to the update title.

Dashboard only: no backend, no `ee/` file, no schema change. `npm run lint` (no new warnings) and `npm run build` pass.

Happy to split this into three commits, or to drop any of the three if you would rather keep the current density.

My problem:
<img width="3248" height="2122" alt="Screenshot 2026-09-01 at 16 05 23" src="https://github.com/user-attachments/assets/82397409-03e9-4305-ace4-9752868fc79a" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KwFirWRCJn6D75u5qYEEZ5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
* Added compact timestamp displays with full details available on hover.
* Improved date formatting, including “Today” labels and optional seconds.
* Simplified update titles by removing matching commit identifiers.
* Shortened long runtime version labels while preserving full values on hover.
* Added fallback labels when update titles are unavailable.

## UI Improvements
* Adjusted the Updates table layout to provide more space for update titles.
* Applied compact timestamps to update and group-member entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->