### PR TITLE
feat(dashboard): link updates to source repositories

### DIFF
--- a/apps/dashboard/src/components/GitCommitLink.tsx
+++ b/apps/dashboard/src/components/GitCommitLink.tsx
@@ -1,0 +1,135 @@
+import { ExternalLink, GitCommitHorizontal } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { gitRepositoryFor, type GitProvider } from '@/lib/git';
+
+const BitbucketIcon = ({ className }: { className?: string }) => (
+  <svg viewBox="0 0 24 24" fill="currentColor" className={className} aria-hidden="true">
+    <path d="M.778 1.213a.768.768 0 0 0-.768.892l3.263 19.81c.084.5.515.868 1.022.873H19.95a.772.772 0 0 0 .77-.646l3.27-20.03a.768.768 0 0 0-.768-.891zM14.52 15.53H9.522L8.17 8.466h7.561z" />
+  </svg>
+);
+
+const CursorIcon = ({ className }: { className?: string }) => (
+  <svg viewBox="90 67 332 379" fill="currentColor" className={className} aria-hidden="true">
+    <path d="m415.348 156.575-151.504-87.4699c-4.865-2.8094-10.868-2.8094-15.733 0l-151.4964 87.4699c-4.0897 2.361-6.6146 6.728-6.6146 11.458v176.383c0 4.73 2.5249 9.097 6.6146 11.459l151.5034 87.469c4.865 2.81 10.868 2.81 15.733 0l151.504-87.469c4.09-2.362 6.615-6.729 6.615-11.459v-176.383c0-4.73-2.525-9.097-6.615-11.458zm-9.517 18.528-146.254 253.319c-.989 1.707-3.599 1.01-3.599-.967v-165.871c0-3.314-1.771-6.38-4.645-8.044l-143.644-82.932c-1.707-.989-1.01-3.599.967-3.599h292.51c4.153 0 6.749 4.502 4.672 8.101h-.007z" />
+  </svg>
+);
+
+const GitHubIcon = ({ className }: { className?: string }) => (
+  <svg viewBox="0 0 24 24" fill="currentColor" className={className} aria-hidden="true">
+    <path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12" />
+  </svg>
+);
+
+const GitLabIcon = ({ className }: { className?: string }) => (
+  <svg viewBox="0 0 24 24" fill="currentColor" className={className} aria-hidden="true">
+    <path d="m23.6004 9.5927-.0337-.0862L20.3.9814a.851.851 0 0 0-.3362-.405.8748.8748 0 0 0-.9997.0539.8748.8748 0 0 0-.29.4399l-2.2055 6.748H7.5375l-2.2057-6.748a.8573.8573 0 0 0-.29-.4412.8748.8748 0 0 0-.9997-.0537.8585.8585 0 0 0-.3362.4049L.4332 9.5015l-.0325.0862a6.0657 6.0657 0 0 0 2.0119 7.0105l.0113.0087.03.0213 4.976 3.7264 2.462 1.8633 1.4995 1.1321a1.0085 1.0085 0 0 0 1.2197 0l1.4995-1.1321 2.4619-1.8633 5.006-3.7489.0125-.01a6.0682 6.0682 0 0 0 2.0094-7.003z" />
+  </svg>
+);
+
+const providerStyles: Record<GitProvider, { icon: string; chip: string; chipIcon: string }> = {
+  github: {
+    icon: 'text-[#24292f] dark:text-white',
+    chip: 'border-[#1F2328]/30 bg-card text-[#1F2328] dark:border-white/25 dark:text-white',
+    chipIcon: 'bg-[#1F2328] text-white',
+  },
+  gitlab: {
+    icon: 'text-[#FC6D26]',
+    chip: 'border-[#FC6D26]/40 bg-card text-[#9B2C0E] dark:text-[#FC9A6C]',
+    chipIcon: 'bg-[#FC6D26] text-white',
+  },
+  bitbucket: {
+    icon: 'text-[#0052CC] dark:text-[#579DFF]',
+    chip: 'border-[#0C66E4]/40 bg-card text-[#0052CC] dark:text-[#579DFF]',
+    chipIcon: 'bg-[#0C66E4] text-white',
+  },
+  cursor: {
+    icon: 'text-[#26251E] dark:text-[#F7F7F4]',
+    chip: 'border-[#26251E]/30 bg-card text-[#26251E] dark:border-[#F7F7F4]/25 dark:text-[#F7F7F4]',
+    chipIcon: 'bg-[#26251E] text-[#F7F7F4] dark:bg-[#F7F7F4] dark:text-[#26251E]',
+  },
+  generic: {
+    icon: 'text-muted-foreground',
+    chip: 'border-input bg-card text-foreground',
+    chipIcon: 'bg-muted text-muted-foreground',
+  },
+};
+
+const ProviderIcon = ({ provider, className }: { provider: GitProvider; className?: string }) => {
+  if (provider === 'github') return <GitHubIcon className={className} />;
+  if (provider === 'gitlab') return <GitLabIcon className={className} />;
+  if (provider === 'bitbucket') return <BitbucketIcon className={className} />;
+  if (provider === 'cursor') return <CursorIcon className={className} />;
+  return <GitCommitHorizontal className={className} />;
+};
+
+export const GitCommitLink = ({
+  commitHash,
+  gitUrl,
+  variant = 'chip',
+}: {
+  commitHash: string;
+  gitUrl?: string;
+  variant?: 'chip' | 'button';
+}) => {
+  if (!commitHash) return null;
+  const repository = gitRepositoryFor(gitUrl);
+
+  if (variant === 'button') {
+    if (!repository) return null;
+    return (
+      <Button
+        asChild
+        size="sm"
+        variant="outline"
+        className="h-7 shrink-0 gap-1.5 px-2.5 text-xs text-muted-foreground hover:text-foreground">
+        <a
+          href={repository.commitUrl(commitHash)}
+          target="_blank"
+          rel="noreferrer"
+          title={`Open commit ${commitHash} in ${repository.label}`}>
+          <ProviderIcon
+            provider={repository.provider}
+            className={providerStyles[repository.provider].icon}
+          />
+          View on {repository.label}
+        </a>
+      </Button>
+    );
+  }
+
+  const chip = (
+    <span
+      className={`inline-flex h-7 items-center overflow-hidden rounded-md border text-xs font-medium shadow-sm transition-all group-hover:-translate-y-px group-hover:shadow-md group-focus-visible:ring-2 group-focus-visible:ring-ring/40 ${
+        providerStyles[repository?.provider ?? 'generic'].chip
+      }`}
+      title={commitHash || undefined}>
+      <span
+        className={`flex h-full w-7 items-center justify-center [&_svg]:h-3.5 [&_svg]:w-3.5 ${
+          providerStyles[repository?.provider ?? 'generic'].chipIcon
+        }`}>
+        <ProviderIcon provider={repository?.provider ?? 'generic'} />
+      </span>
+      <code className="px-2 font-mono">
+        {commitHash.length > 10 ? commitHash.slice(0, 8) : commitHash}
+      </code>
+      {repository && (
+        <span className="flex h-full w-6 items-center justify-center border-l border-current/15 text-current/55 transition-colors group-hover:text-current [&_svg]:h-3 [&_svg]:w-3">
+          <ExternalLink />
+        </span>
+      )}
+    </span>
+  );
+
+  if (!repository) return chip;
+  return (
+    <a
+      href={repository.commitUrl(commitHash)}
+      target="_blank"
+      rel="noreferrer"
+      className="group inline-flex cursor-pointer rounded-md outline-none"
+      aria-label={`Open commit ${commitHash} in ${repository.label}`}
+      onClick={event => event.stopPropagation()}>
+      {chip}
+    </a>
+  );
+};

