### PR TITLE
ci: create release tags through the xprem-release GitHub App

### DIFF
--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -59,6 +59,7 @@ jobs:
         with:
           app-id: ${{ secrets.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          permission-contents: write
 
       - name: Checkout ${{ inputs.branch }}
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0

--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -12,7 +12,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Tag to create (vX.Y.Z or vX.Y.Z-suffix)"
+        description: "Tag to create (vX.Y.Z, or vX.Y.Z-beta1 / -alpha2 / -rc1)"
         required: true
       ref:
         description: "Commit or branch to tag"
@@ -33,14 +33,17 @@ jobs:
         env:
           TAG: ${{ inputs.tag }}
         run: |
-          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$ ]]; then
-            echo "::error::Tag must look like v1.2.3 or v1.2.3-beta1, got: $TAG"
+          # Only the suffixes release.yml recognises as pre-releases: anything
+          # else (v1.2.3-test) would be published to npm as latest and as a
+          # stable GitHub release.
+          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|rc)[0-9]*)?$ ]]; then
+            echo "::error::Tag must look like v1.2.3, v1.2.3-beta1, v1.2.3-alpha2 or v1.2.3-rc1, got: $TAG"
             exit 1
           fi
 
       - name: Mint xprem-release App token
         id: app
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
@@ -60,7 +63,7 @@ jobs:
             exit 1
           fi
           git config user.name "xprem-release[bot]"
-          git config user.email "xprem-release[bot]@users.noreply.github.com"
+          git config user.email "324931244+xprem-release[bot]@users.noreply.github.com"
           git tag -a "$TAG" -m "$TAG"
           git push origin "refs/tags/$TAG"
           echo "Tagged $(git rev-parse --short HEAD) as $TAG"

--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -1,10 +1,10 @@
-name: Cut release
+name: Create tag
 
 # The only way a v* tag gets created. The "Protect release tags" ruleset lets
 # nothing but the xprem-release GitHub App create, move or delete v* tags, so a
 # leaked user token cannot trigger release.yml. Run it with:
 #
-#   gh workflow run cut-release -f tag=v3.2.0
+#   gh workflow run create-tag -f tag=v3.2.0
 #
 # The tag is pushed with an App installation token (not GITHUB_TOKEN, whose
 # pushes never trigger other workflows), so release.yml starts as usual.

--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -23,6 +23,12 @@ on:
 permissions:
   contents: read
 
+# Two runs for the same tag would both pass the "already exists" check before
+# either pushes. Queue them instead.
+concurrency:
+  group: create-tag-${{ inputs.tag }}
+  cancel-in-progress: false
+
 jobs:
   tag:
     runs-on: ubuntu-latest
@@ -49,13 +55,13 @@ jobs:
 
       - name: Mint xprem-release App token
         id: app
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
 
       - name: Checkout ${{ inputs.branch }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           ref: refs/heads/${{ inputs.branch }}
           token: ${{ steps.app.outputs.token }}

--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -5,6 +5,7 @@ name: Create tag
 # leaked user token cannot trigger release.yml. Run it with:
 #
 #   gh workflow run create-tag -f tag=v3.2.0
+#   gh workflow run create-tag -f tag=v2.3.1 -f branch=release/v2.3
 #
 # The tag is pushed with an App installation token (not GITHUB_TOKEN, whose
 # pushes never trigger other workflows), so release.yml starts as usual.
@@ -14,8 +15,8 @@ on:
       tag:
         description: "Tag to create (vX.Y.Z, or vX.Y.Z-beta1 / -alpha2 / -rc1)"
         required: true
-      ref:
-        description: "Commit or branch to tag"
+      branch:
+        description: "Branch to tag: main or release/*"
         required: false
         default: "main"
 
@@ -29,15 +30,20 @@ jobs:
     # main: a workflow on any other branch reads them as empty.
     environment: create-tag
     steps:
-      - name: Validate tag name
+      - name: Validate inputs
         env:
           TAG: ${{ inputs.tag }}
+          BRANCH: ${{ inputs.branch }}
         run: |
           # Only the suffixes release.yml recognises as pre-releases: anything
           # else (v1.2.3-test) would be published to npm as latest and as a
           # stable GitHub release.
           if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|rc)[0-9]*)?$ ]]; then
             echo "::error::Tag must look like v1.2.3, v1.2.3-beta1, v1.2.3-alpha2 or v1.2.3-rc1, got: $TAG"
