### PR TITLE
feat: Display selected app name on browser title

### DIFF
--- a/apps/dashboard/src/containers/Layout/index.tsx
+++ b/apps/dashboard/src/containers/Layout/index.tsx
@@ -9,11 +9,22 @@ import { useLocation } from 'react-router';
 import { Button } from '@/components/ui/button';
 import { Sheet, SheetContent, SheetTitle } from '@/components/ui/sheet';
 import { CommandPalette } from '@/components/CommandPalette';
+import { useSelectedApp } from '@/lib/SelectedAppContext';
 
 export const Layout = ({ children }: { children: React.ReactNode }) => {
   const [mobileNavOpen, setMobileNavOpen] = useState(false);
   const [commandPaletteOpen, setCommandPaletteOpen] = useState(false);
   const { pathname } = useLocation();
+  const { apps, selectedAppId } = useSelectedApp();
+  const selectedApp = apps.find(app => app.id === selectedAppId);
+  const appName = selectedApp?.name || selectedApp?.id;
+
+  useEffect(() => {
+    document.title = appName ? `${appName} | xprem` : 'xprem';
+    return () => {
+      document.title = 'xprem';
+    };
+  }, [appName]);
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {


### PR DESCRIPTION
close #220 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - The browser tab title now reflects the selected app, using its name or ID followed by “| xprem”.
  - The title resets to “xprem” when no app is selected or when leaving the page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->