--- a/apps/dashboard/src/components/LinkedUpdateTitle.tsx
+++ b/apps/dashboard/src/components/LinkedUpdateTitle.tsx
@@ -1,0 +1,29 @@
+import { Fragment } from 'react';
+import { gitRepositoryFor } from '@/lib/git';
+import { splitReviewReferences } from '@/lib/update-format';
+
+export const LinkedUpdateTitle = ({ title, gitUrl }: { title: string; gitUrl?: string }) => {
+  const review = gitRepositoryFor(gitUrl)?.review;
+  if (!review) return <>{title}</>;
+
+  return (
+    <>
+      {splitReviewReferences(title, review.marker).map((part, index) =>
+        'number' in part ? (
+          <a
+            key={index}
+            href={review.url(part.number)}
+            target="_blank"
+            rel="noreferrer"
+            className="text-link hover:underline"
+            onClick={event => event.stopPropagation()}>
+            {review.marker}
+            {part.number}
+          </a>
+        ) : (
+          <Fragment key={index}>{part.text}</Fragment>
+        )
+      )}
+    </>
+  );
+};

--- a/apps/dashboard/src/ee/lib/auditCatalog.ts
+++ b/apps/dashboard/src/ee/lib/auditCatalog.ts
@@ -48,6 +48,7 @@ export const AUDIT_ACTION_GROUPS: AuditActionGroup[] = [
     actions: [
       'app.created',
       'app.renamed',
+      'app.git_url_updated',
       'app.deleted',
       'channel.created',
       'channel.deleted',

--- a/apps/dashboard/src/lib/api.ts
+++ b/apps/dashboard/src/lib/api.ts
@@ -98,6 +98,7 @@ export type AuditEventsPage = {
 
 export type AppDetails = AppDescriptor & {
   keys: KeysConfig;
+  gitUrl?: string;
   createdAt?: number;
 };
 
@@ -1368,11 +1369,19 @@ export class ApiClient {
     });
   }
 
-  public async updateApp(payload: { name?: string }) {
-    return this.request<void>(`${this.appScope()}`, {
+  public async updateAppName(name: string) {
+    return this.request<void>(`${this.appScope()}/name`, {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(payload),
+      body: JSON.stringify({ name }),
+    });
+  }
+
+  public async updateAppGitUrl(gitUrl: string) {
+    return this.request<void>(`${this.appScope()}/git-url`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ gitUrl }),
     });
   }
 

--- a/apps/dashboard/src/lib/git.ts
+++ b/apps/dashboard/src/lib/git.ts
@@ -28,8 +28,9 @@ export const gitRepositoryFor = (gitUrl: string | undefined): GitRepository | nu
     let cursorUrl: string | undefined;
     if (hostname === 'origin.cursor.com') {
       const pathSegments = repositoryUrl.pathname.split('/').filter(Boolean);
-      if (pathSegments.length !== 2) return null;
-      cursorUrl = `https://cursor.com/codebase/${pathSegments.join('/')}`;
+      const repositorySegments = pathSegments[0] === 'git' ? pathSegments.slice(1) : pathSegments;
+      if (repositorySegments.length !== 2) return null;
+      cursorUrl = `https://cursor.com/codebase/${repositorySegments.join('/')}`;
     } else if (hostname === 'cursor.com' || hostname === 'www.cursor.com') {
       const pathSegments = repositoryUrl.pathname.split('/').filter(Boolean);
       if (pathSegments.length !== 3 || pathSegments[0] !== 'codebase') return null;

--- a/apps/dashboard/src/lib/git.ts
+++ b/apps/dashboard/src/lib/git.ts
@@ -1,0 +1,90 @@
+export type GitProvider = 'github' | 'gitlab' | 'bitbucket' | 'cursor' | 'generic';
+
+export type GitRepository = {
+  provider: GitProvider;
+  label: string;
+  commitUrl: (commitHash: string) => string;
+  review?: {
+    marker: '#' | '!';
+    url: (number: string) => string;
+  };
+};
+
+export const gitRepositoryFor = (gitUrl: string | undefined): GitRepository | null => {
+  if (!gitUrl) return null;
+
+  try {
+    const repositoryUrl = new URL(gitUrl);
+    if (repositoryUrl.protocol !== 'https:' && repositoryUrl.protocol !== 'http:') return null;
+    if (repositoryUrl.username || repositoryUrl.password) return null;
+
+    repositoryUrl.pathname = repositoryUrl.pathname.replace(/\/+$/, '').replace(/\.git$/i, '');
+    if (!repositoryUrl.pathname || repositoryUrl.pathname === '/') return null;
+    repositoryUrl.search = '';
+    repositoryUrl.hash = '';
+    const baseUrl = repositoryUrl.toString();
+    const hostname = repositoryUrl.hostname.toLowerCase();
+
+    let cursorUrl: string | undefined;
+    if (hostname === 'origin.cursor.com') {
+      const pathSegments = repositoryUrl.pathname.split('/').filter(Boolean);
+      if (pathSegments.length !== 2) return null;
+      cursorUrl = `https://cursor.com/codebase/${pathSegments.join('/')}`;
+    } else if (hostname === 'cursor.com' || hostname === 'www.cursor.com') {
+      const pathSegments = repositoryUrl.pathname.split('/').filter(Boolean);
+      if (pathSegments.length !== 3 || pathSegments[0] !== 'codebase') return null;
+      cursorUrl = `https://cursor.com/${pathSegments.join('/')}`;
+    }
+    if (cursorUrl) {
+      return {
+        provider: 'cursor',
+        label: 'Cursor',
+        commitUrl: hash => `${cursorUrl}/commit/${encodeURIComponent(hash)}`,
+        review: {
+          marker: '#',
+          url: number => `${cursorUrl}/pull/${encodeURIComponent(number)}`,
+        },
+      };
+    }
+    if (hostname === 'github.com' || hostname === 'www.github.com') {
+      return {
+        provider: 'github',
+        label: 'GitHub',
+        commitUrl: hash => `${baseUrl}/commit/${encodeURIComponent(hash)}`,
+        review: {
+          marker: '#',
+          url: number => `${baseUrl}/pull/${encodeURIComponent(number)}`,
+        },
+      };
+    }
+    if (hostname === 'gitlab.com' || hostname === 'www.gitlab.com') {
+      return {
+        provider: 'gitlab',
+        label: 'GitLab',
+        commitUrl: hash => `${baseUrl}/-/commit/${encodeURIComponent(hash)}`,
+        review: {
+          marker: '!',
+          url: number => `${baseUrl}/-/merge_requests/${encodeURIComponent(number)}`,
+        },
+      };
+    }
+    if (hostname === 'bitbucket.org' || hostname === 'www.bitbucket.org') {
+      return {
+        provider: 'bitbucket',
+        label: 'Bitbucket',
+        commitUrl: hash => `${baseUrl}/commits/${encodeURIComponent(hash)}`,
+        review: {
+          marker: '#',
+          url: number => `${baseUrl}/pull-requests/${encodeURIComponent(number)}`,
+        },
+      };
+    }
+    return {
+      provider: 'generic',
+      label: 'Git',
+      commitUrl: hash => `${baseUrl}/commit/${encodeURIComponent(hash)}`,
+    };
+  } catch {
+    return null;
+  }
+};

--- a/apps/dashboard/src/lib/update-format.ts
+++ b/apps/dashboard/src/lib/update-format.ts
@@ -16,6 +16,23 @@ export const updateTitle = (message: string | undefined, commitHash: string) => 
 export const shortRuntimeVersion = (value: string) =>
   /^[0-9a-f]{40}$/i.test(value) ? value.slice(0, 8) : value;
 
+export type ReviewReferencePart = { text: string } | { number: string };
+
+export const splitReviewReferences = (title: string, marker: '#' | '!'): ReviewReferencePart[] => {
+  const parts: ReviewReferencePart[] = [];
+  const pattern = new RegExp(`(^|[^A-Za-z0-9_#!])\\${marker}(\\d+)(?![A-Za-z0-9_])`, 'g');
+  let cursor = 0;
+
+  for (const match of title.matchAll(pattern)) {
+    const referenceStart = (match.index ?? 0) + match[1].length;
+    if (referenceStart > cursor) parts.push({ text: title.slice(cursor, referenceStart) });
+    parts.push({ number: match[2] });
+    cursor = referenceStart + marker.length + match[2].length;
+  }
+  if (cursor < title.length) parts.push({ text: title.slice(cursor) });
+  return parts;
+};
+
 // The update page lives under the view it was opened from, so the back link
 // and the active sidebar entry follow the reader: the feed or the branch.
 export type UpdateDetailsOrigin = 'updates' | 'branch';

--- a/apps/dashboard/src/pages/AppInfo/index.tsx
+++ b/apps/dashboard/src/pages/AppInfo/index.tsx
@@ -3,7 +3,7 @@ import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { api, ApiProblemError } from '@/lib/api';
 import { useSelectedApp } from '@/lib/SelectedAppContext';
 import { useToast } from '@/hooks/use-toast';
-import { ShieldAlert, Download, Edit2, Check, X, Trash2, Copy } from 'lucide-react';
+import { ShieldAlert, Download, Edit2, Check, X, Trash2, Copy, GitBranch } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { PageHeader } from '@/components/PageHeader';
@@ -61,6 +61,8 @@ export const AppInfo = () => {
   const [isEditingName, setIsEditingName] = useState(false);
   const [editNameValue, setEditNameValue] = useState('');
   const [isUpdatingName, setIsUpdatingName] = useState(false);
+  const [gitUrlValue, setGitUrlValue] = useState('');
+  const [isUpdatingGitUrl, setIsUpdatingGitUrl] = useState(false);
 
   const [showDeleteAppDialog, setShowDeleteAppDialog] = useState(false);
   const [isDeletingApp, setIsDeletingApp] = useState(false);
@@ -79,6 +81,10 @@ export const AppInfo = () => {
       setEditNameValue(appData.name);
     }
   }, [appData?.name]);
+
+  useEffect(() => {
+    setGitUrlValue(appData?.gitUrl ?? '');
+  }, [appData?.gitUrl]);
 
   if (!selectedAppId) {
     return (
@@ -99,7 +105,7 @@ export const AppInfo = () => {
     }
     setIsUpdatingName(true);
     try {
-      await api.updateApp({ name: editNameValue.trim() });
+      await api.updateAppName(editNameValue.trim());
       await queryClient.invalidateQueries({ queryKey: ['appDetails', selectedAppId] });
       toast({ title: 'Name updated', description: 'The app was renamed.' });
       setIsEditingName(false);
@@ -145,6 +151,37 @@ export const AppInfo = () => {
         variant: 'destructive',
       });
       setIsDeletingApp(false);
+    }
+  };
+
+  const handleUpdateGitUrl = async () => {
+    const gitUrl = gitUrlValue.trim();
+    if (gitUrl === (appData?.gitUrl ?? '')) return;
+
+    setIsUpdatingGitUrl(true);
+    try {
+      await api.updateAppGitUrl(gitUrl);
+      await queryClient.invalidateQueries({ queryKey: ['appDetails', selectedAppId] });
+      toast({
+        title: gitUrl ? 'Repository updated' : 'Repository removed',
+        description: gitUrl
+          ? 'Commit hashes now open their source page.'
+          : 'Commit hashes are no longer linked.',
+      });
+    } catch (error) {
+      let errorTitle = 'Error updating repository';
+      let errorMessage = 'An unexpected server error occurred.';
+      if (error instanceof ApiProblemError) {
+        errorTitle = error.title;
+        errorMessage = error.detail;
+      } else if (error instanceof Error) errorMessage = error.message;
+      toast({
+        title: errorTitle,
+        description: errorMessage,
+        variant: 'destructive',
+      });
+    } finally {
+      setIsUpdatingGitUrl(false);
     }
   };
 
@@ -253,6 +290,53 @@ export const AppInfo = () => {
             You do not have permission to rename or delete this app or download its signing
             certificate. Ask an admin to grant you access.
           </AdminOnlyNote>
+        )}
+
+        {CONTROL_PLANE_ENABLED && (
+          <div className="overflow-hidden rounded-xl border bg-card">
+            <div className="space-y-4 p-5">
+              <div className="flex items-start gap-3">
+                <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-muted text-muted-foreground">
+                  <GitBranch className="h-4 w-4" />
+                </span>
+                <div>
+                  <h3 className="text-sm font-medium">Source repository</h3>
+                  <p className="mt-0.5 max-w-md text-xs leading-relaxed text-muted-foreground">
+                    Open commit hashes and PR or merge request references in your Git host.
+                  </p>
+                </div>
+              </div>
+
+              <form
+                className="flex flex-col gap-2 sm:flex-row"
+                onSubmit={event => {
+                  event.preventDefault();
+                  void handleUpdateGitUrl();
+                }}>
+                <Input
+                  type="url"
+                  aria-label="Repository URL"
+                  placeholder="https://github.com/organization/repository"
+                  value={gitUrlValue}
+                  maxLength={2048}
+                  disabled={!canRenameApp || isUpdatingGitUrl || appDetailsQuery.isLoading}
+                  onChange={event => setGitUrlValue(event.target.value)}
+                />
+                <Button
+                  type="submit"
+                  size="sm"
+                  className="shrink-0"
+                  disabled={
+                    !canRenameApp ||
+                    isUpdatingGitUrl ||
+                    appDetailsQuery.isLoading ||
+                    gitUrlValue.trim() === (appData?.gitUrl ?? '')
+                  }>
+                  {isUpdatingGitUrl ? 'Saving…' : 'Save'}
+                </Button>
+              </form>
+            </div>
+          </div>
         )}
 
         <KeystoreCard isLoading={appDetailsQuery.isLoading} appData={appData} />