+            exit 1
+          fi
+          if [[ ! "$BRANCH" =~ ^(main|release/[0-9A-Za-z_-][0-9A-Za-z._-]*(/[0-9A-Za-z_-][0-9A-Za-z._-]*)*)$ ]]; then
+            echo "::error::Only main or a release/* branch can be tagged, got: $BRANCH"
             exit 1
           fi
 
@@ -48,10 +54,10 @@ jobs:
           app-id: ${{ secrets.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
 
-      - name: Checkout ${{ inputs.ref }}
+      - name: Checkout ${{ inputs.branch }}
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.ref }}
+          ref: refs/heads/${{ inputs.branch }}
           token: ${{ steps.app.outputs.token }}
 
       - name: Create and push tag

--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -25,6 +25,9 @@ permissions:
 jobs:
   tag:
     runs-on: ubuntu-latest
+    # The App secrets live in this environment, which only accepts runs from
+    # main: a workflow on any other branch reads them as empty.
+    environment: create-tag
     steps:
       - name: Validate tag name
         env:

--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -1,0 +1,63 @@
+name: Cut release
+
+# The only way a v* tag gets created. The "Protect release tags" ruleset lets
+# nothing but the xprem-release GitHub App create, move or delete v* tags, so a
+# leaked user token cannot trigger release.yml. Run it with:
+#
+#   gh workflow run cut-release -f tag=v3.2.0
+#
+# The tag is pushed with an App installation token (not GITHUB_TOKEN, whose
+# pushes never trigger other workflows), so release.yml starts as usual.
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to create (vX.Y.Z or vX.Y.Z-suffix)"
+        required: true
+      ref:
+        description: "Commit or branch to tag"
+        required: false
+        default: "main"
+
+permissions:
+  contents: read
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate tag name
+        env:
+          TAG: ${{ inputs.tag }}
+        run: |
+          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$ ]]; then
+            echo "::error::Tag must look like v1.2.3 or v1.2.3-beta1, got: $TAG"
+            exit 1
+          fi
+
+      - name: Mint xprem-release App token
+        id: app
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
+      - name: Checkout ${{ inputs.ref }}
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+          token: ${{ steps.app.outputs.token }}
+
+      - name: Create and push tag
+        env:
+          TAG: ${{ inputs.tag }}
+        run: |
+          if git ls-remote --exit-code --tags origin "refs/tags/$TAG" >/dev/null; then
+            echo "::error::Tag $TAG already exists"
+            exit 1
+          fi
+          git config user.name "xprem-release[bot]"
+          git config user.email "xprem-release[bot]@users.noreply.github.com"
+          git tag -a "$TAG" -m "$TAG"
+          git push origin "refs/tags/$TAG"
+          echo "Tagged $(git rev-parse --short HEAD) as $TAG"

--- a/.github/workflows/promote-latest.yml
+++ b/.github/workflows/promote-latest.yml
@@ -1,7 +1,7 @@
 name: Promote release to latest
 
 # Manually promotes an already-released version to the "latest" Docker tag,
-# across the canonical xprem image and the deprecated expo-open-ota paths.
+# on the canonical xprem image and the deprecated expo-open-ota path.
 # The release workflow never touches "latest" anymore.
 
 on:
@@ -11,11 +11,9 @@ on:
         description: "Stable release tag to promote (e.g. v3.0.0)"
         required: true
 
