### PR TITLE
fix: change side bar opening direction

### DIFF
--- a/apps/dashboard/src/containers/Layout/index.tsx
+++ b/apps/dashboard/src/containers/Layout/index.tsx
@@ -60,7 +60,7 @@ export const Layout = ({ children }: { children: React.ReactNode }) => {
         </main>
       </div>
       <Sheet open={mobileNavOpen} onOpenChange={setMobileNavOpen}>
-        <SheetContent side="left" className="w-72 p-0">
+        <SheetContent side="right" className="w-72 p-0">
           <SheetTitle className="sr-only">Navigation</SheetTitle>
           <AppSidebar
             mobile


### PR DESCRIPTION
This pull request changes the side on which the mobile navigation sheet appears in the dashboard layout. The navigation sheet now opens from the right side of the screen instead of the left.

- Changed the `SheetContent` component in `Layout` to open on the right side (`side="right"`) instead of the left (`side="left"`) for mobile navigation.

Closes: #207 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Mobile navigation now opens from the right side of the screen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->