### PR TITLE
add build endpoints for android 

### DIFF
--- a/internal/database/postgres/pgdb/queries.sql.go
+++ b/internal/database/postgres/pgdb/queries.sql.go
@@ -6057,6 +6057,68 @@ func (q *Queries) ResolveDeviceUpdateFailures(ctx context.Context, arg ResolveDe
 	return result.RowsAffected(), nil
 }
 
+const resolveEnvironmentVariables = `-- name: ResolveEnvironmentVariables :many
+WITH selected AS (
+    SELECT e.id AS environment_id
+    FROM environments e
+    WHERE e.app_id = $1::uuid
+      AND $2::text <> ''
+      AND e.name = $2::text
+    UNION ALL
+    SELECT c.environment_id
+    FROM channels c
+    WHERE c.app_id = $1::uuid
+      AND $3::text <> ''
+      AND c.name = $3::text
+)
+SELECT e.id AS environment_id, e.name AS environment_name,
+       ev.key, ev.is_public, ev.sealed_value
+FROM selected s
+LEFT JOIN environments e ON e.id = s.environment_id AND e.app_id = $1::uuid
+LEFT JOIN environment_vars ev ON ev.environment_id = e.id
+ORDER BY ev.key ASC
+`
+
+type ResolveEnvironmentVariablesParams struct {
+	AppID           pgtype.UUID `json:"app_id"`
+	EnvironmentName string      `json:"environment_name"`
+	ChannelName     string      `json:"channel_name"`
+}
+
+type ResolveEnvironmentVariablesRow struct {
+	EnvironmentID   pgtype.UUID `json:"environment_id"`
+	EnvironmentName *string     `json:"environment_name"`
+	Key             *string     `json:"key"`
+	IsPublic        *bool       `json:"is_public"`
+	SealedValue     *string     `json:"sealed_value"`
+}
+
+func (q *Queries) ResolveEnvironmentVariables(ctx context.Context, arg ResolveEnvironmentVariablesParams) ([]ResolveEnvironmentVariablesRow, error) {
+	rows, err := q.db.Query(ctx, resolveEnvironmentVariables, arg.AppID, arg.EnvironmentName, arg.ChannelName)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ResolveEnvironmentVariablesRow
+	for rows.Next() {
+		var i ResolveEnvironmentVariablesRow
+		if err := rows.Scan(
+			&i.EnvironmentID,
+			&i.EnvironmentName,
+			&i.Key,
+			&i.IsPublic,
+			&i.SealedValue,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const revokeApiKeyByID = `-- name: RevokeApiKeyByID :one
 UPDATE api_keys
 SET revoked_at = CURRENT_TIMESTAMP

--- a/internal/database/postgres/queries/queries.sql
+++ b/internal/database/postgres/queries/queries.sql
@@ -2737,3 +2737,24 @@ VALUES ($1, $2, $3, $4);
 -- name: InsertApiKeySubmitRule :exec
 INSERT INTO api_key_submit_rules (api_key_id, app_id, app_identifier_id, destination, actions)
 VALUES ($1, $2, $3, $4, $5);
+
+-- name: ResolveEnvironmentVariables :many
+WITH selected AS (
+    SELECT e.id AS environment_id
+    FROM environments e
+    WHERE e.app_id = sqlc.arg('app_id')::uuid
+      AND sqlc.arg('environment_name')::text <> ''
+      AND e.name = sqlc.arg('environment_name')::text
+    UNION ALL
+    SELECT c.environment_id
+    FROM channels c
+    WHERE c.app_id = sqlc.arg('app_id')::uuid
+      AND sqlc.arg('channel_name')::text <> ''
+      AND c.name = sqlc.arg('channel_name')::text
+)
+SELECT e.id AS environment_id, e.name AS environment_name,
+       ev.key, ev.is_public, ev.sealed_value
+FROM selected s
+LEFT JOIN environments e ON e.id = s.environment_id AND e.app_id = sqlc.arg('app_id')::uuid
+LEFT JOIN environment_vars ev ON ev.environment_id = e.id
+ORDER BY ev.key ASC;

--- a/internal/handlers/build_handler.go
+++ b/internal/handlers/build_handler.go
@@ -1,0 +1,86 @@
+package handlers
+
+import (
+	"errors"
+	"net/http"
+	"net/url"
+	"xprem/internal/services"
+	"xprem/internal/store"
+	"xprem/internal/validation"
+
+	"github.com/gorilla/mux"
+)
+
+type BuildHandler struct {
+	environments *services.EnvironmentService
+	credentials  *services.CredentialsService
+}
+
+func NewBuildHandler(environments *services.EnvironmentService, credentials *services.CredentialsService) *BuildHandler {
+	return &BuildHandler{environments: environments, credentials: credentials}
+}
+
+func RenderBuildInputError(w http.ResponseWriter, err error) {
+	var missing *store.ErrResourceNotFound
+	switch {
+	case validation.IsValidationError(err):
+		RenderError(w, http.StatusBadRequest, err.Error())
+	case errors.As(err, &missing):
+		RenderError(w, http.StatusNotFound, missing.Error())
+	case errors.Is(err, store.ErrNotSupportedInStatelessMode):
+		RenderError(w, http.StatusBadRequest, err.Error())
+	default:
+		RenderError(w, http.StatusInternalServerError, "Could not retrieve build inputs.")
+	}
+}
+func (h *BuildHandler) Environment(w http.ResponseWriter, r *http.Request) {
+	query, err := buildEnvironmentQuery(r)
+	if err != nil {
+		RenderBuildInputError(w, err)
+		return
+	}
+	environment, err := h.environments.ExportVariables(r.Context(), mux.Vars(r)["APP_ID"], query["channel"], query["environment"])
+	if err != nil {
+		RenderBuildInputError(w, err)
+		return
+	}
+	RenderJSON(w, http.StatusOK, environment)
+}
+
+// Reject ambiguous selectors rather than silently using the first query value.
+func buildEnvironmentQuery(r *http.Request) (map[string]string, error) {
+	query, err := url.ParseQuery(r.URL.RawQuery)
+	if err != nil {
+		return nil, validation.Errorf("query", "invalid query parameters")
+	}
+	selectors := map[string]string{}
+	for key, values := range query {
+		if (key != "channel" && key != "environment") || len(values) != 1 || values[0] == "" {
+			return nil, validation.Errorf("query", "expected a single non-empty channel or environment")
+		}
+		selectors[key] = values[0]
+	}
+	if len(selectors) > 1 {
+		return nil, validation.Errorf("query", "channel and environment are mutually exclusive")
+	}
+	return selectors, nil
+}
+
+// Deliberate allowlist: never serialize the credential record or Google Play
+// service account. encoding/json represents the complete file bytes as base64.
+type AndroidBuildCredentials struct {
+	Keystore         []byte `json:"keystore"`
+	KeystorePassword string `json:"keystorePassword"`
+	KeyAlias         string `json:"keyAlias"`
+	KeyPassword      string `json:"keyPassword"`
+}
+
+func (h *BuildHandler) AndroidCredentials(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	exported, err := h.credentials.ExportAndroidKeystore(r.Context(), vars["APP_ID"], vars["IDENTIFIER_ID"])
+	if err != nil {
+		RenderBuildInputError(w, err)
+		return
+	}
+	RenderJSON(w, http.StatusOK, AndroidBuildCredentials{Keystore: exported.Keystore, KeystorePassword: exported.KeystorePassword, KeyAlias: exported.KeyAlias, KeyPassword: exported.KeyPassword})
+}

--- a/internal/handlers/build_handler.go
+++ b/internal/handlers/build_handler.go
@@ -33,6 +33,12 @@ func RenderBuildInputError(w http.ResponseWriter, err error) {
 		RenderError(w, http.StatusInternalServerError, "Could not retrieve build inputs.")
 	}
 }
+
+// renderBuildSecrets writes a build input export that must never be cached.
+func renderBuildSecrets(w http.ResponseWriter, payload interface{}) {
+	w.Header().Set("Cache-Control", "no-store")
+	RenderJSON(w, http.StatusOK, payload)
+}
 func (h *BuildHandler) Environment(w http.ResponseWriter, r *http.Request) {
 	query, err := buildEnvironmentQuery(r)
 	if err != nil {
@@ -44,7 +50,7 @@ func (h *BuildHandler) Environment(w http.ResponseWriter, r *http.Request) {
 		RenderBuildInputError(w, err)
 		return
 	}
-	RenderJSON(w, http.StatusOK, environment)
+	renderBuildSecrets(w, environment)
 }
 
 // Reject ambiguous selectors rather than silently using the first query value.
@@ -82,5 +88,5 @@ func (h *BuildHandler) AndroidCredentials(w http.ResponseWriter, r *http.Request
 		RenderBuildInputError(w, err)
 		return
 	}
-	RenderJSON(w, http.StatusOK, AndroidBuildCredentials{Keystore: exported.Keystore, KeystorePassword: exported.KeystorePassword, KeyAlias: exported.KeyAlias, KeyPassword: exported.KeyPassword})
+	renderBuildSecrets(w, AndroidBuildCredentials{Keystore: exported.Keystore, KeystorePassword: exported.KeystorePassword, KeyAlias: exported.KeyAlias, KeyPassword: exported.KeyPassword})
 }

--- a/internal/handlers/build_handler_test.go
+++ b/internal/handlers/build_handler_test.go
@@ -1,0 +1,94 @@
+package handlers
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"net/http/httptest"
+	"testing"
+	"xprem/internal/android/androidtest"
+	"xprem/internal/services"
+	"xprem/internal/store"
+
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/require"
+)
+
+type buildCredentialRepository struct {
+	services.CredentialsRepository
+	credentials *store.SealedAndroidCredentials
+	err         error
+	id          string
+}
+
+func (repo *buildCredentialRepository) UpsertAndroidCredentials(_ context.Context, id string, credentials store.SealedAndroidCredentials) error {
+	repo.credentials = &credentials
+	return nil
+}
+func (repo *buildCredentialRepository) GetAndroidCredentials(_ context.Context, id string) (*store.SealedAndroidCredentials, error) {
+	repo.id = id
+	return repo.credentials, repo.err
+}
+
+type buildIdentifierRepository struct {
+	services.AppIdentifierRepository
+	app, id string
+}
+
+func (repo *buildIdentifierRepository) GetAppIdentifierByID(_ context.Context, app, id string) (*store.AppIdentifierRef, error) {
+	repo.app, repo.id = app, id
+	if app != "app-1" || id != "id-1" {
+		return nil, nil
+	}
+	return &store.AppIdentifierRef{Id: id, Platform: services.PlatformAndroid}, nil
+}
+func TestBuildCredentialsAllowlistAndWholeFile(t *testing.T) {
+	t.Setenv("AWSSM_DB_KEYS_MASTER_KEY_SECRET_ID", "")
+	t.Setenv("DB_KEYS_MASTER_KEY_B64", base64.StdEncoding.EncodeToString([]byte("0123456789abcdef0123456789abcdef")))
+	raw := androidtest.JKSKeystore("store-password", "key-password", "selected-alias")
+	repo := &buildCredentialRepository{}
+	identifiers := &buildIdentifierRepository{}
+	credentials := services.NewCredentialsService(repo, identifiers)
+	require.NoError(t, credentials.SaveAndroidCredentials(context.Background(), "app-1", "id-1", services.AndroidCredentialsInput{
+		KeystoreBase64: base64.StdEncoding.EncodeToString(raw), KeystorePassword: "store-password", KeyAlias: "selected-alias", KeyPassword: "key-password",
+	}))
+	unreadablePlaySecret := "not a decryptable Google Play secret"
+	repo.credentials.SealedGoogleServiceAccountKey = &unreadablePlaySecret
+	h := NewBuildHandler(nil, credentials)
+	req := mux.SetURLVars(httptest.NewRequest("GET", "/", nil), map[string]string{"APP_ID": "app-1", "IDENTIFIER_ID": "id-1"})
+	w := httptest.NewRecorder()
+	h.AndroidCredentials(w, req)
+	require.Equal(t, 200, w.Code)
+	var got map[string]string
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
+	require.Equal(t, map[string]string{"keystore": base64.StdEncoding.EncodeToString(raw), "keystorePassword": "store-password", "keyAlias": "selected-alias", "keyPassword": "key-password"}, got)
+	require.Equal(t, "app-1", identifiers.app)
+	require.Equal(t, "id-1", repo.id)
+}
+func TestBuildCredentialsErrorsDoNotExposeSecrets(t *testing.T) {
+	for _, tc := range []struct {
+		err    error
+		status int
+	}{
+		{errors.New("secret sentinel"), 500},
+		{&store.ErrResourceNotFound{Resource: "android credentials", Identifier: "id"}, 404},
+		{store.ErrNotSupportedInStatelessMode, 400},
+	} {
+		h := NewBuildHandler(nil, services.NewCredentialsService(&buildCredentialRepository{err: tc.err}, &buildIdentifierRepository{}))
+		w := httptest.NewRecorder()
+		h.AndroidCredentials(w, mux.SetURLVars(httptest.NewRequest("GET", "/", nil), map[string]string{"APP_ID": "app-1", "IDENTIFIER_ID": "id-1"}))
+		require.Equal(t, tc.status, w.Code)
+		require.NotContains(t, w.Body.String(), "secret sentinel")
+	}
+}
+func TestBuildEnvironmentRejectsAmbiguousQuery(t *testing.T) {
+	for _, query := range []string{"channel=a&environment=b", "channel=a&channel=b", "environment=", "channel=", "other=x", "environment=%zz", "environment=a;b"} {
+		t.Run(query, func(t *testing.T) {
+			h := NewBuildHandler(nil, nil) // invalid requests cannot reach the service
+			w := httptest.NewRecorder()
+			h.Environment(w, httptest.NewRequest("GET", "/?"+query, nil))
+			require.Equal(t, 400, w.Code, w.Body.String())
+		})
+	}
+}

--- a/internal/handlers/dashboard/channel_environment_test.go
+++ b/internal/handlers/dashboard/channel_environment_test.go
@@ -84,3 +84,7 @@ func TestSetChannelEnvironmentRefusesMissingKey(t *testing.T) {
 		assert.Empty(t, repo.written, body)
 	}
 }
+
+func (r *channelEnvRepo) ResolveEnvironmentVariables(context.Context, string, string, string) (*store.ResolvedEnvironment, error) {
+	panic("unexpected environment export")
+}

--- a/internal/router/access_builds.go
+++ b/internal/router/access_builds.go
@@ -1,0 +1,78 @@
+package infrastructure
+
+import (
+	"context"
+	"net/http"
+	"xprem/ee/apikeyrestrictions"
+	"xprem/internal/handlers"
+	"xprem/internal/helpers"
+	"xprem/internal/services"
+	"xprem/internal/store"
+	"xprem/internal/validation"
+
+	"github.com/google/uuid"
+	"github.com/gorilla/mux"
+)
+
+type buildAccessPolicy interface {
+	AuthorizeBuild(context.Context, apikeyrestrictions.BuildRequest) error
+}
+type buildGroup struct {
+	router       *mux.Router
+	cliAuth      *services.CliAuthService
+	apiKeyAccess buildAccessPolicy
+	identifiers  services.AppIdentifierRepository
+}
+
+// route applies the action declared by each build-input endpoint.
+func (g buildGroup) route(method, path string, handler http.HandlerFunc, action apikeyrestrictions.BuildAction) {
+	g.router.Handle(path, g.guard(action)(handler)).Methods(method)
+}
+
+func (g buildGroup) guard(action apikeyrestrictions.BuildAction) mux.MiddlewareFunc {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			vars := mux.Vars(r)
+			credential, err := g.cliAuth.AuthenticateCliCredential(r.Context(), vars["APP_ID"], helpers.GetAuth(r))
+			if err != nil {
+				handlers.RenderCliAuthError(w, err)
+				return
+			}
+			// Build requires a registered app token; Expo stateless credentials have no key ID.
+			if credential.KeyID <= 0 {
+				handlers.RenderCliAuthError(w, services.ErrUnauthorized)
+				return
+			}
+			if g.identifiers == nil {
+				handlers.RenderBuildInputError(w, store.ErrNotSupportedInStatelessMode)
+				return
+			}
+			identifierID, err := uuid.Parse(vars["IDENTIFIER_ID"])
+			if err != nil {
+				handlers.RenderBuildInputError(w, validation.Errorf("identifierId", "invalid identifier id"))
+				return
+			}
+			ref, err := g.identifiers.GetAppIdentifierByID(r.Context(), credential.AppID, identifierID.String())
+			if err != nil {
+				handlers.RenderBuildInputError(w, err)
+				return
+			}
+			if ref == nil {
+				handlers.RenderBuildInputError(w, &store.ErrResourceNotFound{Resource: "app identifier", Identifier: identifierID.String()})
+				return
+			}
+			err = g.apiKeyAccess.AuthorizeBuild(r.Context(), apikeyrestrictions.BuildRequest{
+				APIKeyContext:   apikeyrestrictions.APIKeyContext{AppID: credential.AppID, APIKeyID: credential.KeyID, ClientIP: helpers.ClientIP(r)},
+				AppIdentifierID: ref.Id,
+				Action:          action,
+			})
+			if err != nil {
+				handlers.RenderCliAuthError(w, err)
+				return
+			}
+			// Both exports use the resolved canonical ID, never a payload-selected target.
+			vars["IDENTIFIER_ID"] = ref.Id
+			next.ServeHTTP(w, r.WithContext(services.WithCliAuth(r.Context(), credential)))
+		})
+	}
+}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -38,6 +38,7 @@ func NewRouter(container *AppContainer) *mux.Router {
 	registerInfraRoutes(r)
 	registerMCPRoutes(r, container)
 	registerPublishRoutes(r, container)
+	registerBuildRoutes(r, container)
 	registerIngestRoutes(r, container)
 	registerClientRoutes(r, container)
 	registerPreAuthRoutes(r, container)

--- a/internal/router/routes_build.go
+++ b/internal/router/routes_build.go
@@ -1,0 +1,27 @@
+package infrastructure
+
+import (
+	"net/http"
+	"xprem/ee/apikeyrestrictions"
+	"xprem/internal/middleware"
+
+	"github.com/gorilla/mux"
+)
+
+// registerBuildRoutes declares the CLI endpoints that retrieve build inputs.
+func registerBuildRoutes(r *mux.Router, container *AppContainer) {
+	router := r.PathPrefix("/{APP_ID}/build/{IDENTIFIER_ID}").Subrouter()
+	router.Use(middleware.AppResolverMiddleware(container.AppRepo))
+
+	build := buildGroup{
+		router:       router,
+		cliAuth:      container.CliAuthService,
+		apiKeyAccess: container.ApiKeyAccessService,
+		identifiers:   container.AppIdentifierRepo,
+	}
+
+	build.route(http.MethodGet, "/environment", container.BuildHandler.Environment,
+		apikeyrestrictions.BuildActionCreate)
+	build.route(http.MethodGet, "/credentials/android", container.BuildHandler.AndroidCredentials,
+		apikeyrestrictions.BuildActionCreate)
+}

--- a/internal/router/routes_build_test.go
+++ b/internal/router/routes_build_test.go
@@ -1,0 +1,293 @@
+package infrastructure
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/netip"
+	"testing"
+	"xprem/config"
+	"xprem/ee/apikeyrestrictions"
+	"xprem/ee/licensing"
+	"xprem/internal/android/androidtest"
+	"xprem/internal/handlers"
+	"xprem/internal/services"
+	"xprem/internal/store"
+	"xprem/internal/types"
+
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/require"
+)
+
+const buildID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+
+type buildIdentifierRepo struct {
+	services.AppIdentifierRepository
+	app      string
+	platform string
+}
+
+func (repo *buildIdentifierRepo) GetAppIdentifierByID(_ context.Context, app, id string) (*store.AppIdentifierRef, error) {
+	repo.app = app
+	if app != "app-1" || id != buildID {
+		return nil, nil
+	}
+	return &store.AppIdentifierRef{Id: buildID, Platform: repo.platform}, nil
+}
+
+type recordingBuildPolicy struct {
+	requests []apikeyrestrictions.BuildRequest
+	err      error
+}
+
+func (p *recordingBuildPolicy) AuthorizeBuild(_ context.Context, req apikeyrestrictions.BuildRequest) error {
+	p.requests = append(p.requests, req)
+	return p.err
+}
+func TestBuildGuardAuthorizesResolvedTargetBeforeSecrets(t *testing.T) {
+	for _, tc := range []struct {
+		name, app, id, platform string
+		deny                    error
+		status                  int
+		decisions               int
+	}{
+		{"allowed", "app-1", buildID, "android", nil, 200, 1},
+		{"denied", "app-1", buildID, "android", services.ErrCliAccessDenied, 403, 1},
+		{"outage", "app-1", buildID, "android", services.ErrCliAuthUnavailable, 500, 1},
+		{"revoked", "app-1", buildID, "android", apikeyrestrictions.ErrApiKeyNotFound, 401, 1},
+		{"foreign app", "app-2", buildID, "android", nil, 404, 0},
+		{"foreign identifier", "app-1", "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb", "android", nil, 404, 0},
+		{"ios", "app-1", buildID, "ios", nil, 200, 1},
+		{"malformed", "app-1", "bad", "android", nil, 400, 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := &buildIdentifierRepo{platform: tc.platform}
+			policy := &recordingBuildPolicy{err: tc.deny}
+			group := buildGroup{cliAuth: services.NewCliAuthService(acceptingCliRepo{}), apiKeyAccess: policy, identifiers: repo}
+			router := mux.NewRouter()
+			called := false
+			router.Handle("/{APP_ID}/build/{IDENTIFIER_ID}/environment", group.guard(apikeyrestrictions.BuildActionCreate)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				called = true
+				require.NotNil(t, services.CliAuthFromContext(r.Context()))
+				w.WriteHeader(200)
+			})))
+			req := httptest.NewRequest("GET", "/"+tc.app+"/build/"+tc.id+"/environment?channel=production", nil)
+			req.Header.Set("Authorization", "Bearer eoo_key")
+			req.RemoteAddr = "192.0.2.1:4000"
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+			require.Equal(t, tc.status, w.Code, w.Body.String())
+			require.Equal(t, tc.status == 200, called)
+			require.Len(t, policy.requests, tc.decisions)
+			require.Empty(t, w.Header().Get("Cache-Control"))
+			if tc.decisions > 0 {
+				decision := policy.requests[0]
+				require.Equal(t, tc.app, decision.AppID)
+				require.Equal(t, buildID, decision.AppIdentifierID)
+				require.Equal(t, apikeyrestrictions.BuildActionCreate, decision.Action)
+				require.Equal(t, int64(42), decision.APIKeyID)
+				require.Equal(t, "192.0.2.1", decision.ClientIP.String())
+			}
+		})
+	}
+}
+
+// Authentication failures must prevent even the target lookup.
+func TestBuildGuardAuthenticationFailure(t *testing.T) {
+	group := buildGroup{cliAuth: services.NewCliAuthService(failingBuildAuth{}), identifiers: nil}
+	w := httptest.NewRecorder()
+	group.guard(apikeyrestrictions.BuildActionCreate)(http.HandlerFunc(func(http.ResponseWriter, *http.Request) { t.Fatal("secret handler reached") })).ServeHTTP(w, httptest.NewRequest("GET", "/", nil))
+	require.Equal(t, 401, w.Code)
+}
+
+type failingBuildAuth struct{ acceptingCliRepo }
+
+func (failingBuildAuth) ValidateCliCredential(context.Context, string, types.Auth) (int64, error) {
+	return 0, errors.New("invalid")
+}
+
+type buildAccessRepo struct {
+	apikeyrestrictions.ApiKeyAccessRepository
+	access apikeyrestrictions.ApiKeyAccess
+	app    string
+}
+
+func (repo *buildAccessRepo) GetAccess(_ context.Context, app string, key int64) (apikeyrestrictions.ApiKeyAccess, error) {
+	repo.app = app
+	if app != "app-1" || key != 42 {
+		return apikeyrestrictions.ApiKeyAccess{}, apikeyrestrictions.ErrApiKeyNotFound
+	}
+	return repo.access, nil
+}
+
+// Exercise both real route registrations with the real Enterprise policy, not
+// only a stubbed allow/deny decision. Other domains must never reach exports.
+func TestBuildRoutesEnterpriseDomains(t *testing.T) {
+	t.Setenv("AWSSM_DB_KEYS_MASTER_KEY_SECRET_ID", "")
+	t.Setenv("DB_KEYS_MASTER_KEY_B64", base64.StdEncoding.EncodeToString([]byte("0123456789abcdef0123456789abcdef")))
+	previous := licensing.Current()
+	licensing.Activate(licensing.License{PlanCode: licensing.PlanEnterprise})
+	t.Cleanup(func() {
+		if previous == nil {
+			licensing.Deactivate()
+		} else {
+			licensing.Activate(*previous)
+		}
+	})
+	for _, tc := range []struct {
+		name   string
+		access apikeyrestrictions.ApiKeyAccess
+		status int
+	}{
+		{"build", apikeyrestrictions.ApiKeyAccess{BuildRules: []apikeyrestrictions.BuildRule{{AppIdentifierID: buildID, Actions: []apikeyrestrictions.BuildAction{apikeyrestrictions.BuildActionCreate}}}}, 200},
+		{"ota", apikeyrestrictions.ApiKeyAccess{UpdateRules: []apikeyrestrictions.UpdateRule{{Pattern: "*", Actions: []apikeyrestrictions.UpdateAction{apikeyrestrictions.UpdateActionPublish}}}}, 403},
+		{"submit", apikeyrestrictions.ApiKeyAccess{SubmitRules: []apikeyrestrictions.SubmitRule{{AppIdentifierID: buildID, Destination: apikeyrestrictions.SubmitDestinationInternal, Actions: []apikeyrestrictions.SubmitAction{apikeyrestrictions.SubmitActionUpload}}}}, 403},
+		{"empty", apikeyrestrictions.ApiKeyAccess{}, 403},
+		{"other identifier", apikeyrestrictions.ApiKeyAccess{BuildRules: []apikeyrestrictions.BuildRule{{AppIdentifierID: "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb", Actions: []apikeyrestrictions.BuildAction{apikeyrestrictions.BuildActionCreate}}}}, 403},
+		{"blocked IP", apikeyrestrictions.ApiKeyAccess{AllowedIps: []netip.Prefix{netip.MustParsePrefix("203.0.113.0/24")}, BuildRules: []apikeyrestrictions.BuildRule{{AppIdentifierID: buildID, Actions: []apikeyrestrictions.BuildAction{apikeyrestrictions.BuildActionCreate}}}}, 403},
+	} {
+		for _, target := range []struct{ platform, endpoint string }{{"android", "environment"}, {"ios", "environment"}, {"android", "credentials/android"}} {
+			endpoint := target.endpoint
+			t.Run(tc.name+"/"+target.platform+"/"+endpoint, func(t *testing.T) {
+				access := tc.access
+				access.ApiKeyID = 42
+				repo := &buildAccessRepo{access: access}
+				identifiers := &buildIdentifierRepo{platform: target.platform}
+				environments := services.NewEnvironmentService(nil)
+				vault := &buildCredentialsRepo{}
+				credentials := services.NewCredentialsService(vault, identifiers)
+				if target.platform == services.PlatformAndroid {
+					require.NoError(t, credentials.SaveAndroidCredentials(context.Background(), "app-1", buildID, services.AndroidCredentialsInput{
+						KeystoreBase64:   base64.StdEncoding.EncodeToString(androidtest.JKSKeystore("store-pass", "key-pass", "upload")),
+						KeystorePassword: "store-pass", KeyPassword: "key-pass", KeyAlias: "upload",
+					}))
+				}
+				container := &AppContainer{AppRepo: buildAppRepo{}, CliAuthService: services.NewCliAuthService(acceptingCliRepo{}), ApiKeyAccessService: apikeyrestrictions.NewApiKeyAccessService(repo), AppIdentifierRepo: identifiers, BuildHandler: handlers.NewBuildHandler(environments, credentials)}
+				router := mux.NewRouter()
+				registerBuildRoutes(router, container)
+				req := httptest.NewRequest("GET", "/app-1/build/"+buildID+"/"+endpoint, nil)
+				req.Header.Set("Authorization", "Bearer eoo_key")
+				req.RemoteAddr = "192.0.2.1:4000"
+				w := httptest.NewRecorder()
+				router.ServeHTTP(w, req)
+				require.Equal(t, tc.status, w.Code, w.Body.String())
+				require.Equal(t, "app-1", repo.app)
+				require.Equal(t, tc.status == 200 && endpoint == "credentials/android", vault.read)
+				if tc.status == 200 && endpoint == "environment" {
+					require.JSONEq(t, `{"environment":null,"variables":{}}`, w.Body.String())
+				}
+			})
+		}
+	}
+}
+
+type buildAppRepo struct{ services.AppRepository }
+
+func (buildAppRepo) GetAppByID(context.Context, string) (config.AppConfig, error) {
+	return config.AppConfig{}, nil
+}
+
+func TestBuildRoutePropagatesAction(t *testing.T) {
+	// A sentinel action distinguishes propagation from a hardcoded create grant.
+	// Route registration leaves validation to the policy, which must receive it unchanged.
+	action := apikeyrestrictions.BuildAction("sentinel")
+	policy := &recordingBuildPolicy{err: services.ErrCliAccessDenied}
+	group := buildGroup{router: mux.NewRouter(), cliAuth: services.NewCliAuthService(acceptingCliRepo{}), apiKeyAccess: policy, identifiers: &buildIdentifierRepo{platform: "android"}}
+	req := httptest.NewRequest(http.MethodGet, "/app-1/build/"+buildID, nil)
+	w := httptest.NewRecorder()
+	group.route(http.MethodGet, "/{APP_ID}/build/{IDENTIFIER_ID}", func(http.ResponseWriter, *http.Request) { t.Fatal("denied action reached handler") }, action)
+	group.router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusForbidden, w.Code)
+	require.Len(t, policy.requests, 1)
+	require.Equal(t, action, policy.requests[0].Action)
+}
+
+// A successfully authenticated Expo credential has no registered API key.
+// Build must refuse it before touching even the identifier repository.
+func TestBuildGuardRejectsUnregisteredCredential(t *testing.T) {
+	for _, keyID := range []int64{0, -1} {
+		group := buildGroup{cliAuth: services.NewCliAuthService(buildAuthKeyID{keyID: keyID})}
+		w := httptest.NewRecorder()
+		group.guard(apikeyrestrictions.BuildActionCreate)(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+			t.Fatal("unregistered credential reached build handler")
+		})).ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/", nil))
+		require.Equal(t, http.StatusUnauthorized, w.Code)
+	}
+}
+
+type buildAuthKeyID struct {
+	acceptingCliRepo
+	keyID int64
+}
+
+func (repo buildAuthKeyID) ValidateCliCredential(context.Context, string, types.Auth) (int64, error) {
+	return repo.keyID, nil
+}
+
+func TestBuildGuardAllowsRegisteredCommunityToken(t *testing.T) {
+	previous := licensing.Current()
+	licensing.Deactivate()
+	t.Cleanup(func() {
+		if previous != nil {
+			licensing.Activate(*previous)
+		}
+	})
+	group := buildGroup{
+		cliAuth:      services.NewCliAuthService(acceptingCliRepo{}),
+		apiKeyAccess: apikeyrestrictions.NewApiKeyAccessService(&buildAccessRepo{}),
+		identifiers:  &buildIdentifierRepo{platform: "android"},
+	}
+	req := mux.SetURLVars(httptest.NewRequest(http.MethodGet, "/", nil), map[string]string{"APP_ID": "app-1", "IDENTIFIER_ID": buildID})
+	w := httptest.NewRecorder()
+	group.guard(apikeyrestrictions.BuildActionCreate)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, int64(42), services.CliAuthFromContext(r.Context()).KeyID)
+		w.WriteHeader(http.StatusOK)
+	})).ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+}
+
+// The actual credentials service validates Android before reading/decrypting
+// the keystore. The common guard must still authorize the target first.
+func TestAndroidBuildCredentialsPlatform(t *testing.T) {
+	for _, platform := range []string{services.PlatformAndroid, services.PlatformIOS} {
+		t.Run(platform, func(t *testing.T) {
+			identifiers := &buildIdentifierRepo{platform: platform}
+			credentials := &buildCredentialsRepo{}
+			handler := handlers.NewBuildHandler(nil, services.NewCredentialsService(credentials, identifiers))
+			policy := &recordingBuildPolicy{}
+			group := buildGroup{router: mux.NewRouter(), cliAuth: services.NewCliAuthService(acceptingCliRepo{}), apiKeyAccess: policy, identifiers: identifiers}
+			group.route(http.MethodGet, "/{APP_ID}/build/{IDENTIFIER_ID}/credentials/android", handler.AndroidCredentials, apikeyrestrictions.BuildActionCreate)
+			req := httptest.NewRequest(http.MethodGet, "/app-1/build/"+buildID+"/credentials/android", nil)
+			w := httptest.NewRecorder()
+			group.router.ServeHTTP(w, req)
+			require.Len(t, policy.requests, 1)
+			require.Equal(t, buildID, policy.requests[0].AppIdentifierID)
+			if platform == services.PlatformIOS {
+				require.Equal(t, http.StatusBadRequest, w.Code, w.Body.String())
+				require.False(t, credentials.read)
+			} else {
+				// No stored key in this fixture; reaching the vault yields its normal 404.
+				require.Equal(t, http.StatusNotFound, w.Code, w.Body.String())
+				require.True(t, credentials.read)
+			}
+		})
+	}
+}
+
+type buildCredentialsRepo struct {
+	services.CredentialsRepository
+	credentials *store.SealedAndroidCredentials
+	read        bool
+}
+
+func (repo *buildCredentialsRepo) GetAndroidCredentials(context.Context, string) (*store.SealedAndroidCredentials, error) {
+	repo.read = true
+	return repo.credentials, nil
+}
+
+func (repo *buildCredentialsRepo) UpsertAndroidCredentials(_ context.Context, _ string, credentials store.SealedAndroidCredentials) error {
+	repo.credentials = &credentials
+	return nil
+}

--- a/internal/router/wire.go
+++ b/internal/router/wire.go
@@ -36,6 +36,8 @@ import (
 )
 
 type AppContainer struct {
+	AppIdentifierRepo           services.AppIdentifierRepository
+	BuildHandler                *handlers.BuildHandler
 	AuthHandler                 *dashhandlers.AuthHandler
 	BlobService                 *services.BlobService
 	DashboardAuthService        *services.DashboardAuthService
@@ -382,6 +384,8 @@ func InitDependencies(ctx context.Context) (*AppContainer, func()) {
 		ChannelHandler:              dashhandlers.NewChannelHandler(channelService),
 		AppIdentifiersHandler:       dashhandlers.NewAppIdentifiersHandler(appIdentifierService),
 		CredentialsHandler:          dashhandlers.NewCredentialsHandler(credentialsService),
+		AppIdentifierRepo:            appIdentifierRepo,
+		BuildHandler:                handlers.NewBuildHandler(environmentService, credentialsService),
 		EnvironmentsHandler:         dashhandlers.NewEnvironmentsHandler(environmentService),
 		ExpoProtocolHandler:         handlers.NewExpoProtocolHandler(expoProtocolService),
 		LicenseHandler:              licensing.NewLicenseHandler(licenseService),

--- a/internal/services/credentials_service_test.go
+++ b/internal/services/credentials_service_test.go
@@ -5,6 +5,7 @@
 package services
 
 import (
+	"bytes"
 	"context"
 	"encoding/base64"
 	"encoding/json"
@@ -16,6 +17,7 @@ import (
 	"xprem/internal/store"
 	"xprem/internal/validation"
 
+	keystore "github.com/pavlo-v-chernykh/keystore-go/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -365,4 +367,31 @@ func TestAndroidCredentialsUnsupportedInStatelessMode(t *testing.T) {
 	assert.ErrorIs(t, err, store.ErrNotSupportedInStatelessMode)
 	assert.ErrorIs(t, service.SaveGooglePlayServiceAccountKey(ctx, testAppId, testIdentifierId, `{}`), store.ErrNotSupportedInStatelessMode)
 	assert.ErrorIs(t, service.DeleteGooglePlayServiceAccountKey(ctx, testAppId, testIdentifierId), store.ErrNotSupportedInStatelessMode)
+}
+
+// A full imported multi-key file survives the reused export service unchanged;
+// only the configured alias is selected, and the Play secret need not decrypt.
+func TestBuildKeystoreExportPreservesMultiKeyFile(t *testing.T) {
+	setMasterKey(t)
+	service, repo, _ := newCredentialsFixture()
+	input := validAndroidInput()
+	raw, err := base64.StdEncoding.DecodeString(input.KeystoreBase64)
+	require.NoError(t, err)
+	ks := keystore.New()
+	require.NoError(t, ks.Load(bytes.NewReader(raw), []byte(input.KeystorePassword)))
+	entry, err := ks.GetPrivateKeyEntry(input.KeyAlias, []byte(input.KeyPassword))
+	require.NoError(t, err)
+	require.NoError(t, ks.SetPrivateKeyEntry("second-alias", entry, []byte("second-password")))
+	var file bytes.Buffer
+	require.NoError(t, ks.Store(&file, []byte(input.KeystorePassword)))
+	input.KeystoreBase64 = base64.StdEncoding.EncodeToString(file.Bytes())
+	require.NoError(t, service.SaveAndroidCredentials(context.Background(), testAppId, testIdentifierId, input))
+	stored := repo.byIdentifierId[testIdentifierId]
+	unreadablePlaySecret := "not a decryptable Google Play secret"
+	stored.SealedGoogleServiceAccountKey = &unreadablePlaySecret
+	repo.byIdentifierId[testIdentifierId] = stored
+	exported, err := service.ExportAndroidKeystore(context.Background(), testAppId, testIdentifierId)
+	require.NoError(t, err)
+	require.Equal(t, file.Bytes(), exported.Keystore)
+	require.Equal(t, input.KeyAlias, exported.KeyAlias)
 }

--- a/internal/services/environment_service.go
+++ b/internal/services/environment_service.go
@@ -24,6 +24,7 @@ const maxEnvValueBytes = 8 * 1024
 var envKeyPattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
 
 type EnvironmentRepository interface {
+	ResolveEnvironmentVariables(ctx context.Context, appID, channel, environment string) (*store.ResolvedEnvironment, error)
 	InsertEnvironment(ctx context.Context, appId string, name string) (string, error)
 	ListEnvironments(ctx context.Context, appId string) ([]store.EnvironmentRow, error)
 	// GetEnvironmentIdByName returns ErrResourceNotFound for an unknown name.
@@ -61,7 +62,7 @@ type EnvironmentService struct {
 }
 
 // NewEnvironmentService builds the service; a nil repo (stateless mode) makes
-// every method answer ErrNotSupportedInStatelessMode.
+// repository-backed operations answer ErrNotSupportedInStatelessMode.
 func NewEnvironmentService(repo EnvironmentRepository) *EnvironmentService {
 	return &EnvironmentService{repo: repo}
 }
@@ -245,7 +246,12 @@ func (s *EnvironmentService) RevealEnvVar(ctx context.Context, appId string, env
 	if sealedValue == nil {
 		return "", &store.ErrResourceNotFound{Resource: "env var", Identifier: key}
 	}
-	value, err := crypto.UnsealAESGCM(*sealedValue, []byte(keyStore.ReadDBKeysMasterKey()), envVarAAD(appId, environmentId, key))
+	return s.revealEnvValue(ctx, appId, environmentName, environmentId, key, *sealedValue)
+}
+
+// Shared decryption and audit path for individual reveals and grouped exports.
+func (s *EnvironmentService) revealEnvValue(ctx context.Context, appId, environmentName, environmentId, key, sealedValue string) (string, error) {
+	value, err := crypto.UnsealAESGCM(sealedValue, []byte(keyStore.ReadDBKeysMasterKey()), envVarAAD(appId, environmentId, key))
 	if err != nil {
 		return "", err
 	}
@@ -319,4 +325,54 @@ func (s *EnvironmentService) SetChannelEnvironment(ctx context.Context, appId st
 	})
 	invalidateChannelCaches(appId)
 	return nil
+}
+
+type EnvironmentValues struct {
+	Environment *string           `json:"environment"`
+	Variables   map[string]string `json:"variables"`
+}
+
+// ExportVariables resolves an app environment and returns its decrypted values.
+// There is no implicit default; callers authorize access before exporting.
+func (s *EnvironmentService) ExportVariables(ctx context.Context, appID, channel, environment string) (*EnvironmentValues, error) {
+	if channel != "" && environment != "" {
+		return nil, validation.Errorf("environment", "channel and environment are mutually exclusive")
+	}
+	output := &EnvironmentValues{Variables: map[string]string{}}
+	if channel == "" && environment == "" {
+		return output, nil
+	}
+	if channel != "" {
+		if err := validation.Name("channel", channel); err != nil {
+			return nil, err
+		}
+	} else if err := validateEnvironmentName(environment); err != nil {
+		return nil, err
+	}
+	if s.repo == nil {
+		return nil, store.ErrNotSupportedInStatelessMode
+	}
+	resolved, err := s.repo.ResolveEnvironmentVariables(ctx, appID, channel, environment)
+	if err != nil {
+		return nil, err
+	}
+	output.Environment = resolved.Name
+	if resolved.Name == nil {
+		return output, nil
+	}
+	for _, variable := range resolved.Variables {
+		if err := validateEnvKey(variable.Key); err != nil {
+			return nil, err
+		}
+		value, err := s.revealEnvValue(ctx, appID, *resolved.Name, resolved.ID, variable.Key, variable.SealedValue)
+		if err != nil {
+			return nil, err
+		}
+		name := variable.Key
+		if variable.IsPublic {
+			name = PublicEnvPrefix + name
+		}
+		output.Variables[name] = value
+	}
+	return output, nil
 }

--- a/internal/services/environment_service_test.go
+++ b/internal/services/environment_service_test.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 	"xprem/internal/auditlog"
 	"xprem/internal/crypto"
@@ -28,9 +29,14 @@ type envScopeKey struct {
 }
 
 type fakeEnvironmentRepo struct {
-	environments map[string]string // name -> id
-	byScopeKey   map[envScopeKey]fakeSealedEnvVar
-	channelEnvs  map[string]*string
+	exportApp, exportEnvironment string
+	exportCalls                  int
+	listCalls, valueCalls        int
+	channelApp                   string
+	channelLookups               []string
+	environments                 map[string]string // name -> id
+	byScopeKey                   map[envScopeKey]fakeSealedEnvVar
+	channelEnvs                  map[string]*string
 }
 
 func newFakeEnvironmentRepo() *fakeEnvironmentRepo {
@@ -51,6 +57,7 @@ func (f *fakeEnvironmentRepo) InsertEnvironment(_ context.Context, _ string, nam
 }
 
 func (f *fakeEnvironmentRepo) ListEnvironments(_ context.Context, _ string) ([]store.EnvironmentRow, error) {
+	f.listCalls++
 	rows := make([]store.EnvironmentRow, 0, len(f.environments))
 	for name, id := range f.environments {
 		rows = append(rows, store.EnvironmentRow{Id: id, Name: name})
@@ -85,6 +92,7 @@ func (f *fakeEnvironmentRepo) UpsertEnvVar(_ context.Context, environmentId stri
 }
 
 func (f *fakeEnvironmentRepo) ListEnvVars(_ context.Context, _ string) ([]store.EnvVarRow, error) {
+	f.listCalls++
 	rows := make([]store.EnvVarRow, 0, len(f.byScopeKey))
 	for scopeKey, envVar := range f.byScopeKey {
 		rows = append(rows, store.EnvVarRow{EnvironmentId: scopeKey.environmentId, Key: scopeKey.key, IsPublic: envVar.isPublic})
@@ -93,6 +101,7 @@ func (f *fakeEnvironmentRepo) ListEnvVars(_ context.Context, _ string) ([]store.
 }
 
 func (f *fakeEnvironmentRepo) GetSealedValue(_ context.Context, environmentId string, key string) (*string, error) {
+	f.valueCalls++
 	envVar, ok := f.byScopeKey[envScopeKey{environmentId, key}]
 	if !ok {
 		return nil, nil
@@ -301,4 +310,153 @@ func TestEnvironmentsUnsupportedInStatelessMode(t *testing.T) {
 	assert.ErrorIs(t, err, store.ErrNotSupportedInStatelessMode)
 	assert.ErrorIs(t, service.DeleteEnvVar(ctx, "app-1", "staging", "K"), store.ErrNotSupportedInStatelessMode)
 	assert.ErrorIs(t, service.SetChannelEnvironment(ctx, "app-1", "prod-channel", nil), store.ErrNotSupportedInStatelessMode)
+}
+
+func TestBuildEnvironmentSelection(t *testing.T) {
+	setMasterKey(t)
+	ctx := context.Background()
+	repo := newFakeEnvironmentRepo()
+	id := stagingEnvId
+	repo.channelEnvs["release"] = &id
+	repo.channelEnvs["unbound"] = nil
+	env := NewEnvironmentService(repo)
+	require.NoError(t, env.SetEnvVar(ctx, "app-1", "staging", "URL", "https://example.test", true))
+	require.NoError(t, env.SetEnvVar(ctx, "app-1", "staging", "EMPTY", "", false))
+	require.NoError(t, env.SetEnvVar(ctx, "app-1", "production", "PRIVATE", "other environment", false))
+
+	for _, tc := range []struct {
+		name, channel, environment string
+		wantErr                    bool
+		count                      int
+	}{
+		{name: "none"}, {name: "direct", environment: "staging", count: 2}, {name: "channel", channel: "release", count: 2},
+		{name: "unbound", channel: "unbound"}, {name: "unknown channel", channel: "foreign", wantErr: true},
+		{name: "unknown environment", environment: "foreign", wantErr: true}, {name: "both", channel: "release", environment: "staging", wantErr: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			before := repo.exportCalls
+			got, err := env.ExportVariables(ctx, "app-1", tc.channel, tc.environment)
+			expectedCalls := 1
+			if tc.name == "none" || tc.name == "both" {
+				expectedCalls = 0
+			}
+			require.Equal(t, expectedCalls, repo.exportCalls-before)
+			if tc.wantErr {
+				require.Error(t, err)
+				require.Nil(t, got)
+				return
+			}
+			require.NoError(t, err)
+			require.Len(t, got.Variables, tc.count)
+			if tc.count > 0 {
+				require.Equal(t, "staging", *got.Environment)
+				require.Equal(t, "https://example.test", got.Variables["EXPO_PUBLIC_URL"])
+				require.Contains(t, got.Variables, "EMPTY")
+				require.NotContains(t, got.Variables, "PRIVATE")
+			} else {
+				require.Nil(t, got.Environment)
+				require.NotNil(t, got.Variables)
+			}
+		})
+	}
+	require.Equal(t, "app-1", repo.channelApp)
+	require.Equal(t, []string{"release", "unbound", "foreign"}, repo.channelLookups)
+	require.Zero(t, repo.listCalls)
+	require.Zero(t, repo.valueCalls)
+}
+
+func TestBuildEnvironmentAuditAndDecryptionFailure(t *testing.T) {
+	setMasterKey(t)
+	repo := newFakeEnvironmentRepo()
+	env := NewEnvironmentService(repo)
+	ctx := context.Background()
+	require.NoError(t, env.SetEnvVar(ctx, "app-1", "staging", "TOKEN", "secret sentinel", false))
+	var events []auditlog.Event
+	env.SetOnAuditEvent(func(_ context.Context, event auditlog.Event) { events = append(events, event) })
+	got, err := env.ExportVariables(ctx, "app-1", "", "staging")
+	require.NoError(t, err)
+	require.Equal(t, "secret sentinel", got.Variables["TOKEN"])
+	require.Len(t, events, 1)
+	require.Equal(t, auditlog.ActionEnvVarRevealed, events[0].Action)
+	encoded, err := json.Marshal(events)
+	require.NoError(t, err)
+	require.NotContains(t, string(encoded), "secret sentinel")
+	repo.byScopeKey[envScopeKey{stagingEnvId, "TOKEN"}] = fakeSealedEnvVar{sealedValue: "corrupt"}
+	got, err = env.ExportVariables(ctx, "app-1", "", "staging")
+	require.Error(t, err)
+	require.Nil(t, got)
+	require.Len(t, events, 1)
+}
+
+func (f *fakeEnvironmentRepo) ResolveEnvironmentVariables(_ context.Context, appID, channel, environment string) (*store.ResolvedEnvironment, error) {
+	f.exportCalls++
+	f.exportApp = appID
+	resolved := &store.ResolvedEnvironment{Variables: []store.SealedEnvVar{}}
+	if channel != "" {
+		f.channelApp = appID
+		f.channelLookups = append(f.channelLookups, channel)
+		id, found := f.channelEnvs[channel]
+		if !found {
+			return nil, &store.ErrResourceNotFound{Resource: "channel", Identifier: channel}
+		}
+		if id == nil {
+			return resolved, nil
+		}
+		for name, candidate := range f.environments {
+			if candidate == *id {
+				environment = name
+				break
+			}
+		}
+	}
+	id, found := f.environments[environment]
+	if !found {
+		return nil, &store.ErrResourceNotFound{Resource: "environment", Identifier: environment}
+	}
+	resolved.ID, resolved.Name = id, &environment
+	f.exportEnvironment = id
+	for scope, variable := range f.byScopeKey {
+		if scope.environmentId == id {
+			resolved.Variables = append(resolved.Variables, store.SealedEnvVar{Key: scope.key, IsPublic: variable.isPublic, SealedValue: variable.sealedValue})
+		}
+	}
+	return resolved, nil
+}
+
+func TestExportVariablesEmptyEnvironmentAndTargetedReads(t *testing.T) {
+	setMasterKey(t)
+	repo := newFakeEnvironmentRepo()
+	service := NewEnvironmentService(repo)
+	got, err := service.ExportVariables(context.Background(), "app-1", "", "staging")
+	require.NoError(t, err)
+	require.Equal(t, "staging", *got.Environment)
+	require.Empty(t, got.Variables)
+	require.NotNil(t, got.Variables)
+	require.Equal(t, "app-1", repo.exportApp)
+	require.Equal(t, stagingEnvId, repo.exportEnvironment)
+	require.Equal(t, 1, repo.exportCalls)
+	require.Zero(t, repo.listCalls)
+	require.Zero(t, repo.valueCalls)
+}
+
+func TestExportVariablesRejectsForeignCiphertext(t *testing.T) {
+	setMasterKey(t)
+	for _, tc := range []struct{ name, app, environment string }{
+		{"another app", "other-app", stagingEnvId},
+		{"another environment", "app-1", productionEnvId},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := newFakeEnvironmentRepo()
+			sealed, err := crypto.SealAESGCM([]byte("secret sentinel"), []byte(testMasterKey), envVarAAD(tc.app, tc.environment, "TOKEN"))
+			require.NoError(t, err)
+			repo.byScopeKey[envScopeKey{stagingEnvId, "TOKEN"}] = fakeSealedEnvVar{sealedValue: sealed}
+			service := NewEnvironmentService(repo)
+			events := 0
+			service.SetOnAuditEvent(func(context.Context, auditlog.Event) { events++ })
+			got, err := service.ExportVariables(context.Background(), "app-1", "", "staging")
+			require.Error(t, err)
+			require.Nil(t, got)
+			require.Zero(t, events)
+		})
+	}
 }

--- a/internal/store/environment_postgres.go
+++ b/internal/store/environment_postgres.go
@@ -185,3 +185,38 @@ func (s *PostgresEnvironmentStore) SetChannelEnvironment(ctx context.Context, ap
 	}
 	return nil
 }
+
+// SealedEnvVar contains encrypted values for an authorized environment export.
+type SealedEnvVar struct {
+	Key         string
+	IsPublic    bool
+	SealedValue string
+}
+
+// ResolvedEnvironment distinguishes an unbound channel (nil name) from an
+// existing empty environment; unknown selectors return ErrResourceNotFound.
+type ResolvedEnvironment struct {
+	ID        string
+	Name      *string
+	Variables []SealedEnvVar
+}
+
+func (s *PostgresEnvironmentStore) ResolveEnvironmentVariables(ctx context.Context, appID, channel, environment string) (*ResolvedEnvironment, error) {
+	rows, err := s.engine.Queries.ResolveEnvironmentVariables(ctx, pgdb.ResolveEnvironmentVariablesParams{AppID: ToPgUUID(appID), ChannelName: channel, EnvironmentName: environment})
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve environment values from database: %w", err)
+	}
+	if len(rows) == 0 {
+		if channel != "" {
+			return nil, &ErrResourceNotFound{Resource: "channel", Identifier: channel}
+		}
+		return nil, &ErrResourceNotFound{Resource: "environment", Identifier: environment}
+	}
+	resolved := &ResolvedEnvironment{ID: rows[0].EnvironmentID.String(), Name: rows[0].EnvironmentName, Variables: []SealedEnvVar{}}
+	for _, row := range rows {
+		if row.Key != nil {
+			resolved.Variables = append(resolved.Variables, SealedEnvVar{Key: *row.Key, IsPublic: *row.IsPublic, SealedValue: *row.SealedValue})
+		}
+	}
+	return resolved, nil
+}

--- a/internal/store/environment_postgres_test.go
+++ b/internal/store/environment_postgres_test.go
@@ -187,3 +187,42 @@ func TestEnvVarUpsertOnDeletedEnvironmentIsNotFound(t *testing.T) {
 	notFoundErr := (*store.ErrResourceNotFound)(nil)
 	require.True(t, errors.As(err, &notFoundErr))
 }
+
+func TestResolveEnvironmentVariablesSelectorsAndAppScope(t *testing.T) {
+	envStore, channels, appID, pool := setupEnvironmentStore(t)
+	ctx := context.Background()
+	otherAppID := insertBareApp(t, pool)
+	selectedID := insertEnvironment(t, envStore, appID, "staging")
+	foreignID := insertEnvironment(t, envStore, otherAppID, "staging")
+	emptyID := insertEnvironment(t, envStore, appID, "empty")
+	for _, target := range []struct{ app, id, value string }{{appID, selectedID, "selected"}, {otherAppID, foreignID, "foreign"}} {
+		_, err := channels.InsertChannel(ctx, target.app, nil, "release")
+		require.NoError(t, err)
+		require.NoError(t, envStore.SetChannelEnvironment(ctx, target.app, "release", &target.id))
+		require.NoError(t, envStore.UpsertEnvVar(ctx, target.id, "TOKEN", true, target.value))
+		for _, selector := range []struct{ channel, env string }{{"release", ""}, {"", "staging"}} {
+			resolved, err := envStore.ResolveEnvironmentVariables(ctx, target.app, selector.channel, selector.env)
+			require.NoError(t, err)
+			require.Equal(t, target.id, resolved.ID)
+			require.Equal(t, "staging", *resolved.Name)
+			require.Equal(t, []store.SealedEnvVar{{Key: "TOKEN", IsPublic: true, SealedValue: target.value}}, resolved.Variables)
+		}
+	}
+	_, err := channels.InsertChannel(ctx, appID, nil, "unbound")
+	require.NoError(t, err)
+	resolved, err := envStore.ResolveEnvironmentVariables(ctx, appID, "unbound", "")
+	require.NoError(t, err)
+	require.Nil(t, resolved.Name)
+	require.Empty(t, resolved.Variables)
+	resolved, err = envStore.ResolveEnvironmentVariables(ctx, appID, "", "empty")
+	require.NoError(t, err)
+	require.Equal(t, emptyID, resolved.ID)
+	require.Equal(t, "empty", *resolved.Name)
+	require.Empty(t, resolved.Variables)
+	for _, target := range []struct{ app, channel, env string }{{otherAppID, "unbound", ""}, {otherAppID, "", "empty"}, {appID, "missing", ""}, {appID, "", "missing"}} {
+		resolved, err := envStore.ResolveEnvironmentVariables(ctx, target.app, target.channel, target.env)
+		require.Nil(t, resolved)
+		var missing *store.ErrResourceNotFound
+		require.ErrorAs(t, err, &missing)
+	}
+}


### PR DESCRIPTION
Implements /credentials & /credentials/android endpoint for eoas build cli

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added build endpoints for retrieving an app’s environment variables by environment or channel.
  - Added Android build credential retrieval, including keystore and signing credentials.
  - Added access controls to ensure only authorized build requests can retrieve build inputs.
  - Added validation for ambiguous, missing, or invalid environment and channel selections.

- **Bug Fixes**
  - Preserved complete Android keystore files while selecting the configured signing alias.
  - Prevented unrelated secrets, including Google Play credentials, from being exposed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->