### PR TITLE
Validate Android build tools and sync maintained projects

### DIFF
--- a/apps/eoas/src/lib/build/android/__tests__/android.test.ts
+++ b/apps/eoas/src/lib/build/android/__tests__/android.test.ts
@@ -35,12 +35,14 @@ describe('Android orchestration', () => {
   let sdk: string;
   const events: string[] = [];
   let temporaryProject: string | undefined;
+  let syncArgs: string[] | undefined;
   let failExport = false;
   beforeEach(async () => {
     vi.clearAllMocks();
     events.length = 0;
     failExport = false;
     temporaryProject = undefined;
+    syncArgs = undefined;
     project = await fs.mkdtemp(path.join(os.tmpdir(), 'eoas-test-project-'));
     sdk = path.join(project, 'sdk');
     vi.mocked(resolveAndroidTools).mockResolvedValue({
@@ -126,6 +128,10 @@ describe('Android orchestration', () => {
               'expo-router is incompatible with react-navigation. store-secret file-secret-value',
           });
         }
+      }
+      if (args?.includes('configuration:syncnative')) {
+        events.push('sync-updates');
+        syncArgs = [...(args ?? [])];
       }
       if (args?.includes('prebuild')) {
         events.push('prebuild');
@@ -217,6 +223,26 @@ describe('Android orchestration', () => {
     const log = await fs.readFile(path.join(project, 'build-artifacts/logs', logs[0]), 'utf8');
     expect(log).toContain('Building signed AAB');
     expect(log).toContain('versionCode 42');
+  });
+  it('syncs the expo-updates configuration into a maintained Android project instead of prebuilding', async () => {
+    await fs.outputFile(path.join(project, 'android/app/build.gradle'), 'android {}');
+    await fs.outputFile(
+      path.join(project, 'android/app/src/main/AndroidManifest.xml'),
+      '<manifest />'
+    );
+    await fs.outputFile(path.join(project, 'android/gradlew'), '#!/bin/sh\nexit 0\n');
+    await buildAndroid(project, {
+      profile: 'production',
+      envFile: 'override.env',
+      serverUrl: 'https://example.com',
+      appId: 'app',
+    });
+    expect(events).not.toContain('prebuild');
+    expect(events.indexOf('sync-updates')).toBeGreaterThan(events.indexOf('allocate'));
+    expect(events.indexOf('sync-updates')).toBeLessThan(events.indexOf('gradle'));
+    expect(syncArgs).toEqual(
+      expect.arrayContaining(['expo-updates', '--platform', 'android', '--workflow', 'generic'])
+    );
   });
   it('does not fetch an environment when the profile selects neither channel nor environment', async () => {
     const file = path.join(project, 'xprem.json');

--- a/apps/eoas/src/lib/build/android/__tests__/android.test.ts
+++ b/apps/eoas/src/lib/build/android/__tests__/android.test.ts
@@ -28,6 +28,7 @@ vi.mock('../tools', async importOriginal => ({
 }));
 vi.mock('../../../log', () => ({
   default: { log: vi.fn(), warn: vi.fn(), succeed: vi.fn(), fail: vi.fn() },
+  link: (url: string) => url,
 }));
 
 describe('Android orchestration', () => {
@@ -231,6 +232,7 @@ describe('Android orchestration', () => {
       '<manifest />'
     );
     await fs.outputFile(path.join(project, 'android/gradlew'), '#!/bin/sh\nexit 0\n');
+    await fs.outputFile(path.join(project, 'node_modules/expo-updates/bin/cli.js'), '');
     await buildAndroid(project, {
       profile: 'production',
       envFile: 'override.env',
@@ -240,9 +242,28 @@ describe('Android orchestration', () => {
     expect(events).not.toContain('prebuild');
     expect(events.indexOf('sync-updates')).toBeGreaterThan(events.indexOf('allocate'));
     expect(events.indexOf('sync-updates')).toBeLessThan(events.indexOf('gradle'));
+    expect(syncArgs?.[0]).toMatch(/node_modules\/expo-updates\/bin\/cli\.js$/);
     expect(syncArgs).toEqual(
-      expect.arrayContaining(['expo-updates', '--platform', 'android', '--workflow', 'generic'])
+      expect.arrayContaining([
+        'configuration:syncnative',
+        '--platform',
+        'android',
+        '--workflow',
+        'generic',
+      ])
     );
+  });
+  it('refuses a maintained Android project without expo-updates instead of downloading it', async () => {
+    await fs.outputFile(path.join(project, 'android/app/build.gradle'), 'android {}');
+    await expect(
+      buildAndroid(project, {
+        profile: 'production',
+        envFile: 'override.env',
+        serverUrl: 'https://example.com',
+        appId: 'app',
+      })
+    ).rejects.toThrow('`expo-updates` package was not found');
+    expect(events).not.toContain('sync-updates');
   });
   it('does not fetch an environment when the profile selects neither channel nor environment', async () => {
     const file = path.join(project, 'xprem.json');

--- a/apps/eoas/src/lib/build/android/__tests__/tools.test.ts
+++ b/apps/eoas/src/lib/build/android/__tests__/tools.test.ts
@@ -17,15 +17,12 @@ describe('local Android tools', () => {
     sdk = path.join(project, 'Android SDK');
     await fs.outputFile(path.join(sdk, 'platforms/android-35/android.jar'), '');
     await fs.outputFile(path.join(sdk, 'build-tools/35.0.0/aapt2'), '');
-    vi.mocked(spawnAsync).mockImplementation(
-      async command =>
-        ({
-          stdout: command.endsWith('javac') ? 'javac 17.0.12' : '',
-          stderr: command.endsWith('javac')
-            ? ''
-            : '    java.home = /detected-jdk\n    java.version = 17.0.12\n',
-        }) as never
-    );
+    vi.mocked(spawnAsync).mockImplementation((async (command: string) => ({
+      stdout: command.endsWith('javac') ? 'javac 17.0.12' : '',
+      stderr: command.endsWith('javac')
+        ? ''
+        : '    java.home = /detected-jdk\n    java.version = 17.0.12\n',
+    })) as never);
   });
   afterEach(async () => {
     vi.restoreAllMocks();

--- a/apps/eoas/src/lib/build/android/__tests__/tools.test.ts
+++ b/apps/eoas/src/lib/build/android/__tests__/tools.test.ts
@@ -1,3 +1,4 @@
+import spawnAsync from '@expo/spawn-async';
 import fs from 'fs-extra';
 import os from 'os';
 import path from 'path';
@@ -5,13 +6,26 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { configureAndroidSdk, resolveAndroidTools } from '../tools';
 
+vi.mock('@expo/spawn-async', () => ({ default: vi.fn() }));
+
 describe('local Android tools', () => {
   let project: string;
   let sdk: string;
   beforeEach(async () => {
+    vi.mocked(spawnAsync).mockReset();
     project = await fs.mkdtemp(path.join(os.tmpdir(), 'eoas-android-tools-'));
     sdk = path.join(project, 'Android SDK');
-    await fs.ensureDir(sdk);
+    await fs.outputFile(path.join(sdk, 'platforms/android-35/android.jar'), '');
+    await fs.outputFile(path.join(sdk, 'build-tools/35.0.0/aapt2'), '');
+    vi.mocked(spawnAsync).mockImplementation(
+      async command =>
+        ({
+          stdout: command.endsWith('javac') ? 'javac 17.0.12' : '',
+          stderr: command.endsWith('javac')
+            ? ''
+            : '    java.home = /detected-jdk\n    java.version = 17.0.12\n',
+        }) as never
+    );
   });
   afterEach(async () => {
     vi.restoreAllMocks();
@@ -21,7 +35,11 @@ describe('local Android tools', () => {
   it('exports the configured SDK and JAVA_HOME without changing process.env', async () => {
     const previous = { ...process.env };
     const env = await resolveAndroidTools(project, {}, { ANDROID_HOME: sdk, JAVA_HOME: '/jdk' });
-    expect(env).toEqual({ ANDROID_HOME: sdk, ANDROID_SDK_ROOT: sdk, JAVA_HOME: '/jdk' });
+    expect(env).toMatchObject({ ANDROID_HOME: sdk, ANDROID_SDK_ROOT: sdk, JAVA_HOME: '/jdk' });
+    expect(vi.mocked(spawnAsync).mock.calls.map(([command]) => command)).toEqual([
+      '/jdk/bin/java',
+      '/jdk/bin/javac',
+    ]);
     expect(process.env).toEqual(previous);
   });
 
@@ -35,10 +53,11 @@ describe('local Android tools', () => {
     expect(env.JAVA_HOME).toBe('/flag-jdk');
   });
 
-  it('falls back to ANDROID_SDK_ROOT and leaves JAVA_HOME to gradlew when unset', async () => {
+  it('falls back to ANDROID_SDK_ROOT and pins the JDK discovered through PATH', async () => {
     const env = await resolveAndroidTools(project, {}, { ANDROID_SDK_ROOT: sdk });
     expect(env.ANDROID_HOME).toBe(sdk);
-    expect(env.JAVA_HOME).toBeUndefined();
+    expect(env.JAVA_HOME).toBe('/detected-jdk');
+    expect(vi.mocked(spawnAsync).mock.calls[1][0]).toBe('/detected-jdk/bin/javac');
   });
 
   it('finds the standard Linux SDK path when no path is configured', async () => {
@@ -53,6 +72,63 @@ describe('local Android tools', () => {
     await expect(
       resolveAndroidTools(project, { androidSdk: '/missing-sdk' }, { ANDROID_HOME: sdk })
     ).rejects.toThrow(/ANDROID_HOME.*--androidSdk/);
+  });
+
+  it('rejects a directory that is not an installed SDK', async () => {
+    await fs.remove(path.join(sdk, 'platforms'));
+    await expect(resolveAndroidTools(project, { androidSdk: sdk })).rejects.toThrow(
+      /SDK Platforms.*Android Studio/
+    );
+  });
+
+  it('rejects a file used as an SDK directory', async () => {
+    const file = path.join(project, 'not-a-directory');
+    await fs.writeFile(file, '');
+    await expect(resolveAndroidTools(project, { androidSdk: file })).rejects.toThrow(
+      /Android SDK.*--androidSdk/
+    );
+  });
+
+  it('explains how to fix an unavailable Java executable', async () => {
+    vi.mocked(spawnAsync).mockRejectedValue(
+      Object.assign(new Error('spawn ENOENT'), { code: 'ENOENT' })
+    );
+    await expect(
+      resolveAndroidTools(project, { androidSdk: sdk, javaHome: '/bad-jdk' })
+    ).rejects.toThrow(/Java.*bad-jdk.*JAVA_HOME.*--javaHome/);
+  });
+
+  it('requires a compiler from the selected JDK, not an unrelated javac from PATH', async () => {
+    vi.mocked(spawnAsync).mockReset();
+    vi.mocked(spawnAsync).mockResolvedValueOnce({
+      stderr: 'java.home = /jre\njava.version = 17.0.12',
+      stdout: '',
+    } as never);
+    vi.mocked(spawnAsync).mockRejectedValueOnce(new Error('spawn ENOENT'));
+    await expect(resolveAndroidTools(project, { androidSdk: sdk }, {})).rejects.toThrow(
+      /compiler.*JDK.*--javaHome/
+    );
+    expect(vi.mocked(spawnAsync).mock.calls[1][0]).toBe('/jre/bin/javac');
+  });
+
+  it('rejects a mismatched compiler version', async () => {
+    vi.mocked(spawnAsync).mockResolvedValueOnce({
+      stderr: 'java.home = /jdk\njava.version = 17.0.12',
+      stdout: '',
+    } as never);
+    vi.mocked(spawnAsync).mockResolvedValueOnce({ stderr: '', stdout: 'javac 21.0.1' } as never);
+    await expect(resolveAndroidTools(project, { androidSdk: sdk }, {})).rejects.toThrow(
+      /Java 17.*javac 21/
+    );
+  });
+
+  it('accepts legacy Java version syntax without imposing an Expo-to-Java table', async () => {
+    vi.mocked(spawnAsync).mockResolvedValueOnce({
+      stderr: 'java.home = /jdk/jre\njava.version = 1.8.0_412',
+      stdout: '',
+    } as never);
+    vi.mocked(spawnAsync).mockResolvedValueOnce({ stderr: '', stdout: 'javac 1.8.0_412' } as never);
+    expect((await resolveAndroidTools(project, { androidSdk: sdk }, {})).JAVA_HOME).toBe('/jdk');
   });
 
   it('updates only sdk.dir in the build copy using the selected SDK', async () => {

--- a/apps/eoas/src/lib/build/android/index.ts
+++ b/apps/eoas/src/lib/build/android/index.ts
@@ -71,9 +71,14 @@ async function prepareBuild(
   const profile = await selectProfile(project, options);
   const local = await readEnvFile(project, options.envFile);
   buildLog.info('Locating local Android tools');
-  const toolEnv = await resolveAndroidTools(project, options, { ...process.env, ...local });
+  const toolEnv = await resolveAndroidTools(
+    project,
+    options,
+    { ...process.env, ...local },
+    buildLog.info
+  );
   buildLog.info(`Android SDK: ${toolEnv.ANDROID_HOME}`);
-  buildLog.info(`JAVA_HOME: ${toolEnv.JAVA_HOME ?? '(unset; gradlew uses java from PATH)'}`);
+  buildLog.info(`JAVA_HOME: ${toolEnv.JAVA_HOME}`);
   const packageRunner = splitPackageRunner(resolvePackageRunner(options.packageRunner, project));
   const nodeEnv = nodeEnvFor(profile.android.mode);
   const endpoint = await resolveBuildEndpoint(
@@ -130,9 +135,27 @@ async function buildInWorkspace(
     android: { ...expo.android, package: applicationId, versionCode },
   });
   if (await fs.pathExists(path.join(working, 'android'))) {
-    buildLog.warn(
-      'Using maintained Android project. Existing native Expo settings are retained; package, versionCode and signing are overridden in the temporary copy.'
+    buildLog.info(
+      'Using maintained Android project. Native settings are retained; package, versionCode, signing and the expo-updates configuration are overridden in the temporary copy.'
     );
+    // Same as EAS for bare projects: the manifest keeps whatever environment
+    // the last prebuild saw, so channel, URL and runtime are re-synced here.
+    const [command, prefix] = build.packageRunner;
+    await stages.run({
+      title: 'Syncing expo-updates configuration',
+      command,
+      args: [
+        ...prefix,
+        'expo-updates',
+        'configuration:syncnative',
+        '--platform',
+        'android',
+        '--workflow',
+        'generic',
+      ],
+      cwd: working,
+      env: build.env,
+    });
   } else {
     await stages.run(
       expoStage(build, working, 'Generating Android project', [

--- a/apps/eoas/src/lib/build/android/index.ts
+++ b/apps/eoas/src/lib/build/android/index.ts
@@ -6,6 +6,7 @@ import path from 'path';
 import { AndroidToolsOptions, configureAndroidSdk, resolveAndroidTools } from './tools';
 import Log from '../../log';
 import { resolvePackageRunner, splitPackageRunner } from '../../packageRunner';
+import { resolveExpoUpdatesCli } from '../../runtimeVersion';
 import { secretsToRedact } from '../errors';
 import { BuildLog, withBuildLog } from '../log';
 import {
@@ -140,13 +141,11 @@ async function buildInWorkspace(
     );
     // Same as EAS for bare projects: the manifest keeps whatever environment
     // the last prebuild saw, so channel, URL and runtime are re-synced here.
-    const [command, prefix] = build.packageRunner;
     await stages.run({
       title: 'Syncing expo-updates configuration',
-      command,
+      command: process.execPath,
       args: [
-        ...prefix,
-        'expo-updates',
+        resolveExpoUpdatesCli(working),
         'configuration:syncnative',
         '--platform',
         'android',

--- a/apps/eoas/src/lib/build/android/tools.ts
+++ b/apps/eoas/src/lib/build/android/tools.ts
@@ -1,4 +1,6 @@
 import { AndroidConfig } from '@expo/config-plugins';
+import spawnAsync from '@expo/spawn-async';
+import fg from 'fast-glob';
 import fs from 'fs-extra';
 import os from 'os';
 import path from 'path';
@@ -9,11 +11,12 @@ export interface AndroidToolsOptions {
 }
 
 // Same SDK lookup as Expo CLI: ANDROID_HOME, then ANDROID_SDK_ROOT, then the
-// platform's default install location. Gradle validates the JDK and the SDK contents.
+// platform's default install location. Gradle checks project-specific versions.
 export async function resolveAndroidTools(
   project: string,
   options: AndroidToolsOptions = {},
-  environment: NodeJS.ProcessEnv = process.env
+  environment: NodeJS.ProcessEnv = process.env,
+  report: (message: string) => void = () => {}
 ): Promise<Record<string, string>> {
   if (!['darwin', 'linux'].includes(os.platform())) {
     throw new Error(
@@ -21,12 +24,30 @@ export async function resolveAndroidTools(
     );
   }
   const sdk = await locateAndroidSdk(project, options, environment);
-  const env: Record<string, string> = { ANDROID_HOME: sdk, ANDROID_SDK_ROOT: sdk };
-  const javaHome = options.javaHome || environment.JAVA_HOME;
-  if (javaHome) {
-    env.JAVA_HOME = path.resolve(project, javaHome);
+  for (const [pattern, component] of [
+    ['platforms/*/android.jar', 'SDK Platforms'],
+    ['build-tools/*/aapt2', 'SDK Build-Tools'],
+  ]) {
+    if (!(await fg(pattern, { cwd: sdk, onlyFiles: true })).length) {
+      throw new Error(
+        `Android ${component} missing in ${sdk}. Install them using Android Studio's SDK Manager, or select another SDK with --androidSdk.`
+      );
+    }
   }
-  return env;
+  const javaHome = await checkJava(
+    project,
+    options.javaHome || environment.JAVA_HOME,
+    environment,
+    report
+  );
+  return {
+    ANDROID_HOME: sdk,
+    ANDROID_SDK_ROOT: sdk,
+    JAVA_HOME: javaHome,
+    PATH: [path.join(javaHome, 'bin'), environment.PATH ?? process.env.PATH ?? ''].join(
+      path.delimiter
+    ),
+  };
 }
 
 async function locateAndroidSdk(
@@ -37,7 +58,7 @@ async function locateAndroidSdk(
   const configured = options.androidSdk || environment.ANDROID_HOME || environment.ANDROID_SDK_ROOT;
   if (configured) {
     const sdk = path.resolve(project, configured);
-    if (!(await fs.pathExists(sdk))) {
+    if (!(await isDirectory(sdk))) {
       throw new Error(
         `Android SDK not found at ${sdk}. Fix ANDROID_HOME or pass --androidSdk /path/to/sdk.`
       );
@@ -49,13 +70,90 @@ async function locateAndroidSdk(
       ? [path.join(os.homedir(), 'Library/Android/sdk')]
       : [path.join(os.homedir(), 'Android/Sdk'), path.join(os.homedir(), 'Android/sdk')];
   for (const candidate of defaults) {
-    if (await fs.pathExists(candidate)) {
+    if (await isDirectory(candidate)) {
       return candidate;
     }
   }
   throw new Error(
     `Android SDK not found at ${defaults[0]}. Install it with Android Studio and set ANDROID_HOME or pass --androidSdk /path/to/sdk.`
   );
+}
+
+async function isDirectory(directory: string): Promise<boolean> {
+  try {
+    return (await fs.stat(directory)).isDirectory();
+  } catch (error) {
+    if (['ENOENT', 'ENOTDIR'].includes((error as NodeJS.ErrnoException).code ?? '')) {
+      return false;
+    }
+    throw error;
+  }
+}
+
+async function checkJava(
+  project: string,
+  configuredHome: string | undefined,
+  environment: NodeJS.ProcessEnv,
+  report: (message: string) => void
+): Promise<string> {
+  let javaHome = configuredHome ? path.resolve(project, configuredHome) : undefined;
+  const java = javaHome ? path.join(javaHome, 'bin/java') : 'java';
+  const env = { ...environment, ...(javaHome ? { JAVA_HOME: javaHome } : {}) };
+  let settings: string;
+  try {
+    const output = await spawnAsync(java, ['-XshowSettings:properties', '-version'], {
+      cwd: project,
+      env,
+      timeout: 10000,
+    });
+    settings = `${output.stdout}\n${output.stderr}`;
+  } catch {
+    throw new Error(
+      `Java could not run (${java}). Install a JDK and set JAVA_HOME or pass --javaHome /path/to/jdk.`
+    );
+  }
+  const version = settings.match(/^\s*java\.version\s*=\s*(\S+)/m)?.[1];
+  const major = javaMajor(version);
+  if (!javaHome) {
+    javaHome = settings.match(/^\s*java\.home\s*=\s*(.+)$/m)?.[1].trim();
+    // Java 8 reports the embedded JRE rather than its enclosing JDK.
+    if (major === 8 && javaHome && path.basename(javaHome) === 'jre') {
+      javaHome = path.dirname(javaHome);
+    }
+  }
+  if (!major || !javaHome || !path.isAbsolute(javaHome)) {
+    throw new Error(
+      'Could not determine the Java version or JDK directory. Set JAVA_HOME or pass --javaHome /path/to/jdk.'
+    );
+  }
+  let compiler: string;
+  try {
+    const output = await spawnAsync(path.join(javaHome, 'bin/javac'), ['-version'], {
+      cwd: project,
+      env: { ...env, JAVA_HOME: javaHome },
+      timeout: 10000,
+    });
+    compiler = `${output.stdout}\n${output.stderr}`;
+  } catch {
+    throw new Error(
+      `Java compiler unavailable in ${javaHome}. A full JDK is required; set JAVA_HOME or pass --javaHome /path/to/jdk.`
+    );
+  }
+  const compilerMajor = javaMajor(compiler.match(/\bjavac\s+(\S+)/)?.[1]);
+  if (compilerMajor !== major) {
+    throw new Error(
+      `Java ${major} and javac ${
+        compilerMajor ?? '(unknown)'
+      } do not match in ${javaHome}. Select a complete JDK with JAVA_HOME or --javaHome.`
+    );
+  }
+  report(`Java ${version} (JDK: ${javaHome}); project compatibility is checked by Gradle.`);
+  return javaHome;
+}
+
+function javaMajor(version: string | undefined): number | undefined {
+  const match = version?.match(/^(?:1\.)?(\d+)/);
+  return match ? Number(match[1]) : undefined;
 }
 
 // Only call on the temporary project so sdk.dir agrees with the selected SDK.

--- a/apps/eoas/src/lib/build/android/tools.ts
+++ b/apps/eoas/src/lib/build/android/tools.ts
@@ -96,6 +96,7 @@ async function checkJava(
   environment: NodeJS.ProcessEnv,
   report: (message: string) => void
 ): Promise<string> {
+  // is configuredHome is an absolute path path.resolve will just resolve "configureHome"
   let javaHome = configuredHome ? path.resolve(project, configuredHome) : undefined;
   const java = javaHome ? path.join(javaHome, 'bin/java') : 'java';
   const env = { ...environment, ...(javaHome ? { JAVA_HOME: javaHome } : {}) };

--- a/apps/eoas/src/lib/runtimeVersion.ts
+++ b/apps/eoas/src/lib/runtimeVersion.ts
@@ -12,16 +12,12 @@ export class ExpoUpdatesCLIModuleNotFoundError extends Error {}
 export class ExpoUpdatesCLIInvalidCommandError extends Error {}
 export class ExpoUpdatesCLICommandFailedError extends Error {}
 
-export async function expoUpdatesCommandAsync(
-  projectDir: string,
-  args: string[],
-  options: { env: Env | undefined; cwd?: string }
-): Promise<string> {
-  let expoUpdatesCli;
+export function resolveExpoUpdatesCli(projectDir: string): string {
   try {
-    expoUpdatesCli =
+    return (
       silentResolveFrom(projectDir, 'expo-updates/bin/cli') ??
-      resolveFrom(projectDir, 'expo-updates/bin/cli.js');
+      resolveFrom(projectDir, 'expo-updates/bin/cli.js')
+    );
   } catch (e: any) {
     if (e.code === 'MODULE_NOT_FOUND') {
       throw new ExpoUpdatesCLIModuleNotFoundError(
@@ -32,6 +28,14 @@ export async function expoUpdatesCommandAsync(
     }
     throw e;
   }
+}
+
+export async function expoUpdatesCommandAsync(
+  projectDir: string,
+  args: string[],
+  options: { env: Env | undefined; cwd?: string }
+): Promise<string> {
+  const expoUpdatesCli = resolveExpoUpdatesCli(projectDir);
 
   try {
     return (


### PR DESCRIPTION
Local Android builds now validate the selected JDK and Android SDK before starting, with actionable errors when tools are missing. Maintained Android projects synchronize their expo-updates configuration before Gradle runs.

Validation: TypeScript build, targeted lint and 72 build/configuration tests pass. Tests cover tool discovery and overrides, missing tools and the maintained-native workflow.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Android builds now synchronize native configuration for maintained projects before Gradle execution.
  - Android tool detection validates required SDK platforms, build tools, and Java installations.
  - Build environments consistently configure Android SDK and Java paths.

- **Bug Fixes**
  - Improved handling of missing, invalid, or incompatible Android SDK and Java installations.
  - Builds now clearly report detected Android and Java tooling.
  - Android builds fail with a clear error when `expo-updates` is unavailable instead of attempting to download it.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->