### PR TITLE
feat(dashboard): link update commit hashes and #123 refs to GitHub

### DIFF
--- a/apps/dashboard/src/components/UpdateDetailsSheet/index.tsx
+++ b/apps/dashboard/src/components/UpdateDetailsSheet/index.tsx
@@ -15,6 +15,8 @@ import { Badge } from '@/components/ui/badge.tsx';
 import { Button } from '@/components/ui/button.tsx';
 import { useSelectedApp } from '@/lib/SelectedAppContext';
 import { formatTimestamp } from '@/lib/utils';
+import { UpdateTitle } from '@/components/ui/update-title';
+import { useRepoLinks } from '@/hooks/use-repo-links';
 import { RolloutBar } from '@/components/rollout/RolloutBar';
 import { Check, ChevronDown, ChevronUp, Copy, Package, Split, Undo2 } from 'lucide-react';
 import { UpdateHealthHistory } from '@/ee/components/UpdateHealthHistory';
@@ -96,6 +98,7 @@ const UpdateDetailsBody = ({
   runtimeVersion: string;
 }) => {
   const { selectedAppId } = useSelectedApp();
+  const repo = useRepoLinks();
   const [showRawConfig, setShowRawConfig] = useState(false);
   // Keyed on what the fetch actually uses. Never updateUUID: every rollback
   // row shares the literal "Rollback to embedded", so two rollbacks from
@@ -105,6 +108,8 @@ const UpdateDetailsBody = ({
     enabled: !!update.updateId && !!selectedAppId && !!branch && !!runtimeVersion,
     queryFn: () => api.getUpdateDetails(branch, runtimeVersion, update.updateId),
   });
+
+  const commitUrl = data?.commitHash ? repo?.commitUrl(data.commitHash) : null;
 
   const expoConfig = useMemo(() => {
     if (!data?.expoConfig) return null;
@@ -233,13 +238,26 @@ const UpdateDetailsBody = ({
 
         <DetailSection title="Source">
           <DetailRow label="Commit">
-            <MonoValue value={data.commitHash} />
+            {commitUrl ? (
+              // truncate belongs on the anchor: it replaces MonoValue as the flex child.
+              <a
+                href={commitUrl}
+                target="_blank"
+                rel="noreferrer"
+                className="min-w-0 truncate text-link hover:underline">
+                <MonoValue value={data.commitHash} />
+              </a>
+            ) : (
+              <MonoValue value={data.commitHash} />
+            )}
             <CopyButton value={data.commitHash} label="commit hash" />
           </DetailRow>
           {data.message && (
             <div className="space-y-1 px-4 py-2.5">
               <span className="text-sm text-muted-foreground">Message</span>
-              <p className="text-sm font-medium">{data.message}</p>
+              <p className="text-sm font-medium">
+                <UpdateTitle title={data.message} links={repo} />
+              </p>
             </div>
           )}
         </DetailSection>

--- a/apps/dashboard/src/components/ui/update-title.tsx
+++ b/apps/dashboard/src/components/ui/update-title.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { splitPullRequestRefs } from '@/lib/update-format';
+import type { RepoLinks } from '@/lib/repo-links';
+
+type UpdateTitleProps = {
+  title: string;
+  links: RepoLinks | null;
+};
+
+// Links every `#123` in a title. The rows these sit in are clickable, so each
+// link stops its click from reaching the row.
+export const UpdateTitle: React.FC<UpdateTitleProps> = ({ title, links }) => {
+  if (!links) return <>{title}</>;
+  return (
+    <>
+      {splitPullRequestRefs(title).map((part, index) =>
+        'pr' in part ? (
+          <a
+            key={index}
+            href={links.pullUrl(part.pr)}
+            target="_blank"
+            rel="noreferrer"
+            className="text-link hover:underline"
+            onClick={event => event.stopPropagation()}>
+            #{part.pr}
+          </a>
+        ) : (
+          <React.Fragment key={index}>{part.text}</React.Fragment>
+        )
+      )}
+    </>
+  );
+};

--- a/apps/dashboard/src/hooks/use-repo-links.ts
+++ b/apps/dashboard/src/hooks/use-repo-links.ts
@@ -1,0 +1,12 @@
+import { useMemo } from 'react';
+import { useSelectedApp } from '@/lib/SelectedAppContext';
+import { repoLinksFor, type RepoLinks } from '@/lib/repo-links';
+
+// Null when the selected app has no repository, or it is not a GitHub one.
+export const useRepoLinks = (): RepoLinks | null => {
+  const { apps, selectedAppId } = useSelectedApp();
+  return useMemo(
+    () => repoLinksFor(apps.find(app => app.id === selectedAppId)?.repositoryUrl),
+    [apps, selectedAppId]
+  );
+};

--- a/apps/dashboard/src/lib/SelectedAppContext.tsx
+++ b/apps/dashboard/src/lib/SelectedAppContext.tsx
@@ -8,15 +8,10 @@ import {
   ReactNode,
 } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { api } from '@/lib/api';
+import { api, type AppDescriptor } from '@/lib/api';
 import { isAuthenticated } from '@/lib/auth.ts';
 
 const STORAGE_KEY = 'eoota.selectedAppId';
-
-export type AppDescriptor = {
-  id: string;
-  name?: string;
-};
 
 type SelectedAppContextValue = {
   apps: AppDescriptor[];

--- a/apps/dashboard/src/lib/api.ts
+++ b/apps/dashboard/src/lib/api.ts
@@ -54,6 +54,8 @@ export type KeysConfig = {
 export type AppDescriptor = {
   id: string;
   name?: string;
+  // Drives the commit and pull-request links on the updates screen.
+  repositoryUrl?: string;
 };
 
 // One audit log entry, as served by GET /api/audit/events. Displays are
@@ -841,7 +843,7 @@ export type ServerSettings = {
   CDN_TYPE: '' | 'cloudfront' | 'gcs-direct' | 's3-direct' | 'azure-direct' | 'generic';
   EXPO_ACCOUNT_USERNAME: string;
   SSO_ENABLED: boolean;
-  APPS: { id: string; name?: string }[];
+  APPS: AppDescriptor[];
 };
 
 // All per-app routes (branches, channels, runtime versions, updates,

--- a/apps/dashboard/src/lib/repo-links.ts
+++ b/apps/dashboard/src/lib/repo-links.ts
@@ -1,0 +1,40 @@
+// Links an update's commit hash and the `#123` in its message back to GitHub,
+// using the repository the server reports per app (EXPO_APP_REPOSITORY_URL).
+// Only github.com: the /commit/<sha> and /pull/<n> shapes are host-specific, and
+// guessing them elsewhere yields 404s, so anything else returns null and the
+// caller renders plain text.
+export type RepoLinks = {
+  // Null for a rollback, which stores no commit hash.
+  commitUrl: (sha: string) => string | null;
+  pullUrl: (pullNumber: string) => string;
+};
+
+const GITHUB_HOSTS = new Set(['github.com', 'www.github.com']);
+
+export const repoLinksFor = (repositoryUrl: string | undefined): RepoLinks | null => {
+  if (!repositoryUrl) return null;
+
+  let parsed: URL;
+  try {
+    parsed = new URL(repositoryUrl);
+  } catch {
+    return null;
+  }
+  if (!GITHUB_HOSTS.has(parsed.hostname.toLowerCase())) return null;
+
+  // Exactly owner + repo: a deeper path links into the repository, not to it.
+  const segments = parsed.pathname.split('/').filter(Boolean);
+  if (segments.length !== 2) return null;
+
+  const [owner, repoSegment] = segments;
+  // `git remote get-url` hands out the .git suffix; the web UI does not use it.
+  const repo = repoSegment.replace(/\.git$/i, '');
+  if (!repo) return null;
+
+  const base = `https://github.com/${owner}/${repo}`;
+  return {
+    commitUrl: sha => (sha ? `${base}/commit/${encodeURIComponent(sha)}` : null),
+    // GitHub redirects /pull/<n> to the issue when that number is one.
+    pullUrl: pullNumber => `${base}/pull/${encodeURIComponent(pullNumber)}`,
+  };
+};

--- a/apps/dashboard/src/lib/update-format.ts
+++ b/apps/dashboard/src/lib/update-format.ts
@@ -15,3 +15,23 @@ export const updateTitle = (message: string | undefined, commitHash: string) => 
 // named versions ("1.0.0", "exposdk:52.0.0") are left as they were set.
 export const shortRuntimeVersion = (value: string) =>
   /^[0-9a-f]{40}$/i.test(value) ? value.slice(0, 8) : value;
+
+// A squash merge puts the pull request number in the commit subject. Split
+// rather than replace, so `updateTitle` stays a plain string for the republish
+// dialog label and the `title` tooltips.
+export type TitlePart = { text: string } | { pr: string };
+
+export const splitPullRequestRefs = (title: string): TitlePart[] => {
+  const parts: TitlePart[] = [];
+  let cursor = 0;
+  // Trailing \w guard: "#123abc" is not a reference, so it must not link the
+  // "#123" prefix at some unrelated pull request.
+  for (const match of title.matchAll(/#(\d+)(?!\w)/g)) {
+    const start = match.index ?? 0;
+    if (start > cursor) parts.push({ text: title.slice(cursor, start) });
+    parts.push({ pr: match[1] });
+    cursor = start + match[0].length;
+  }
+  if (cursor < title.length) parts.push({ text: title.slice(cursor) });
+  return parts;
+};

--- a/apps/dashboard/src/pages/Updates/components/UpdatesTable/index.tsx
+++ b/apps/dashboard/src/pages/Updates/components/UpdatesTable/index.tsx
@@ -16,6 +16,8 @@ import { UpdateRolloutCard } from '@/pages/Updates/components/UpdateRolloutCard'
 import { aggregateUpdateHealth } from '@/pages/Updates/components/updateHealth';
 import { Button } from '@/components/ui/button';
 import { updateTitle } from '@/lib/update-format';
+import { UpdateTitle } from '@/components/ui/update-title';
+import { useRepoLinks } from '@/hooks/use-repo-links';
 
 const UPDATES_PAGE_SIZE = 20;
 
@@ -30,6 +32,7 @@ export const UpdatesTable = ({
 }) => {
   const sheetRef = useRef<UpdateDetailsRef>(null);
   const { selectedAppId } = useSelectedApp();
+  const repo = useRepoLinks();
   const { CONTROL_PLANE_ENABLED } = useSettings();
   const canManageUpdateRollout = useAppPermission('update-rollout:manage', 'admin-only');
   const updatesQuery = useInfiniteQuery({
@@ -148,7 +151,7 @@ export const UpdatesTable = ({
               const msg = updateTitle(row.original.message, row.original.commitHash);
               return msg ? (
                 <span className="block max-w-[200px] truncate text-sm text-muted-foreground">
-                  {msg}
+                  <UpdateTitle title={msg} links={repo} />
                 </span>
               ) : (
                 <span className="text-sm text-muted-foreground/60">No message</span>
@@ -159,10 +162,26 @@ export const UpdatesTable = ({
             header: 'Commit',
             accessorKey: 'commitHash',
             cell: ({ row }) => {
-              return (
-                <Badge variant="outline" className="font-mono text-xs">
+              const badge = (
+                <Badge
+                  variant="outline"
+                  className="font-mono text-xs"
+                  title={row.original.commitHash || undefined}>
                   {row.original.commitHash.slice(0, 7)}
                 </Badge>
+              );
+              const href = repo?.commitUrl(row.original.commitHash);
+              return href ? (
+                <a
+                  href={href}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="inline-flex hover:underline"
+                  onClick={event => event.stopPropagation()}>
+                  {badge}
+                </a>
+              ) : (
+                badge
               );
             },
           },

--- a/apps/dashboard/src/pages/Updates/index.tsx
+++ b/apps/dashboard/src/pages/Updates/index.tsx
@@ -35,6 +35,7 @@ import {
   TableRow,
 } from '@/components/ui/table';
 import { TimestampCell } from '@/components/ui/timestamp-cell';
+import { UpdateTitle } from '@/components/ui/update-title';
 import { UpdateDetailsRef, UpdateDetailsSheet } from '@/components/UpdateDetailsSheet';
 import {
   ManagedUpdateRollout,
@@ -50,6 +51,7 @@ import android from '@/assets/android.svg';
 import { HealthBadge } from '@/pages/Updates/components/HealthBadge';
 import { aggregateUpdateHealth } from '@/pages/Updates/components/updateHealth';
 import { shortRuntimeVersion, updateTitle } from '@/lib/update-format';
+import { useRepoLinks } from '@/hooks/use-repo-links';
 
 type FeedGroup = {
   key: string;
@@ -152,12 +154,44 @@ const RuntimeLabel = ({ value }: { value: string }) => (
   </span>
 );
 
-const CommitLabel = ({ value }: { value: string }) => (
-  <span className="inline-flex items-center gap-1.5 rounded-md border border-primary/20 bg-primary/[0.07] px-2 py-1 text-xs font-medium text-link">
-    <GitCommitHorizontal className="h-3 w-3 text-link/80" />
-    {shortId(value)}
-  </span>
-);
+// Unlinked for a rollback (no hash) or an unconfigured repo. The row is
+// clickable, so the anchor stops its click.
+const CommitLabel = ({ value, href }: { value: string; href?: string | null }) => {
+  const chip = (
+    <span
+      className="inline-flex items-center gap-1.5 rounded-md border border-primary/20 bg-primary/[0.07] px-2 py-1 text-xs font-medium text-link"
+      title={value || undefined}>
+      <GitCommitHorizontal className="h-3 w-3 text-link/80" />
+      {shortId(value)}
+    </span>
+  );
+  if (!href) return chip;
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noreferrer"
+      className="inline-flex hover:underline"
+      onClick={event => event.stopPropagation()}>
+      {chip}
+    </a>
+  );
+};
+
+// CommitLabel without the chip, for the rollout banner's plain text run.
+const CommitText = ({ value, href }: { value: string; href?: string | null }) =>
+  href ? (
+    <a
+      href={href}
+      target="_blank"
+      rel="noreferrer"
+      title={value}
+      className="text-link hover:underline">
+      {shortId(value)}
+    </a>
+  ) : (
+    <span title={value || undefined}>{shortId(value)}</span>
+  );
 
 const BranchLabel = ({ branch }: { branch: string }) => (
   <span className="inline-flex max-w-full items-center gap-1.5 font-medium text-foreground">
@@ -168,6 +202,7 @@ const BranchLabel = ({ branch }: { branch: string }) => (
 
 export const Updates = () => {
   const { selectedAppId } = useSelectedApp();
+  const repo = useRepoLinks();
   const canManageUpdateRollout = useAppPermission('update-rollout:manage', 'admin-only');
   const canPublishUpdate = useAppPermission('update:publish', 'admin-only');
   const [searchParams, setSearchParams] = useSearchParams();
@@ -605,7 +640,10 @@ export const Updates = () => {
                       {shortRuntimeVersion(rollout.runtimeVersion)}
                     </span>
                     <span aria-hidden="true">·</span>
-                    <span>{shortId(rollout.commitHash)}</span>
+                    <CommitText
+                      value={rollout.commitHash}
+                      href={repo?.commitUrl(rollout.commitHash)}
+                    />
                   </div>
                 </div>
               </div>
@@ -695,8 +733,13 @@ export const Updates = () => {
                             <p
                               className="block max-w-full truncate font-medium text-foreground"
                               title={primary.message || `Update ${primary.updateId}`}>
-                              {updateTitle(primary.message, primary.commitHash) ||
-                                `Update ${primary.updateId}`}
+                              <UpdateTitle
+                                title={
+                                  updateTitle(primary.message, primary.commitHash) ||
+                                  `Update ${primary.updateId}`
+                                }
+                                links={repo}
+                              />
                             </p>
                             <div className="mt-1 flex min-w-0 items-center gap-2 text-xs text-muted-foreground">
                               {isGroup && (
@@ -737,7 +780,10 @@ export const Updates = () => {
                         <HealthBadge health={groupHealth} />
                       </TableCell>
                       <TableCell>
-                        <CommitLabel value={primary.commitHash} />
+                        <CommitLabel
+                          value={primary.commitHash}
+                          href={repo?.commitUrl(primary.commitHash)}
+                        />
                       </TableCell>
                       <TableCell>
                         <TimestampCell dateString={primary.createdAt} compact />
@@ -824,7 +870,10 @@ export const Updates = () => {
                             <HealthBadge health={healthByUuid[update.updateUUID]} />
                           </TableCell>
                           <TableCell>
-                            <CommitLabel value={update.commitHash} />
+                            <CommitLabel
+                              value={update.commitHash}
+                              href={repo?.commitUrl(update.commitHash)}
+                            />
                           </TableCell>
                           <TableCell>
                             <TimestampCell dateString={update.createdAt} compact />

--- a/apps/eoas/src/lib/serverConfig/envCatalog.ts
+++ b/apps/eoas/src/lib/serverConfig/envCatalog.ts
@@ -416,6 +416,14 @@ export const ENV_SECTIONS: EnvSection[] = [
         comment: 'Key prefix inside the bucket, for a bucket shared with other data.',
       },
       {
+        name: 'EXPO_APP_REPOSITORY_URL',
+        applies: () => true,
+        required: false,
+        value: () => '',
+        comment:
+          "Source repository (e.g. https://github.com/acme/mobile-app). Lets the dashboard link an update's commit hash and any #123 in its message. GitHub only.",
+      },
+      {
         name: 'AZURE_BLOB_ENDPOINT',
         applies: c => c.storage === 'azure',
         required: false,

--- a/config/apps.go
+++ b/config/apps.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 	"unicode"
+	"xprem/internal/helpers"
 )
 
 // maxAppIdLen caps the app id length. Long enough for UUIDs (36), ULIDs (26),
@@ -76,6 +77,8 @@ type AppConfig struct {
 	AccessToken string        `json:"accessToken,omitempty"`
 	Keys        KeysConfig    `json:"keys"`
 	CreatedAt   time.Duration `json:"createTime,omitempty"`
+	// Display-only, like Name: never participates in routing.
+	RepositoryUrl string `json:"repositoryUrl,omitempty"`
 }
 
 // AppDescriptor is the public-safe view of an AppConfig (no token, no keys)
@@ -84,6 +87,8 @@ type AppConfig struct {
 type AppDescriptor struct {
 	Id   string `json:"id"`
 	Name string `json:"name,omitempty"`
+	// Safe to expose for the same reason Name is: a label, not a credential.
+	RepositoryUrl string `json:"repositoryUrl,omitempty"`
 }
 
 var (
@@ -166,8 +171,9 @@ func LegacyFallbackAppId() string {
 // JSON case.
 func parseFlatEnvApp(appId string) AppConfig {
 	app := AppConfig{
-		Id:          appId,
-		AccessToken: os.Getenv("EXPO_ACCESS_TOKEN"),
+		Id:            appId,
+		AccessToken:   os.Getenv("EXPO_ACCESS_TOKEN"),
+		RepositoryUrl: RepositoryURL(),
 	}
 	switch os.Getenv("KEYS_STORAGE_TYPE") {
 	case "local", "":
@@ -203,6 +209,10 @@ func validateApp(app *AppConfig, index int) error {
 	}
 	if app.AccessToken == "" {
 		return fmt.Errorf("%s.accessToken is required", prefix)
+	}
+	// A typo'd value would silently render dead links, so reject it at boot.
+	if app.RepositoryUrl != "" && !helpers.IsValidURL(app.RepositoryUrl) {
+		return fmt.Errorf("%s.repositoryUrl %q is not a valid URL", prefix, app.RepositoryUrl)
 	}
 	return ValidateKeys(&app.Keys, prefix+".keys")
 }
@@ -346,7 +356,7 @@ func ListApps() []AppDescriptor {
 	defer appsByIdMu.RUnlock()
 	out := make([]AppDescriptor, 0, len(appsById))
 	for _, app := range appsById {
-		out = append(out, AppDescriptor{Id: app.Id, Name: app.Name})
+		out = append(out, AppDescriptor{Id: app.Id, Name: app.Name, RepositoryUrl: app.RepositoryUrl})
 	}
 	return out
 }

--- a/config/apps_test.go
+++ b/config/apps_test.go
@@ -32,6 +32,7 @@ func resetAppsEnv(t *testing.T) {
 		"AWSSM_EXPO_PRIVATE_KEY_SECRET_ID",
 		"PUBLIC_EXPO_KEY_B64",
 		"PRIVATE_EXPO_KEY_B64",
+		"EXPO_APP_REPOSITORY_URL",
 	}
 	for _, v := range vars {
 		os.Unsetenv(v)
@@ -515,6 +516,84 @@ func TestListApps_ReturnsDescriptorsWithName(t *testing.T) {
 func TestListApps_EmptyWhenNoConfigLoaded(t *testing.T) {
 	resetAppsEnv(t)
 	assert.Empty(t, ListApps())
+}
+
+// -----------------------------------------------------------------------------
+// Optional RepositoryUrl. A malformed value must fail at boot rather than render
+// dead links, and the value has to reach the descriptor.
+// -----------------------------------------------------------------------------
+
+func TestLoadAppsFromFlatEnv_CarriesRepositoryUrl(t *testing.T) {
+	resetAppsEnv(t)
+	os.Setenv("EXPO_APP_ID", "solo")
+	os.Setenv("EXPO_ACCESS_TOKEN", "tok")
+	os.Setenv("PUBLIC_LOCAL_EXPO_KEY_PATH", "/k/pub.pem")
+	os.Setenv("PRIVATE_LOCAL_EXPO_KEY_PATH", "/k/priv.pem")
+	os.Setenv("EXPO_APP_REPOSITORY_URL", "https://github.com/acme/mobile-app")
+
+	require.NoError(t, LoadAppsFromFlatEnv())
+	a, err := GetAppConfig("solo")
+	require.NoError(t, err)
+	assert.Equal(t, "https://github.com/acme/mobile-app", a.RepositoryUrl)
+}
+
+func TestLoadAppsFromFlatEnv_TrimsRepositoryUrlTrailingSlash(t *testing.T) {
+	// The dashboard appends /commit/<sha>, so a trailing slash would double up.
+	resetAppsEnv(t)
+	os.Setenv("EXPO_APP_ID", "solo")
+	os.Setenv("EXPO_ACCESS_TOKEN", "tok")
+	os.Setenv("PUBLIC_LOCAL_EXPO_KEY_PATH", "/k/pub.pem")
+	os.Setenv("PRIVATE_LOCAL_EXPO_KEY_PATH", "/k/priv.pem")
+	os.Setenv("EXPO_APP_REPOSITORY_URL", "  https://github.com/acme/mobile-app/  ")
+
+	require.NoError(t, LoadAppsFromFlatEnv())
+	a, err := GetAppConfig("solo")
+	require.NoError(t, err)
+	assert.Equal(t, "https://github.com/acme/mobile-app", a.RepositoryUrl)
+}
+
+func TestLoadAppsFromFlatEnv_RepositoryUrlIsOptional(t *testing.T) {
+	resetAppsEnv(t)
+	os.Setenv("EXPO_APP_ID", "solo")
+	os.Setenv("EXPO_ACCESS_TOKEN", "tok")
+	os.Setenv("PUBLIC_LOCAL_EXPO_KEY_PATH", "/k/pub.pem")
+	os.Setenv("PRIVATE_LOCAL_EXPO_KEY_PATH", "/k/priv.pem")
+
+	require.NoError(t, LoadAppsFromFlatEnv())
+	a, err := GetAppConfig("solo")
+	require.NoError(t, err)
+	assert.Empty(t, a.RepositoryUrl)
+}
+
+func TestValidateApp_RejectsMalformedRepositoryUrl(t *testing.T) {
+	app := AppConfig{
+		Id:            "app-1",
+		AccessToken:   "token",
+		RepositoryUrl: "github.com/acme/mobile-app",
+		Keys: KeysConfig{
+			Mode:        KeysModeLocal,
+			PublicPath:  "/p",
+			PrivatePath: "/q",
+		},
+	}
+	err := validateApp(&app, 0)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "apps[0].repositoryUrl")
+}
+
+func TestListApps_ReturnsDescriptorsWithRepositoryUrl(t *testing.T) {
+	resetAppsEnv(t)
+	SetAppsForTest([]AppConfig{
+		{Id: "a", RepositoryUrl: "https://github.com/acme/a", AccessToken: "t", Keys: KeysConfig{Mode: KeysModeLocal, PublicPath: "/p", PrivatePath: "/q"}},
+		{Id: "b", AccessToken: "t", Keys: KeysConfig{Mode: KeysModeLocal, PublicPath: "/p", PrivatePath: "/q"}},
+	})
+
+	byId := map[string]AppDescriptor{}
+	for _, d := range ListApps() {
+		byId[d.Id] = d
+	}
+	assert.Equal(t, "https://github.com/acme/a", byId["a"].RepositoryUrl)
+	assert.Equal(t, "", byId["b"].RepositoryUrl)
 }
 
 func TestResetAppsForTest_ClearsRegistry(t *testing.T) {

--- a/config/config.go
+++ b/config/config.go
@@ -135,6 +135,12 @@ func BaseURL() string {
 	return strings.TrimRight(GetEnv("BASE_URL"), "/")
 }
 
+// RepositoryURL is the repository published updates come from, so the dashboard
+// can link a commit hash and any #123 in a message. Empty means unconfigured.
+func RepositoryURL() string {
+	return strings.TrimRight(strings.TrimSpace(GetEnv("EXPO_APP_REPOSITORY_URL")), "/")
+}
+
 // ServeFromSubPath reports whether the server itself serves under BASE_URL's
 // path; when false the reverse proxy is expected to strip the prefix.
 func ServeFromSubPath() bool {
@@ -200,6 +206,11 @@ func LoadConfig() {
 	jwtSecret := GetEnv("JWT_SECRET")
 	if jwtSecret == "" {
 		log.Fatalf("JWT_SECRET not set")
+	}
+	// Checked here rather than only in validateApp, which the control plane
+	// never reaches: both modes read this var, so both must reject a bad one.
+	if repositoryUrl := RepositoryURL(); repositoryUrl != "" && !helpers.IsValidURL(repositoryUrl) {
+		log.Fatalf("Invalid EXPO_APP_REPOSITORY_URL: %s", repositoryUrl)
 	}
 }
 

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -465,6 +465,12 @@ environment:
     value: ""
     enabled: true
     required: false
+  # Source repository, e.g. "https://github.com/acme/mobile-app". Lets the
+  # dashboard link an update's commit hash and any #123 in its message. GitHub only.
+  - name: "EXPO_APP_REPOSITORY_URL"
+    value: ""
+    enabled: true
+    required: false
   # Control Plane (DB mode). Rendered only when controlPlane="true". Set DB_URL
   # and the master key, whose source is picked by dbKeysMasterKeySource. The
   # master key seals per-app signing keys at rest — generate it with

--- a/internal/dashboard/dashboard.go
+++ b/internal/dashboard/dashboard.go
@@ -1,6 +1,8 @@
 package dashboard
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"xprem/config"
 	"xprem/internal/version"
@@ -10,15 +12,23 @@ func IsDashboardEnabled() bool {
 	return config.GetEnv("USE_DASHBOARD") == "true"
 }
 
+// The app payloads carry the repository URL, which comes from an env var, not
+// the store: without it in the key, a cache outliving the process (redis) would
+// keep serving the old value past a restart.
+func repositoryFingerprint() string {
+	sum := sha256.Sum256([]byte(config.RepositoryURL()))
+	return hex.EncodeToString(sum[:4])
+}
+
 // Dashboard cache keys must include the appId so entries from one app aren't
 // served to another within the TTL (multi-tenant cache bleeding).
 
 func ComputeGetAppCacheKey(appId string) string {
-	return fmt.Sprintf("dashboard:%s:app:%s:request:getApp", version.Version, appId)
+	return fmt.Sprintf("dashboard:%s:%s:app:%s:request:getApp", version.Version, repositoryFingerprint(), appId)
 }
 
 func ComputeGetAppsCacheKey() string {
-	return fmt.Sprintf("dashboard:%s:request:getApps", version.Version)
+	return fmt.Sprintf("dashboard:%s:%s:request:getApps", version.Version, repositoryFingerprint())
 }
 
 func ComputeGetRuntimeVersionsCacheKey(appId, branch string) string {

--- a/internal/services/app_service.go
+++ b/internal/services/app_service.go
@@ -160,7 +160,24 @@ func (s *AppService) DeleteApp(ctx context.Context, app config.AppConfig) error 
 }
 
 func (s *AppService) GetApps(ctx context.Context) ([]config.AppDescriptor, error) {
-	return s.appRepo.GetApps(ctx)
+	apps, err := s.appRepo.GetApps(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for i := range apps {
+		apps[i].RepositoryUrl = resolveRepositoryUrl(apps[i].RepositoryUrl)
+	}
+	return apps, nil
+}
+
+// resolveRepositoryUrl fills in the repository for an app that carries none.
+// The control plane has no apps.repository_url column yet, so its rows fall back
+// to the server-wide env var: right for one repo, wrong for a plane hosting many.
+func resolveRepositoryUrl(configured string) string {
+	if configured != "" {
+		return configured
+	}
+	return config.RepositoryURL()
 }
 
 func (s *AppService) GetAppByID(ctx context.Context, appId string) (config.AppConfig, error) {
@@ -190,6 +207,8 @@ func (s *AppService) PresentApp(ctx context.Context, app config.AppConfig) confi
 		// device-facing OTA path never pays the Expo round-trip.
 		app.Name = expo.FetchAppName(ctx, app.Id)
 	}
+	// Same fallback the listing applies, so /api/apps/{id} and /api/apps agree.
+	app.RepositoryUrl = resolveRepositoryUrl(app.RepositoryUrl)
 	return app
 }
 


### PR DESCRIPTION
Rebased onto `main` now that #202 has landed — this PR is just the linking feature.

## Problem

On `/dashboard/updates` the commit hash and the `#12345` in an update title are dead text. The data is already there — the `eoas` CLI sends `commitHash` at publish time, and a squash merge puts the PR number in the message — but **xprem has no idea which repository an app publishes from**. No `repository_url` exists anywhere in `config/`, `internal/`, the migrations, or the dashboard.

## Config — `EXPO_APP_REPOSITORY_URL`

Per app, no DB migration:

- `config.AppConfig` / `config.AppDescriptor` gain `RepositoryUrl`. The descriptor is what `/api/settings` (`APPS`) and `/api/apps` already return, so the dashboard gets it with no extra call.
- Stateless mode reads it in `parseFlatEnvApp`; a malformed value fails at boot in `validateApp` rather than rendering dead links.
- The control plane has no `apps.repository_url` column yet, so its rows fall back to the same server-wide value in `AppService.GetApps` / `PresentApp`. That is right for the common one-server-one-repo deploy and wrong for a control plane serving apps from different repositories — which is exactly what a column would later fix. Called out in a comment at the fallback.
- Declared in `helm/values.yaml` and `apps/eoas/src/lib/serverConfig/envCatalog.ts`, the two hand-maintained mirrors of the server config.

## Dashboard

`repoLinksFor()` understands **github.com only**. The `/commit/<sha>` and `/pull/<n>` path shapes are host-specific, and guessing them for a host we have not been taught produces links that 404 — worse than the plain text they replaced. Anything else (GitLab, a deep path, a malformed value, unset) returns null and every call site renders exactly what it renders today.

Linked in four places: the commit chips on the feed (group and child rows), the active-rollout banner, the details sheet, and the per-branch updates table. Every `#123` in a title links too, wherever it appears in the string.

### Details worth a look

- **Row clicks**: feed rows carry an `onClick` that opens the details sheet or toggles the group. Every anchor calls `stopPropagation()`, matching the guard the republish button already uses.
- **Rollbacks** store no commit hash, so `commitUrl('')` returns null and the chip stays an unlinked label.
- `splitPullRequestRefs` splits rather than replaces, so `updateTitle` stays a pure string for the republish dialog label and the `title` tooltips.
- Commit chips now carry `title={fullHash}`, putting the full hash one hover away — matching what `RuntimeLabel` already did.

## Verification

- `gofmt -l` clean, `go vet`, `go build ./...`, and `go test ./config/... ./internal/services/...` all pass, run in `golang:1.26-alpine` to match the Dockerfile.
- Six new cases in `config/apps_test.go`: the env var landing on the config, trailing-slash and whitespace trimming, it being optional, a malformed URL rejected at boot, and the descriptor carrying it. `EXPO_APP_REPOSITORY_URL` added to `resetAppsEnv`, as that helper's comment requires.
- `apps/dashboard`: `npm run build` and `npm run lint` clean — 12 warnings, byte-identical to base, 0 introduced here.
- `apps/eoas`: 188 tests pass.
- URL building and title splitting exercised directly against the real modules: `.git` suffix, trailing slash, `www.`, GitLab, owner-only and deep paths, an empty sha, multiple `#refs` in one title, and `C#`/`F#` correctly not matched.

Not covered: `apps/dashboard` has no test runner at all, so `repo-links.ts` and `splitPullRequestRefs` ship as pure functions ready for one, but without unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S998aEjkjwBu3CKTuwKVZe

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updates now link commit hashes and pull request references to the configured GitHub repository.
  * Update titles and commit messages display in a clearer, more readable format.
  * Added optional repository URL configuration for applications, with server-level fallback support.

* **Bug Fixes**
  * Unsupported GitHub URL formats safely fall back to plain text.
  * Invalid configured repository URLs are rejected during startup.
  * Rollback commits without hashes no longer produce broken links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->