### PR TITLE
fix(eoas): hint when the server predates the 3.2.0 upload protocol

### DIFF
--- a/apps/eoas/src/lib/assets.ts
+++ b/apps/eoas/src/lib/assets.ts
@@ -8,7 +8,7 @@ import { Credentials, getAuthHeaders, missingEooTokenHint } from './auth';
 import { FileDigest, digestFile } from './crypto';
 import { RequestedPlatform } from './expoConfig';
 import { fetchWithRetries } from './fetch';
-import Log from './log';
+import Log, { learnMore } from './log';
 
 const fileMetadataJoi = Joi.object({
   assets: Joi.array()
@@ -388,11 +388,10 @@ export class NoChangesDetectedError extends Error {
   }
 }
 
-function outdatedServerHint(status: number, text: string): string {
-  if (status !== 400 || text.trim() !== 'No file names provided') {
-    return '';
-  }
-  return '\nHint: the server did not understand the file list, so it runs a version older than 3.2.0. Upgrade the server to 3.2.0 or later, or pin eoas@3.1.X in devDependencies until then. See https://xprem.dev/changelog/bundle-diffing-and-cas';
+function outdatedServerHint(): string {
+  return `Hint: the server did not understand the file list, so it runs a version older than 3.2.0. Upgrade the server to 3.2.0 or later, or pin eoas@3.1.X in devDependencies until then. ${learnMore(
+    'https://xprem.dev/changelog/bundle-diffing-and-cas'
+  )}`;
 }
 
 export async function requestUploadUrls({
@@ -455,9 +454,11 @@ export async function requestUploadUrls({
     throw new NoChangesDetectedError(platform);
   }
   if (!response.ok) {
-    const text = await response.text();
-    const hint = missingEooTokenHint(response.status) || outdatedServerHint(response.status, text);
-    throw new Error(`Failed to request upload URL: ${text}${hint}`);
+    const text = (await response.text()).trimEnd();
+    if (response.status === 400 && text === 'No file names provided') {
+      throw new Error(`Failed to request upload URL: ${text}\n${outdatedServerHint()}`);
+    }
+    throw new Error(`Failed to request upload URL: ${text}${missingEooTokenHint(response.status)}`);
   }
   const json = await response.json();
   // Joi's sanitized value, not the raw payload: it is the object the schema

--- a/apps/eoas/src/lib/assets.ts
+++ b/apps/eoas/src/lib/assets.ts
@@ -388,6 +388,13 @@ export class NoChangesDetectedError extends Error {
   }
 }
 
+function outdatedServerHint(status: number, text: string): string {
+  if (status !== 400 || text.trim() !== 'No file names provided') {
+    return '';
+  }
+  return '\nHint: the server did not understand the file list, so it runs a version older than 3.2.0. Upgrade the server to 3.2.0 or later, or pin eoas@3.1.X in devDependencies until then. See https://xprem.dev/changelog/bundle-diffing-and-cas';
+}
+
 export async function requestUploadUrls({
   body,
   requestUploadUrl,
@@ -449,7 +456,8 @@ export async function requestUploadUrls({
   }
   if (!response.ok) {
     const text = await response.text();
-    throw new Error(`Failed to request upload URL: ${text}${missingEooTokenHint(response.status)}`);
+    const hint = missingEooTokenHint(response.status) || outdatedServerHint(response.status, text);
+    throw new Error(`Failed to request upload URL: ${text}${hint}`);
   }
   const json = await response.json();
   // Joi's sanitized value, not the raw payload: it is the object the schema


### PR DESCRIPTION
eoas 3.2.0 sends the file list as `files` (path, hash, role). Servers older than 3.2.0 only read `fileNames`, so they see an empty list and answer 400 "No file names provided". The CLI surfaced that message as is, which reads like an empty export instead of a version mismatch.

The CLI now appends a hint on that exact 400: upgrade the server to 3.2.0 or later, or pin eoas@3.1.3 in devDependencies until then, with a link to https://xprem.dev/changelog/bundle-diffing-and-cas.

Detection relies on the server text, which is identical across 3.1.x. This CLI never sends an empty list, so that 400 can only come from an older server.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Upload failures from outdated servers now provide clearer guidance to upgrade when the server cannot process the current file-list format.
  * Error messages are cleaned up for easier reading, while authentication-related failures continue to display the appropriate sign-in guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->