-# The GHCR push authenticates with its own token, so this workflow never needs
-# anything from GITHUB_TOKEN. Stated explicitly rather than inherited from the
-# org-wide default.
 permissions:
   contents: read
+  packages: write
 
 jobs:
   promote:
@@ -34,12 +32,11 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to GitHub Container Registry
-        run: echo "${{ secrets.DOCKER_GITHUB_CONTAINER_REGISTRY_TOKEN }}" | docker login ghcr.io -u axelmarciano --password-stdin
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
 
       - name: Tag Docker image as latest in every namespace
         run: |
           for REPO in "ghcr.io/${{ github.repository_owner }}/xprem" \
-                      "ghcr.io/${{ github.repository_owner }}/expo-open-ota" \
-                      "ghcr.io/axelmarciano/expo-open-ota"; do
+                      "ghcr.io/${{ github.repository_owner }}/expo-open-ota"; do
             docker buildx imagetools create -t "$REPO:latest" "$REPO:$TAG"
           done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      packages: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -27,20 +28,16 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      # The personal token has write access to both the mercuretechnologies and
-      # the legacy axelmarciano namespaces (GHCR packages do not follow repo
-      # transfers, and existing deployments still pull the old path).
       - name: Log in to GitHub Container Registry
-        run: echo "${{ secrets.DOCKER_GITHUB_CONTAINER_REGISTRY_TOKEN }}" | docker login ghcr.io -u axelmarciano --password-stdin
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
 
-      # xprem is the canonical image. The two expo-open-ota paths are kept in
-      # sync so deployments made under the old project name keep pulling.
+      # xprem is the canonical image. The expo-open-ota path is kept in sync so
+      # deployments made under the old project name keep pulling.
       - name: Build and push multi-platform Docker image
         run: |
           IMAGE_TAG="${GITHUB_REF#refs/tags/}"
           REPO="ghcr.io/${{ github.repository_owner }}/xprem"
           DEPRECATED_REPO="ghcr.io/${{ github.repository_owner }}/expo-open-ota"
-          LEGACY_REPO="ghcr.io/axelmarciano/expo-open-ota"
 
           echo "Building Docker image with tag: $IMAGE_TAG"
           docker buildx build \
@@ -48,7 +45,6 @@ jobs:
             --build-arg VERSION="$IMAGE_TAG" \
             -t "$REPO:$IMAGE_TAG" \
             -t "$DEPRECATED_REPO:$IMAGE_TAG" \
-            -t "$LEGACY_REPO:$IMAGE_TAG" \
             --push .
 
   helm:
@@ -56,6 +52,7 @@ jobs:
     needs: docker
     permissions:
       contents: read
+      packages: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -79,7 +76,7 @@ jobs:
           sed -i 's/^name: expo-open-ota$/name: xprem/' helm/Chart.yaml
 
       - name: Log in to GitHub Container Registry
-        run: echo "${{ secrets.DOCKER_GITHUB_CONTAINER_REGISTRY_TOKEN }}" | helm registry login ghcr.io -u axelmarciano --password-stdin
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io -u "${{ github.actor }}" --password-stdin
 
       - name: Push Helm chart to GHCR
         run: |
@@ -88,7 +85,6 @@ jobs:
           OWNER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
           for CHART in xprem expo-open-ota; do
             helm push "./charts/${CHART}-${CHART_VERSION}.tgz" "oci://ghcr.io/${OWNER}/charts"
-            helm push "./charts/${CHART}-${CHART_VERSION}.tgz" "oci://ghcr.io/axelmarciano/charts"
           done
 
       # Only the canonical chart ships as a release asset; the deprecated copy


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a manually triggered workflow for creating validated semantic-version release tags.
  * Supports selecting a permitted branch as the tagging source.
  * Prevents duplicate tags and publishes annotated tags using authorized release credentials.

* **Release Improvements**
  * Updated container image and Helm chart publishing to use the current repository namespace.
  * Removed publishing of the legacy container image path.
  * Improved package permissions and GHCR authentication for release publishing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->