--- a/apps/dashboard/src/pages/UpdateDetails/index.tsx
+++ b/apps/dashboard/src/pages/UpdateDetails/index.tsx
@@ -16,8 +16,11 @@ import { api } from '@/lib/api';
 import { useSelectedApp } from '@/lib/SelectedAppContext';
 import { useSettings } from '@/lib/SettingsContext';
 import { formatTimestamp } from '@/lib/utils';
+import { updateTitle } from '@/lib/update-format';
 import { PageHeader } from '@/components/PageHeader';
 import { ApiError } from '@/components/APIError';
+import { GitCommitLink } from '@/components/GitCommitLink';
+import { LinkedUpdateTitle } from '@/components/LinkedUpdateTitle';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
@@ -93,6 +96,11 @@ export const UpdateDetails = () => {
     queryKey: ['update-details', selectedAppId, branch, runtimeVersion, updateId],
     enabled: !!updateId && !!selectedAppId && !!branch && !!runtimeVersion,
     queryFn: () => api.getUpdateDetails(branch, runtimeVersion, updateId),
+  });
+  const appDetailsQuery = useQuery({
+    queryKey: ['appDetails', selectedAppId],
+    queryFn: () => api.getApp(selectedAppId!),
+    enabled: !!selectedAppId && CONTROL_PLANE_ENABLED,
   });
 
   const expoConfig = useMemo(() => {
@@ -254,11 +262,21 @@ export const UpdateDetails = () => {
             <DetailRow label="Commit">
               <MonoValue value={data.commitHash} />
               <CopyButton value={data.commitHash} label="commit hash" />
+              <GitCommitLink
+                commitHash={data.commitHash}
+                gitUrl={appDetailsQuery.data?.gitUrl}
+                variant="button"
+              />
             </DetailRow>
             {data.message && (
               <div className="space-y-1 px-4 py-2.5">
                 <span className="text-sm text-muted-foreground">Message</span>
-                <p className="text-sm font-medium">{data.message}</p>
+                <p className="text-sm font-medium">
+                  <LinkedUpdateTitle
+                    title={updateTitle(data.message, data.commitHash)}
+                    gitUrl={appDetailsQuery.data?.gitUrl}
+                  />
+                </p>
               </div>
             )}
           </DetailSection>

--- a/apps/dashboard/src/pages/Updates/components/UpdatesTable/index.tsx
+++ b/apps/dashboard/src/pages/Updates/components/UpdatesTable/index.tsx
@@ -15,6 +15,8 @@ import { UpdateRolloutCard } from '@/pages/Updates/components/UpdateRolloutCard'
 import { aggregateUpdateHealth } from '@/pages/Updates/components/updateHealth';
 import { Button } from '@/components/ui/button';
 import { updateDetailsPath, updateTitle } from '@/lib/update-format';
+import { GitCommitLink } from '@/components/GitCommitLink';
+import { LinkedUpdateTitle } from '@/components/LinkedUpdateTitle';
 
 const UPDATES_PAGE_SIZE = 20;
 
@@ -42,6 +44,11 @@ export const UpdatesTable = ({
     refetchOnWindowFocus: false,
   });
   const updates = updatesQuery.data?.pages.flatMap(page => page.items) ?? [];
+  const appDetailsQuery = useQuery({
+    queryKey: ['appDetails', selectedAppId],
+    queryFn: () => api.getApp(selectedAppId!),
+    enabled: !!selectedAppId && CONTROL_PLANE_ENABLED,
+  });
 
   // Rollout state is read fresh (control-plane only). It drives the card above
   // the table and the "Control" markers in the passive Rollout column.
@@ -146,7 +153,7 @@ export const UpdatesTable = ({
               const msg = updateTitle(row.original.message, row.original.commitHash);
               return msg ? (
                 <span className="block max-w-[200px] truncate text-sm text-muted-foreground">
-                  {msg}
+                  <LinkedUpdateTitle title={msg} gitUrl={appDetailsQuery.data?.gitUrl} />
                 </span>
               ) : (
                 <span className="text-sm text-muted-foreground/60">No message</span>
@@ -156,13 +163,12 @@ export const UpdatesTable = ({
           {
             header: 'Commit',
             accessorKey: 'commitHash',
-            cell: ({ row }) => {
-              return (
-                <Badge variant="outline" className="font-mono text-xs">
-                  {row.original.commitHash.slice(0, 7)}
-                </Badge>
-              );
-            },
+            cell: ({ row }) => (
+              <GitCommitLink
+                commitHash={row.original.commitHash}
+                gitUrl={appDetailsQuery.data?.gitUrl}
+              />
+            ),
           },
           ...(CONTROL_PLANE_ENABLED
             ? [

--- a/apps/dashboard/src/pages/Updates/index.tsx
+++ b/apps/dashboard/src/pages/Updates/index.tsx
@@ -6,7 +6,6 @@ import {
   Box,
   Gauge,
   GitBranch,
-  GitCommitHorizontal,
   Layers3,
   Loader2,
   Search,
@@ -49,6 +48,8 @@ import android from '@/assets/android.svg';
 import { HealthBadge } from '@/pages/Updates/components/HealthBadge';
 import { aggregateUpdateHealth } from '@/pages/Updates/components/updateHealth';
 import { shortRuntimeVersion, updateDetailsPath, updateTitle } from '@/lib/update-format';
+import { GitCommitLink } from '@/components/GitCommitLink';
+import { LinkedUpdateTitle } from '@/components/LinkedUpdateTitle';
 
 type FeedGroup = {
   key: string;
@@ -126,8 +127,6 @@ const PlatformIcon = ({ platform }: { platform: string }) => {
   );
 };
 
-const shortId = (value: string) => (value.length > 10 ? value.slice(0, 8) : value);
-
 const UpdateRolloutBadge = ({ percentage }: { percentage: number }) => (
   <Badge className="h-5 whitespace-nowrap border-emerald-400/25 bg-emerald-400/10 px-1.5 text-[11px] text-emerald-700 dark:text-emerald-300">
     <Gauge className="h-2.5 w-2.5" />
@@ -141,13 +140,6 @@ const RuntimeLabel = ({ value }: { value: string }) => (
     title={value}>
     <Box className="h-3 w-3 shrink-0 text-amber-600 dark:text-amber-300/80" />
     <span className="truncate">{shortRuntimeVersion(value)}</span>
-  </span>
-);
-
-const CommitLabel = ({ value }: { value: string }) => (
-  <span className="inline-flex items-center gap-1.5 rounded-md border border-primary/20 bg-primary/[0.07] px-2 py-1 text-xs font-medium text-link">
-    <GitCommitHorizontal className="h-3 w-3 text-link/80" />
-    {shortId(value)}
   </span>
 );
 
@@ -252,6 +244,11 @@ export const Updates = () => {
     queryKey: ['runtimeVersions', selectedAppId, filters.branch],
     queryFn: () => api.getRuntimeVersions(filters.branch),
     enabled: !!selectedAppId && !!filters.branch,
+  });
+  const appDetailsQuery = useQuery({
+    queryKey: ['appDetails', selectedAppId],
+    queryFn: () => api.getApp(selectedAppId!),
+    enabled: !!selectedAppId,
   });
 
   const updates = useMemo(() => query.data?.pages.flatMap(page => page.items) ?? [], [query.data]);
@@ -600,7 +597,10 @@ export const Updates = () => {
                       {shortRuntimeVersion(rollout.runtimeVersion)}
                     </span>
                     <span aria-hidden="true">·</span>
-                    <span>{shortId(rollout.commitHash)}</span>
+                    <GitCommitLink
+                      commitHash={rollout.commitHash}
+                      gitUrl={appDetailsQuery.data?.gitUrl}
+                    />
                   </div>
                 </div>
               </div>
@@ -628,13 +628,13 @@ export const Updates = () => {
         <Table className="min-w-[1150px] table-fixed">
           <TableHeader>
             <TableRow>
-              <TableHead className={canPublishUpdate ? 'w-[32%]' : 'w-[36%]'}>Update</TableHead>
+              <TableHead className={canPublishUpdate ? 'w-[26%]' : 'w-[30%]'}>Update</TableHead>
               <TableHead className="w-[11%]">Branch</TableHead>
               <TableHead className="w-[8%]">Runtime</TableHead>
               <TableHead className="w-[7%]">Platform</TableHead>
               <TableHead className="w-[8%] text-right">Devices</TableHead>
               <TableHead className="w-[9%]">Health</TableHead>
-              <TableHead className="w-[9%]">Commit</TableHead>
+              <TableHead className="w-[15%]">Commit</TableHead>
               <TableHead className={canPublishUpdate ? 'w-[10%]' : 'w-[12%]'}>Published</TableHead>
               {canPublishUpdate && <TableHead className="w-[6%]" />}
             </TableRow>
@@ -688,8 +688,13 @@ export const Updates = () => {
                             <p
                               className="block max-w-full truncate font-medium text-foreground"
                               title={primary.message || `Update ${primary.updateId}`}>
-                              {updateTitle(primary.message, primary.commitHash) ||
-                                `Update ${primary.updateId}`}
+                              <LinkedUpdateTitle
+                                title={
+                                  updateTitle(primary.message, primary.commitHash) ||
+                                  `Update ${primary.updateId}`
+                                }
+                                gitUrl={appDetailsQuery.data?.gitUrl}
+                              />
                             </p>
                             <div className="mt-1 flex min-w-0 items-center gap-2 text-xs text-muted-foreground">
                               {isGroup && (
@@ -730,7 +735,10 @@ export const Updates = () => {
                         <HealthBadge health={groupHealth} />
                       </TableCell>
                       <TableCell>
-                        <CommitLabel value={primary.commitHash} />
+                        <GitCommitLink
+                          commitHash={primary.commitHash}
+                          gitUrl={appDetailsQuery.data?.gitUrl}
+                        />
                       </TableCell>
                       <TableCell>
                         <TimestampCell dateString={primary.createdAt} compact />
@@ -817,7 +825,10 @@ export const Updates = () => {
                             <HealthBadge health={healthByUuid[update.updateUUID]} />
                           </TableCell>
                           <TableCell>
-                            <CommitLabel value={update.commitHash} />
+                            <GitCommitLink
+                              commitHash={update.commitHash}
+                              gitUrl={appDetailsQuery.data?.gitUrl}
+                            />
                           </TableCell>
                           <TableCell>
                             <TimestampCell dateString={update.createdAt} compact />

--- a/config/apps.go
+++ b/config/apps.go
@@ -73,6 +73,7 @@ type KeysConfig struct {
 type AppConfig struct {
 	Id          string        `json:"id"`
 	Name        string        `json:"name,omitempty"`
+	GitURL      string        `json:"gitUrl,omitempty"`
 	AccessToken string        `json:"accessToken,omitempty"`
 	Keys        KeysConfig    `json:"keys"`
 	CreatedAt   time.Duration `json:"createTime,omitempty"`

--- a/ee/observe/middleware_test.go
+++ b/ee/observe/middleware_test.go
@@ -45,6 +45,9 @@ func (r *countingAppRepo) InsertApp(context.Context, store.InsertAppParameters) 
 func (r *countingAppRepo) DeleteAppByID(context.Context, string) error             { return nil }
 func (r *countingAppRepo) GetApps(context.Context) ([]config.AppDescriptor, error) { return nil, nil }
 func (r *countingAppRepo) UpdateAppNameByID(context.Context, string, string) error { return nil }
+func (r *countingAppRepo) UpdateAppGitURLByID(context.Context, string, string) error {
+	return nil
+}
 
 var _ services.AppRepository = (*countingAppRepo)(nil)
 

--- a/internal/auditlog/auditlog.go
+++ b/internal/auditlog/auditlog.go
@@ -71,6 +71,7 @@ const (
 	// App management.
 	ActionAppCreated           Action = "app.created"
 	ActionAppRenamed           Action = "app.renamed"
+	ActionAppGitURLUpdated     Action = "app.git_url_updated"
 	ActionAppDeleted           Action = "app.deleted"
 	ActionChannelCreated       Action = "channel.created"
 	ActionChannelDeleted       Action = "channel.deleted"

--- a/internal/database/postgres/migrations/20260903120000_app_git_url.sql
+++ b/internal/database/postgres/migrations/20260903120000_app_git_url.sql
@@ -1,0 +1,7 @@
+-- +goose Up
+
+ALTER TABLE apps ADD COLUMN git_url VARCHAR(2048);
+
+-- +goose Down
+
+ALTER TABLE apps DROP COLUMN git_url;

--- a/internal/database/postgres/pgdb/models.go
+++ b/internal/database/postgres/pgdb/models.go
@@ -43,6 +43,7 @@ type App struct {
 	AwsSecretIDPrivate *string            `json:"aws_secret_id_private"`
 	CreatedAt          pgtype.Timestamptz `json:"created_at"`
 	UpdatedAt          pgtype.Timestamptz `json:"updated_at"`
+	GitUrl             *string            `json:"git_url"`
 }
 
 type AuditExportState struct {

--- a/internal/database/postgres/pgdb/queries.sql.go
+++ b/internal/database/postgres/pgdb/queries.sql.go
@@ -1010,7 +1010,7 @@ func (q *Queries) GetApiKeysMetadataByAppID(ctx context.Context, appID pgtype.UU
 }
 
 const getAppByID = `-- name: GetAppByID :one
-SELECT id, name, keys_mode, sealed_public_key, sealed_private_key, path_public_key, path_private_key, aws_secret_id_public, aws_secret_id_private, created_at, updated_at FROM apps
+SELECT id, name, keys_mode, sealed_public_key, sealed_private_key, path_public_key, path_private_key, aws_secret_id_public, aws_secret_id_private, created_at, updated_at, git_url FROM apps
 WHERE id = $1 LIMIT 1
 `
 
@@ -1029,6 +1029,7 @@ func (q *Queries) GetAppByID(ctx context.Context, id pgtype.UUID) (App, error) {
 		&i.AwsSecretIDPrivate,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.GitUrl,
 	)
 	return i, err
 }
@@ -5973,6 +5974,21 @@ func (q *Queries) UpdateApiKeyAccess(ctx context.Context, arg UpdateApiKeyAccess
 		return 0, err
 	}
 	return result.RowsAffected(), nil
+}
+
+const updateAppGitURLByID = `-- name: UpdateAppGitURLByID :execresult
+UPDATE apps
+SET git_url = NULLIF($1::text, ''), updated_at = CURRENT_TIMESTAMP
+WHERE id = $2
+`
+
+type UpdateAppGitURLByIDParams struct {
+	GitUrl string      `json:"git_url"`
+	ID     pgtype.UUID `json:"id"`
+}
+
+func (q *Queries) UpdateAppGitURLByID(ctx context.Context, arg UpdateAppGitURLByIDParams) (pgconn.CommandTag, error) {
+	return q.db.Exec(ctx, updateAppGitURLByID, arg.GitUrl, arg.ID)
 }
 
 const updateAppNameByID = `-- name: UpdateAppNameByID :execresult

--- a/internal/database/postgres/queries/queries.sql
+++ b/internal/database/postgres/queries/queries.sql
@@ -21,6 +21,11 @@ UPDATE apps
 SET name = $2, updated_at = CURRENT_TIMESTAMP
 WHERE id = $1;
 
+-- name: UpdateAppGitURLByID :execresult
+UPDATE apps
+SET git_url = NULLIF(sqlc.arg('git_url')::text, ''), updated_at = CURRENT_TIMESTAMP
+WHERE id = sqlc.arg('id');
+
 -- name: InsertChannel :one
 INSERT INTO channels (app_id, branch_id, name)
 VALUES ($1, $2, $3)

--- a/internal/expoimport/service_test.go
+++ b/internal/expoimport/service_test.go
@@ -52,6 +52,9 @@ func (f *importFakeAppRepo) GetApps(_ context.Context) ([]config.AppDescriptor, 
 func (f *importFakeAppRepo) UpdateAppNameByID(_ context.Context, _ string, _ string) error {
 	panic("unused")
 }
+func (f *importFakeAppRepo) UpdateAppGitURLByID(_ context.Context, _ string, _ string) error {
+	panic("unused")
+}
 func (f *importFakeAppRepo) GetAppByID(_ context.Context, id string) (config.AppConfig, error) {
 	if f.missing {
 		return config.AppConfig{}, fmt.Errorf("app %s not found", id)

--- a/internal/handlers/dashboard/apps_handler.go
+++ b/internal/handlers/dashboard/apps_handler.go
@@ -177,7 +177,7 @@ func (h *AppHandler) GetAppsHandler(w http.ResponseWriter, r *http.Request) {
 	w.Write(marshaledResponse)
 }
 
-func (h *AppHandler) UpdateAppHandler(w http.ResponseWriter, r *http.Request) {
+func (h *AppHandler) UpdateAppNameHandler(w http.ResponseWriter, r *http.Request) {
 	app := services.AppFromContext(r.Context())
 	if app == nil {
 		handlers.RenderError(w, http.StatusInternalServerError, "app not resolved for this route")
@@ -191,14 +191,11 @@ func (h *AppHandler) UpdateAppHandler(w http.ResponseWriter, r *http.Request) {
 		handlers.RenderError(w, http.StatusBadRequest, "Invalid request body: "+err.Error())
 		return
 	}
-
 	if requestBody.Name == "" {
 		handlers.RenderError(w, http.StatusBadRequest, "Display name cannot be empty")
 		return
 	}
-
-	err := h.appService.UpdateApp(r.Context(), *app, requestBody.Name)
-	if err != nil {
+	if err := h.appService.UpdateAppName(r.Context(), *app, requestBody.Name); err != nil {
 		var valErr *validation.Error
 		if errors.As(err, &valErr) {
 			handlers.RenderError(w, http.StatusBadRequest, valErr.Error())
@@ -214,6 +211,38 @@ func (h *AppHandler) UpdateAppHandler(w http.ResponseWriter, r *http.Request) {
 	cache.Delete(appsCacheKey)
 	cache.Delete(appCacheKey)
 
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (h *AppHandler) UpdateAppGitURLHandler(w http.ResponseWriter, r *http.Request) {
+	app := services.AppFromContext(r.Context())
+	if app == nil {
+		handlers.RenderError(w, http.StatusInternalServerError, "app not resolved for this route")
+		return
+	}
+
+	var requestBody struct {
+		GitURL *string `json:"gitUrl"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&requestBody); err != nil {
+		handlers.RenderError(w, http.StatusBadRequest, "Invalid request body: "+err.Error())
+		return
+	}
+	if requestBody.GitURL == nil {
+		handlers.RenderError(w, http.StatusBadRequest, "gitUrl is required")
+		return
+	}
+	if err := h.appService.UpdateAppGitURL(r.Context(), *app, *requestBody.GitURL); err != nil {
+		var valErr *validation.Error
+		if errors.As(err, &valErr) {
+			handlers.RenderError(w, http.StatusBadRequest, valErr.Error())
+			return
+		}
+		handlers.RenderError(w, http.StatusInternalServerError, "An internal error occurred while updating the repository URL.")
+		return
+	}
+
+	cache2.GetCache().Delete(dashboard.ComputeGetAppCacheKey(app.Id))
 	w.WriteHeader(http.StatusNoContent)
 }
 

--- a/internal/handlers/dashboard/apps_handler_test.go
+++ b/internal/handlers/dashboard/apps_handler_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"xprem/config"
@@ -29,6 +30,9 @@ func (f *fakeAppRepo) GetApps(_ context.Context) ([]config.AppDescriptor, error)
 	return f.apps, nil
 }
 func (f *fakeAppRepo) UpdateAppNameByID(_ context.Context, _ string, _ string) error {
+	panic("unused")
+}
+func (f *fakeAppRepo) UpdateAppGitURLByID(_ context.Context, _ string, _ string) error {
 	panic("unused")
 }
 func (f *fakeAppRepo) GetAppByID(_ context.Context, _ string) (config.AppConfig, error) {
@@ -89,4 +93,66 @@ func TestGetAppsHandlerFiltersAfterCacheRead(t *testing.T) {
 	status, apps = getApps(t, community)
 	require.Equal(t, http.StatusOK, status)
 	require.Len(t, apps, 2)
+}
+
+type mutableAppRepo struct {
+	app config.AppConfig
+}
+
+func (f *mutableAppRepo) InsertApp(context.Context, store.InsertAppParameters) (string, error) {
+	panic("unused")
+}
+func (f *mutableAppRepo) DeleteAppByID(context.Context, string) error { panic("unused") }
+func (f *mutableAppRepo) GetApps(context.Context) ([]config.AppDescriptor, error) {
+	return nil, nil
+}
+func (f *mutableAppRepo) UpdateAppNameByID(_ context.Context, _ string, name string) error {
+	f.app.Name = name
+	return nil
+}
+func (f *mutableAppRepo) UpdateAppGitURLByID(_ context.Context, _ string, gitURL string) error {
+	f.app.GitURL = gitURL
+	return nil
+}
+func (f *mutableAppRepo) GetAppByID(context.Context, string) (config.AppConfig, error) {
+	return f.app, nil
+}
+
+func updateAppGitURL(t *testing.T, handler *AppHandler, app config.AppConfig, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodPatch, "/api/apps/"+app.Id+"/git-url", strings.NewReader(body))
+	request = request.WithContext(services.WithApp(request.Context(), app))
+	handler.UpdateAppGitURLHandler(recorder, request)
+	return recorder
+}
+
+func TestUpdateAppGitURLHandlerSavesOrClearsGitURL(t *testing.T) {
+	repo := &mutableAppRepo{app: config.AppConfig{Id: "app-1", Name: "Mobile"}}
+	handler := NewAppHandler(services.NewAppService(repo), nil)
+
+	recorder := updateAppGitURL(t, handler, repo.app, `{"gitUrl":"https://github.com/acme/mobile.git/"}`)
+	require.Equal(t, http.StatusNoContent, recorder.Code, recorder.Body.String())
+	require.Equal(t, "https://github.com/acme/mobile", repo.app.GitURL)
+
+	recorder = updateAppGitURL(t, handler, repo.app, `{"gitUrl":""}`)
+	require.Equal(t, http.StatusNoContent, recorder.Code, recorder.Body.String())
+	require.Empty(t, repo.app.GitURL)
+}
+
+func TestUpdateAppGitURLHandlerRejectsInvalidOrMissingGitURL(t *testing.T) {
+	repo := &mutableAppRepo{app: config.AppConfig{Id: "app-1", Name: "Mobile"}}
+	handler := NewAppHandler(services.NewAppService(repo), nil)
+
+	for name, body := range map[string]string{
+		"credentials": `{"gitUrl":"https://user:token@github.com/acme/mobile"}`,
+		"missing":     `{}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			recorder := updateAppGitURL(t, handler, repo.app, body)
+			require.Equal(t, http.StatusBadRequest, recorder.Code, recorder.Body.String())
+		})
+	}
+	require.Equal(t, "Mobile", repo.app.Name)
+	require.Empty(t, repo.app.GitURL)
 }

--- a/internal/router/routes_app.go
+++ b/internal/router/routes_app.go
@@ -31,7 +31,9 @@ func registerAppRoutes(
 		AnyViewer())
 	app.route(http.MethodDelete, "", container.AppHandler.DeleteAppHandler,
 		NeedsPermission(rbac.PermAppDelete, rbac.FallbackAdminOnly))
-	app.route(http.MethodPatch, "", container.AppHandler.UpdateAppHandler,
+	app.route(http.MethodPatch, "/name", container.AppHandler.UpdateAppNameHandler,
+		NeedsPermission(rbac.PermAppRename, rbac.FallbackAdminOnly))
+	app.route(http.MethodPatch, "/git-url", container.AppHandler.UpdateAppGitURLHandler,
 		NeedsPermission(rbac.PermAppRename, rbac.FallbackAdminOnly))
 	app.route(http.MethodGet, "/certificate", container.AppHandler.DownloadAppCertificateHandler,
 		NeedsPermission(rbac.PermCertificateRead, rbac.FallbackAdminOnly))

--- a/internal/services/app_service.go
+++ b/internal/services/app_service.go
@@ -30,6 +30,7 @@ type AppRepository interface {
 	DeleteAppByID(ctx context.Context, id string) error
 	GetApps(ctx context.Context) ([]config.AppDescriptor, error)
 	UpdateAppNameByID(ctx context.Context, id string, newName string) error
+	UpdateAppGitURLByID(ctx context.Context, id string, gitURL string) error
 	GetAppByID(ctx context.Context, id string) (config.AppConfig, error)
 }
 
@@ -193,7 +194,7 @@ func (s *AppService) PresentApp(ctx context.Context, app config.AppConfig) confi
 	return app
 }
 
-func (s *AppService) UpdateApp(ctx context.Context, app config.AppConfig, newName string) error {
+func (s *AppService) UpdateAppName(ctx context.Context, app config.AppConfig, newName string) error {
 	if err := validation.DisplayName("name", newName); err != nil {
 		return err
 	}
@@ -211,6 +212,35 @@ func (s *AppService) UpdateApp(ctx context.Context, app config.AppConfig, newNam
 		TargetDisplay: newName,
 		AppID:         app.Id,
 		Metadata:      map[string]any{"name": newName, "previous_name": app.Name},
+	})
+	return nil
+}
+
+func (s *AppService) UpdateAppGitURL(ctx context.Context, app config.AppConfig, gitURL string) error {
+	normalized, err := validation.GitURL("gitUrl", gitURL)
+	if err != nil {
+		return err
+	}
+	if app.GitURL == normalized {
+		return nil
+	}
+	if err := s.appRepo.UpdateAppGitURLByID(ctx, app.Id, normalized); err != nil {
+		return err
+	}
+	displayName := app.Name
+	if displayName == "" {
+		displayName = app.Id
+	}
+	recordManagementEvent(ctx, s.onAuditEvent, auditlog.Event{
+		Action:        auditlog.ActionAppGitURLUpdated,
+		TargetType:    "app",
+		TargetID:      app.Id,
+		TargetDisplay: displayName,
+		AppID:         app.Id,
+		Metadata: map[string]any{
+			"git_url":          normalized,
+			"previous_git_url": app.GitURL,
+		},
 	})
 	return nil
 }

--- a/internal/services/management_audit_test.go
+++ b/internal/services/management_audit_test.go
@@ -34,6 +34,12 @@ func (f *fakeMgmtAppRepo) UpdateAppNameByID(_ context.Context, id string, newNam
 	f.apps[id] = app
 	return nil
 }
+func (f *fakeMgmtAppRepo) UpdateAppGitURLByID(_ context.Context, id string, gitURL string) error {
+	app := f.apps[id]
+	app.GitURL = gitURL
+	f.apps[id] = app
+	return nil
+}
 func (f *fakeMgmtAppRepo) GetAppByID(_ context.Context, id string) (config.AppConfig, error) {
 	app, ok := f.apps[id]
 	if !ok {
@@ -127,7 +133,7 @@ func TestAppLifecycleEmitsAuditEvents(t *testing.T) {
 	// The rename carries both names; an idempotent rename emits nothing.
 	app, err := appService.GetAppByID(ctx, appId)
 	require.NoError(t, err)
-	require.NoError(t, appService.UpdateApp(ctx, app, "Renamed App"))
+	require.NoError(t, appService.UpdateAppName(ctx, app, "Renamed App"))
 	require.Len(t, recorder.events, 2)
 	renamed := recorder.events[1]
 	assert.Equal(t, auditlog.ActionAppRenamed, renamed.Action)
@@ -135,16 +141,36 @@ func TestAppLifecycleEmitsAuditEvents(t *testing.T) {
 
 	app, err = appService.GetAppByID(ctx, appId)
 	require.NoError(t, err)
-	require.NoError(t, appService.UpdateApp(ctx, app, "Renamed App"))
+	require.NoError(t, appService.UpdateAppName(ctx, app, "Renamed App"))
 	require.Len(t, recorder.events, 2)
+
+	app, err = appService.GetAppByID(ctx, appId)
+	require.NoError(t, err)
+	require.NoError(t, appService.UpdateAppGitURL(ctx, app, "https://github.com/acme/mobile.git/"))
+	require.Len(t, recorder.events, 3)
+	gitURLUpdated := recorder.events[2]
+	assert.Equal(t, auditlog.ActionAppGitURLUpdated, gitURLUpdated.Action)
+	assert.Equal(t, map[string]any{
+		"git_url":          "https://github.com/acme/mobile",
+		"previous_git_url": "",
+	}, gitURLUpdated.Metadata)
+
+	app, err = appService.GetAppByID(ctx, appId)
+	require.NoError(t, err)
+	require.NoError(t, appService.UpdateAppGitURL(ctx, app, "https://github.com/acme/mobile"))
+	require.Len(t, recorder.events, 3)
+
+	require.NoError(t, appService.UpdateAppGitURL(ctx, app, ""))
+	require.Len(t, recorder.events, 4)
+	assert.Equal(t, auditlog.ActionAppGitURLUpdated, recorder.events[3].Action)
 
 	// The deletion entry still names the app.
 	app, err = appService.GetAppByID(ctx, appId)
 	require.NoError(t, err)
 	require.NoError(t, appService.DeleteApp(ctx, app))
-	require.Len(t, recorder.events, 3)
-	assert.Equal(t, auditlog.ActionAppDeleted, recorder.events[2].Action)
-	assert.Equal(t, "Renamed App", recorder.events[2].TargetDisplay)
+	require.Len(t, recorder.events, 5)
+	assert.Equal(t, auditlog.ActionAppDeleted, recorder.events[4].Action)
+	assert.Equal(t, "Renamed App", recorder.events[4].TargetDisplay)
 }
 
 func TestChannelEventsEmitAuditEvents(t *testing.T) {

--- a/internal/services/rollout_resolution_test.go
+++ b/internal/services/rollout_resolution_test.go
@@ -546,6 +546,8 @@ func (fakeAppRepo) GetApps(_ context.Context) ([]config.AppDescriptor, error) { 
 
 func (fakeAppRepo) UpdateAppNameByID(_ context.Context, _, _ string) error { return nil }
 
+func (fakeAppRepo) UpdateAppGitURLByID(_ context.Context, _, _ string) error { return nil }
+
 func (fakeAppRepo) GetAppByID(_ context.Context, _ string) (config.AppConfig, error) {
 	return config.AppConfig{}, nil
 }

--- a/internal/store/app_bucket.go
+++ b/internal/store/app_bucket.go
@@ -55,3 +55,7 @@ func (s *BucketAppStore) DeleteAppByID(ctx context.Context, id string) error {
 func (s *BucketAppStore) UpdateAppNameByID(ctx context.Context, id string, newName string) error {
 	return ErrNotSupportedInStatelessMode
 }
+
+func (s *BucketAppStore) UpdateAppGitURLByID(ctx context.Context, id string, gitURL string) error {
+	return ErrNotSupportedInStatelessMode
+}

--- a/internal/store/app_postgres.go
+++ b/internal/store/app_postgres.go
@@ -96,6 +96,21 @@ func (s *PostgresAppStore) UpdateAppNameByID(ctx context.Context, id string, new
 	return nil
 }
 
+func (s *PostgresAppStore) UpdateAppGitURLByID(ctx context.Context, id string, gitURL string) error {
+	pgAppID := ToPgUUID(id)
+	commandTag, err := s.engine.Queries.UpdateAppGitURLByID(ctx, pgdb.UpdateAppGitURLByIDParams{
+		GitUrl: gitURL,
+		ID:     pgAppID,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to update app git URL in database: %w", err)
+	}
+	if commandTag.RowsAffected() == 0 {
+		return &ErrResourceNotFound{Resource: "app", Identifier: id}
+	}
+	return nil
+}
+
 func safeStr(p *string) string {
 	if p == nil {
 		return ""
@@ -110,8 +125,9 @@ func (s *PostgresAppStore) GetAppByID(ctx context.Context, id string) (config.Ap
 		return config.AppConfig{}, fmt.Errorf("failed to retrieve app from database: %w", err)
 	}
 	return config.AppConfig{
-		Id:   row.ID.String(),
-		Name: row.Name,
+		Id:     row.ID.String(),
+		Name:   row.Name,
+		GitURL: safeStr(row.GitUrl),
 		Keys: config.KeysConfig{
 			Mode: func() config.KeysMode {
 				if row.KeysMode != nil {

--- a/internal/validation/validation.go
+++ b/internal/validation/validation.go
@@ -7,6 +7,7 @@ package validation
 import (
 	"errors"
 	"fmt"
+	"net/url"
 	"strconv"
 	"strings"
 	"unicode"
@@ -25,6 +26,8 @@ const maxDisplayNameLen = 255
 // api_key_branch_rules.pattern. Wider than maxNameLen so a rule can name a
 // legacy branch that predates the maxNameLen cap.
 const maxPatternLen = 255
+
+const maxGitURLLen = 2048
 
 // Error is a validation failure on user-supplied input. Handlers detect it with
 // errors.As and map it to HTTP 400, surfacing Message to the caller, while
@@ -135,6 +138,42 @@ func DisplayName(field, value string) error {
 		}
 	}
 	return nil
+}
+
+func GitURL(field, value string) (string, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "", nil
+	}
+	if len(value) > maxGitURLLen {
+		return "", fail(field, "exceeds max length %d", maxGitURLLen)
+	}
+	for _, r := range value {
+		if unicode.IsControl(r) {
+			return "", fail(field, "must not contain control characters")
+		}
+	}
+
+	parsed, err := url.Parse(value)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" || parsed.Opaque != "" {
+		return "", fail(field, "must be a valid HTTP(S) repository URL")
+	}
+	if parsed.Scheme != "https" && parsed.Scheme != "http" {
+		return "", fail(field, "must use http or https")
+	}
+	if parsed.User != nil {
+		return "", fail(field, "must not contain credentials")
+	}
+	if parsed.RawQuery != "" || parsed.ForceQuery || parsed.Fragment != "" {
+		return "", fail(field, "must not contain a query string or fragment")
+	}
+
+	parsed.Path = strings.TrimSuffix(strings.TrimRight(parsed.Path, "/"), ".git")
+	parsed.RawPath = ""
+	if parsed.Path == "" || parsed.Path == "/" {
+		return "", fail(field, "must include a repository path")
+	}
+	return parsed.String(), nil
 }
 
 // RolloutPercentage parses a rollout percentage passed as a string (the

--- a/internal/validation/validation_test.go
+++ b/internal/validation/validation_test.go
@@ -92,6 +92,46 @@ func TestDisplayName_Rejects(t *testing.T) {
 	}
 }
 
+func TestGitURL_NormalizesRepositoryURLs(t *testing.T) {
+	for name, tc := range map[string]struct {
+		input string
+		want  string
+	}{
+		"github":         {"https://github.com/acme/mobile", "https://github.com/acme/mobile"},
+		"trailing slash": {"https://gitlab.com/acme/mobile/", "https://gitlab.com/acme/mobile"},
+		"git suffix":     {"https://bitbucket.org/acme/mobile.git", "https://bitbucket.org/acme/mobile"},
+		"self hosted":    {"http://git.internal:8080/team/mobile", "http://git.internal:8080/team/mobile"},
+		"clear setting":  {"   ", ""},
+	} {
+		t.Run(name, func(t *testing.T) {
+			got, err := GitURL("gitUrl", tc.input)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestGitURL_RejectsUnsafeOrNonWebURLs(t *testing.T) {
+	for name, value := range map[string]string{
+		"ssh remote":      "git@github.com:acme/mobile.git",
+		"file URL":        "file:///tmp/mobile",
+		"missing host":    "https:///acme/mobile",
+		"missing repo":    "https://github.com",
+		"credentials":     "https://user:token@github.com/acme/mobile",
+		"query":           "https://github.com/acme/mobile?token=secret",
+		"fragment":        "https://github.com/acme/mobile#readme",
+		"control char":    "https://github.com/acme/mobile\nother",
+		"over max length": "https://github.com/acme/" + strings.Repeat("a", maxGitURLLen),
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, err := GitURL("gitUrl", value)
+			require.Error(t, err)
+			assert.True(t, IsValidationError(err))
+			assert.Contains(t, err.Error(), "gitUrl")
+		})
+	}
+}
+
 func TestNumericID(t *testing.T) {
 	for _, v := range []string{"1", "42", "9223372036854775807"} {
 		assert.NoError(t, NumericID("apiKeyId", v), "expected %q to be valid", v)

--- a/test/cli_token_reach_test.go
+++ b/test/cli_token_reach_test.go
@@ -115,7 +115,8 @@ func TestPublishingTokenIsRefusedOnAppScopedMutations(t *testing.T) {
 
 	for _, tc := range []struct{ method, path string }{
 		{http.MethodDelete, "/api/apps/test-app-id"},
-		{http.MethodPatch, "/api/apps/test-app-id"},
+		{http.MethodPatch, "/api/apps/test-app-id/name"},
+		{http.MethodPatch, "/api/apps/test-app-id/git-url"},
 		{http.MethodPost, "/api/apps/test-app-id/branches"},
 		{http.MethodDelete, "/api/apps/test-app-id/branches/branch-1"},
 		{http.MethodPost, "/api/apps/test-app-id/channels"},

--- a/test/trailing_slash_test.go
+++ b/test/trailing_slash_test.go
@@ -31,7 +31,8 @@ func TestTrailingSlashIsRefusedNotRedirected(t *testing.T) {
 	for _, tc := range []struct{ method, path string }{
 		// The app root, where the hazard was worst: these two mutate.
 		{http.MethodDelete, "/api/apps/test-app-id/"},
-		{http.MethodPatch, "/api/apps/test-app-id/"},
+		{http.MethodPatch, "/api/apps/test-app-id/name/"},
+		{http.MethodPatch, "/api/apps/test-app-id/git-url/"},
 		{http.MethodGet, "/api/apps/test-app-id/"},
 		// A collection under it, which StrictSlash also used to redirect on a
 		// non-GET method, from before this change.
@@ -62,7 +63,8 @@ func TestSlashlessFormStillMatches(t *testing.T) {
 	for _, tc := range []struct{ method, path string }{
 		{http.MethodGet, "/api/apps/test-app-id"},
 		{http.MethodDelete, "/api/apps/test-app-id"},
-		{http.MethodPatch, "/api/apps/test-app-id"},
+		{http.MethodPatch, "/api/apps/test-app-id/name"},
+		{http.MethodPatch, "/api/apps/test-app-id/git-url"},
 		{http.MethodGet, "/api/apps/test-app-id/branches"},
 	} {
 		recorder := httptest.NewRecorder()
@@ -94,7 +96,8 @@ func TestDoubleSlashIsRefusedNotRedirected(t *testing.T) {
 
 	for _, tc := range []struct{ method, path string }{
 		{http.MethodDelete, "//api/apps/test-app-id"},
-		{http.MethodPatch, "//api/apps/test-app-id"},
+		{http.MethodPatch, "//api/apps/test-app-id/name"},
+		{http.MethodPatch, "//api/apps/test-app-id/git-url"},
 		{http.MethodDelete, "/api/apps//test-app-id"},
 		{http.MethodPost, "//api/apps/test-app-id/branches"},
 		{http.MethodPost, "/api/apps/test-app-id//branches"},


### PR DESCRIPTION
  Adds an optional source repository URL to each app.

  When configured:

  - Commit hashes link directly to their source commit.
  - `#123` references link to pull requests on GitHub, Bitbucket and Cursor Origin.
  - `!123` references link to merge requests on GitLab.
  - Commit links use the branding of each supported forge.

  This is available in control-plane mode only. Stateless behavior remains unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Configure an app’s source repository URL from the app information page.
  - View linked Git commit hashes and review references in update lists and details.
  - Support GitHub, GitLab, Bitbucket, Cursor, and generic web repositories.
  - Repository URLs are validated, normalized, and safely handled when unavailable.

- **Audit & Reliability**
  - Git repository URL changes are recorded in management audit logs.
  - Invalid, credential-bearing, or unsupported repository URLs are rejected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->