### PR TITLE
fix(v2): prevent stale latest-update cache after publish

### DIFF
--- a/internal/update/prewarm.go
+++ b/internal/update/prewarm.go
@@ -1,13 +1,39 @@
 package update
 
 import (
+	"expo-open-ota/internal/types"
 	"log"
 )
 
-// PreWarmManifestCache populates the manifest cache layers for the given
-// branch/runtimeVersion/platform combination. It is intended to be called
-// as a goroutine after MarkUpdateAsChecked so the first client request
-// hits warm caches instead of rebuilding everything from scratch.
+// PreWarmUpdateManifestCache populates the metadata/manifest cache layers for a
+// known update. It intentionally does not resolve the latest update or write the
+// lastUpdate cache: callers that just marked an update as checked already know
+// which update should be warmed, and resolving latest here can race with stale
+// lastUpdate entries.
+func PreWarmUpdateManifestCache(update types.Update, platform string) {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Printf("[PreWarm] panic recovered for update=%s platform=%s: %v", update.UpdateId, platform, r)
+		}
+	}()
+
+	metadata, err := GetMetadata(update)
+	if err != nil {
+		log.Printf("[PreWarm] error getting metadata for update=%s: %v", update.UpdateId, err)
+		return
+	}
+
+	_, err = ComposeUpdateManifest(&metadata, update, platform)
+	if err != nil {
+		log.Printf("[PreWarm] error composing manifest for update=%s platform=%s: %v", update.UpdateId, platform, err)
+		return
+	}
+
+	log.Printf("[PreWarm] successfully pre-warmed manifest cache for update=%s platform=%s", update.UpdateId, platform)
+}
+
+// PreWarmManifestCache resolves the latest checked update for the given
+// branch/runtimeVersion/platform combination and warms its manifest cache.
 func PreWarmManifestCache(branch, runtimeVersion, platform string) {
 	defer func() {
 		if r := recover(); r != nil {

--- a/internal/update/updates.go
+++ b/internal/update/updates.go
@@ -96,8 +96,7 @@ func MarkUpdateAsChecked(update types.Update) error {
 	}
 	reader := strings.NewReader(".check")
 	_ = resolvedBucket.UploadFileIntoUpdate(update, ".check", reader)
-	go PreWarmManifestCache(update.Branch, update.RuntimeVersion, "ios")
-	go PreWarmManifestCache(update.Branch, update.RuntimeVersion, "android")
+	go PreWarmUpdateManifestCache(update, storedMetadata.Platform)
 	return nil
 }
 

--- a/internal/update/updates.go
+++ b/internal/update/updates.go
@@ -85,18 +85,34 @@ func MarkUpdateAsChecked(update types.Update) error {
 	if err != nil || storedMetadata == nil {
 		return err
 	}
-	cacheKeys := []string{ComputeLastUpdateCacheKey(update.Branch, update.RuntimeVersion, storedMetadata.Platform), branchesCacheKey, runTimeVersionsCacheKey, updatesCacheKey}
-	for _, cacheKey := range cacheKeys {
-		cache.Delete(cacheKey)
-	}
 	resolvedBucket := bucket.GetBucket()
 	err = StoreUpdateUUIDInMetadata(update)
 	if err != nil {
 		return err
 	}
-	reader := strings.NewReader(".check")
-	_ = resolvedBucket.UploadFileIntoUpdate(update, ".check", reader)
-	go PreWarmUpdateManifestCache(update, storedMetadata.Platform)
+	cacheKeys := []string{ComputeLastUpdateCacheKey(update.Branch, update.RuntimeVersion, storedMetadata.Platform), branchesCacheKey, runTimeVersionsCacheKey, updatesCacheKey}
+	return finalizeCheckedUpdate(
+		func() error {
+			return resolvedBucket.UploadFileIntoUpdate(update, ".check", strings.NewReader(".check"))
+		},
+		func() {
+			for _, cacheKey := range cacheKeys {
+				cache.Delete(cacheKey)
+			}
+		},
+		func() { PreWarmUpdateManifestCache(update, storedMetadata.Platform) },
+	)
+}
+
+// finalizeCheckedUpdate publishes the validity marker before invalidating the
+// cached latest update. Otherwise a concurrent manifest request can repopulate
+// lastUpdate with the previous update while the new update is still invalid.
+func finalizeCheckedUpdate(uploadCheck func() error, invalidate func(), prewarm func()) error {
+	if err := uploadCheck(); err != nil {
+		return err
+	}
+	invalidate()
+	go prewarm()
 	return nil
 }
 

--- a/internal/update/updates_test.go
+++ b/internal/update/updates_test.go
@@ -1,0 +1,61 @@
+package update
+
+import (
+	"errors"
+	"sync/atomic"
+	"testing"
+)
+
+func TestFinalizeCheckedUpdatePublishesCheckBeforeInvalidatingLatestCache(t *testing.T) {
+	uploadStarted := make(chan struct{})
+	allowUpload := make(chan struct{})
+	done := make(chan error, 1)
+	var invalidated atomic.Bool
+	prewarmed := make(chan struct{})
+
+	go func() {
+		done <- finalizeCheckedUpdate(
+			func() error {
+				close(uploadStarted)
+				<-allowUpload
+				return nil
+			},
+			func() { invalidated.Store(true) },
+			func() { close(prewarmed) },
+		)
+	}()
+
+	<-uploadStarted
+	if invalidated.Load() {
+		t.Fatal("latest-update cache was invalidated before .check was published")
+	}
+	close(allowUpload)
+	if err := <-done; err != nil {
+		t.Fatalf("finalizeCheckedUpdate() error = %v", err)
+	}
+	if !invalidated.Load() {
+		t.Fatal("latest-update cache was not invalidated after .check was published")
+	}
+	<-prewarmed
+}
+
+func TestFinalizeCheckedUpdateUploadFailurePreservesLatestCache(t *testing.T) {
+	wantErr := errors.New("upload failed")
+	var invalidated atomic.Bool
+	var prewarmed atomic.Bool
+
+	err := finalizeCheckedUpdate(
+		func() error { return wantErr },
+		func() { invalidated.Store(true) },
+		func() { prewarmed.Store(true) },
+	)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("finalizeCheckedUpdate() error = %v, want %v", err, wantErr)
+	}
+	if invalidated.Load() {
+		t.Fatal("latest-update cache was invalidated after .check upload failed")
+	}
+	if prewarmed.Load() {
+		t.Fatal("cache prewarm ran after .check upload failed")
+	}
+}

--- a/test/manifest_test.go
+++ b/test/manifest_test.go
@@ -636,7 +636,6 @@ func TestEmptyRequestForAndroid(t *testing.T) {
 	assert.Equal(t, "{\"type\":\"noUpdateAvailable\"}", body)
 }
 
-
 func TestPreWarmManifestCache(t *testing.T) {
 	teardown := setup(t)
 	defer teardown()
@@ -665,4 +664,26 @@ func TestPreWarmManifestCache(t *testing.T) {
 	// Verify manifest cache was populated
 	manifestKey := update.ComputeUpdataManifestCacheKey("branch-1", "1", cachedUpdate.UpdateId, "android")
 	assert.NotEqual(t, "", cache.Get(manifestKey), "manifest cache should be populated after prewarm")
+}
+
+func TestPreWarmUpdateManifestCacheDoesNotPopulateLastUpdateCache(t *testing.T) {
+	teardown := setup(t)
+	defer teardown()
+	mockWorkingExpoResponse("staging")
+
+	cache := cache2.GetCache()
+	checkedUpdate := types.Update{
+		Branch:         "branch-1",
+		RuntimeVersion: "1",
+		UpdateId:       "1674170951",
+	}
+
+	lastUpdateKey := update.ComputeLastUpdateCacheKey("branch-1", "1", "android")
+	assert.Equal(t, "", cache.Get(lastUpdateKey), "lastUpdate cache should be empty before prewarm")
+
+	update.PreWarmUpdateManifestCache(checkedUpdate, "android")
+
+	manifestKey := update.ComputeUpdataManifestCacheKey("branch-1", "1", "1674170951", "android")
+	assert.NotEqual(t, "", cache.Get(manifestKey), "manifest cache should be populated after prewarm")
+	assert.Equal(t, "", cache.Get(lastUpdateKey), "prewarming a known update should not populate lastUpdate cache")
 }


### PR DESCRIPTION
## Summary

This v2.3.x backport fixes the stale manifest / `lastUpdate` cache race discussed in #201 and #84, and completes the earlier work from #85. It supersedes the incorrectly based, closed PR #200.

- Prewarms the known checked update directly, so prewarm does not resolve or repopulate `lastUpdate`.
- Writes the new update's `.check` marker before invalidating `lastUpdate` and related dashboard caches, preventing a concurrent manifest request from recaching the previous update during publication.
- Returns `.check` upload failures instead of invalidating caches and reporting success.
- Adds deterministic ordering/concurrency coverage and an integration regression for known-update prewarm.

## Verification

Verified on a remote Windows/WSL environment against exact head `e2f60c16fcc700a9060191e5937fff5767419269`:

```text
gofmt -w internal/update/updates.go internal/update/updates_test.go
go test ./internal/update -run TestFinalizeCheckedUpdate -count=20
go test ./test -run TestPreWarmUpdateManifestCacheDoesNotPopulateLastUpdateCache -count=10
go build ./...
go vet ./internal/update ./test
go test ./...
```

All commands above passed. Full-repository `go vet ./...` was also run and reported only the pre-existing v2.3.22 finding in unchanged `internal/auth/auth.go:24`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved update-check completion handling so cache invalidation occurs only after the update validity marker is successfully published.
  - Ensured publication errors are reported instead of being ignored.
  - Limited manifest prewarming to the update’s stored platform.
  - Prevented manifest prewarming from altering the latest-update cache.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->