### PR TITLE
Expose the build registry and artifact lifecycle API

### DIFF
--- a/ee/rbac/mcptools_test.go
+++ b/ee/rbac/mcptools_test.go
@@ -38,8 +38,8 @@ func TestMCPDecisionFunctions(t *testing.T) {
 	require.False(t, description.RolesEnforced)
 	require.Equal(t, "member", description.Role)
 	require.Len(t, description.Apps, 1)
-	require.Equal(t, []string{string(PermEnvRead), string(PermIdentityRead), string(PermObserveRead)}, description.Apps[0].Granted)
-	require.Len(t, description.Apps[0].Denied, len(AllPermissions)-3)
+	require.Equal(t, []string{string(PermBuildRead), string(PermEnvRead), string(PermIdentityRead), string(PermObserveRead)}, description.Apps[0].Granted)
+	require.Len(t, description.Apps[0].Denied, len(AllPermissions)-4)
 
 	adminDescription, err := service.MCPDescribePermissions(ctx, admin, []string{"app-1"})
 	require.NoError(t, err)

--- a/ee/rbac/mcptools_test.go
+++ b/ee/rbac/mcptools_test.go
@@ -38,8 +38,8 @@ func TestMCPDecisionFunctions(t *testing.T) {
 	require.False(t, description.RolesEnforced)
 	require.Equal(t, "member", description.Role)
 	require.Len(t, description.Apps, 1)
-	require.Equal(t, []string{string(PermBuildRead), string(PermEnvRead), string(PermIdentityRead), string(PermObserveRead)}, description.Apps[0].Granted)
-	require.Len(t, description.Apps[0].Denied, len(AllPermissions)-4)
+	require.Equal(t, []string{string(PermBuildRead), string(PermBuildDownload), string(PermEnvRead), string(PermIdentityRead), string(PermObserveRead)}, description.Apps[0].Granted)
+	require.Len(t, description.Apps[0].Denied, len(AllPermissions)-5)
 
 	adminDescription, err := service.MCPDescribePermissions(ctx, admin, []string{"app-1"})
 	require.NoError(t, err)

--- a/ee/rbac/permissions.go
+++ b/ee/rbac/permissions.go
@@ -62,6 +62,12 @@ const (
 	// identifiers) and their signing credentials (Android keystore, submit
 	// keys). Reading the non-secret metadata is open to any viewer.
 	PermCredentialsManage Permission = "credentials:manage"
+	// PermBuildRead lists the app's builds and opens one: its metadata and
+	// its log. It does not cover the artifact itself.
+	PermBuildRead Permission = "build:read"
+	// PermBuildDownload fetches the signed artifact (APK or AAB) of a ready
+	// build.
+	PermBuildDownload Permission = "build:download"
 	// PermEnvRead reveals the plaintext values of the app's environment
 	// variables. Listing environments and keys (never values) is open to any
 	// viewer.
@@ -89,6 +95,8 @@ var AllPermissions = []Permission{
 	PermUpdateRolloutManage,
 	PermUpdatePublish,
 	PermCredentialsManage,
+	PermBuildRead,
+	PermBuildDownload,
 	PermEnvRead,
 	PermEnvManage,
 	PermApiKeysManage,
@@ -118,6 +126,7 @@ var anyMemberPermissions = map[Permission]bool{
 	PermIdentityRead: true,
 	PermObserveRead:  true,
 	PermEnvRead:      true,
+	PermBuildRead:    true,
 }
 
 // DefaultFallback is what gates a permission's actions when roles are not

--- a/ee/rbac/permissions.go
+++ b/ee/rbac/permissions.go
@@ -123,10 +123,11 @@ func IsValidPermission(p string) bool {
 // FallbackAnyMember; everything else falls back to admin-only. The route and
 // tool declarations pair the same values.
 var anyMemberPermissions = map[Permission]bool{
-	PermIdentityRead: true,
-	PermObserveRead:  true,
-	PermEnvRead:      true,
-	PermBuildRead:    true,
+	PermIdentityRead:  true,
+	PermObserveRead:   true,
+	PermEnvRead:       true,
+	PermBuildRead:     true,
+	PermBuildDownload: true,
 }
 
 // DefaultFallback is what gates a permission's actions when roles are not

--- a/internal/bucket/azureBucket.go
+++ b/internal/bucket/azureBucket.go
@@ -662,17 +662,17 @@ func (b *AzureBucket) deleteObject(ctx context.Context, key string) error {
 	return err
 }
 
-func (b *AzureBucket) RequestBuildArtifactUploadURL(_ context.Context, ref BuildArtifact) (string, error) {
+func (b *AzureBucket) RequestBuildArtifactUploadURL(_ context.Context, _ string, ref BuildArtifact) (*UploadRequest, error) {
 	key, err := b.buildArtifactKey(ref, true)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	if b.ContainerName == "" {
-		return "", errors.New("ContainerName not set")
+		return nil, errors.New("ContainerName not set")
 	}
 	url, err := azure.SignBlobSAS(b.ContainerName, key, sas.BlobPermissions{Create: true, Write: true}, buildUploadExpiry)
 	if err != nil {
-		return "", fmt.Errorf("error generating SAS URL: %w", err)
+		return nil, fmt.Errorf("error generating SAS URL: %w", err)
 	}
-	return url, nil
+	return &UploadRequest{URL: url, Method: "PUT", Headers: b.uploadHeaders()}, nil
 }

--- a/internal/bucket/bucket.go
+++ b/internal/bucket/bucket.go
@@ -330,7 +330,7 @@ type UploadFile struct {
 }
 
 // uploadHeaders are the headers the uploader must send verbatim on its PUT.
-func UploadHeaders(bucket Bucket) map[string]string {
+func uploadHeaders(bucket Bucket) map[string]string {
 	if _, ok := UnwrapBucket(bucket).(*AzureBucket); ok {
 		return map[string]string{"x-ms-blob-type": "BlockBlob"}
 	}
@@ -342,7 +342,7 @@ func UploadHeaders(bucket Bucket) map[string]string {
 // folder for the rest.
 func RequestUploadUrlsForFileUpdates(appId, branch, runtimeVersion, updateId string, files []UploadFile) ([]FileUploadRequest, error) {
 	resolvedBucket := GetBucket()
-	headers := UploadHeaders(resolvedBucket)
+	headers := uploadHeaders(resolvedBucket)
 
 	// Several files may name the same blob; presign it once.
 	toSign := make([]UploadFile, 0, len(files))

--- a/internal/bucket/bucket.go
+++ b/internal/bucket/bucket.go
@@ -306,6 +306,8 @@ func ResetBucketInstance() {
 	once = sync.Once{}
 }
 
+const LocalUploadTokenHeader = "local-upload-token"
+
 type FileUploadRequest struct {
 	RequestUploadUrl string `json:"requestUploadUrl"`
 	FileName         string `json:"fileName"`

--- a/internal/bucket/bucket.go
+++ b/internal/bucket/bucket.go
@@ -330,7 +330,7 @@ type UploadFile struct {
 }
 
 // uploadHeaders are the headers the uploader must send verbatim on its PUT.
-func uploadHeaders(bucket Bucket) map[string]string {
+func UploadHeaders(bucket Bucket) map[string]string {
 	if _, ok := UnwrapBucket(bucket).(*AzureBucket); ok {
 		return map[string]string{"x-ms-blob-type": "BlockBlob"}
 	}
@@ -342,7 +342,7 @@ func uploadHeaders(bucket Bucket) map[string]string {
 // folder for the rest.
 func RequestUploadUrlsForFileUpdates(appId, branch, runtimeVersion, updateId string, files []UploadFile) ([]FileUploadRequest, error) {
 	resolvedBucket := GetBucket()
-	headers := uploadHeaders(resolvedBucket)
+	headers := UploadHeaders(resolvedBucket)
 
 	// Several files may name the same blob; presign it once.
 	toSign := make([]UploadFile, 0, len(files))

--- a/internal/bucket/bucket.go
+++ b/internal/bucket/bucket.go
@@ -223,7 +223,7 @@ type Bucket interface {
 	GetBuildArtifact(ctx context.Context, ref BuildArtifact, staging bool) (*types.BucketFile, error)
 	PutBuildArtifact(ctx context.Context, ref BuildArtifact, staging bool, body io.Reader) error
 	DeleteBuildArtifact(ctx context.Context, ref BuildArtifact, staging bool) error
-	RequestBuildArtifactUploadURL(ctx context.Context, ref BuildArtifact) (string, error)
+	RequestBuildArtifactUploadURL(ctx context.Context, appID string, ref BuildArtifact) (*UploadRequest, error)
 }
 
 type BucketType string

--- a/internal/bucket/build_artifacts.go
+++ b/internal/bucket/build_artifacts.go
@@ -1,7 +1,6 @@
 package bucket
 
 import (
-	"context"
 	"time"
 	"xprem/internal/types"
 )
@@ -19,26 +18,6 @@ type BuildArtifact struct {
 	IdentifierID string
 	BuildID      string
 	Type         types.BuildArtifactType
-}
-
-type BuildUpload struct {
-	URL     string            `json:"url"`
-	Method  string            `json:"method"`
-	Headers map[string]string `json:"headers,omitempty"`
-}
-
-// RequestBuildArtifactUpload returns the upload instructions for an artifact.
-// An empty URL leaves local upload authorization to the service.
-func RequestBuildArtifactUpload(ctx context.Context, storage Bucket, ref BuildArtifact) (*BuildUpload, error) {
-	url, err := storage.RequestBuildArtifactUploadURL(ctx, ref)
-	if err != nil {
-		return nil, err
-	}
-	upload := &BuildUpload{URL: url, Method: "PUT"}
-	if provider, ok := UnwrapBucket(storage).(interface{ uploadHeaders() map[string]string }); ok {
-		upload.Headers = provider.uploadHeaders()
-	}
-	return upload, nil
 }
 
 func (r BuildArtifact) Validate() error {

--- a/internal/bucket/build_artifacts.go
+++ b/internal/bucket/build_artifacts.go
@@ -1,6 +1,7 @@
 package bucket
 
 import (
+	"context"
 	"time"
 	"xprem/internal/types"
 )
@@ -18,6 +19,22 @@ type BuildArtifact struct {
 	IdentifierID string
 	BuildID      string
 	Type         types.BuildArtifactType
+}
+
+type BuildUpload struct {
+	URL     string            `json:"url"`
+	Method  string            `json:"method"`
+	Headers map[string]string `json:"headers,omitempty"`
+}
+
+// RequestBuildArtifactUpload returns the upload instructions for an artifact.
+// An empty URL leaves local upload authorization to the service.
+func RequestBuildArtifactUpload(ctx context.Context, storage Bucket, ref BuildArtifact) (*BuildUpload, error) {
+	url, err := storage.RequestBuildArtifactUploadURL(ctx, ref)
+	if err != nil {
+		return nil, err
+	}
+	return &BuildUpload{URL: url, Method: "PUT", Headers: uploadHeaders(storage)}, nil
 }
 
 func (r BuildArtifact) Validate() error {

--- a/internal/bucket/build_artifacts_test.go
+++ b/internal/bucket/build_artifacts_test.go
@@ -9,8 +9,10 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 	"xprem/internal/types"
 
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/require"
 )
 
@@ -28,6 +30,8 @@ func testBuildBucket(base, keyPrefix string) *validatingBucket {
 }
 
 func TestRequestBuildArtifactUpload(t *testing.T) {
+	t.Setenv("BASE_URL", "https://ota.example.com/sub/path/?ignored=query#fragment")
+	t.Setenv("JWT_SECRET", "build-upload-test-secret")
 	t.Setenv("AZURE_STORAGE_ACCOUNT_NAME", "buildtest")
 	t.Setenv("AZURE_STORAGE_ACCOUNT_KEY", base64.StdEncoding.EncodeToString([]byte("build-upload-test-key")))
 	t.Setenv("AZURE_BLOB_ENDPOINT", "")
@@ -39,13 +43,27 @@ func TestRequestBuildArtifactUpload(t *testing.T) {
 		{"azure", &AzureBucket{ContainerName: "artifacts", KeyPrefix: "prefix/"}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			storage := &validatingBucket{Inner: tc.storage}
-			upload, err := RequestBuildArtifactUpload(context.Background(), storage, testArtifact())
+			var storage Bucket = &validatingBucket{Inner: tc.storage}
+			before := time.Now()
+			upload, err := storage.RequestBuildArtifactUploadURL(context.Background(), "app-1", testArtifact())
 			require.NoError(t, err)
 			require.Equal(t, "PUT", upload.Method)
 			if tc.name == "local" {
-				require.Empty(t, upload.URL, "the service supplies the authorized local URL")
-				require.Nil(t, upload.Headers)
+				require.Equal(t, "https://ota.example.com/sub/path/app-1/build/"+testIdentifierID+"/artifacts/"+testBuildID+"/upload", upload.URL)
+				require.Len(t, upload.Headers, 1)
+				require.NoError(t, ValidateBuildUploadToken(upload.Headers[LocalUploadTokenHeader], "app-1", testIdentifierID, testBuildID))
+				claims := jwt.MapClaims{}
+				_, err := jwt.ParseWithClaims(upload.Headers[LocalUploadTokenHeader], claims, func(*jwt.Token) (any, error) {
+					return []byte("build-upload-test-secret"), nil
+				}, jwt.WithValidMethods([]string{"HS256"}), jwt.WithExpirationRequired(), jwt.WithSubject("build-upload"))
+				require.NoError(t, err)
+				require.Equal(t, "app-1", claims["appId"])
+				require.Equal(t, testIdentifierID, claims["identifierId"])
+				require.Equal(t, testBuildID, claims["buildId"])
+				expiresAt, err := claims.GetExpirationTime()
+				require.NoError(t, err)
+				require.GreaterOrEqual(t, expiresAt.Unix(), before.Add(10*time.Minute).Unix())
+				require.LessOrEqual(t, expiresAt.Unix(), time.Now().Add(10*time.Minute).Unix())
 			} else {
 				require.Equal(t, map[string]string{"x-ms-blob-type": "BlockBlob"}, upload.Headers)
 				signedURL, err := url.Parse(upload.URL)
@@ -55,9 +73,51 @@ func TestRequestBuildArtifactUpload(t *testing.T) {
 				require.Equal(t, "cw", signedURL.Query().Get("sp"))
 			}
 
-			upload, err = RequestBuildArtifactUpload(context.Background(), storage, BuildArtifact{})
+			upload, err = storage.RequestBuildArtifactUploadURL(context.Background(), "app-1", BuildArtifact{})
 			require.Error(t, err)
 			require.Nil(t, upload, "validation failures do not return an upload descriptor")
+		})
+	}
+}
+
+func TestValidateBuildUploadTokenRejectsInvalidGrants(t *testing.T) {
+	t.Setenv("JWT_SECRET", "build-upload-test-secret")
+	require.Error(t, ValidateBuildUploadToken("not-a-token", "app-1", testIdentifierID, testBuildID))
+	for name, tc := range map[string]struct {
+		change func(jwt.MapClaims)
+		method jwt.SigningMethod
+		secret string
+	}{
+		"expired":            {change: func(c jwt.MapClaims) { c["exp"] = time.Now().Add(-time.Minute).Unix() }},
+		"missing expiration": {change: func(c jwt.MapClaims) { delete(c, "exp") }},
+		"wrong subject":      {change: func(c jwt.MapClaims) { c["sub"] = "uploadLocalFile" }},
+		"missing subject":    {change: func(c jwt.MapClaims) { delete(c, "sub") }},
+		"another app":        {change: func(c jwt.MapClaims) { c["appId"] = "app-2" }},
+		"another identifier": {change: func(c jwt.MapClaims) { c["identifierId"] = testBuildID }},
+		"another build":      {change: func(c jwt.MapClaims) { c["buildId"] = testIdentifierID }},
+		"missing app":        {change: func(c jwt.MapClaims) { delete(c, "appId") }},
+		"missing identifier": {change: func(c jwt.MapClaims) { delete(c, "identifierId") }},
+		"missing build":      {change: func(c jwt.MapClaims) { delete(c, "buildId") }},
+		"wrong algorithm":    {method: jwt.SigningMethodHS384},
+		"wrong secret":       {secret: "other-secret"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			claims := jwt.MapClaims{
+				"sub": "build-upload", "exp": time.Now().Add(10 * time.Minute).Unix(),
+				"appId": "app-1", "identifierId": testIdentifierID, "buildId": testBuildID,
+			}
+			if tc.change != nil {
+				tc.change(claims)
+			}
+			if tc.method == nil {
+				tc.method = jwt.SigningMethodHS256
+			}
+			if tc.secret == "" {
+				tc.secret = "build-upload-test-secret"
+			}
+			token, err := jwt.NewWithClaims(tc.method, claims).SignedString([]byte(tc.secret))
+			require.NoError(t, err)
+			require.Error(t, ValidateBuildUploadToken(token, "app-1", testIdentifierID, testBuildID))
 		})
 	}
 }
@@ -89,8 +149,13 @@ func TestBuildObjectKeysAreIsolatedAndValidated(t *testing.T) {
 		require.Error(t, err, name)
 		require.Error(t, v.PutBuildArtifact(ctx, bad, false, strings.NewReader("x")), name)
 		require.Error(t, v.DeleteBuildArtifact(ctx, bad, false), name)
-		_, err = v.RequestBuildArtifactUploadURL(ctx, bad)
+		_, err = v.RequestBuildArtifactUploadURL(ctx, "app-1", bad)
 		require.Error(t, err, name)
+	}
+	for _, appID := range []string{"", "../escape", "app/other"} {
+		upload, err := v.RequestBuildArtifactUploadURL(ctx, appID, ref)
+		require.Error(t, err, appID)
+		require.Nil(t, upload)
 	}
 	require.False(t, stub.called)
 }

--- a/internal/bucket/build_artifacts_test.go
+++ b/internal/bucket/build_artifacts_test.go
@@ -2,7 +2,9 @@ package bucket
 
 import (
 	"context"
+	"encoding/base64"
 	"io"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -23,6 +25,41 @@ func testArtifact() BuildArtifact {
 
 func testBuildBucket(base, keyPrefix string) *validatingBucket {
 	return &validatingBucket{Inner: &LocalBucket{BasePath: base, KeyPrefix: keyPrefix}}
+}
+
+func TestRequestBuildArtifactUpload(t *testing.T) {
+	t.Setenv("AZURE_STORAGE_ACCOUNT_NAME", "buildtest")
+	t.Setenv("AZURE_STORAGE_ACCOUNT_KEY", base64.StdEncoding.EncodeToString([]byte("build-upload-test-key")))
+	t.Setenv("AZURE_BLOB_ENDPOINT", "")
+	for _, tc := range []struct {
+		name    string
+		storage Bucket
+	}{
+		{"local", &LocalBucket{BasePath: t.TempDir()}},
+		{"azure", &AzureBucket{ContainerName: "artifacts", KeyPrefix: "prefix/"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			storage := &validatingBucket{Inner: tc.storage}
+			upload, err := RequestBuildArtifactUpload(context.Background(), storage, testArtifact())
+			require.NoError(t, err)
+			require.Equal(t, "PUT", upload.Method)
+			if tc.name == "local" {
+				require.Empty(t, upload.URL, "the service supplies the authorized local URL")
+				require.Nil(t, upload.Headers)
+			} else {
+				require.Equal(t, map[string]string{"x-ms-blob-type": "BlockBlob"}, upload.Headers)
+				signedURL, err := url.Parse(upload.URL)
+				require.NoError(t, err)
+				require.Equal(t, "/artifacts/prefix/builds/android/"+testIdentifierID+"/.uploads/"+testBuildID+".apk", signedURL.Path)
+				require.NotEmpty(t, signedURL.Query().Get("sig"))
+				require.Equal(t, "cw", signedURL.Query().Get("sp"))
+			}
+
+			upload, err = RequestBuildArtifactUpload(context.Background(), storage, BuildArtifact{})
+			require.Error(t, err)
+			require.Nil(t, upload, "validation failures do not return an upload descriptor")
+		})
+	}
 }
 
 func TestBuildObjectKeysAreIsolatedAndValidated(t *testing.T) {

--- a/internal/bucket/gcsBucket.go
+++ b/internal/bucket/gcsBucket.go
@@ -636,17 +636,17 @@ func (b *GCSBucket) deleteObject(ctx context.Context, key string) error {
 	return err
 }
 
-func (b *GCSBucket) RequestBuildArtifactUploadURL(_ context.Context, ref BuildArtifact) (string, error) {
+func (b *GCSBucket) RequestBuildArtifactUploadURL(_ context.Context, _ string, ref BuildArtifact) (*UploadRequest, error) {
 	key, err := b.buildArtifactKey(ref, true)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	if b.BucketName == "" {
-		return "", errors.New("BucketName not set")
+		return nil, errors.New("BucketName not set")
 	}
 	url, err := gcp.SignedURL(b.BucketName, key, "PUT", "", buildUploadExpiry)
 	if err != nil {
-		return "", fmt.Errorf("error generating signed URL: %w", err)
+		return nil, fmt.Errorf("error generating signed URL: %w", err)
 	}
-	return url, nil
+	return &UploadRequest{URL: url, Method: "PUT"}, nil
 }

--- a/internal/bucket/localBucket.go
+++ b/internal/bucket/localBucket.go
@@ -862,8 +862,50 @@ func pruneEmptyBuildDirs(root, dir string) {
 	}
 }
 
-// RequestBuildArtifactUploadURL returns an empty URL: local uploads go
-// through the server.
-func (b *LocalBucket) RequestBuildArtifactUploadURL(context.Context, BuildArtifact) (string, error) {
-	return "", nil
+// buildUploadClaims binds a local upload token to one app, identifier, and build.
+type buildUploadClaims struct {
+	jwt.RegisteredClaims
+	AppID        string `json:"appId"`
+	IdentifierID string `json:"identifierId"`
+	BuildID      string `json:"buildId"`
+}
+
+// ValidateBuildUploadToken verifies a local build upload token and its scope
+// against the app, identifier, and build named in the request.
+func ValidateBuildUploadToken(token, appID, identifierID, buildID string) error {
+	claims := &buildUploadClaims{}
+	_, err := jwt.ParseWithClaims(token, claims, func(*jwt.Token) (any, error) {
+		return []byte(config.GetEnv("JWT_SECRET")), nil
+	}, jwt.WithValidMethods([]string{"HS256"}), jwt.WithExpirationRequired(), jwt.WithSubject("build-upload"))
+	if err != nil {
+		return err
+	}
+	if claims.AppID != appID || claims.IdentifierID != identifierID || claims.BuildID != buildID {
+		return errors.New("upload token does not match the requested build")
+	}
+	return nil
+}
+
+// RequestBuildArtifactUploadURL returns the server URL and authorization header
+// for a local build artifact upload.
+func (b *LocalBucket) RequestBuildArtifactUploadURL(_ context.Context, appID string, ref BuildArtifact) (*UploadRequest, error) {
+	uploadURL, err := url.Parse(strings.TrimRight(config.GetEnv("BASE_URL"), "/"))
+	if err != nil || uploadURL.Host == "" || (uploadURL.Scheme != "https" && uploadURL.Scheme != "http") || uploadURL.User != nil {
+		return nil, errors.New("invalid BASE_URL")
+	}
+	uploadURL.Path = strings.TrimRight(uploadURL.Path, "/") + fmt.Sprintf("/%s/build/%s/artifacts/%s/upload", appID, ref.IdentifierID, ref.BuildID)
+	uploadURL.RawPath = ""
+	uploadURL.RawQuery = ""
+	uploadURL.Fragment = ""
+	token, err := jwt.NewWithClaims(jwt.SigningMethodHS256, buildUploadClaims{
+		RegisteredClaims: jwt.RegisteredClaims{
+			Subject:   "build-upload",
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(buildUploadExpiry)),
+		},
+		AppID: appID, IdentifierID: ref.IdentifierID, BuildID: ref.BuildID,
+	}).SignedString([]byte(config.GetEnv("JWT_SECRET")))
+	if err != nil {
+		return nil, err
+	}
+	return &UploadRequest{URL: uploadURL.String(), Method: "PUT", Headers: map[string]string{LocalUploadTokenHeader: token}}, nil
 }

--- a/internal/bucket/s3Bucket.go
+++ b/internal/bucket/s3Bucket.go
@@ -796,17 +796,17 @@ func (b *S3Bucket) deleteObject(ctx context.Context, key string) error {
 	return nil
 }
 
-func (b *S3Bucket) RequestBuildArtifactUploadURL(ctx context.Context, ref BuildArtifact) (string, error) {
+func (b *S3Bucket) RequestBuildArtifactUploadURL(ctx context.Context, _ string, ref BuildArtifact) (*UploadRequest, error) {
 	key, err := b.buildArtifactKey(ref, true)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	if b.BucketName == "" {
-		return "", errors.New("BucketName not set")
+		return nil, errors.New("BucketName not set")
 	}
 	s3Client, err := aws.GetS3Client()
 	if err != nil {
-		return "", fmt.Errorf("error getting S3 client: %w", err)
+		return nil, fmt.Errorf("error getting S3 client: %w", err)
 	}
 	presignResult, err := s3.NewPresignClient(s3Client).PresignPutObject(ctx, &s3.PutObjectInput{
 		Bucket: awssdk.String(b.BucketName),
@@ -815,7 +815,7 @@ func (b *S3Bucket) RequestBuildArtifactUploadURL(ctx context.Context, ref BuildA
 		opt.Expires = buildUploadExpiry
 	})
 	if err != nil {
-		return "", fmt.Errorf("error presigning URL: %w", err)
+		return nil, fmt.Errorf("error presigning URL: %w", err)
 	}
-	return presignResult.URL, nil
+	return &UploadRequest{URL: presignResult.URL, Method: "PUT"}, nil
 }

--- a/internal/bucket/validatingBucket.go
+++ b/internal/bucket/validatingBucket.go
@@ -287,9 +287,12 @@ func (v *validatingBucket) DeleteBuildArtifact(ctx context.Context, ref BuildArt
 	return v.Inner.DeleteBuildArtifact(ctx, ref, staging)
 }
 
-func (v *validatingBucket) RequestBuildArtifactUploadURL(ctx context.Context, ref BuildArtifact) (string, error) {
-	if err := ref.Validate(); err != nil {
-		return "", err
+func (v *validatingBucket) RequestBuildArtifactUploadURL(ctx context.Context, appID string, ref BuildArtifact) (*UploadRequest, error) {
+	if err := validateSegment("appId", appID); err != nil {
+		return nil, err
 	}
-	return v.Inner.RequestBuildArtifactUploadURL(ctx, ref)
+	if err := ref.Validate(); err != nil {
+		return nil, err
+	}
+	return v.Inner.RequestBuildArtifactUploadURL(ctx, appID, ref)
 }

--- a/internal/bucket/validatingBucket_test.go
+++ b/internal/bucket/validatingBucket_test.go
@@ -380,9 +380,9 @@ func (s *stubBucket) DeleteBuildArtifact(context.Context, BuildArtifact, bool) e
 	s.mark()
 	return nil
 }
-func (s *stubBucket) RequestBuildArtifactUploadURL(context.Context, BuildArtifact) (string, error) {
+func (s *stubBucket) RequestBuildArtifactUploadURL(context.Context, string, BuildArtifact) (*UploadRequest, error) {
 	s.mark()
-	return "", nil
+	return &UploadRequest{Method: "PUT"}, nil
 }
 
 func TestValidateBSDiffKey(t *testing.T) {

--- a/internal/bucketmigrations/20260422_v2_scope_data_under_appid/20260422_v2_scope_data_under_appid_test.go
+++ b/internal/bucketmigrations/20260422_v2_scope_data_under_appid/20260422_v2_scope_data_under_appid_test.go
@@ -172,7 +172,7 @@ func (u unreachableBucket) DeleteBuildArtifact(context.Context, bucket.BuildArti
 	return nil
 }
 
-func (u unreachableBucket) RequestBuildArtifactUploadURL(context.Context, bucket.BuildArtifact) (string, error) {
+func (u unreachableBucket) RequestBuildArtifactUploadURL(context.Context, string, bucket.BuildArtifact) (*bucket.UploadRequest, error) {
 	u.t.Fatal("migration should have skipped")
-	return "", nil
+	return nil, nil
 }

--- a/internal/handlers/build_registry_handler.go
+++ b/internal/handlers/build_registry_handler.go
@@ -34,7 +34,7 @@ func renderBuildRegistryError(w http.ResponseWriter, err error) {
 	case errors.Is(err, services.ErrBuildIntegrity):
 		RenderError(w, http.StatusBadRequest, err.Error())
 	case errors.As(err, &missing):
-		RenderError(w, http.StatusNotFound, "Build or share not found.")
+		RenderError(w, http.StatusNotFound, "Build not found.")
 	case validation.IsValidationError(err), errors.Is(err, store.ErrNotSupportedInStatelessMode):
 		RenderError(w, http.StatusBadRequest, err.Error())
 	default:

--- a/internal/handlers/build_registry_handler.go
+++ b/internal/handlers/build_registry_handler.go
@@ -6,10 +6,8 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"net/url"
 	"strconv"
-	"strings"
-	"xprem/config"
+	"xprem/internal/bucket"
 	"xprem/internal/services"
 	"xprem/internal/store"
 	"xprem/internal/types"
@@ -42,19 +40,6 @@ func renderBuildRegistryError(w http.ResponseWriter, err error) {
 	default:
 		RenderError(w, http.StatusInternalServerError, "Could not process the build request.")
 	}
-}
-
-// publicBuildURL appends route to BASE_URL, keeping any sub-path it is served from.
-func publicBuildURL(route string) (string, error) {
-	base, err := url.Parse(strings.TrimRight(config.GetEnv("BASE_URL"), "/"))
-	if err != nil || base.Host == "" || (base.Scheme != "https" && base.Scheme != "http") || base.User != nil {
-		return "", fmt.Errorf("invalid BASE_URL")
-	}
-	base.Path = strings.TrimRight(base.Path, "/") + route
-	base.RawPath = ""
-	base.RawQuery = ""
-	base.Fragment = ""
-	return base.String(), nil
 }
 
 func decodeBuildBody(w http.ResponseWriter, r *http.Request, target any) bool {
@@ -91,13 +76,6 @@ func (h *BuildRegistryHandler) RegisterArtifact(w http.ResponseWriter, r *http.R
 		renderBuildRegistryError(w, err)
 		return
 	}
-	if result.LocalToken != "" {
-		result.Upload.URL, err = publicBuildURL("/build-uploads/" + result.LocalToken)
-		if err != nil {
-			renderBuildRegistryError(w, err)
-			return
-		}
-	}
 	w.Header().Set("Cache-Control", "no-store")
 	RenderJSON(w, http.StatusOK, result)
 }
@@ -129,7 +107,7 @@ func (h *BuildRegistryHandler) Complete(w http.ResponseWriter, r *http.Request) 
 func (h *BuildRegistryHandler) UploadLocal(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Cache-Control", "no-store")
 	r.Body = http.MaxBytesReader(w, r.Body, services.MaxBuildSize+1)
-	if err := h.service.UploadLocal(r.Context(), mux.Vars(r)["TOKEN"], r.Body); err != nil {
+	if err := h.service.UploadLocal(r.Context(), mux.Vars(r)["APP_ID"], services.BuildIdentifierFromContext(r.Context()), mux.Vars(r)["BUILD_ID"], r.Header.Get(bucket.LocalUploadTokenHeader), r.Body); err != nil {
 		renderBuildRegistryError(w, err)
 		return
 	}

--- a/internal/handlers/build_registry_handler.go
+++ b/internal/handlers/build_registry_handler.go
@@ -10,7 +10,6 @@ import (
 	"strconv"
 	"strings"
 	"xprem/config"
-	"xprem/internal/bucket"
 	"xprem/internal/services"
 	"xprem/internal/store"
 	"xprem/internal/types"
@@ -34,8 +33,6 @@ func renderBuildRegistryError(w http.ResponseWriter, err error) {
 		RenderError(w, http.StatusUnauthorized, "Invalid or expired upload authorization.")
 	case errors.Is(err, services.ErrBuildConflict), errors.Is(err, services.ErrBuildNotReady), errors.Is(err, services.ErrBuildState):
 		RenderError(w, http.StatusConflict, err.Error())
-	case errors.Is(err, bucket.ErrBuildNamespaceConflict):
-		RenderError(w, http.StatusConflict, bucket.ErrBuildNamespaceConflict.Error())
 	case errors.Is(err, services.ErrBuildIntegrity):
 		RenderError(w, http.StatusBadRequest, err.Error())
 	case errors.As(err, &missing):

--- a/internal/handlers/build_registry_handler.go
+++ b/internal/handlers/build_registry_handler.go
@@ -81,12 +81,12 @@ func (h *BuildRegistryHandler) Start(w http.ResponseWriter, r *http.Request) {
 	RenderJSON(w, http.StatusOK, build)
 }
 
-func (h *BuildRegistryHandler) Begin(w http.ResponseWriter, r *http.Request) {
+func (h *BuildRegistryHandler) RegisterArtifact(w http.ResponseWriter, r *http.Request) {
 	var input services.RegisterBuildInput
 	if !decodeBuildBody(w, r, &input) {
 		return
 	}
-	result, err := h.service.Begin(r.Context(), mux.Vars(r)["APP_ID"], services.BuildIdentifierFromContext(r.Context()), mux.Vars(r)["BUILD_ID"], input)
+	result, err := h.service.RegisterArtifact(r.Context(), mux.Vars(r)["APP_ID"], services.BuildIdentifierFromContext(r.Context()), mux.Vars(r)["BUILD_ID"], input)
 	if err != nil {
 		renderBuildRegistryError(w, err)
 		return

--- a/internal/handlers/build_registry_handler.go
+++ b/internal/handlers/build_registry_handler.go
@@ -1,0 +1,204 @@
+package handlers
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"xprem/config"
+	"xprem/internal/bucket"
+	"xprem/internal/services"
+	"xprem/internal/store"
+	"xprem/internal/types"
+	"xprem/internal/validation"
+
+	"github.com/gorilla/mux"
+)
+
+const buildRequestBodyLimit = 16 << 10
+
+type BuildRegistryHandler struct{ service *services.BuildService }
+
+func NewBuildRegistryHandler(service *services.BuildService) *BuildRegistryHandler {
+	return &BuildRegistryHandler{service: service}
+}
+
+func renderBuildRegistryError(w http.ResponseWriter, err error) {
+	var missing *store.ErrResourceNotFound
+	switch {
+	case errors.Is(err, services.ErrUnauthorized):
+		RenderError(w, http.StatusUnauthorized, "Invalid or expired upload authorization.")
+	case errors.Is(err, services.ErrBuildConflict), errors.Is(err, services.ErrBuildNotReady), errors.Is(err, services.ErrBuildState):
+		RenderError(w, http.StatusConflict, err.Error())
+	case errors.Is(err, bucket.ErrBuildNamespaceConflict):
+		RenderError(w, http.StatusConflict, bucket.ErrBuildNamespaceConflict.Error())
+	case errors.Is(err, services.ErrBuildIntegrity):
+		RenderError(w, http.StatusBadRequest, err.Error())
+	case errors.As(err, &missing):
+		RenderError(w, http.StatusNotFound, "Build or share not found.")
+	case validation.IsValidationError(err), errors.Is(err, store.ErrNotSupportedInStatelessMode):
+		RenderError(w, http.StatusBadRequest, err.Error())
+	default:
+		RenderError(w, http.StatusInternalServerError, "Could not process the build request.")
+	}
+}
+
+// publicBuildURL appends route to BASE_URL, keeping any sub-path it is served from.
+func publicBuildURL(route string) (string, error) {
+	base, err := url.Parse(strings.TrimRight(config.GetEnv("BASE_URL"), "/"))
+	if err != nil || base.Host == "" || (base.Scheme != "https" && base.Scheme != "http") || base.User != nil {
+		return "", fmt.Errorf("invalid BASE_URL")
+	}
+	base.Path = strings.TrimRight(base.Path, "/") + route
+	base.RawPath = ""
+	base.RawQuery = ""
+	base.Fragment = ""
+	return base.String(), nil
+}
+
+func decodeBuildBody(w http.ResponseWriter, r *http.Request, target any) bool {
+	decoder := json.NewDecoder(http.MaxBytesReader(w, r.Body, buildRequestBodyLimit))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(target); err != nil || decoder.More() {
+		RenderError(w, http.StatusBadRequest, "Invalid build request body.")
+		return false
+	}
+	return true
+}
+
+func (h *BuildRegistryHandler) Start(w http.ResponseWriter, r *http.Request) {
+	var input services.BuildStartInput
+	if !decodeBuildBody(w, r, &input) {
+		return
+	}
+	build, err := h.service.Start(r.Context(), mux.Vars(r)["APP_ID"], services.BuildIdentifierFromContext(r.Context()), mux.Vars(r)["BUILD_ID"], input)
+	if err != nil {
+		renderBuildRegistryError(w, err)
+		return
+	}
+	w.Header().Set("Cache-Control", "no-store")
+	RenderJSON(w, http.StatusOK, build)
+}
+
+func (h *BuildRegistryHandler) Begin(w http.ResponseWriter, r *http.Request) {
+	var input services.RegisterBuildInput
+	if !decodeBuildBody(w, r, &input) {
+		return
+	}
+	result, err := h.service.Begin(r.Context(), mux.Vars(r)["APP_ID"], services.BuildIdentifierFromContext(r.Context()), mux.Vars(r)["BUILD_ID"], input)
+	if err != nil {
+		renderBuildRegistryError(w, err)
+		return
+	}
+	if result.LocalToken != "" {
+		result.Upload.URL, err = publicBuildURL("/build-uploads/" + result.LocalToken)
+		if err != nil {
+			renderBuildRegistryError(w, err)
+			return
+		}
+	}
+	w.Header().Set("Cache-Control", "no-store")
+	RenderJSON(w, http.StatusOK, result)
+}
+
+func (h *BuildRegistryHandler) Fail(w http.ResponseWriter, r *http.Request) {
+	var input services.FailBuildInput
+	if !decodeBuildBody(w, r, &input) {
+		return
+	}
+	build, err := h.service.Fail(r.Context(), mux.Vars(r)["APP_ID"], services.BuildIdentifierFromContext(r.Context()), mux.Vars(r)["BUILD_ID"], input)
+	if err != nil {
+		renderBuildRegistryError(w, err)
+		return
+	}
+	w.Header().Set("Cache-Control", "no-store")
+	RenderJSON(w, http.StatusOK, build)
+}
+
+func (h *BuildRegistryHandler) Complete(w http.ResponseWriter, r *http.Request) {
+	build, err := h.service.Complete(r.Context(), mux.Vars(r)["APP_ID"], services.BuildIdentifierFromContext(r.Context()), mux.Vars(r)["BUILD_ID"])
+	if err != nil {
+		renderBuildRegistryError(w, err)
+		return
+	}
+	w.Header().Set("Cache-Control", "no-store")
+	RenderJSON(w, http.StatusOK, build)
+}
+
+func (h *BuildRegistryHandler) UploadLocal(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Cache-Control", "no-store")
+	r.Body = http.MaxBytesReader(w, r.Body, services.MaxBuildSize+1)
+	if err := h.service.UploadLocal(r.Context(), mux.Vars(r)["TOKEN"], r.Body); err != nil {
+		renderBuildRegistryError(w, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (h *BuildRegistryHandler) List(w http.ResponseWriter, r *http.Request) {
+	limit, offset := 20, 0
+	var err error
+	if value := r.URL.Query().Get("limit"); value != "" {
+		limit, err = strconv.Atoi(value)
+	}
+	if err == nil {
+		if value := r.URL.Query().Get("offset"); value != "" {
+			offset, err = strconv.Atoi(value)
+		}
+	}
+	if err != nil || limit < 1 || limit > 100 || offset < 0 || offset > 100000 {
+		RenderError(w, http.StatusBadRequest, "Invalid pagination.")
+		return
+	}
+	builds, count, err := h.service.List(r.Context(), mux.Vars(r)["APP_ID"], int32(limit), int32(offset))
+	if err != nil {
+		renderBuildRegistryError(w, err)
+		return
+	}
+	RenderJSON(w, http.StatusOK, map[string]any{"builds": builds, "count": count})
+}
+
+func (h *BuildRegistryHandler) Get(w http.ResponseWriter, r *http.Request) {
+	b, err := h.service.Get(r.Context(), mux.Vars(r)["APP_ID"], mux.Vars(r)["BUILD_ID"])
+	if err != nil {
+		renderBuildRegistryError(w, err)
+		return
+	}
+	RenderJSON(w, http.StatusOK, b)
+}
+
+func (h *BuildRegistryHandler) Download(w http.ResponseWriter, r *http.Request) {
+	b, err := h.service.Get(r.Context(), mux.Vars(r)["APP_ID"], mux.Vars(r)["BUILD_ID"])
+	if err != nil {
+		renderBuildRegistryError(w, err)
+		return
+	}
+	h.download(w, r, *b)
+}
+
+func (h *BuildRegistryHandler) download(w http.ResponseWriter, r *http.Request, b types.BuildRecord) {
+	file, err := h.service.Download(r.Context(), b)
+	if err != nil {
+		renderBuildRegistryError(w, err)
+		return
+	}
+	if file == nil {
+		RenderError(w, http.StatusNotFound, "Artifact not found.")
+		return
+	}
+	defer file.Reader.Close()
+	w.Header().Set("Cache-Control", "private, no-store")
+	w.Header().Set("Referrer-Policy", "no-referrer")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.Header().Set("Content-Type", "application/octet-stream")
+	if b.ArtifactType == "apk" {
+		w.Header().Set("Content-Type", "application/vnd.android.package-archive")
+	}
+	w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s.%s"`, b.ID, b.ArtifactType))
+	w.Header().Set("Content-Length", strconv.FormatInt(b.Size, 10))
+	_, _ = io.Copy(w, file.Reader)
+}

--- a/internal/handlers/build_registry_handler_test.go
+++ b/internal/handlers/build_registry_handler_test.go
@@ -125,7 +125,7 @@ func newRegistryFixture(t *testing.T) *registryFixture {
 	t.Setenv("JWT_SECRET", "registry-secret")
 	t.Setenv("BASE_URL", "https://ota.example.com/sub/path/")
 	repo := newRegistryRepo()
-	service := services.NewBuildService(repo, registryIdentifierRepo{}, bucket.NewBuildArtifactStorage(&bucket.LocalBucket{BasePath: t.TempDir()}))
+	service := services.NewBuildService(repo, registryIdentifierRepo{}, &bucket.LocalBucket{BasePath: t.TempDir()})
 	handler := NewBuildRegistryHandler(service)
 	router := mux.NewRouter()
 	authorized := func(next http.HandlerFunc) http.HandlerFunc {
@@ -347,7 +347,6 @@ func TestBuildRegistryErrorMapping(t *testing.T) {
 	}{
 		{services.ErrUnauthorized, http.StatusUnauthorized},
 		{services.ErrBuildConflict, http.StatusConflict},
-		{bucket.ErrBuildNamespaceConflict, http.StatusConflict},
 		{services.ErrBuildNotReady, http.StatusConflict},
 		{services.ErrBuildState, http.StatusConflict},
 		{services.ErrBuildIntegrity, http.StatusBadRequest},

--- a/internal/handlers/build_registry_handler_test.go
+++ b/internal/handlers/build_registry_handler_test.go
@@ -134,7 +134,7 @@ func newRegistryFixture(t *testing.T) *registryFixture {
 		}
 	}
 	router.HandleFunc("/{APP_ID}/build/{IDENTIFIER_ID}/artifacts/{BUILD_ID}/start", authorized(handler.Start)).Methods(http.MethodPut)
-	router.HandleFunc("/{APP_ID}/build/{IDENTIFIER_ID}/artifacts/{BUILD_ID}", authorized(handler.Begin)).Methods(http.MethodPut)
+	router.HandleFunc("/{APP_ID}/build/{IDENTIFIER_ID}/artifacts/{BUILD_ID}", authorized(handler.RegisterArtifact)).Methods(http.MethodPut)
 	router.HandleFunc("/{APP_ID}/build/{IDENTIFIER_ID}/artifacts/{BUILD_ID}/failed", authorized(handler.Fail)).Methods(http.MethodPost)
 	router.HandleFunc("/{APP_ID}/build/{IDENTIFIER_ID}/artifacts/{BUILD_ID}/complete", authorized(handler.Complete)).Methods(http.MethodPost)
 	router.HandleFunc("/build-uploads/{TOKEN}", handler.UploadLocal).Methods(http.MethodPut)

--- a/internal/handlers/build_registry_handler_test.go
+++ b/internal/handlers/build_registry_handler_test.go
@@ -1,0 +1,373 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+	"xprem/internal/bucket"
+	"xprem/internal/services"
+	"xprem/internal/store"
+	"xprem/internal/types"
+
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	registryApp        = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+	registryIdentifier = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"
+	registryBuild      = "cccccccc-cccc-4ccc-8ccc-cccccccccccc"
+)
+
+type registryIdentifierRepo struct {
+	services.AppIdentifierRepository
+}
+
+func (registryIdentifierRepo) GetAppIdentifierByID(_ context.Context, app, id string) (*store.AppIdentifierRef, error) {
+	if app != registryApp || id != registryIdentifier {
+		return nil, nil
+	}
+	return &store.AppIdentifierRef{Id: id, Platform: types.PlatformAndroid, Identifier: "com.example.app"}, nil
+}
+
+type registryRepo struct {
+	mu     sync.Mutex
+	builds map[string]types.BuildRecord
+	err    error
+}
+
+func newRegistryRepo() *registryRepo {
+	return &registryRepo{builds: map[string]types.BuildRecord{}}
+}
+
+func (r *registryRepo) Create(_ context.Context, record types.BuildRecord) (*types.BuildRecord, bool, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.err != nil {
+		return nil, false, r.err
+	}
+	if existing, ok := r.builds[record.ID]; ok {
+		return &existing, false, nil
+	}
+	record.CreatedAt = time.Now()
+	r.builds[record.ID] = record
+	return &record, true, nil
+}
+
+func (r *registryRepo) Get(_ context.Context, appID, id string) (*types.BuildRecord, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.err != nil {
+		return nil, r.err
+	}
+	record, ok := r.builds[id]
+	if !ok || record.AppID != appID {
+		return nil, &store.ErrResourceNotFound{Resource: "build", Identifier: id}
+	}
+	return &record, nil
+}
+
+func (r *registryRepo) List(_ context.Context, appID string, _, _ int32) ([]types.BuildRecord, int64, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.err != nil {
+		return nil, 0, r.err
+	}
+	records := []types.BuildRecord{}
+	for _, record := range r.builds {
+		if record.AppID == appID {
+			records = append(records, record)
+		}
+	}
+	return records, int64(len(records)), nil
+}
+
+func (r *registryRepo) Transition(_ context.Context, appID, id string, decide func(types.BuildRecord) (*types.BuildRecord, error)) (*types.BuildRecord, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	current, ok := r.builds[id]
+	if !ok || current.AppID != appID {
+		return nil, &store.ErrResourceNotFound{Resource: "build", Identifier: id}
+	}
+	next, err := decide(current)
+	if err != nil {
+		return nil, err
+	}
+	if next == nil {
+		return &current, nil
+	}
+	if next.Status == types.BuildStatusReady && next.ReadyAt == nil {
+		now := time.Now()
+		next.ReadyAt = &now
+	}
+	r.builds[id] = *next
+	return next, nil
+}
+
+type registryFixture struct {
+	handler *BuildRegistryHandler
+	repo    *registryRepo
+	router  *mux.Router
+}
+
+func newRegistryFixture(t *testing.T) *registryFixture {
+	t.Helper()
+	t.Setenv("JWT_SECRET", "registry-secret")
+	t.Setenv("BASE_URL", "https://ota.example.com/sub/path/")
+	repo := newRegistryRepo()
+	service := services.NewBuildService(repo, registryIdentifierRepo{}, bucket.NewBuildArtifactStorage(&bucket.LocalBucket{BasePath: t.TempDir()}))
+	handler := NewBuildRegistryHandler(service)
+	router := mux.NewRouter()
+	authorized := func(next http.HandlerFunc) http.HandlerFunc {
+		return func(w http.ResponseWriter, r *http.Request) {
+			next(w, r.WithContext(services.WithBuildIdentifier(services.WithCliAuth(r.Context(), services.CliCredential{AppID: registryApp, KeyID: 42, KeyName: "ci"}), registryIdentifier)))
+		}
+	}
+	router.HandleFunc("/{APP_ID}/build/{IDENTIFIER_ID}/artifacts/{BUILD_ID}/start", authorized(handler.Start)).Methods(http.MethodPut)
+	router.HandleFunc("/{APP_ID}/build/{IDENTIFIER_ID}/artifacts/{BUILD_ID}", authorized(handler.Begin)).Methods(http.MethodPut)
+	router.HandleFunc("/{APP_ID}/build/{IDENTIFIER_ID}/artifacts/{BUILD_ID}/failed", authorized(handler.Fail)).Methods(http.MethodPost)
+	router.HandleFunc("/{APP_ID}/build/{IDENTIFIER_ID}/artifacts/{BUILD_ID}/complete", authorized(handler.Complete)).Methods(http.MethodPost)
+	router.HandleFunc("/build-uploads/{TOKEN}", handler.UploadLocal).Methods(http.MethodPut)
+	router.HandleFunc("/api/app/{APP_ID}/builds", handler.List).Methods(http.MethodGet)
+	router.HandleFunc("/api/app/{APP_ID}/builds/{BUILD_ID}", handler.Get).Methods(http.MethodGet)
+	router.HandleFunc("/api/app/{APP_ID}/builds/{BUILD_ID}/download", handler.Download).Methods(http.MethodGet)
+	return &registryFixture{handler: handler, repo: repo, router: router}
+}
+
+func (f *registryFixture) do(method, path string, body string, headers ...string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(method, path, strings.NewReader(body))
+	for i := 0; i+1 < len(headers); i += 2 {
+		req.Header.Set(headers[i], headers[i+1])
+	}
+	w := httptest.NewRecorder()
+	f.router.ServeHTTP(w, req)
+	return w
+}
+
+func (f *registryFixture) build(t *testing.T, w *httptest.ResponseRecorder) types.BuildRecord {
+	t.Helper()
+	var record types.BuildRecord
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &record), w.Body.String())
+	return record
+}
+
+const registryPath = "/" + registryApp + "/build/" + registryIdentifier + "/artifacts/" + registryBuild
+
+func startBody(startedAt time.Time) string {
+	body, _ := json.Marshal(map[string]any{"artifactType": "apk", "metadata": map[string]any{"profile": "production", "channel": "stable", "cliVersion": "2.0.0", "gitCommit": "abc", "gitMessage": "release", "gitDirty": true, "startedAt": startedAt}})
+	return string(body)
+}
+
+func registerBody(content []byte, startedAt time.Time) string {
+	sum := sha256.Sum256(content)
+	body, _ := json.Marshal(map[string]any{"artifactType": "apk", "size": len(content), "sha256": hex.EncodeToString(sum[:]), "metadata": map[string]any{
+		"profile": "production", "channel": "stable", "cliVersion": "2.0.0", "gitCommit": "abc", "gitMessage": "release", "gitDirty": true, "startedAt": startedAt,
+		"version": "1.0.0", "buildNumber": "42", "fingerprint": strings.Repeat("a", 64), "finishedAt": startedAt.Add(4 * time.Minute), "durationMs": 1,
+	}})
+	return string(body)
+}
+
+func TestBuildRegistryStartAndFail(t *testing.T) {
+	f := newRegistryFixture(t)
+	startedAt := time.Now().Add(-5 * time.Minute).UTC().Truncate(time.Microsecond)
+
+	w := f.do(http.MethodPut, registryPath+"/start", startBody(startedAt))
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	require.Equal(t, "no-store", w.Header().Get("Cache-Control"))
+	started := f.build(t, w)
+	require.Equal(t, types.BuildStatusBuilding, started.Status)
+	require.Equal(t, registryBuild, started.ID)
+	require.Equal(t, registryIdentifier, started.AppIdentifierID)
+	require.Equal(t, "com.example.app", started.ApplicationID)
+	require.Equal(t, "42", started.ActorID)
+	require.NotContains(t, w.Body.String(), `"size"`, "unknown artifact fields are omitted while building")
+	require.NotContains(t, w.Body.String(), `"finishedAt"`)
+	require.NotContains(t, w.Body.String(), `"fingerprint"`)
+
+	w = f.do(http.MethodPut, registryPath+"/start", startBody(startedAt))
+	require.Equal(t, http.StatusOK, w.Code, "idempotent")
+	w = f.do(http.MethodPut, registryPath+"/start", strings.Replace(startBody(startedAt), `"production"`, `"preview"`, 1))
+	require.Equal(t, http.StatusConflict, w.Code)
+
+	for name, body := range map[string]string{
+		"unknown field":  `{"artifactType":"apk","metadata":{"profile":"p","cliVersion":"1","startedAt":"2026-09-09T10:00:00Z","fingerprint":"abc"}}`,
+		"not json":       `nope`,
+		"trailing json":  startBody(startedAt) + `{}`,
+		"missing fields": `{"artifactType":"apk","metadata":{}}`,
+		"oversized":      `{"artifactType":"apk","metadata":{"profile":"` + strings.Repeat("p", 17<<10) + `"}}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			w := f.do(http.MethodPut, "/"+registryApp+"/build/"+registryIdentifier+"/artifacts/dddddddd-dddd-4ddd-8ddd-dddddddddddd/start", body)
+			require.Equal(t, http.StatusBadRequest, w.Code, w.Body.String())
+			require.Len(t, f.repo.builds, 1)
+		})
+	}
+
+	w = f.do(http.MethodPost, registryPath+"/failed", `{"finishedAt":"`+time.Now().UTC().Format(time.RFC3339Nano)+`","error":"Exception: keystore password hunter2"}`)
+	require.Equal(t, http.StatusBadRequest, w.Code, "raw exception text is not accepted")
+	require.Equal(t, types.BuildStatusBuilding, f.repo.builds[registryBuild].Status)
+	w = f.do(http.MethodPost, registryPath+"/failed", `{}`)
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	w = f.do(http.MethodPost, registryPath+"/failed", `{"finishedAt":"`+startedAt.Add(-time.Second).Format(time.RFC3339Nano)+`"}`)
+	require.Equal(t, http.StatusBadRequest, w.Code)
+
+	finishedAt := startedAt.Add(2 * time.Minute)
+	w = f.do(http.MethodPost, registryPath+"/failed", `{"finishedAt":"`+finishedAt.Format(time.RFC3339Nano)+`"}`)
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	require.Equal(t, "no-store", w.Header().Get("Cache-Control"))
+	failed := f.build(t, w)
+	require.Equal(t, types.BuildStatusFailed, failed.Status)
+	require.Equal(t, int64(120000), failed.Metadata.DurationMs)
+	require.True(t, failed.Metadata.FinishedAt.Equal(finishedAt))
+	require.Nil(t, failed.ReadyAt)
+
+	w = f.do(http.MethodPost, registryPath+"/failed", `{"finishedAt":"`+time.Now().UTC().Format(time.RFC3339Nano)+`"}`)
+	require.Equal(t, http.StatusOK, w.Code)
+	require.True(t, f.build(t, w).Metadata.FinishedAt.Equal(finishedAt), "idempotent")
+	w = f.do(http.MethodPost, registryPath+"/complete", "")
+	require.Equal(t, http.StatusConflict, w.Code, w.Body.String())
+
+	w = f.do(http.MethodPost, "/"+registryApp+"/build/"+registryIdentifier+"/artifacts/dddddddd-dddd-4ddd-8ddd-dddddddddddd/failed", `{"finishedAt":"`+time.Now().UTC().Format(time.RFC3339Nano)+`"}`)
+	require.Equal(t, http.StatusNotFound, w.Code, "failure reports do not create rows")
+	require.Len(t, f.repo.builds, 1)
+}
+
+func TestBuildRegistryLocalUploadFlow(t *testing.T) {
+	f := newRegistryFixture(t)
+	startedAt := time.Now().Add(-5 * time.Minute).UTC()
+	content := []byte("apk payload")
+
+	w := f.do(http.MethodPut, registryPath+"/start", startBody(startedAt))
+	require.Equal(t, http.StatusOK, w.Code)
+	w = f.do(http.MethodPut, registryPath, registerBody(content, startedAt))
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	require.Equal(t, "no-store", w.Header().Get("Cache-Control"))
+	var registration struct {
+		Build  types.BuildRecord `json:"build"`
+		Upload *struct {
+			URL    string `json:"url"`
+			Method string `json:"method"`
+		} `json:"upload"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &registration))
+	require.Equal(t, types.BuildStatusUploading, registration.Build.Status)
+	require.Equal(t, int64(240000), registration.Build.Metadata.DurationMs, "the client's durationMs is ignored")
+	require.NotNil(t, registration.Upload)
+	require.Equal(t, "PUT", registration.Upload.Method)
+	require.True(t, strings.HasPrefix(registration.Upload.URL, "https://ota.example.com/sub/path/build-uploads/"), registration.Upload.URL)
+	token := strings.TrimPrefix(registration.Upload.URL, "https://ota.example.com/sub/path/build-uploads/")
+	require.NotContains(t, token, "/")
+
+	w = f.do(http.MethodPut, "/build-uploads/"+token, string(content)+"extra")
+	require.Equal(t, http.StatusBadRequest, w.Code, "bodies beyond the declared size are refused")
+	w = f.do(http.MethodPut, "/build-uploads/forged", string(content))
+	require.Equal(t, http.StatusUnauthorized, w.Code)
+	w = f.do(http.MethodPut, "/build-uploads/"+token, string(content))
+	require.Equal(t, http.StatusNoContent, w.Code, w.Body.String())
+	require.Equal(t, "no-store", w.Header().Get("Cache-Control"))
+
+	w = f.do(http.MethodPost, registryPath+"/complete", "")
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	require.Equal(t, "no-store", w.Header().Get("Cache-Control"))
+	ready := f.build(t, w)
+	require.Equal(t, types.BuildStatusReady, ready.Status)
+	require.NotNil(t, ready.ReadyAt)
+
+	w = f.do(http.MethodPut, "/build-uploads/"+token, string(content))
+	require.Equal(t, http.StatusConflict, w.Code, "a ready build accepts no further bytes")
+	w = f.do(http.MethodPut, registryPath, registerBody(content, startedAt))
+	require.Equal(t, http.StatusOK, w.Code)
+	require.NotContains(t, w.Body.String(), `"upload"`, "ready builds get no upload grant")
+	w = f.do(http.MethodPut, registryPath, registerBody([]byte("other"), startedAt))
+	require.Equal(t, http.StatusConflict, w.Code)
+	w = f.do(http.MethodPost, registryPath+"/failed", `{"finishedAt":"`+time.Now().UTC().Format(time.RFC3339Nano)+`"}`)
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, types.BuildStatusReady, f.build(t, w).Status, "ready never regresses")
+
+	w = f.do(http.MethodGet, "/api/app/"+registryApp+"/builds/"+registryBuild+"/download", "")
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, "application/vnd.android.package-archive", w.Header().Get("Content-Type"))
+	require.Equal(t, content, w.Body.Bytes())
+	w = f.do(http.MethodGet, "/api/app/"+registryApp+"/builds", "")
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Contains(t, w.Body.String(), `"count":1`)
+	w = f.do(http.MethodGet, "/api/app/"+registryApp+"/builds?limit=0", "")
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	w = f.do(http.MethodGet, "/api/app/"+registryApp+"/builds/not-a-uuid", "")
+	require.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestBuildRegistryUsesAuthorizedIdentifierNotPath(t *testing.T) {
+	f := newRegistryFixture(t)
+	startedAt := time.Now().Add(-time.Minute).UTC()
+	w := f.do(http.MethodPut, "/"+registryApp+"/build/eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee/artifacts/"+registryBuild+"/start", startBody(startedAt))
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	require.Equal(t, registryIdentifier, f.build(t, w).AppIdentifierID, "the identifier comes from the authorization context")
+
+	bare := mux.NewRouter()
+	bare.HandleFunc("/{APP_ID}/build/{IDENTIFIER_ID}/artifacts/{BUILD_ID}/start", f.handler.Start).Methods(http.MethodPut)
+	bare.HandleFunc("/{APP_ID}/build/{IDENTIFIER_ID}/artifacts/{BUILD_ID}/failed", f.handler.Fail).Methods(http.MethodPost)
+	for _, tc := range []struct{ method, suffix, body string }{{http.MethodPut, "/start", startBody(startedAt)}, {http.MethodPost, "/failed", `{"finishedAt":"` + time.Now().UTC().Format(time.RFC3339Nano) + `"}`}} {
+		req := httptest.NewRequest(tc.method, registryPath+tc.suffix, strings.NewReader(tc.body))
+		w := httptest.NewRecorder()
+		bare.ServeHTTP(w, req)
+		require.Equal(t, http.StatusNotFound, w.Code, "without an authorized identifier in the context the path variable is never trusted")
+	}
+	require.Equal(t, types.BuildStatusBuilding, f.repo.builds[registryBuild].Status)
+}
+
+func TestBuildRegistryPublicURLRequiresValidBaseURL(t *testing.T) {
+	for _, base := range []string{"not a url", "ftp://ota.example.com", "https://user:secret@ota.example.com", "/relative"} {
+		t.Run(base, func(t *testing.T) {
+			f := newRegistryFixture(t)
+			t.Setenv("BASE_URL", base)
+			startedAt := time.Now().Add(-time.Minute).UTC()
+			w := f.do(http.MethodPut, registryPath, registerBody([]byte("apk"), startedAt))
+			require.Equal(t, http.StatusInternalServerError, w.Code, w.Body.String())
+			require.NotContains(t, w.Body.String(), "eyJ", "the upload grant is not leaked in the error")
+			require.Contains(t, w.Body.String(), "Could not process the build request.")
+		})
+	}
+}
+
+func TestBuildRegistryErrorMapping(t *testing.T) {
+	for _, tc := range []struct {
+		err    error
+		status int
+	}{
+		{services.ErrUnauthorized, http.StatusUnauthorized},
+		{services.ErrBuildConflict, http.StatusConflict},
+		{bucket.ErrBuildNamespaceConflict, http.StatusConflict},
+		{services.ErrBuildNotReady, http.StatusConflict},
+		{services.ErrBuildState, http.StatusConflict},
+		{services.ErrBuildIntegrity, http.StatusBadRequest},
+		{&store.ErrResourceNotFound{Resource: "build", Identifier: "x"}, http.StatusNotFound},
+		{store.ErrNotSupportedInStatelessMode, http.StatusBadRequest},
+		{errors.New("connection refused to 10.0.0.1"), http.StatusInternalServerError},
+	} {
+		w := httptest.NewRecorder()
+		renderBuildRegistryError(w, tc.err)
+		require.Equal(t, tc.status, w.Code, tc.err.Error())
+		if tc.status == http.StatusInternalServerError {
+			require.NotContains(t, w.Body.String(), "10.0.0.1")
+		}
+	}
+}
+
+func TestBuildRegistryUploadBodyIsBounded(t *testing.T) {
+	f := newRegistryFixture(t)
+	req := httptest.NewRequest(http.MethodPut, "/build-uploads/forged", io.LimitReader(bytes.NewReader(make([]byte, 1)), 1))
+	w := httptest.NewRecorder()
+	f.router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusUnauthorized, w.Code, "the token is checked before any byte is read")
+}

--- a/internal/handlers/build_registry_handler_test.go
+++ b/internal/handlers/build_registry_handler_test.go
@@ -137,7 +137,7 @@ func newRegistryFixture(t *testing.T) *registryFixture {
 	router.HandleFunc("/{APP_ID}/build/{IDENTIFIER_ID}/artifacts/{BUILD_ID}", authorized(handler.RegisterArtifact)).Methods(http.MethodPut)
 	router.HandleFunc("/{APP_ID}/build/{IDENTIFIER_ID}/artifacts/{BUILD_ID}/failed", authorized(handler.Fail)).Methods(http.MethodPost)
 	router.HandleFunc("/{APP_ID}/build/{IDENTIFIER_ID}/artifacts/{BUILD_ID}/complete", authorized(handler.Complete)).Methods(http.MethodPost)
-	router.HandleFunc("/build-uploads/{TOKEN}", handler.UploadLocal).Methods(http.MethodPut)
+	router.HandleFunc("/{APP_ID}/build/{IDENTIFIER_ID}/artifacts/{BUILD_ID}/upload", authorized(handler.UploadLocal)).Methods(http.MethodPut)
 	router.HandleFunc("/api/app/{APP_ID}/builds", handler.List).Methods(http.MethodGet)
 	router.HandleFunc("/api/app/{APP_ID}/builds/{BUILD_ID}", handler.Get).Methods(http.MethodGet)
 	router.HandleFunc("/api/app/{APP_ID}/builds/{BUILD_ID}/download", handler.Download).Methods(http.MethodGet)
@@ -255,8 +255,9 @@ func TestBuildRegistryLocalUploadFlow(t *testing.T) {
 	var registration struct {
 		Build  types.BuildRecord `json:"build"`
 		Upload *struct {
-			URL    string `json:"url"`
-			Method string `json:"method"`
+			URL     string            `json:"url"`
+			Method  string            `json:"method"`
+			Headers map[string]string `json:"headers"`
 		} `json:"upload"`
 	}
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &registration))
@@ -264,15 +265,20 @@ func TestBuildRegistryLocalUploadFlow(t *testing.T) {
 	require.Equal(t, int64(240000), registration.Build.Metadata.DurationMs, "the client's durationMs is ignored")
 	require.NotNil(t, registration.Upload)
 	require.Equal(t, "PUT", registration.Upload.Method)
-	require.True(t, strings.HasPrefix(registration.Upload.URL, "https://ota.example.com/sub/path/build-uploads/"), registration.Upload.URL)
-	token := strings.TrimPrefix(registration.Upload.URL, "https://ota.example.com/sub/path/build-uploads/")
-	require.NotContains(t, token, "/")
+	require.Equal(t, "https://ota.example.com/sub/path"+registryPath+"/upload", registration.Upload.URL)
+	token := registration.Upload.Headers[bucket.LocalUploadTokenHeader]
+	require.NotEmpty(t, token)
+	require.NotContains(t, registration.Upload.URL, token)
 
-	w = f.do(http.MethodPut, "/build-uploads/"+token, string(content)+"extra")
+	for _, target := range []string{registryPath + "/upload", registryPath + "/upload?token=" + token} {
+		w = f.do(http.MethodPut, target, string(content))
+		require.Equal(t, http.StatusUnauthorized, w.Code, "only the local-upload-token header authorizes the upload")
+	}
+	w = f.do(http.MethodPut, registryPath+"/upload", string(content)+"extra", bucket.LocalUploadTokenHeader, token)
 	require.Equal(t, http.StatusBadRequest, w.Code, "bodies beyond the declared size are refused")
-	w = f.do(http.MethodPut, "/build-uploads/forged", string(content))
+	w = f.do(http.MethodPut, registryPath+"/upload", string(content), bucket.LocalUploadTokenHeader, "forged")
 	require.Equal(t, http.StatusUnauthorized, w.Code)
-	w = f.do(http.MethodPut, "/build-uploads/"+token, string(content))
+	w = f.do(http.MethodPut, registryPath+"/upload", string(content), bucket.LocalUploadTokenHeader, token)
 	require.Equal(t, http.StatusNoContent, w.Code, w.Body.String())
 	require.Equal(t, "no-store", w.Header().Get("Cache-Control"))
 
@@ -283,7 +289,7 @@ func TestBuildRegistryLocalUploadFlow(t *testing.T) {
 	require.Equal(t, types.BuildStatusReady, ready.Status)
 	require.NotNil(t, ready.ReadyAt)
 
-	w = f.do(http.MethodPut, "/build-uploads/"+token, string(content))
+	w = f.do(http.MethodPut, registryPath+"/upload", string(content), bucket.LocalUploadTokenHeader, token)
 	require.Equal(t, http.StatusConflict, w.Code, "a ready build accepts no further bytes")
 	w = f.do(http.MethodPut, registryPath, registerBody(content, startedAt))
 	require.Equal(t, http.StatusOK, w.Code)
@@ -365,7 +371,7 @@ func TestBuildRegistryErrorMapping(t *testing.T) {
 
 func TestBuildRegistryUploadBodyIsBounded(t *testing.T) {
 	f := newRegistryFixture(t)
-	req := httptest.NewRequest(http.MethodPut, "/build-uploads/forged", io.LimitReader(bytes.NewReader(make([]byte, 1)), 1))
+	req := httptest.NewRequest(http.MethodPut, registryPath+"/upload", io.LimitReader(bytes.NewReader(make([]byte, 1)), 1))
 	w := httptest.NewRecorder()
 	f.router.ServeHTTP(w, req)
 	require.Equal(t, http.StatusUnauthorized, w.Code, "the token is checked before any byte is read")

--- a/internal/middleware/logging_middleware.go
+++ b/internal/middleware/logging_middleware.go
@@ -3,18 +3,39 @@ package middleware
 import (
 	"log"
 	"net/http"
+	"net/url"
+	"regexp"
 	"runtime/debug"
 	"strings"
 	"time"
 )
 
+var buildCapabilityPath = regexp.MustCompile(`(/build-(?:uploads|shares)/)[^/?]+`)
+
+func redactBuildCapability(value string) string {
+	redacted := buildCapabilityPath.ReplaceAllString(value, "${1}[REDACTED]")
+	if redacted != value {
+		if i := strings.IndexByte(redacted, '?'); i >= 0 {
+			redacted = redacted[:i] + "?[REDACTED]"
+		}
+		return redacted
+	}
+	if decoded, err := url.PathUnescape(value); err == nil && buildCapabilityPath.MatchString(decoded) {
+		return "[REDACTED]"
+	}
+	return value
+}
+
 func redactHeaders(headers http.Header) http.Header {
 	redactedHeaders := make(http.Header)
 	for key, values := range headers {
-		if strings.EqualFold(key, "Authorization") || strings.EqualFold(key, "X-Expo-Access-Token") {
+		if strings.EqualFold(key, "Authorization") || strings.EqualFold(key, "X-Expo-Access-Token") || strings.EqualFold(key, "Expo-Session") || strings.EqualFold(key, "Cookie") {
 			redactedHeaders[key] = []string{"REDACTED"}
 		} else {
-			redactedHeaders[key] = values
+			redactedHeaders[key] = append([]string(nil), values...)
+			for i, value := range redactedHeaders[key] {
+				redactedHeaders[key][i] = redactBuildCapability(value)
+			}
 		}
 	}
 	return redactedHeaders
@@ -28,10 +49,19 @@ func LoggingMiddleware(next http.Handler) http.Handler {
 		}
 
 		safeHeaders := redactHeaders(r.Header)
+		safeURI := redactBuildCapability(r.RequestURI)
+		safeQuery := r.URL.RawQuery
+		if safeURI != r.RequestURI {
+			// A capability URL may echo its token in the query, so the whole query goes.
+			safeQuery = "[REDACTED]"
+			if i := strings.IndexByte(safeURI, '?'); i >= 0 {
+				safeURI = safeURI[:i] + "?[REDACTED]"
+			}
+		}
 		defer func() {
 			if err := recover(); err != nil {
 				log.Printf("Panic recovered during %s %s\nQuery: %s\nHeaders: %v\nError: %v\nStack Trace:\n%s",
-					r.Method, r.RequestURI, r.URL.RawQuery, safeHeaders, err, debug.Stack())
+					r.Method, safeURI, safeQuery, safeHeaders, err, debug.Stack())
 				http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 			}
 		}()
@@ -44,16 +74,16 @@ func LoggingMiddleware(next http.Handler) http.Handler {
 		}
 		start := time.Now()
 
-		log.Printf("Started %s %s with query: %s and headers: %v", r.Method, r.RequestURI, r.URL.RawQuery, safeHeaders)
+		log.Printf("Started %s %s with query: %s and headers: %v", r.Method, safeURI, safeQuery, safeHeaders)
 
 		recorder := &statusRecorder{ResponseWriter: w, statusCode: http.StatusOK}
 
 		next.ServeHTTP(recorder, r)
 
 		if recorder.statusCode >= 500 {
-			log.Printf("Error detected: %s %s returned status %d", r.Method, r.RequestURI, recorder.statusCode)
+			log.Printf("Error detected: %s %s returned status %d", r.Method, safeURI, recorder.statusCode)
 		}
-		log.Printf("Completed %s %d in %v", r.RequestURI, recorder.statusCode, time.Since(start))
+		log.Printf("Completed %s %d in %v", safeURI, recorder.statusCode, time.Since(start))
 	})
 }
 

--- a/internal/middleware/logging_middleware.go
+++ b/internal/middleware/logging_middleware.go
@@ -29,7 +29,7 @@ func redactBuildCapability(value string) string {
 func redactHeaders(headers http.Header) http.Header {
 	redactedHeaders := make(http.Header)
 	for key, values := range headers {
-		if strings.EqualFold(key, "Authorization") || strings.EqualFold(key, "X-Expo-Access-Token") || strings.EqualFold(key, "Expo-Session") || strings.EqualFold(key, "Cookie") {
+		if strings.EqualFold(key, "Authorization") || strings.EqualFold(key, "X-Expo-Access-Token") || strings.EqualFold(key, "Expo-Session") || strings.EqualFold(key, "Cookie") || strings.EqualFold(key, "local-upload-token") {
 			redactedHeaders[key] = []string{"REDACTED"}
 		} else {
 			redactedHeaders[key] = append([]string(nil), values...)

--- a/internal/middleware/logging_middleware.go
+++ b/internal/middleware/logging_middleware.go
@@ -3,28 +3,10 @@ package middleware
 import (
 	"log"
 	"net/http"
-	"net/url"
-	"regexp"
 	"runtime/debug"
 	"strings"
 	"time"
 )
-
-var buildCapabilityPath = regexp.MustCompile(`(/build-(?:uploads|shares)/)[^/?]+`)
-
-func redactBuildCapability(value string) string {
-	redacted := buildCapabilityPath.ReplaceAllString(value, "${1}[REDACTED]")
-	if redacted != value {
-		if i := strings.IndexByte(redacted, '?'); i >= 0 {
-			redacted = redacted[:i] + "?[REDACTED]"
-		}
-		return redacted
-	}
-	if decoded, err := url.PathUnescape(value); err == nil && buildCapabilityPath.MatchString(decoded) {
-		return "[REDACTED]"
-	}
-	return value
-}
 
 func redactHeaders(headers http.Header) http.Header {
 	redactedHeaders := make(http.Header)
@@ -32,10 +14,7 @@ func redactHeaders(headers http.Header) http.Header {
 		if strings.EqualFold(key, "Authorization") || strings.EqualFold(key, "X-Expo-Access-Token") || strings.EqualFold(key, "Expo-Session") || strings.EqualFold(key, "Cookie") || strings.EqualFold(key, "local-upload-token") {
 			redactedHeaders[key] = []string{"REDACTED"}
 		} else {
-			redactedHeaders[key] = append([]string(nil), values...)
-			for i, value := range redactedHeaders[key] {
-				redactedHeaders[key][i] = redactBuildCapability(value)
-			}
+			redactedHeaders[key] = values
 		}
 	}
 	return redactedHeaders
@@ -49,19 +28,10 @@ func LoggingMiddleware(next http.Handler) http.Handler {
 		}
 
 		safeHeaders := redactHeaders(r.Header)
-		safeURI := redactBuildCapability(r.RequestURI)
-		safeQuery := r.URL.RawQuery
-		if safeURI != r.RequestURI {
-			// A capability URL may echo its token in the query, so the whole query goes.
-			safeQuery = "[REDACTED]"
-			if i := strings.IndexByte(safeURI, '?'); i >= 0 {
-				safeURI = safeURI[:i] + "?[REDACTED]"
-			}
-		}
 		defer func() {
 			if err := recover(); err != nil {
 				log.Printf("Panic recovered during %s %s\nQuery: %s\nHeaders: %v\nError: %v\nStack Trace:\n%s",
-					r.Method, safeURI, safeQuery, safeHeaders, err, debug.Stack())
+					r.Method, r.RequestURI, r.URL.RawQuery, safeHeaders, err, debug.Stack())
 				http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 			}
 		}()
@@ -74,16 +44,16 @@ func LoggingMiddleware(next http.Handler) http.Handler {
 		}
 		start := time.Now()
 
-		log.Printf("Started %s %s with query: %s and headers: %v", r.Method, safeURI, safeQuery, safeHeaders)
+		log.Printf("Started %s %s with query: %s and headers: %v", r.Method, r.RequestURI, r.URL.RawQuery, safeHeaders)
 
 		recorder := &statusRecorder{ResponseWriter: w, statusCode: http.StatusOK}
 
 		next.ServeHTTP(recorder, r)
 
 		if recorder.statusCode >= 500 {
-			log.Printf("Error detected: %s %s returned status %d", r.Method, safeURI, recorder.statusCode)
+			log.Printf("Error detected: %s %s returned status %d", r.Method, r.RequestURI, recorder.statusCode)
 		}
-		log.Printf("Completed %s %d in %v", safeURI, recorder.statusCode, time.Since(start))
+		log.Printf("Completed %s %d in %v", r.RequestURI, recorder.statusCode, time.Since(start))
 	})
 }
 

--- a/internal/middleware/logging_middleware_test.go
+++ b/internal/middleware/logging_middleware_test.go
@@ -58,7 +58,6 @@ func captureLogs(t *testing.T) *bytes.Buffer {
 }
 
 const uploadGrant = "eyJhbGciOiJIUzI1NiJ9.UPLOADGRANT.sig"
-const shareToken = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
 
 func TestLoggingMiddlewareRedactsLocalUploadHeader(t *testing.T) {
 	for _, target := range []string{"/app-1/build/identifier-1/artifacts/build-1/upload", "/app-1/uploadLocalFile"} {
@@ -76,78 +75,22 @@ func TestLoggingMiddlewareRedactsLocalUploadHeader(t *testing.T) {
 					request := httptest.NewRequest(http.MethodPut, target, nil)
 					request.Header[header] = []string{uploadGrant}
 					request.Header.Set("Authorization", "Bearer eoo-secret")
+					request.Header.Set("X-Expo-Access-Token", "expo-secret")
+					request.Header.Set("Expo-Session", "session-secret")
+					request.Header.Set("Cookie", "session=cookie-secret")
+					request.Header.Set("User-Agent", "eoas/2.0")
 					handler.ServeHTTP(httptest.NewRecorder(), request)
 					require.Contains(t, logs.String(), "REDACTED")
 					require.NotContains(t, logs.String(), uploadGrant)
 					require.NotContains(t, logs.String(), "eoo-secret")
+					require.NotContains(t, logs.String(), "expo-secret")
+					require.NotContains(t, logs.String(), "session-secret")
+					require.NotContains(t, logs.String(), "cookie-secret")
+					require.Contains(t, logs.String(), "eoas/2.0", "ordinary headers stay visible")
 				}
 			}
 		})
 	}
-}
-
-func TestLoggingMiddlewareRedactsBuildCapabilities(t *testing.T) {
-	for _, tc := range []struct {
-		name, method, target string
-		status               int
-	}{
-		{"upload grant", http.MethodPut, "/build-uploads/" + uploadGrant, http.StatusNoContent},
-		{"upload grant with query", http.MethodPut, "/build-uploads/" + uploadGrant + "?debug=" + uploadGrant, http.StatusNoContent},
-		{"share page", http.MethodGet, "/build-shares/" + shareToken, http.StatusOK},
-		{"encoded slash", http.MethodGet, "/build-shares%2F" + shareToken, http.StatusOK},
-		{"encoded route", http.MethodGet, "/build-%73hares/" + shareToken, http.StatusOK},
-		{"encoded query link", http.MethodGet, "/api?next=%2Fbuild-shares%2F" + shareToken, http.StatusOK},
-		{"share download", http.MethodGet, "/build-shares/" + shareToken + "/download", http.StatusOK},
-		{"share under sub path", http.MethodGet, "/ota/build-shares/" + shareToken + "/download", http.StatusOK},
-		{"server error", http.MethodGet, "/build-shares/" + shareToken, http.StatusInternalServerError},
-		{"token in another query", http.MethodGet, "/api/app/app-1?next=/build-shares/" + shareToken, http.StatusOK},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			logs := captureLogs(t)
-			handler := LoggingMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.WriteHeader(tc.status)
-			}))
-			request := httptest.NewRequest(tc.method, tc.target, nil)
-			request.Header.Set("Referer", "https://ota.example.com/build-shares/"+shareToken)
-			request.Header.Set("Authorization", "Bearer eoo_secret")
-			request.Header.Set("Expo-Session", "session-secret")
-			request.Header.Set("Cookie", "session=cookie-secret")
-			request.Header.Set("User-Agent", "eoas/2.0")
-			request.Header.Set("X-Link", "https://ota.example.com/build-shares/"+shareToken+"?echo="+shareToken)
-			request.Header.Set("X-Encoded-Link", "https://ota.example.com/build-shares%2F"+shareToken)
-			recorder := httptest.NewRecorder()
-			handler.ServeHTTP(recorder, request)
-			require.Equal(t, tc.status, recorder.Code)
-			output := logs.String()
-			require.Contains(t, output, "Started "+tc.method)
-			require.Contains(t, output, "Completed")
-			require.Contains(t, output, "[REDACTED]")
-			require.Contains(t, output, "eoas/2.0", "ordinary headers stay visible")
-			for _, secret := range []string{uploadGrant, shareToken, "UPLOADGRANT", "eoo_secret", "session-secret", "cookie-secret"} {
-				require.NotContains(t, output, secret)
-			}
-			if tc.status >= 500 {
-				require.Contains(t, output, "Error detected")
-			}
-		})
-	}
-}
-
-func TestLoggingMiddlewareRedactsCapabilityInPanic(t *testing.T) {
-	logs := captureLogs(t)
-	handler := LoggingMiddleware(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
-		panic("upload failed")
-	}))
-	request := httptest.NewRequest(http.MethodPut, "/build-uploads/"+uploadGrant+"?x=1", nil)
-	request.Header.Set("Referer", "https://ota.example.com/build-shares/"+shareToken)
-	recorder := httptest.NewRecorder()
-	require.NotPanics(t, func() { handler.ServeHTTP(recorder, request) })
-	require.Equal(t, http.StatusInternalServerError, recorder.Code)
-	output := logs.String()
-	require.Contains(t, output, "Panic recovered")
-	require.Contains(t, output, "/build-uploads/[REDACTED]")
-	require.NotContains(t, output, uploadGrant)
-	require.NotContains(t, output, shareToken)
 }
 
 func TestLoggingMiddlewareKeepsOrdinaryQueries(t *testing.T) {
@@ -166,12 +109,4 @@ func TestLoggingMiddlewareKeepsOrdinaryQueries(t *testing.T) {
 	require.NotContains(t, output, "?[REDACTED]")
 	require.NotContains(t, output, "eoo_secret")
 	require.Contains(t, output, "Authorization:[REDACTED]")
-}
-
-func TestRedactBuildCapability(t *testing.T) {
-	require.Equal(t, "/build-uploads/[REDACTED]", redactBuildCapability("/build-uploads/"+uploadGrant))
-	require.Equal(t, "/build-shares/[REDACTED]/download", redactBuildCapability("/build-shares/"+shareToken+"/download"))
-	require.Equal(t, "https://h/x/build-shares/[REDACTED]?[REDACTED]", redactBuildCapability("https://h/x/build-shares/"+shareToken+"?a=1"))
-	require.Equal(t, "/build-shares/", redactBuildCapability("/build-shares/"))
-	require.Equal(t, "/api/app/app-1/builds/b-1/shares", redactBuildCapability("/api/app/app-1/builds/b-1/shares"))
 }

--- a/internal/middleware/logging_middleware_test.go
+++ b/internal/middleware/logging_middleware_test.go
@@ -1,7 +1,9 @@
 package middleware
 
 import (
+	"bytes"
 	"context"
+	"log"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -44,4 +46,106 @@ func TestLoggingMiddlewarePreservesFlush(t *testing.T) {
 	handler.ServeHTTP(recorder, request)
 
 	require.True(t, recorder.Flushed, "the flush must reach the underlying writer")
+}
+
+func captureLogs(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var buffer bytes.Buffer
+	previous := log.Writer()
+	log.SetOutput(&buffer)
+	t.Cleanup(func() { log.SetOutput(previous) })
+	return &buffer
+}
+
+const uploadGrant = "eyJhbGciOiJIUzI1NiJ9.UPLOADGRANT.sig"
+const shareToken = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+
+func TestLoggingMiddlewareRedactsBuildCapabilities(t *testing.T) {
+	for _, tc := range []struct {
+		name, method, target string
+		status               int
+	}{
+		{"upload grant", http.MethodPut, "/build-uploads/" + uploadGrant, http.StatusNoContent},
+		{"upload grant with query", http.MethodPut, "/build-uploads/" + uploadGrant + "?debug=" + uploadGrant, http.StatusNoContent},
+		{"share page", http.MethodGet, "/build-shares/" + shareToken, http.StatusOK},
+		{"encoded slash", http.MethodGet, "/build-shares%2F" + shareToken, http.StatusOK},
+		{"encoded route", http.MethodGet, "/build-%73hares/" + shareToken, http.StatusOK},
+		{"encoded query link", http.MethodGet, "/api?next=%2Fbuild-shares%2F" + shareToken, http.StatusOK},
+		{"share download", http.MethodGet, "/build-shares/" + shareToken + "/download", http.StatusOK},
+		{"share under sub path", http.MethodGet, "/ota/build-shares/" + shareToken + "/download", http.StatusOK},
+		{"server error", http.MethodGet, "/build-shares/" + shareToken, http.StatusInternalServerError},
+		{"token in another query", http.MethodGet, "/api/app/app-1?next=/build-shares/" + shareToken, http.StatusOK},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			logs := captureLogs(t)
+			handler := LoggingMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tc.status)
+			}))
+			request := httptest.NewRequest(tc.method, tc.target, nil)
+			request.Header.Set("Referer", "https://ota.example.com/build-shares/"+shareToken)
+			request.Header.Set("Authorization", "Bearer eoo_secret")
+			request.Header.Set("Expo-Session", "session-secret")
+			request.Header.Set("Cookie", "session=cookie-secret")
+			request.Header.Set("User-Agent", "eoas/2.0")
+			request.Header.Set("X-Link", "https://ota.example.com/build-shares/"+shareToken+"?echo="+shareToken)
+			request.Header.Set("X-Encoded-Link", "https://ota.example.com/build-shares%2F"+shareToken)
+			recorder := httptest.NewRecorder()
+			handler.ServeHTTP(recorder, request)
+			require.Equal(t, tc.status, recorder.Code)
+			output := logs.String()
+			require.Contains(t, output, "Started "+tc.method)
+			require.Contains(t, output, "Completed")
+			require.Contains(t, output, "[REDACTED]")
+			require.Contains(t, output, "eoas/2.0", "ordinary headers stay visible")
+			for _, secret := range []string{uploadGrant, shareToken, "UPLOADGRANT", "eoo_secret", "session-secret", "cookie-secret"} {
+				require.NotContains(t, output, secret)
+			}
+			if tc.status >= 500 {
+				require.Contains(t, output, "Error detected")
+			}
+		})
+	}
+}
+
+func TestLoggingMiddlewareRedactsCapabilityInPanic(t *testing.T) {
+	logs := captureLogs(t)
+	handler := LoggingMiddleware(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		panic("upload failed")
+	}))
+	request := httptest.NewRequest(http.MethodPut, "/build-uploads/"+uploadGrant+"?x=1", nil)
+	request.Header.Set("Referer", "https://ota.example.com/build-shares/"+shareToken)
+	recorder := httptest.NewRecorder()
+	require.NotPanics(t, func() { handler.ServeHTTP(recorder, request) })
+	require.Equal(t, http.StatusInternalServerError, recorder.Code)
+	output := logs.String()
+	require.Contains(t, output, "Panic recovered")
+	require.Contains(t, output, "/build-uploads/[REDACTED]")
+	require.NotContains(t, output, uploadGrant)
+	require.NotContains(t, output, shareToken)
+}
+
+func TestLoggingMiddlewareKeepsOrdinaryQueries(t *testing.T) {
+	logs := captureLogs(t)
+	handler := LoggingMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	request := httptest.NewRequest(http.MethodGet, "/app-1/build/id-1/environment?channel=production", nil)
+	request.Header.Set("Authorization", "Bearer eoo_secret")
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, request)
+	output := logs.String()
+	require.Contains(t, output, "channel=production")
+	require.Contains(t, output, "/app-1/build/id-1/environment?channel=production")
+	require.NotContains(t, output, "/[REDACTED]")
+	require.NotContains(t, output, "?[REDACTED]")
+	require.NotContains(t, output, "eoo_secret")
+	require.Contains(t, output, "Authorization:[REDACTED]")
+}
+
+func TestRedactBuildCapability(t *testing.T) {
+	require.Equal(t, "/build-uploads/[REDACTED]", redactBuildCapability("/build-uploads/"+uploadGrant))
+	require.Equal(t, "/build-shares/[REDACTED]/download", redactBuildCapability("/build-shares/"+shareToken+"/download"))
+	require.Equal(t, "https://h/x/build-shares/[REDACTED]?[REDACTED]", redactBuildCapability("https://h/x/build-shares/"+shareToken+"?a=1"))
+	require.Equal(t, "/build-shares/", redactBuildCapability("/build-shares/"))
+	require.Equal(t, "/api/app/app-1/builds/b-1/shares", redactBuildCapability("/api/app/app-1/builds/b-1/shares"))
 }

--- a/internal/middleware/logging_middleware_test.go
+++ b/internal/middleware/logging_middleware_test.go
@@ -60,6 +60,28 @@ func captureLogs(t *testing.T) *bytes.Buffer {
 const uploadGrant = "eyJhbGciOiJIUzI1NiJ9.UPLOADGRANT.sig"
 const shareToken = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
 
+func TestLoggingMiddlewareRedactsLocalUploadHeader(t *testing.T) {
+	for _, header := range []string{"local-upload-token", "Local-Upload-Token", "LOCAL-UPLOAD-TOKEN"} {
+		for _, panics := range []bool{false, true} {
+			logs := captureLogs(t)
+			handler := LoggingMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				require.Equal(t, []string{uploadGrant}, r.Header[header], "logging must not alter the request")
+				if panics {
+					panic("upload failed")
+				}
+				w.WriteHeader(http.StatusNoContent)
+			}))
+			request := httptest.NewRequest(http.MethodPut, "/app-1/build/identifier-1/artifacts/build-1/upload", nil)
+			request.Header[header] = []string{uploadGrant}
+			request.Header.Set("Authorization", "Bearer eoo-secret")
+			handler.ServeHTTP(httptest.NewRecorder(), request)
+			require.Contains(t, logs.String(), "REDACTED")
+			require.NotContains(t, logs.String(), uploadGrant)
+			require.NotContains(t, logs.String(), "eoo-secret")
+		}
+	}
+}
+
 func TestLoggingMiddlewareRedactsBuildCapabilities(t *testing.T) {
 	for _, tc := range []struct {
 		name, method, target string

--- a/internal/router/access_builds.go
+++ b/internal/router/access_builds.go
@@ -51,7 +51,12 @@ func (g buildGroup) guard(action apikeyrestrictions.BuildAction) mux.MiddlewareF
 			var ref *store.AppIdentifierRef
 			target := vars["APPLICATION_ID"]
 			if target != "" {
-				ref, err = g.identifiers.GetAppIdentifierByPlatformAndIdentifier(r.Context(), credential.AppID, types.PlatformAndroid, target)
+				platform, parseErr := types.ParsePlatform(vars["PLATFORM"])
+				if parseErr != nil {
+					handlers.RenderBuildInputError(w, validation.Errorf("platform", "%s", parseErr))
+					return
+				}
+				ref, err = g.identifiers.GetAppIdentifierByPlatformAndIdentifier(r.Context(), credential.AppID, platform, target)
 			} else {
 				identifierID, parseErr := uuid.Parse(vars["IDENTIFIER_ID"])
 				if parseErr != nil {

--- a/internal/router/routes_app.go
+++ b/internal/router/routes_app.go
@@ -29,7 +29,7 @@ func registerAppRoutes(
 
 	app.route(http.MethodGet, "/builds", container.BuildRegistryHandler.List, NeedsPermission(rbac.PermBuildRead, rbac.FallbackAnyMember))
 	app.route(http.MethodGet, "/builds/{BUILD_ID}", container.BuildRegistryHandler.Get, NeedsPermission(rbac.PermBuildRead, rbac.FallbackAnyMember))
-	app.route(http.MethodGet, "/builds/{BUILD_ID}/download", container.BuildRegistryHandler.Download, NeedsPermission(rbac.PermBuildDownload, rbac.FallbackAdminOnly))
+	app.route(http.MethodGet, "/builds/{BUILD_ID}/download", container.BuildRegistryHandler.Download, NeedsPermission(rbac.PermBuildDownload, rbac.FallbackAnyMember))
 
 	app.route(http.MethodGet, "", container.AppHandler.GetAppHandler,
 		AnyViewer())

--- a/internal/router/routes_app.go
+++ b/internal/router/routes_app.go
@@ -27,6 +27,10 @@ func registerAppRoutes(
 		apiKeyAccess: container.ApiKeyAccessService,
 	}
 
+	app.route(http.MethodGet, "/builds", container.BuildRegistryHandler.List, NeedsPermission(rbac.PermBuildRead, rbac.FallbackAnyMember))
+	app.route(http.MethodGet, "/builds/{BUILD_ID}", container.BuildRegistryHandler.Get, NeedsPermission(rbac.PermBuildRead, rbac.FallbackAnyMember))
+	app.route(http.MethodGet, "/builds/{BUILD_ID}/download", container.BuildRegistryHandler.Download, NeedsPermission(rbac.PermBuildDownload, rbac.FallbackAdminOnly))
+
 	app.route(http.MethodGet, "", container.AppHandler.GetAppHandler,
 		AnyViewer())
 	app.route(http.MethodDelete, "", container.AppHandler.DeleteAppHandler,

--- a/internal/router/routes_build.go
+++ b/internal/router/routes_build.go
@@ -21,7 +21,7 @@ func registerBuildRoutes(r *mux.Router, container *AppContainer) {
 	}
 
 	build.route(http.MethodPut, "/{IDENTIFIER_ID}/artifacts/{BUILD_ID}/start", container.BuildRegistryHandler.Start, apikeyrestrictions.BuildActionCreate)
-	build.route(http.MethodPut, "/{IDENTIFIER_ID}/artifacts/{BUILD_ID}", container.BuildRegistryHandler.Begin, apikeyrestrictions.BuildActionCreate)
+	build.route(http.MethodPut, "/{IDENTIFIER_ID}/artifacts/{BUILD_ID}", container.BuildRegistryHandler.RegisterArtifact, apikeyrestrictions.BuildActionCreate)
 	build.route(http.MethodPost, "/{IDENTIFIER_ID}/artifacts/{BUILD_ID}/failed", container.BuildRegistryHandler.Fail, apikeyrestrictions.BuildActionCreate)
 	build.route(http.MethodPost, "/{IDENTIFIER_ID}/artifacts/{BUILD_ID}/complete", container.BuildRegistryHandler.Complete, apikeyrestrictions.BuildActionCreate)
 	r.HandleFunc("/build-uploads/{TOKEN}", container.BuildRegistryHandler.UploadLocal).Methods(http.MethodPut)

--- a/internal/router/routes_build.go
+++ b/internal/router/routes_build.go
@@ -8,7 +8,7 @@ import (
 	"github.com/gorilla/mux"
 )
 
-// registerBuildRoutes declares the CLI endpoints that retrieve build inputs.
+// registerBuildRoutes declares the CLI build endpoints: inputs, artifact lifecycle and the public upload and share links.
 func registerBuildRoutes(r *mux.Router, container *AppContainer) {
 	router := r.PathPrefix("/{APP_ID}/build").Subrouter()
 	router.Use(middleware.AppResolverMiddleware(container.AppRepo))
@@ -19,6 +19,12 @@ func registerBuildRoutes(r *mux.Router, container *AppContainer) {
 		apiKeyAccess: container.ApiKeyAccessService,
 		identifiers:  container.AppIdentifierRepo,
 	}
+
+	build.route(http.MethodPut, "/{IDENTIFIER_ID}/artifacts/{BUILD_ID}/start", container.BuildRegistryHandler.Start, apikeyrestrictions.BuildActionCreate)
+	build.route(http.MethodPut, "/{IDENTIFIER_ID}/artifacts/{BUILD_ID}", container.BuildRegistryHandler.Begin, apikeyrestrictions.BuildActionCreate)
+	build.route(http.MethodPost, "/{IDENTIFIER_ID}/artifacts/{BUILD_ID}/failed", container.BuildRegistryHandler.Fail, apikeyrestrictions.BuildActionCreate)
+	build.route(http.MethodPost, "/{IDENTIFIER_ID}/artifacts/{BUILD_ID}/complete", container.BuildRegistryHandler.Complete, apikeyrestrictions.BuildActionCreate)
+	r.HandleFunc("/build-uploads/{TOKEN}", container.BuildRegistryHandler.UploadLocal).Methods(http.MethodPut)
 
 	build.route(http.MethodGet, "/resolve/android/{APPLICATION_ID}", container.BuildHandler.ResolveIdentifier,
 		apikeyrestrictions.BuildActionCreate)

--- a/internal/router/routes_build.go
+++ b/internal/router/routes_build.go
@@ -26,7 +26,7 @@ func registerBuildRoutes(r *mux.Router, container *AppContainer) {
 	build.route(http.MethodPost, "/{IDENTIFIER_ID}/artifacts/{BUILD_ID}/complete", container.BuildRegistryHandler.Complete, apikeyrestrictions.BuildActionCreate)
 	r.HandleFunc("/build-uploads/{TOKEN}", container.BuildRegistryHandler.UploadLocal).Methods(http.MethodPut)
 
-	build.route(http.MethodGet, "/resolve/android/{APPLICATION_ID}", container.BuildHandler.ResolveIdentifier,
+	build.route(http.MethodGet, "/resolve/{PLATFORM}/{APPLICATION_ID}", container.BuildHandler.ResolveIdentifier,
 		apikeyrestrictions.BuildActionCreate)
 	build.route(http.MethodPost, "/{IDENTIFIER_ID}/build-number", container.BuildHandler.AllocateBuildNumber,
 		apikeyrestrictions.BuildActionCreate)

--- a/internal/router/routes_build.go
+++ b/internal/router/routes_build.go
@@ -8,7 +8,7 @@ import (
 	"github.com/gorilla/mux"
 )
 
-// registerBuildRoutes declares the CLI build endpoints: inputs, artifact lifecycle and the public upload and share links.
+// registerBuildRoutes declares the authenticated CLI build inputs and artifact lifecycle.
 func registerBuildRoutes(r *mux.Router, container *AppContainer) {
 	router := r.PathPrefix("/{APP_ID}/build").Subrouter()
 	router.Use(middleware.AppResolverMiddleware(container.AppRepo))
@@ -24,7 +24,7 @@ func registerBuildRoutes(r *mux.Router, container *AppContainer) {
 	build.route(http.MethodPut, "/{IDENTIFIER_ID}/artifacts/{BUILD_ID}", container.BuildRegistryHandler.RegisterArtifact, apikeyrestrictions.BuildActionCreate)
 	build.route(http.MethodPost, "/{IDENTIFIER_ID}/artifacts/{BUILD_ID}/failed", container.BuildRegistryHandler.Fail, apikeyrestrictions.BuildActionCreate)
 	build.route(http.MethodPost, "/{IDENTIFIER_ID}/artifacts/{BUILD_ID}/complete", container.BuildRegistryHandler.Complete, apikeyrestrictions.BuildActionCreate)
-	r.HandleFunc("/build-uploads/{TOKEN}", container.BuildRegistryHandler.UploadLocal).Methods(http.MethodPut)
+	build.route(http.MethodPut, "/{IDENTIFIER_ID}/artifacts/{BUILD_ID}/upload", container.BuildRegistryHandler.UploadLocal, apikeyrestrictions.BuildActionCreate)
 
 	build.route(http.MethodGet, "/resolve/{PLATFORM}/{APPLICATION_ID}", container.BuildHandler.ResolveIdentifier,
 		apikeyrestrictions.BuildActionCreate)

--- a/internal/router/routes_build_test.go
+++ b/internal/router/routes_build_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"net/netip"
 	"strconv"
+	"strings"
 	"testing"
 	"xprem/config"
 	"xprem/ee/apikeyrestrictions"
@@ -393,4 +394,91 @@ func TestBuildResolveTargetedLookup(t *testing.T) {
 			}
 		})
 	}
+}
+
+// Every build registry mutation runs behind the same guard as the build
+// inputs; the local upload and share links are public and protect themselves.
+func TestBuildRegistryRoutesRequireBuildCreate(t *testing.T) {
+	previous := licensing.Current()
+	licensing.Activate(licensing.License{PlanCode: licensing.PlanEnterprise})
+	t.Cleanup(func() {
+		if previous == nil {
+			licensing.Deactivate()
+		} else {
+			licensing.Activate(*previous)
+		}
+	})
+	registry := handlers.NewBuildRegistryHandler(services.NewBuildService(nil, nil, nil))
+	endpoints := []struct{ method, suffix, body string }{
+		{http.MethodPut, "/artifacts/" + buildID + "/start", `{"artifactType":"apk","metadata":{"profile":"p","cliVersion":"1","startedAt":"2026-09-08T10:00:00Z"}}`},
+		{http.MethodPut, "/artifacts/" + buildID, `{"artifactType":"apk","size":1,"sha256":"` + strings.Repeat("a", 64) + `","metadata":{"profile":"p","cliVersion":"1","buildNumber":"1","fingerprint":"` + strings.Repeat("a", 40) + `","startedAt":"2026-09-08T10:00:00Z","finishedAt":"2026-09-08T10:01:00Z"}}`},
+		{http.MethodPost, "/artifacts/" + buildID + "/failed", `{"finishedAt":"2026-09-08T10:00:00Z"}`},
+		{http.MethodPost, "/artifacts/" + buildID + "/complete", ""},
+	}
+	granted := apikeyrestrictions.ApiKeyAccess{ApiKeyID: 42, BuildRules: []apikeyrestrictions.BuildRule{{AppIdentifierID: buildID, Actions: []apikeyrestrictions.BuildAction{apikeyrestrictions.BuildActionCreate}}}}
+	elsewhere := apikeyrestrictions.ApiKeyAccess{ApiKeyID: 42, BuildRules: []apikeyrestrictions.BuildRule{{AppIdentifierID: "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb", Actions: []apikeyrestrictions.BuildAction{apikeyrestrictions.BuildActionCreate}}}}
+	for _, tc := range []struct {
+		name   string
+		auth   services.CliAuthRepository
+		access apikeyrestrictions.ApiKeyAccess
+		id     string
+		status int
+	}{
+		{"allowed", acceptingCliRepo{}, granted, buildID, http.StatusBadRequest},
+		{"denied", acceptingCliRepo{}, elsewhere, buildID, http.StatusForbidden},
+		{"unauthenticated", failingBuildAuth{}, granted, buildID, http.StatusUnauthorized},
+		{"unregistered token", buildAuthKeyID{keyID: 0}, granted, buildID, http.StatusUnauthorized},
+		{"foreign identifier", acceptingCliRepo{}, granted, "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb", http.StatusNotFound},
+	} {
+		for _, endpoint := range endpoints {
+			t.Run(tc.name+" "+endpoint.method+" "+endpoint.suffix, func(t *testing.T) {
+				access := &buildAccessRepo{access: tc.access}
+				container := &AppContainer{AppRepo: buildAppRepo{}, CliAuthService: services.NewCliAuthService(tc.auth), ApiKeyAccessService: apikeyrestrictions.NewApiKeyAccessService(access), AppIdentifierRepo: &buildIdentifierRepo{platform: types.PlatformAndroid}, BuildHandler: handlers.NewBuildHandler(nil, nil, nil), BuildRegistryHandler: registry}
+				router := mux.NewRouter()
+				registerBuildRoutes(router, container)
+				req := httptest.NewRequest(endpoint.method, "/app-1/build/"+tc.id+endpoint.suffix, strings.NewReader(endpoint.body))
+				req.Header.Set("Authorization", "Bearer eoo_key")
+				req.RemoteAddr = "192.0.2.1:4000"
+				w := httptest.NewRecorder()
+				router.ServeHTTP(w, req)
+				require.Equal(t, tc.status, w.Code, w.Body.String())
+				require.Equal(t, tc.status == http.StatusBadRequest || tc.status == http.StatusForbidden, access.app != "", "the policy is consulted only for an authenticated, resolvable target")
+				if tc.status == http.StatusBadRequest {
+					require.Contains(t, w.Body.String(), "stateless mode", "the guard let the request through to the registry handler")
+				} else {
+					require.NotContains(t, w.Body.String(), "stateless mode", "the registry handler must not run")
+				}
+			})
+		}
+	}
+}
+
+func TestBuildRegistryRouteMethodsAndPublicPaths(t *testing.T) {
+	registry := handlers.NewBuildRegistryHandler(services.NewBuildService(nil, nil, nil))
+	access := &buildAccessRepo{}
+	container := &AppContainer{AppRepo: buildAppRepo{}, CliAuthService: services.NewCliAuthService(acceptingCliRepo{}), ApiKeyAccessService: apikeyrestrictions.NewApiKeyAccessService(access), AppIdentifierRepo: &buildIdentifierRepo{platform: types.PlatformAndroid}, BuildHandler: handlers.NewBuildHandler(nil, nil, nil), BuildRegistryHandler: registry}
+	router := mux.NewRouter()
+	registerBuildRoutes(router, container)
+	for _, tc := range []struct {
+		method, target string
+		status         int
+	}{
+		{http.MethodGet, "/app-1/build/" + buildID + "/artifacts/" + buildID + "/start", http.StatusNotFound},
+		{http.MethodPost, "/app-1/build/" + buildID + "/artifacts/" + buildID + "/start", http.StatusNotFound},
+		{http.MethodPut, "/app-1/build/" + buildID + "/artifacts/" + buildID + "/failed", http.StatusNotFound},
+		{http.MethodGet, "/app-1/build/" + buildID + "/artifacts/" + buildID, http.StatusNotFound},
+		{http.MethodPut, "/build-uploads/forged-grant", http.StatusUnauthorized},
+		{http.MethodPost, "/build-uploads/forged-grant", http.StatusMethodNotAllowed},
+	} {
+		t.Run(tc.method+" "+tc.target, func(t *testing.T) {
+			req := httptest.NewRequest(tc.method, tc.target, strings.NewReader("{}"))
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+			require.Equal(t, tc.status, w.Code, w.Body.String())
+			if tc.status == http.StatusUnauthorized {
+				require.Contains(t, w.Body.String(), "upload authorization", "the public upload path answers itself, not the CLI guard")
+			}
+		})
+	}
+	require.Empty(t, access.app, "public paths and wrong methods never consult the build policy")
 }

--- a/internal/router/routes_build_test.go
+++ b/internal/router/routes_build_test.go
@@ -8,18 +8,23 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/netip"
+	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 	"xprem/config"
 	"xprem/ee/apikeyrestrictions"
 	"xprem/ee/licensing"
 	"xprem/internal/android/androidtest"
+	"xprem/internal/bucket"
 	"xprem/internal/handlers"
 	"xprem/internal/services"
 	"xprem/internal/store"
 	"xprem/internal/types"
 
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/require"
 )
@@ -404,7 +409,7 @@ func TestBuildResolveTargetedLookup(t *testing.T) {
 }
 
 // Every build registry mutation runs behind the same guard as the build
-// inputs; the local upload and share links are public and protect themselves.
+// inputs, including uploads that also require a per-build token.
 func TestBuildRegistryRoutesRequireBuildCreate(t *testing.T) {
 	previous := licensing.Current()
 	licensing.Activate(licensing.License{PlanCode: licensing.PlanEnterprise})
@@ -421,6 +426,7 @@ func TestBuildRegistryRoutesRequireBuildCreate(t *testing.T) {
 		{http.MethodPut, "/artifacts/" + buildID, `{"artifactType":"apk","size":1,"sha256":"` + strings.Repeat("a", 64) + `","metadata":{"profile":"p","cliVersion":"1","buildNumber":"1","fingerprint":"` + strings.Repeat("a", 40) + `","startedAt":"2026-09-08T10:00:00Z","finishedAt":"2026-09-08T10:01:00Z"}}`},
 		{http.MethodPost, "/artifacts/" + buildID + "/failed", `{"finishedAt":"2026-09-08T10:00:00Z"}`},
 		{http.MethodPost, "/artifacts/" + buildID + "/complete", ""},
+		{http.MethodPut, "/artifacts/" + buildID + "/upload", "artifact bytes"},
 	}
 	granted := apikeyrestrictions.ApiKeyAccess{ApiKeyID: 42, BuildRules: []apikeyrestrictions.BuildRule{{AppIdentifierID: buildID, Actions: []apikeyrestrictions.BuildAction{apikeyrestrictions.BuildActionCreate}}}}
 	elsewhere := apikeyrestrictions.ApiKeyAccess{ApiKeyID: 42, BuildRules: []apikeyrestrictions.BuildRule{{AppIdentifierID: "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb", Actions: []apikeyrestrictions.BuildAction{apikeyrestrictions.BuildActionCreate}}}}
@@ -474,18 +480,100 @@ func TestBuildRegistryRouteMethodsAndPublicPaths(t *testing.T) {
 		{http.MethodPost, "/app-1/build/" + buildID + "/artifacts/" + buildID + "/start", http.StatusNotFound},
 		{http.MethodPut, "/app-1/build/" + buildID + "/artifacts/" + buildID + "/failed", http.StatusNotFound},
 		{http.MethodGet, "/app-1/build/" + buildID + "/artifacts/" + buildID, http.StatusNotFound},
-		{http.MethodPut, "/build-uploads/forged-grant", http.StatusUnauthorized},
-		{http.MethodPost, "/build-uploads/forged-grant", http.StatusMethodNotAllowed},
+		{http.MethodPut, "/build-uploads/forged-grant", http.StatusNotFound},
+		{http.MethodPost, "/build-uploads/forged-grant", http.StatusNotFound},
 	} {
 		t.Run(tc.method+" "+tc.target, func(t *testing.T) {
 			req := httptest.NewRequest(tc.method, tc.target, strings.NewReader("{}"))
 			w := httptest.NewRecorder()
 			router.ServeHTTP(w, req)
 			require.Equal(t, tc.status, w.Code, w.Body.String())
-			if tc.status == http.StatusUnauthorized {
-				require.Contains(t, w.Body.String(), "upload authorization", "the public upload path answers itself, not the CLI guard")
+		})
+	}
+	require.Empty(t, access.app, "removed paths and wrong methods never consult the build policy")
+}
+
+type localUploadCliRepo struct{ acceptingCliRepo }
+
+func (localUploadCliRepo) ValidateCliCredential(_ context.Context, app string, auth types.Auth) (int64, error) {
+	if app != "app-1" || auth.Token == nil || *auth.Token != "eoo_valid" {
+		return 0, services.ErrUnauthorized
+	}
+	return 42, nil
+}
+
+type localUploadBuildRepo struct{ services.BuildRepository }
+
+func (localUploadBuildRepo) Get(_ context.Context, app, id string) (*types.BuildRecord, error) {
+	if app != "app-1" || id != buildID {
+		return nil, &store.ErrResourceNotFound{Resource: "build", Identifier: id}
+	}
+	return &types.BuildRecord{ID: id, AppID: app, AppIdentifierID: buildID, ArtifactType: types.BuildArtifactAPK, Status: types.BuildStatusUploading, Size: 3}, nil
+}
+
+func TestBuildLocalUploadRequiresBothTokensAndBuildPermission(t *testing.T) {
+	t.Setenv("JWT_SECRET", "upload-test-secret")
+	previous := licensing.Current()
+	licensing.Activate(licensing.License{PlanCode: licensing.PlanEnterprise})
+	t.Cleanup(func() {
+		if previous == nil {
+			licensing.Deactivate()
+		} else {
+			licensing.Activate(*previous)
+		}
+	})
+	grant, err := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		"sub": "build-upload", "exp": time.Now().Add(time.Minute).Unix(),
+		"appId": "app-1", "identifierId": buildID, "buildId": buildID,
+	}).SignedString([]byte("upload-test-secret"))
+	require.NoError(t, err)
+	for _, tc := range []struct {
+		name, bearer, token, query string
+		denied                     bool
+		status                     int
+	}{
+		{"both tokens", "eoo_valid", grant, "", false, http.StatusNoContent},
+		{"missing EOO", "", grant, "", false, http.StatusUnauthorized},
+		{"invalid EOO", "eoo_invalid", grant, "", false, http.StatusUnauthorized},
+		{"upload grant is not EOO", grant, grant, "", false, http.StatusUnauthorized},
+		{"missing grant", "eoo_valid", "", "", false, http.StatusUnauthorized},
+		{"grant in query", "eoo_valid", "", "?token=" + grant, false, http.StatusUnauthorized},
+		{"invalid grant", "eoo_valid", "forged", "", false, http.StatusUnauthorized},
+		{"denied identifier", "eoo_valid", grant, "", true, http.StatusForbidden},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			identifier := buildID
+			if tc.denied {
+				identifier = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+			}
+			access := &buildAccessRepo{access: apikeyrestrictions.ApiKeyAccess{ApiKeyID: 42, BuildRules: []apikeyrestrictions.BuildRule{{AppIdentifierID: identifier, Actions: []apikeyrestrictions.BuildAction{apikeyrestrictions.BuildActionCreate}}}}}
+			identifiers := &buildIdentifierRepo{platform: types.PlatformAndroid}
+			service := services.NewBuildService(localUploadBuildRepo{}, identifiers, &bucket.LocalBucket{BasePath: root})
+			container := &AppContainer{AppRepo: buildAppRepo{}, CliAuthService: services.NewCliAuthService(localUploadCliRepo{}), ApiKeyAccessService: apikeyrestrictions.NewApiKeyAccessService(access), AppIdentifierRepo: identifiers, BuildHandler: handlers.NewBuildHandler(nil, nil, nil), BuildRegistryHandler: handlers.NewBuildRegistryHandler(service)}
+			router := mux.NewRouter()
+			registerBuildRoutes(router, container)
+			body := strings.NewReader("apk")
+			req := httptest.NewRequest(http.MethodPut, "/app-1/build/"+buildID+"/artifacts/"+buildID+"/upload"+tc.query, body)
+			if tc.bearer != "" {
+				req.Header.Set("Authorization", "Bearer "+tc.bearer)
+			}
+			req.Header.Set(bucket.LocalUploadTokenHeader, tc.token)
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+			require.Equal(t, tc.status, w.Code, w.Body.String())
+			if tc.status == http.StatusNoContent {
+				key, err := (bucket.BuildArtifact{IdentifierID: buildID, BuildID: buildID, Type: types.BuildArtifactAPK}).Key(true)
+				require.NoError(t, err)
+				contents, err := os.ReadFile(filepath.Join(root, key))
+				require.NoError(t, err)
+				require.Equal(t, "apk", string(contents))
+			} else {
+				require.Equal(t, 3, body.Len(), "authorization failures must precede reading the body")
+				entries, err := os.ReadDir(root)
+				require.NoError(t, err)
+				require.Empty(t, entries)
 			}
 		})
 	}
-	require.Empty(t, access.app, "public paths and wrong methods never consult the build policy")
 }

--- a/internal/router/routes_build_test.go
+++ b/internal/router/routes_build_test.go
@@ -173,7 +173,7 @@ func TestBuildRoutesEnterpriseDomains(t *testing.T) {
 		for _, target := range []struct {
 			platform types.Platform
 			endpoint string
-		}{{"android", "environment"}, {"ios", "environment"}, {"android", "credentials/android"}, {"android", "build-number"}, {"ios", "build-number"}, {"android", "resolve/android/com.example.app"}} {
+		}{{"android", "environment"}, {"ios", "environment"}, {"android", "credentials/android"}, {"android", "build-number"}, {"ios", "build-number"}, {"android", "resolve/android/com.example.app"}, {"ios", "resolve/ios/com.example.app"}} {
 			endpoint := target.endpoint
 			t.Run(tc.name+"/"+string(target.platform)+"/"+endpoint, func(t *testing.T) {
 				access := tc.access
@@ -197,7 +197,7 @@ func TestBuildRoutesEnterpriseDomains(t *testing.T) {
 					method = http.MethodPost
 				}
 				requestPath := "/app-1/build/" + buildID + "/" + endpoint
-				if endpoint == "resolve/android/com.example.app" {
+				if strings.HasPrefix(endpoint, "resolve/") {
 					requestPath = "/app-1/build/" + endpoint
 				}
 				req := httptest.NewRequest(method, requestPath, nil)
@@ -214,7 +214,7 @@ func TestBuildRoutesEnterpriseDomains(t *testing.T) {
 				} else {
 					require.Zero(t, identifiers.allocated)
 				}
-				if tc.status == 200 && endpoint == "resolve/android/com.example.app" {
+				if tc.status == 200 && strings.HasPrefix(endpoint, "resolve/") {
 					require.JSONEq(t, `{"identifierId":"`+buildID+`"}`, w.Body.String())
 				}
 				if tc.status == 200 && endpoint == "environment" {
@@ -352,33 +352,40 @@ func (repo *buildIdentifierRepo) AllocateBuildNumber(ctx context.Context, app, i
 
 func TestBuildResolveTargetedLookup(t *testing.T) {
 	for _, tc := range []struct {
-		name, app, identifier string
-		platform              types.Platform
-		err                   error
-		status                int
+		name, app, identifier       string
+		platform, requestedPlatform types.Platform
+		err                         error
+		status                      int
 	}{
-		{"found", "app-1", "com.example.app", types.PlatformAndroid, nil, 200},
-		{"unknown", "app-1", "com.example.missing", types.PlatformAndroid, nil, 404},
-		{"foreign app", "app-2", "com.example.app", types.PlatformAndroid, nil, 404},
-		{"wrong platform", "app-1", "com.example.app", types.PlatformIOS, nil, 404},
-		{"database error", "app-1", "com.example.app", types.PlatformAndroid, errors.New("database unavailable"), 500},
+		{"android", "app-1", "com.example.app", types.PlatformAndroid, types.PlatformAndroid, nil, 200},
+		{"ios", "app-1", "com.example.app", types.PlatformIOS, types.PlatformIOS, nil, 200},
+		{"unknown", "app-1", "com.example.missing", types.PlatformAndroid, types.PlatformAndroid, nil, 404},
+		{"foreign app", "app-2", "com.example.app", types.PlatformAndroid, types.PlatformAndroid, nil, 404},
+		{"android does not resolve ios", "app-1", "com.example.app", types.PlatformIOS, types.PlatformAndroid, nil, 404},
+		{"ios does not resolve android", "app-1", "com.example.app", types.PlatformAndroid, types.PlatformIOS, nil, 404},
+		{"unknown platform", "app-1", "com.example.app", types.PlatformAndroid, "windows", nil, 400},
+		{"database error", "app-1", "com.example.app", types.PlatformAndroid, types.PlatformAndroid, errors.New("database unavailable"), 500},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			repo := &buildIdentifierRepo{platform: tc.platform, lookupErr: tc.err}
 			policy := &recordingBuildPolicy{}
 			group := buildGroup{cliAuth: services.NewCliAuthService(acceptingCliRepo{}), apiKeyAccess: policy, identifiers: repo}
 			router := mux.NewRouter()
-			router.Handle("/{APP_ID}/build/resolve/android/{APPLICATION_ID}", group.guard(apikeyrestrictions.BuildActionCreate)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			router.Handle("/{APP_ID}/build/resolve/{PLATFORM}/{APPLICATION_ID}", group.guard(apikeyrestrictions.BuildActionCreate)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				require.Equal(t, buildID, services.BuildIdentifierFromContext(r.Context()))
 				require.Empty(t, mux.Vars(r)["IDENTIFIER_ID"])
 				require.Equal(t, tc.identifier, mux.Vars(r)["APPLICATION_ID"])
 				w.WriteHeader(200)
 			})))
-			req := httptest.NewRequest("GET", "/"+tc.app+"/build/resolve/android/"+tc.identifier, nil)
+			req := httptest.NewRequest("GET", "/"+tc.app+"/build/resolve/"+string(tc.requestedPlatform)+"/"+tc.identifier, nil)
 			req.Header.Set("Authorization", "Bearer eoo_key")
 			recorder := httptest.NewRecorder()
 			router.ServeHTTP(recorder, req)
 			require.Equal(t, tc.status, recorder.Code, recorder.Body.String())
+			if tc.status == http.StatusBadRequest {
+				require.Contains(t, recorder.Body.String(), "platform")
+				require.Empty(t, repo.app, "invalid platforms must fail before identifier lookup")
+			}
 			if tc.err != nil {
 				var problem handlers.APIError
 				require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &problem))

--- a/internal/router/wire.go
+++ b/internal/router/wire.go
@@ -38,6 +38,7 @@ import (
 type AppContainer struct {
 	AppIdentifierRepo           services.AppIdentifierRepository
 	BuildHandler                *handlers.BuildHandler
+	BuildRegistryHandler        *handlers.BuildRegistryHandler
 	AuthHandler                 *dashhandlers.AuthHandler
 	BlobService                 *services.BlobService
 	DashboardAuthService        *services.DashboardAuthService
@@ -110,6 +111,7 @@ func InitDependencies(ctx context.Context) (*AppContainer, func()) {
 	var bundlePatchRepo services.BundlePatchRepository
 	// nil in stateless mode: store identities and signing credentials only
 	// exist on the control plane.
+	var buildRepo services.BuildRepository
 	var appIdentifierRepo services.AppIdentifierRepository
 	var credentialsRepo services.CredentialsRepository
 	var environmentRepo services.EnvironmentRepository
@@ -144,6 +146,7 @@ func InitDependencies(ctx context.Context) (*AppContainer, func()) {
 	dbUrl := config.GetDBURL()
 
 	resolvedBucket := bucket.GetBucket()
+	buildStorage := bucket.NewBuildArtifactStorage(resolvedBucket)
 
 	if dbUrl != "" {
 		if !database.IsValidDBURL(dbUrl) {
@@ -187,6 +190,7 @@ func InitDependencies(ctx context.Context) (*AppContainer, func()) {
 		rolloutRepo = store.NewPostgresRolloutStore(dbEngine)
 		bundlePatchRepo = store.NewPostgresBundlePatchStore(dbEngine)
 		appIdentifierRepo = store.NewPostgresAppIdentifierStore(dbEngine)
+		buildRepo = store.NewPostgresBuildStore(dbEngine)
 		credentialsRepo = store.NewPostgresCredentialsStore(dbEngine)
 		environmentRepo = store.NewPostgresEnvironmentStore(dbEngine)
 
@@ -317,6 +321,7 @@ func InitDependencies(ctx context.Context) (*AppContainer, func()) {
 	bsDiffService.SetOnAuditEvent(auditService.Record)
 	rolloutService := services.NewRolloutService(rolloutRepo, channelRepo, updateRepo, deploymentService)
 	rolloutService.SetOnAuditEvent(auditService.Record)
+	buildService := services.NewBuildService(buildRepo, appIdentifierRepo, buildStorage)
 	appIdentifierService := services.NewAppIdentifierService(appIdentifierRepo)
 	appIdentifierService.SetOnAuditEvent(auditService.Record)
 	credentialsService := services.NewCredentialsService(credentialsRepo, appIdentifierRepo)
@@ -386,6 +391,7 @@ func InitDependencies(ctx context.Context) (*AppContainer, func()) {
 		CredentialsHandler:          dashhandlers.NewCredentialsHandler(credentialsService),
 		AppIdentifierRepo:           appIdentifierRepo,
 		BuildHandler:                handlers.NewBuildHandler(environmentService, credentialsService, appIdentifierService),
+		BuildRegistryHandler:        handlers.NewBuildRegistryHandler(buildService),
 		EnvironmentsHandler:         dashhandlers.NewEnvironmentsHandler(environmentService),
 		ExpoProtocolHandler:         handlers.NewExpoProtocolHandler(expoProtocolService),
 		LicenseHandler:              licensing.NewLicenseHandler(licenseService),

--- a/internal/router/wire.go
+++ b/internal/router/wire.go
@@ -146,7 +146,6 @@ func InitDependencies(ctx context.Context) (*AppContainer, func()) {
 	dbUrl := config.GetDBURL()
 
 	resolvedBucket := bucket.GetBucket()
-	buildStorage := bucket.NewBuildArtifactStorage(resolvedBucket)
 
 	if dbUrl != "" {
 		if !database.IsValidDBURL(dbUrl) {
@@ -321,7 +320,7 @@ func InitDependencies(ctx context.Context) (*AppContainer, func()) {
 	bsDiffService.SetOnAuditEvent(auditService.Record)
 	rolloutService := services.NewRolloutService(rolloutRepo, channelRepo, updateRepo, deploymentService)
 	rolloutService.SetOnAuditEvent(auditService.Record)
-	buildService := services.NewBuildService(buildRepo, appIdentifierRepo, buildStorage)
+	buildService := services.NewBuildService(buildRepo, appIdentifierRepo, resolvedBucket)
 	appIdentifierService := services.NewAppIdentifierService(appIdentifierRepo)
 	appIdentifierService.SetOnAuditEvent(auditService.Record)
 	credentialsService := services.NewCredentialsService(credentialsRepo, appIdentifierRepo)

--- a/internal/services/build_service.go
+++ b/internal/services/build_service.go
@@ -36,20 +36,14 @@ type BuildRepository interface {
 	List(context.Context, string, int32, int32) ([]types.BuildRecord, int64, error)
 	Transition(context.Context, string, string, func(types.BuildRecord) (*types.BuildRecord, error)) (*types.BuildRecord, error)
 }
-type BuildStorage interface {
-	Get(context.Context, bucket.BuildArtifact, bool) (*types.BucketFile, error)
-	Put(context.Context, bucket.BuildArtifact, bool, io.Reader) error
-	PresignUpload(context.Context, bucket.BuildArtifact) (string, map[string]string, error)
-	Delete(context.Context, bucket.BuildArtifact, bool) error
-}
 type BuildService struct {
 	repo        BuildRepository
 	identifiers AppIdentifierRepository
-	storage     BuildStorage
+	storage     bucket.Bucket
 	now         func() time.Time
 }
 
-func NewBuildService(repo BuildRepository, identifiers AppIdentifierRepository, storage BuildStorage) *BuildService {
+func NewBuildService(repo BuildRepository, identifiers AppIdentifierRepository, storage bucket.Bucket) *BuildService {
 	return &BuildService{repo: repo, identifiers: identifiers, storage: storage, now: time.Now}
 }
 
@@ -66,14 +60,14 @@ type BuildStartMetadata struct {
 	StartedAt   time.Time `json:"startedAt"`
 }
 type BuildStartInput struct {
-	ArtifactType string             `json:"artifactType"`
-	Metadata     BuildStartMetadata `json:"metadata"`
+	ArtifactType types.BuildArtifactType `json:"artifactType"`
+	Metadata     BuildStartMetadata      `json:"metadata"`
 }
 type RegisterBuildInput struct {
-	ArtifactType string              `json:"artifactType"`
-	Size         int64               `json:"size"`
-	SHA256       string              `json:"sha256"`
-	Metadata     types.BuildMetadata `json:"metadata"`
+	ArtifactType types.BuildArtifactType `json:"artifactType"`
+	Size         int64                   `json:"size"`
+	SHA256       string                  `json:"sha256"`
+	Metadata     types.BuildMetadata     `json:"metadata"`
 }
 type FailBuildInput struct {
 	FinishedAt time.Time `json:"finishedAt"`
@@ -102,11 +96,11 @@ func normalizeTime(t time.Time) time.Time {
 	return t.UTC().Truncate(time.Microsecond)
 }
 
-func (s *BuildService) validateStart(id, artifactType string, m *BuildStartMetadata) error {
+func (s *BuildService) validateStart(id string, artifactType types.BuildArtifactType, m *BuildStartMetadata) error {
 	if err := validateBuildID(id); err != nil {
 		return err
 	}
-	if artifactType != "apk" && artifactType != "aab" {
+	if artifactType != types.BuildArtifactAPK && artifactType != types.BuildArtifactAAB {
 		return validation.Errorf("artifactType", "expected apk or aab")
 	}
 	if m.Profile == "" || m.CLIVersion == "" {
@@ -185,10 +179,10 @@ func withArtifact(current, declared types.BuildRecord) *types.BuildRecord {
 }
 
 func artifactRef(b types.BuildRecord) bucket.BuildArtifact {
-	return bucket.BuildArtifact{Platform: b.Platform, IdentifierID: b.AppIdentifierID, BuildID: b.ID, Format: b.ArtifactType}
+	return bucket.BuildArtifact{IdentifierID: b.AppIdentifierID, BuildID: b.ID, Type: b.ArtifactType}
 }
 
-func (s *BuildService) newRecord(ctx context.Context, appID, identifierID, id, artifactType string) (*types.BuildRecord, error) {
+func (s *BuildService) newRecord(ctx context.Context, appID, identifierID, id string, artifactType types.BuildArtifactType) (*types.BuildRecord, error) {
 	if s.repo == nil {
 		return nil, store.ErrNotSupportedInStatelessMode
 	}
@@ -279,11 +273,11 @@ func (s *BuildService) Begin(ctx context.Context, appID, identifierID, id string
 	if existing.Status == types.BuildStatusReady {
 		return result, nil
 	}
-	url, headers, err := s.storage.PresignUpload(ctx, artifactRef(*existing))
+	url, err := s.storage.RequestBuildArtifactUploadURL(ctx, artifactRef(*existing))
 	if err != nil {
 		return nil, err
 	}
-	result.Upload = &BuildUpload{URL: url, Method: "PUT", Headers: headers}
+	result.Upload = &BuildUpload{URL: url, Method: "PUT", Headers: bucket.UploadHeaders(s.storage)}
 	if url == "" {
 		result.LocalToken, err = s.uploadToken(*existing)
 	}
@@ -347,7 +341,7 @@ func (s *BuildService) Fail(ctx context.Context, appID, identifierID, id string,
 		return failed(current, input.FinishedAt), nil
 	})
 	if err == nil && staged {
-		_ = s.storage.Delete(ctx, artifactRef(*record), true)
+		_ = s.storage.DeleteBuildArtifact(ctx, artifactRef(*record), true)
 	}
 	return record, err
 }
@@ -384,13 +378,13 @@ func (s *BuildService) Complete(ctx context.Context, appID, identifierID, id str
 		return &next, nil
 	})
 	if err == nil {
-		_ = s.storage.Delete(ctx, artifactRef(*completed), true)
+		_ = s.storage.DeleteBuildArtifact(ctx, artifactRef(*completed), true)
 	}
 	return completed, err
 }
 
 func (s *BuildService) verifyStaged(ctx context.Context, b types.BuildRecord) error {
-	file, err := s.storage.Get(ctx, artifactRef(b), true)
+	file, err := s.storage.GetBuildArtifact(ctx, artifactRef(b), true)
 	if err != nil {
 		return err
 	}
@@ -415,14 +409,14 @@ func (s *BuildService) verifyStaged(ctx context.Context, b types.BuildRecord) er
 	if _, err = temporary.Seek(0, io.SeekStart); err != nil {
 		return err
 	}
-	return s.storage.Put(ctx, artifactRef(b), false, temporary)
+	return s.storage.PutBuildArtifact(ctx, artifactRef(b), false, temporary)
 }
 
 func (s *BuildService) Download(ctx context.Context, record types.BuildRecord) (*types.BucketFile, error) {
 	if record.Status != types.BuildStatusReady {
 		return nil, ErrBuildNotReady
 	}
-	return s.storage.Get(ctx, artifactRef(record), false)
+	return s.storage.GetBuildArtifact(ctx, artifactRef(record), false)
 }
 
 type buildUploadClaims struct {
@@ -465,11 +459,11 @@ func (s *BuildService) UploadLocal(ctx context.Context, token string, body io.Re
 		return ErrBuildState
 	}
 	reader := &countingReader{Reader: io.LimitReader(body, b.Size+1)}
-	if err := s.storage.Put(ctx, artifactRef(*b), true, reader); err != nil {
+	if err := s.storage.PutBuildArtifact(ctx, artifactRef(*b), true, reader); err != nil {
 		return err
 	}
 	if reader.n > b.Size {
-		_ = s.storage.Delete(ctx, artifactRef(*b), true)
+		_ = s.storage.DeleteBuildArtifact(ctx, artifactRef(*b), true)
 		return ErrBuildIntegrity
 	}
 	return nil

--- a/internal/services/build_service.go
+++ b/internal/services/build_service.go
@@ -72,15 +72,10 @@ type RegisterBuildInput struct {
 type FailBuildInput struct {
 	FinishedAt time.Time `json:"finishedAt"`
 }
-type BuildUpload struct {
-	URL     string            `json:"url"`
-	Method  string            `json:"method"`
-	Headers map[string]string `json:"headers,omitempty"`
-}
 type BuildRegistration struct {
-	Build      *types.BuildRecord `json:"build"`
-	Upload     *BuildUpload       `json:"upload,omitempty"`
-	LocalToken string             `json:"-"`
+	Build      *types.BuildRecord  `json:"build"`
+	Upload     *bucket.BuildUpload `json:"upload,omitempty"`
+	LocalToken string              `json:"-"`
 }
 
 func validateBuildID(id string) error {
@@ -282,12 +277,11 @@ func (s *BuildService) RegisterArtifact(ctx context.Context, appID, identifierID
 	if existing.Status == types.BuildStatusReady {
 		return result, nil
 	}
-	url, err := s.storage.RequestBuildArtifactUploadURL(ctx, artifactRef(*existing))
+	result.Upload, err = bucket.RequestBuildArtifactUpload(ctx, s.storage, artifactRef(*existing))
 	if err != nil {
 		return nil, err
 	}
-	result.Upload = &BuildUpload{URL: url, Method: "PUT", Headers: bucket.UploadHeaders(s.storage)}
-	if url == "" {
+	if result.Upload.URL == "" {
 		result.LocalToken, err = s.uploadToken(*existing)
 	}
 	return result, err

--- a/internal/services/build_service.go
+++ b/internal/services/build_service.go
@@ -1,0 +1,476 @@
+package services
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"io"
+	"os"
+	"regexp"
+	"time"
+	"xprem/config"
+	"xprem/internal/bucket"
+	"xprem/internal/store"
+	"xprem/internal/types"
+	"xprem/internal/validation"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/google/uuid"
+)
+
+const MaxBuildSize int64 = 2 << 30
+const maxBuildDuration = 7 * 24 * time.Hour
+const buildClockSkew = 5 * time.Minute
+
+var ErrBuildConflict = errors.New("build ID already refers to different content")
+var ErrBuildNotReady = errors.New("build artifact is not ready")
+var ErrBuildIntegrity = errors.New("uploaded artifact size or SHA-256 does not match")
+var ErrBuildState = errors.New("build is not awaiting an artifact upload")
+var buildHash = regexp.MustCompile(`^[0-9a-f]{64}$`)
+var fingerprintHash = regexp.MustCompile(`^(?:[0-9a-f]{40}|[0-9a-f]{64})$`)
+
+type BuildRepository interface {
+	Create(context.Context, types.BuildRecord) (*types.BuildRecord, bool, error)
+	Get(context.Context, string, string) (*types.BuildRecord, error)
+	List(context.Context, string, int32, int32) ([]types.BuildRecord, int64, error)
+	Transition(context.Context, string, string, func(types.BuildRecord) (*types.BuildRecord, error)) (*types.BuildRecord, error)
+}
+type BuildStorage interface {
+	Get(context.Context, bucket.BuildArtifact, bool) (*types.BucketFile, error)
+	Put(context.Context, bucket.BuildArtifact, bool, io.Reader) error
+	PresignUpload(context.Context, bucket.BuildArtifact) (string, map[string]string, error)
+	Delete(context.Context, bucket.BuildArtifact, bool) error
+}
+type BuildService struct {
+	repo        BuildRepository
+	identifiers AppIdentifierRepository
+	storage     BuildStorage
+	now         func() time.Time
+}
+
+func NewBuildService(repo BuildRepository, identifiers AppIdentifierRepository, storage BuildStorage) *BuildService {
+	return &BuildService{repo: repo, identifiers: identifiers, storage: storage, now: time.Now}
+}
+
+// BuildStartMetadata is what the CLI knows before compiling.
+type BuildStartMetadata struct {
+	Profile     string    `json:"profile"`
+	Mode        string    `json:"mode,omitempty"`
+	Environment string    `json:"environment,omitempty"`
+	Channel     string    `json:"channel,omitempty"`
+	CLIVersion  string    `json:"cliVersion"`
+	GitCommit   string    `json:"gitCommit,omitempty"`
+	GitMessage  string    `json:"gitMessage,omitempty"`
+	GitDirty    bool      `json:"gitDirty,omitempty"`
+	StartedAt   time.Time `json:"startedAt"`
+}
+type BuildStartInput struct {
+	ArtifactType string             `json:"artifactType"`
+	Metadata     BuildStartMetadata `json:"metadata"`
+}
+type RegisterBuildInput struct {
+	ArtifactType string              `json:"artifactType"`
+	Size         int64               `json:"size"`
+	SHA256       string              `json:"sha256"`
+	Metadata     types.BuildMetadata `json:"metadata"`
+}
+type FailBuildInput struct {
+	FinishedAt time.Time `json:"finishedAt"`
+}
+type BuildUpload struct {
+	URL     string            `json:"url"`
+	Method  string            `json:"method"`
+	Headers map[string]string `json:"headers,omitempty"`
+}
+type BuildRegistration struct {
+	Build      *types.BuildRecord `json:"build"`
+	Upload     *BuildUpload       `json:"upload,omitempty"`
+	LocalToken string             `json:"-"`
+}
+
+func validateBuildID(id string) error {
+	parsed, err := uuid.Parse(id)
+	if err != nil || parsed.String() != id {
+		return validation.Errorf("buildId", "expected a canonical UUID")
+	}
+	return nil
+}
+
+// Postgres keeps microseconds, so inputs are normalized before they are compared with stored rows.
+func normalizeTime(t time.Time) time.Time {
+	return t.UTC().Truncate(time.Microsecond)
+}
+
+func (s *BuildService) validateStart(id, artifactType string, m *BuildStartMetadata) error {
+	if err := validateBuildID(id); err != nil {
+		return err
+	}
+	if artifactType != "apk" && artifactType != "aab" {
+		return validation.Errorf("artifactType", "expected apk or aab")
+	}
+	if m.Profile == "" || m.CLIVersion == "" {
+		return validation.Errorf("metadata", "profile and CLI version are required")
+	}
+	if m.Mode != "" && m.Mode != "debug" && m.Mode != "release" {
+		return validation.Errorf("metadata.mode", "expected debug or release")
+	}
+	for _, v := range []string{m.Profile, m.Environment, m.Channel, m.CLIVersion, m.GitCommit} {
+		if len(v) > 255 {
+			return validation.Errorf("metadata", "field exceeds 255 bytes")
+		}
+	}
+	if len(m.GitMessage) > 1000 {
+		return validation.Errorf("metadata", "commit message exceeds 1000 bytes")
+	}
+	if m.StartedAt.IsZero() || m.StartedAt.After(s.now().Add(buildClockSkew)) {
+		return validation.Errorf("metadata", "startedAt is required and cannot be in the future")
+	}
+	m.StartedAt = normalizeTime(m.StartedAt)
+	return nil
+}
+
+func (s *BuildService) validateFinish(startedAt time.Time, finishedAt *time.Time) error {
+	if finishedAt.IsZero() || finishedAt.Before(startedAt) || finishedAt.After(s.now().Add(buildClockSkew)) || finishedAt.Sub(startedAt) > maxBuildDuration {
+		return validation.Errorf("finishedAt", "expected a timestamp between startedAt and now, at most 7 days after startedAt")
+	}
+	*finishedAt = normalizeTime(*finishedAt)
+	return nil
+}
+
+func (s *BuildService) validateRegister(id string, input *RegisterBuildInput) error {
+	m := &input.Metadata
+	start := BuildStartMetadata{Profile: m.Profile, Mode: m.Mode, Environment: m.Environment, Channel: m.Channel, CLIVersion: m.CLIVersion, GitCommit: m.GitCommit, GitMessage: m.GitMessage, GitDirty: m.GitDirty, StartedAt: m.StartedAt}
+	if err := s.validateStart(id, input.ArtifactType, &start); err != nil {
+		return err
+	}
+	m.StartedAt = start.StartedAt
+	if input.Size <= 0 || input.Size > MaxBuildSize || !buildHash.MatchString(input.SHA256) {
+		return validation.Errorf("artifact", "expected a size up to 2 GiB and SHA-256 hex checksum")
+	}
+	if err := validation.BuildNumber(types.PlatformAndroid, m.BuildNumber); err != nil || m.BuildNumber == "0" {
+		return validation.Errorf("metadata", "buildNumber must be an Android versionCode from 1 to %d", validation.MaxAndroidBuildNumber)
+	}
+	if !fingerprintHash.MatchString(m.Fingerprint) {
+		return validation.Errorf("metadata", "fingerprint must be a 40 or 64 character hex digest")
+	}
+	for _, v := range []string{m.Version, m.RuntimeVersion, m.ExpoSDK} {
+		if len(v) > 255 {
+			return validation.Errorf("metadata", "field exceeds 255 bytes")
+		}
+	}
+	if err := s.validateFinish(m.StartedAt, &m.FinishedAt); err != nil {
+		return err
+	}
+	m.DurationMs = m.FinishedAt.Sub(m.StartedAt).Milliseconds()
+	return nil
+}
+
+func sameInitialInputs(a, b types.BuildRecord) bool {
+	x, y := a.Metadata, b.Metadata
+	return a.AppIdentifierID == b.AppIdentifierID && a.ArtifactType == b.ArtifactType && x.Profile == y.Profile && x.Mode == y.Mode && x.Environment == y.Environment && x.Channel == y.Channel && x.CLIVersion == y.CLIVersion && x.GitCommit == y.GitCommit && x.GitMessage == y.GitMessage && x.GitDirty == y.GitDirty && x.StartedAt.Equal(y.StartedAt)
+}
+
+func sameArtifact(a, b types.BuildRecord) bool {
+	x, y := a.Metadata, b.Metadata
+	return a.Size == b.Size && a.SHA256 == b.SHA256 && x.BuildNumber == y.BuildNumber && x.Version == y.Version && x.Fingerprint == y.Fingerprint && x.RuntimeVersion == y.RuntimeVersion && x.ExpoSDK == y.ExpoSDK
+}
+
+func withArtifact(current, declared types.BuildRecord) *types.BuildRecord {
+	next := current
+	next.Status = types.BuildStatusUploading
+	next.Size, next.SHA256 = declared.Size, declared.SHA256
+	next.Metadata = declared.Metadata
+	return &next
+}
+
+func artifactRef(b types.BuildRecord) bucket.BuildArtifact {
+	return bucket.BuildArtifact{Platform: b.Platform, IdentifierID: b.AppIdentifierID, BuildID: b.ID, Format: b.ArtifactType}
+}
+
+func (s *BuildService) newRecord(ctx context.Context, appID, identifierID, id, artifactType string) (*types.BuildRecord, error) {
+	if s.repo == nil {
+		return nil, store.ErrNotSupportedInStatelessMode
+	}
+	ref, err := s.identifiers.GetAppIdentifierByID(ctx, appID, identifierID)
+	if err != nil {
+		return nil, err
+	}
+	if ref == nil {
+		return nil, &store.ErrResourceNotFound{Resource: "app identifier", Identifier: identifierID}
+	}
+	if ref.Platform != types.PlatformAndroid {
+		return nil, validation.Errorf("platform", "only Android build artifacts are supported")
+	}
+	actorType, actorID, actorDisplay := auditActorFromContext(ctx)
+	record := &types.BuildRecord{ID: id, AppID: appID, AppIdentifierID: identifierID, Platform: ref.Platform, ApplicationID: ref.Identifier, ArtifactType: artifactType, ActorType: string(actorType), ActorID: actorID, ActorDisplay: actorDisplay}
+	record.ArtifactKey, err = artifactRef(*record).Key(false)
+	return record, err
+}
+
+// Start records a build before compilation; repeating it with the same inputs returns the existing row.
+func (s *BuildService) Start(ctx context.Context, appID, identifierID, id string, input BuildStartInput) (*types.BuildRecord, error) {
+	if s.repo == nil {
+		return nil, store.ErrNotSupportedInStatelessMode
+	}
+	if err := s.validateStart(id, input.ArtifactType, &input.Metadata); err != nil {
+		return nil, err
+	}
+	record, err := s.newRecord(ctx, appID, identifierID, id, input.ArtifactType)
+	if err != nil {
+		return nil, err
+	}
+	m := input.Metadata
+	record.Status = types.BuildStatusBuilding
+	record.Metadata = types.BuildMetadata{Profile: m.Profile, Mode: m.Mode, Environment: m.Environment, Channel: m.Channel, CLIVersion: m.CLIVersion, GitCommit: m.GitCommit, GitMessage: m.GitMessage, GitDirty: m.GitDirty, StartedAt: m.StartedAt}
+	existing, _, err := s.repo.Create(ctx, *record)
+	if err != nil {
+		return nil, err
+	}
+	if !sameInitialInputs(*existing, *record) {
+		return nil, ErrBuildConflict
+	}
+	return existing, nil
+}
+
+// Begin declares the compiled artifact and hands back where to upload it.
+func (s *BuildService) Begin(ctx context.Context, appID, identifierID, id string, input RegisterBuildInput) (*BuildRegistration, error) {
+	if s.repo == nil {
+		return nil, store.ErrNotSupportedInStatelessMode
+	}
+	if err := s.validateRegister(id, &input); err != nil {
+		return nil, err
+	}
+	record, err := s.newRecord(ctx, appID, identifierID, id, input.ArtifactType)
+	if err != nil {
+		return nil, err
+	}
+	record.Status, record.Size, record.SHA256, record.Metadata = types.BuildStatusUploading, input.Size, input.SHA256, input.Metadata
+	existing, created, err := s.repo.Create(ctx, *record)
+	if err != nil {
+		return nil, err
+	}
+	if !created {
+		existing, err = s.repo.Transition(ctx, appID, id, func(current types.BuildRecord) (*types.BuildRecord, error) {
+			if !sameInitialInputs(current, *record) {
+				return nil, ErrBuildConflict
+			}
+			switch current.Status {
+			case types.BuildStatusBuilding:
+				return withArtifact(current, *record), nil
+			case types.BuildStatusFailed:
+				// A failed row carries the failure time, so only the artifact fields are compared.
+				if current.Size > 0 && !sameArtifact(current, *record) {
+					return nil, ErrBuildConflict
+				}
+				return withArtifact(current, *record), nil
+			default:
+				if !sameArtifact(current, *record) || !current.Metadata.FinishedAt.Equal(record.Metadata.FinishedAt) {
+					return nil, ErrBuildConflict
+				}
+				return nil, nil
+			}
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+	result := &BuildRegistration{Build: existing}
+	if existing.Status == types.BuildStatusReady {
+		return result, nil
+	}
+	url, headers, err := s.storage.PresignUpload(ctx, artifactRef(*existing))
+	if err != nil {
+		return nil, err
+	}
+	result.Upload = &BuildUpload{URL: url, Method: "PUT", Headers: headers}
+	if url == "" {
+		result.LocalToken, err = s.uploadToken(*existing)
+	}
+	return result, err
+}
+
+func (s *BuildService) Get(ctx context.Context, appID, id string) (*types.BuildRecord, error) {
+	if s.repo == nil {
+		return nil, store.ErrNotSupportedInStatelessMode
+	}
+	if _, err := uuid.Parse(id); err != nil {
+		return nil, validation.Errorf("buildId", "invalid UUID")
+	}
+	return s.repo.Get(ctx, appID, id)
+}
+
+func (s *BuildService) List(ctx context.Context, appID string, limit, offset int32) ([]types.BuildRecord, int64, error) {
+	if s.repo == nil {
+		return nil, 0, store.ErrNotSupportedInStatelessMode
+	}
+	return s.repo.List(ctx, appID, limit, offset)
+}
+
+func (s *BuildService) transition(ctx context.Context, appID, identifierID, id string, decide func(types.BuildRecord) (*types.BuildRecord, error)) (*types.BuildRecord, error) {
+	if s.repo == nil {
+		return nil, store.ErrNotSupportedInStatelessMode
+	}
+	if err := validateBuildID(id); err != nil {
+		return nil, err
+	}
+	return s.repo.Transition(ctx, appID, id, func(current types.BuildRecord) (*types.BuildRecord, error) {
+		if current.AppIdentifierID != identifierID {
+			return nil, &store.ErrResourceNotFound{Resource: "build", Identifier: id}
+		}
+		return decide(current)
+	})
+}
+
+func failed(current types.BuildRecord, finishedAt time.Time) *types.BuildRecord {
+	next := current
+	next.Status = types.BuildStatusFailed
+	next.Metadata.FinishedAt = finishedAt
+	next.Metadata.DurationMs = max(finishedAt.Sub(current.Metadata.StartedAt).Milliseconds(), 0)
+	return &next
+}
+
+// Fail marks an unfinished build failed; ready and already failed builds are returned unchanged.
+func (s *BuildService) Fail(ctx context.Context, appID, identifierID, id string, input FailBuildInput) (*types.BuildRecord, error) {
+	if input.FinishedAt.IsZero() || input.FinishedAt.After(s.now().Add(buildClockSkew)) {
+		return nil, validation.Errorf("finishedAt", "expected a timestamp that is not in the future")
+	}
+	staged := false
+	record, err := s.transition(ctx, appID, identifierID, id, func(current types.BuildRecord) (*types.BuildRecord, error) {
+		if current.Status == types.BuildStatusReady || current.Status == types.BuildStatusFailed {
+			return nil, nil
+		}
+		if err := s.validateFinish(current.Metadata.StartedAt, &input.FinishedAt); err != nil {
+			return nil, err
+		}
+		staged = current.Status == types.BuildStatusUploading
+		return failed(current, input.FinishedAt), nil
+	})
+	if err == nil && staged {
+		_ = s.storage.Delete(ctx, artifactRef(*record), true)
+	}
+	return record, err
+}
+
+func (s *BuildService) Complete(ctx context.Context, appID, identifierID, id string) (*types.BuildRecord, error) {
+	uploadable := func(b types.BuildRecord) (*types.BuildRecord, error) {
+		if b.Status != types.BuildStatusReady && b.Status != types.BuildStatusUploading {
+			return nil, ErrBuildState
+		}
+		return nil, nil
+	}
+	staged, err := s.transition(ctx, appID, identifierID, id, uploadable)
+	if err != nil || staged.Status == types.BuildStatusReady {
+		return staged, err
+	}
+	// The artifact is verified outside the row lock so log appends are not blocked meanwhile.
+	if err := s.verifyStaged(ctx, *staged); err != nil {
+		if errors.Is(err, ErrBuildIntegrity) {
+			_, _ = s.transition(ctx, appID, identifierID, id, func(current types.BuildRecord) (*types.BuildRecord, error) {
+				if current.Status != types.BuildStatusUploading {
+					return nil, nil
+				}
+				return failed(current, normalizeTime(s.now())), nil
+			})
+		}
+		return nil, err
+	}
+	completed, err := s.transition(ctx, appID, identifierID, id, func(b types.BuildRecord) (*types.BuildRecord, error) {
+		if _, err := uploadable(b); err != nil || b.Status == types.BuildStatusReady {
+			return nil, err
+		}
+		next := b
+		next.Status = types.BuildStatusReady
+		return &next, nil
+	})
+	if err == nil {
+		_ = s.storage.Delete(ctx, artifactRef(*completed), true)
+	}
+	return completed, err
+}
+
+func (s *BuildService) verifyStaged(ctx context.Context, b types.BuildRecord) error {
+	file, err := s.storage.Get(ctx, artifactRef(b), true)
+	if err != nil {
+		return err
+	}
+	if file == nil {
+		return ErrBuildIntegrity
+	}
+	defer file.Reader.Close()
+	temporary, err := os.CreateTemp("", "xprem-build-verify-")
+	if err != nil {
+		return err
+	}
+	defer os.Remove(temporary.Name())
+	defer temporary.Close()
+	hash := sha256.New()
+	size, err := io.Copy(io.MultiWriter(temporary, hash), io.LimitReader(file.Reader, b.Size+1))
+	if err != nil {
+		return err
+	}
+	if size != b.Size || hex.EncodeToString(hash.Sum(nil)) != b.SHA256 {
+		return ErrBuildIntegrity
+	}
+	if _, err = temporary.Seek(0, io.SeekStart); err != nil {
+		return err
+	}
+	return s.storage.Put(ctx, artifactRef(b), false, temporary)
+}
+
+func (s *BuildService) Download(ctx context.Context, record types.BuildRecord) (*types.BucketFile, error) {
+	if record.Status != types.BuildStatusReady {
+		return nil, ErrBuildNotReady
+	}
+	return s.storage.Get(ctx, artifactRef(record), false)
+}
+
+type buildUploadClaims struct {
+	jwt.RegisteredClaims
+	AppID        string `json:"appId"`
+	IdentifierID string `json:"identifierId"`
+	BuildID      string `json:"buildId"`
+}
+
+func (s *BuildService) uploadToken(b types.BuildRecord) (string, error) {
+	return jwt.NewWithClaims(jwt.SigningMethodHS256, buildUploadClaims{RegisteredClaims: jwt.RegisteredClaims{Subject: "build-upload", ExpiresAt: jwt.NewNumericDate(s.now().Add(10 * time.Minute))}, AppID: b.AppID, IdentifierID: b.AppIdentifierID, BuildID: b.ID}).SignedString([]byte(config.GetEnv("JWT_SECRET")))
+}
+
+type countingReader struct {
+	io.Reader
+	n int64
+}
+
+func (r *countingReader) Read(p []byte) (int, error) {
+	n, err := r.Reader.Read(p)
+	r.n += int64(n)
+	return n, err
+}
+
+// UploadLocal stores the body in staging; anything beyond the declared size is discarded.
+func (s *BuildService) UploadLocal(ctx context.Context, token string, body io.Reader) error {
+	claims := &buildUploadClaims{}
+	_, err := jwt.ParseWithClaims(token, claims, func(*jwt.Token) (any, error) { return []byte(config.GetEnv("JWT_SECRET")), nil }, jwt.WithValidMethods([]string{"HS256"}), jwt.WithExpirationRequired(), jwt.WithSubject("build-upload"), jwt.WithTimeFunc(s.now))
+	if err != nil {
+		return ErrUnauthorized
+	}
+	b, err := s.Get(ctx, claims.AppID, claims.BuildID)
+	if err != nil {
+		return err
+	}
+	if b.AppIdentifierID != claims.IdentifierID {
+		return &store.ErrResourceNotFound{Resource: "build", Identifier: claims.BuildID}
+	}
+	if b.Status != types.BuildStatusUploading {
+		return ErrBuildState
+	}
+	reader := &countingReader{Reader: io.LimitReader(body, b.Size+1)}
+	if err := s.storage.Put(ctx, artifactRef(*b), true, reader); err != nil {
+		return err
+	}
+	if reader.n > b.Size {
+		_ = s.storage.Delete(ctx, artifactRef(*b), true)
+		return ErrBuildIntegrity
+	}
+	return nil
+}

--- a/internal/services/build_service.go
+++ b/internal/services/build_service.go
@@ -5,20 +5,15 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
-	"fmt"
 	"io"
-	"net/url"
 	"os"
 	"regexp"
-	"strings"
 	"time"
-	"xprem/config"
 	"xprem/internal/bucket"
 	"xprem/internal/store"
 	"xprem/internal/types"
 	"xprem/internal/validation"
 
-	"github.com/golang-jwt/jwt/v5"
 	"github.com/google/uuid"
 )
 
@@ -76,8 +71,8 @@ type FailBuildInput struct {
 	FinishedAt time.Time `json:"finishedAt"`
 }
 type BuildRegistration struct {
-	Build  *types.BuildRecord  `json:"build"`
-	Upload *bucket.BuildUpload `json:"upload,omitempty"`
+	Build  *types.BuildRecord    `json:"build"`
+	Upload *bucket.UploadRequest `json:"upload,omitempty"`
 }
 
 func validateBuildID(id string) error {
@@ -279,35 +274,11 @@ func (s *BuildService) RegisterArtifact(ctx context.Context, appID, identifierID
 	if existing.Status == types.BuildStatusReady {
 		return result, nil
 	}
-	result.Upload, err = bucket.RequestBuildArtifactUpload(ctx, s.storage, artifactRef(*existing))
+	result.Upload, err = s.storage.RequestBuildArtifactUploadURL(ctx, existing.AppID, artifactRef(*existing))
 	if err != nil {
 		return nil, err
 	}
-	if result.Upload.URL == "" {
-		result.Upload.URL, err = publicBuildURL(fmt.Sprintf("/%s/build/%s/artifacts/%s/upload", existing.AppID, existing.AppIdentifierID, existing.ID))
-		if err != nil {
-			return nil, err
-		}
-		token, tokenErr := s.uploadToken(*existing)
-		if tokenErr != nil {
-			return nil, tokenErr
-		}
-		result.Upload.Headers = map[string]string{bucket.LocalUploadTokenHeader: token}
-	}
 	return result, nil
-}
-
-// publicBuildURL appends route to BASE_URL, keeping any sub-path it is served from.
-func publicBuildURL(route string) (string, error) {
-	base, err := url.Parse(strings.TrimRight(config.GetEnv("BASE_URL"), "/"))
-	if err != nil || base.Host == "" || (base.Scheme != "https" && base.Scheme != "http") || base.User != nil {
-		return "", fmt.Errorf("invalid BASE_URL")
-	}
-	base.Path = strings.TrimRight(base.Path, "/") + route
-	base.RawPath = ""
-	base.RawQuery = ""
-	base.Fragment = ""
-	return base.String(), nil
 }
 
 func (s *BuildService) Get(ctx context.Context, appID, id string) (*types.BuildRecord, error) {
@@ -445,17 +416,6 @@ func (s *BuildService) Download(ctx context.Context, record types.BuildRecord) (
 	return s.storage.GetBuildArtifact(ctx, artifactRef(record), false)
 }
 
-type buildUploadClaims struct {
-	jwt.RegisteredClaims
-	AppID        string `json:"appId"`
-	IdentifierID string `json:"identifierId"`
-	BuildID      string `json:"buildId"`
-}
-
-func (s *BuildService) uploadToken(b types.BuildRecord) (string, error) {
-	return jwt.NewWithClaims(jwt.SigningMethodHS256, buildUploadClaims{RegisteredClaims: jwt.RegisteredClaims{Subject: "build-upload", ExpiresAt: jwt.NewNumericDate(s.now().Add(10 * time.Minute))}, AppID: b.AppID, IdentifierID: b.AppIdentifierID, BuildID: b.ID}).SignedString([]byte(config.GetEnv("JWT_SECRET")))
-}
-
 type countingReader struct {
 	io.Reader
 	n int64
@@ -472,17 +432,15 @@ func (s *BuildService) UploadLocal(ctx context.Context, appID, identifierID, id,
 	if s.repo == nil {
 		return store.ErrNotSupportedInStatelessMode
 	}
-	claims := &buildUploadClaims{}
-	_, err := jwt.ParseWithClaims(token, claims, func(*jwt.Token) (any, error) { return []byte(config.GetEnv("JWT_SECRET")), nil }, jwt.WithValidMethods([]string{"HS256"}), jwt.WithExpirationRequired(), jwt.WithSubject("build-upload"), jwt.WithTimeFunc(s.now))
-	if err != nil || claims.AppID != appID || claims.IdentifierID != identifierID || claims.BuildID != id {
+	if err := bucket.ValidateBuildUploadToken(token, appID, identifierID, id); err != nil {
 		return ErrUnauthorized
 	}
 	b, err := s.Get(ctx, appID, id)
 	if err != nil {
 		return err
 	}
-	if b.AppIdentifierID != claims.IdentifierID {
-		return &store.ErrResourceNotFound{Resource: "build", Identifier: claims.BuildID}
+	if b.AppIdentifierID != identifierID {
+		return &store.ErrResourceNotFound{Resource: "build", Identifier: id}
 	}
 	if b.Status != types.BuildStatusUploading {
 		return ErrBuildState

--- a/internal/services/build_service.go
+++ b/internal/services/build_service.go
@@ -227,8 +227,8 @@ func (s *BuildService) Start(ctx context.Context, appID, identifierID, id string
 	return existing, nil
 }
 
-// Begin declares the compiled artifact and hands back where to upload it.
-func (s *BuildService) Begin(ctx context.Context, appID, identifierID, id string, input RegisterBuildInput) (*BuildRegistration, error) {
+// RegisterArtifact declares the compiled artifact and hands back where to upload it.
+func (s *BuildService) RegisterArtifact(ctx context.Context, appID, identifierID, id string, input RegisterBuildInput) (*BuildRegistration, error) {
 	if s.repo == nil {
 		return nil, store.ErrNotSupportedInStatelessMode
 	}

--- a/internal/services/build_service.go
+++ b/internal/services/build_service.go
@@ -96,12 +96,13 @@ func normalizeTime(t time.Time) time.Time {
 	return t.UTC().Truncate(time.Microsecond)
 }
 
-func (s *BuildService) validateStart(id string, artifactType types.BuildArtifactType, m *BuildStartMetadata) error {
-	if err := validateBuildID(id); err != nil {
-		return err
+func (s *BuildService) validateStart(platform types.Platform, artifactType types.BuildArtifactType, m *BuildStartMetadata) error {
+	artifactPlatform, err := artifactType.Platform()
+	if err != nil {
+		return validation.Errorf("artifactType", "%s", err)
 	}
-	if artifactType != types.BuildArtifactAPK && artifactType != types.BuildArtifactAAB {
-		return validation.Errorf("artifactType", "expected apk or aab")
+	if artifactPlatform != platform {
+		return validation.Errorf("artifactType", "%q does not match identifier platform %q", artifactType, platform)
 	}
 	if m.Profile == "" || m.CLIVersion == "" {
 		return validation.Errorf("metadata", "profile and CLI version are required")
@@ -132,17 +133,20 @@ func (s *BuildService) validateFinish(startedAt time.Time, finishedAt *time.Time
 	return nil
 }
 
-func (s *BuildService) validateRegister(id string, input *RegisterBuildInput) error {
+func (s *BuildService) validateRegister(platform types.Platform, input *RegisterBuildInput) error {
 	m := &input.Metadata
 	start := BuildStartMetadata{Profile: m.Profile, Mode: m.Mode, Environment: m.Environment, Channel: m.Channel, CLIVersion: m.CLIVersion, GitCommit: m.GitCommit, GitMessage: m.GitMessage, GitDirty: m.GitDirty, StartedAt: m.StartedAt}
-	if err := s.validateStart(id, input.ArtifactType, &start); err != nil {
+	if err := s.validateStart(platform, input.ArtifactType, &start); err != nil {
 		return err
 	}
 	m.StartedAt = start.StartedAt
 	if input.Size <= 0 || input.Size > MaxBuildSize || !buildHash.MatchString(input.SHA256) {
 		return validation.Errorf("artifact", "expected a size up to 2 GiB and SHA-256 hex checksum")
 	}
-	if err := validation.BuildNumber(types.PlatformAndroid, m.BuildNumber); err != nil || m.BuildNumber == "0" {
+	if err := validation.BuildNumber(platform, m.BuildNumber); err != nil {
+		return err
+	}
+	if platform == types.PlatformAndroid && m.BuildNumber == "0" {
 		return validation.Errorf("metadata", "buildNumber must be an Android versionCode from 1 to %d", validation.MaxAndroidBuildNumber)
 	}
 	if !fingerprintHash.MatchString(m.Fingerprint) {
@@ -186,6 +190,9 @@ func (s *BuildService) newRecord(ctx context.Context, appID, identifierID, id st
 	if s.repo == nil {
 		return nil, store.ErrNotSupportedInStatelessMode
 	}
+	if err := validateBuildID(id); err != nil {
+		return nil, err
+	}
 	ref, err := s.identifiers.GetAppIdentifierByID(ctx, appID, identifierID)
 	if err != nil {
 		return nil, err
@@ -193,25 +200,30 @@ func (s *BuildService) newRecord(ctx context.Context, appID, identifierID, id st
 	if ref == nil {
 		return nil, &store.ErrResourceNotFound{Resource: "app identifier", Identifier: identifierID}
 	}
-	if ref.Platform != types.PlatformAndroid {
-		return nil, validation.Errorf("platform", "only Android build artifacts are supported")
+	// Keep rollout support separate from the platform-specific validation rules.
+	switch ref.Platform {
+	case types.PlatformAndroid:
+	case types.PlatformIOS:
+		return nil, validation.Errorf("platform", "iOS build artifacts are not supported yet")
+	default:
+		return nil, validation.Errorf("platform", "unsupported build platform %q", ref.Platform)
 	}
 	actorType, actorID, actorDisplay := auditActorFromContext(ctx)
 	record := &types.BuildRecord{ID: id, AppID: appID, AppIdentifierID: identifierID, Platform: ref.Platform, ApplicationID: ref.Identifier, ArtifactType: artifactType, ActorType: string(actorType), ActorID: actorID, ActorDisplay: actorDisplay}
 	record.ArtifactKey, err = artifactRef(*record).Key(false)
-	return record, err
+	if err != nil {
+		return nil, validation.Errorf("artifactType", "%s", err)
+	}
+	return record, nil
 }
 
 // Start records a build before compilation; repeating it with the same inputs returns the existing row.
 func (s *BuildService) Start(ctx context.Context, appID, identifierID, id string, input BuildStartInput) (*types.BuildRecord, error) {
-	if s.repo == nil {
-		return nil, store.ErrNotSupportedInStatelessMode
-	}
-	if err := s.validateStart(id, input.ArtifactType, &input.Metadata); err != nil {
-		return nil, err
-	}
 	record, err := s.newRecord(ctx, appID, identifierID, id, input.ArtifactType)
 	if err != nil {
+		return nil, err
+	}
+	if err := s.validateStart(record.Platform, input.ArtifactType, &input.Metadata); err != nil {
 		return nil, err
 	}
 	m := input.Metadata
@@ -229,14 +241,11 @@ func (s *BuildService) Start(ctx context.Context, appID, identifierID, id string
 
 // RegisterArtifact declares the compiled artifact and hands back where to upload it.
 func (s *BuildService) RegisterArtifact(ctx context.Context, appID, identifierID, id string, input RegisterBuildInput) (*BuildRegistration, error) {
-	if s.repo == nil {
-		return nil, store.ErrNotSupportedInStatelessMode
-	}
-	if err := s.validateRegister(id, &input); err != nil {
-		return nil, err
-	}
 	record, err := s.newRecord(ctx, appID, identifierID, id, input.ArtifactType)
 	if err != nil {
+		return nil, err
+	}
+	if err := s.validateRegister(record.Platform, &input); err != nil {
 		return nil, err
 	}
 	record.Status, record.Size, record.SHA256, record.Metadata = types.BuildStatusUploading, input.Size, input.SHA256, input.Metadata

--- a/internal/services/build_service.go
+++ b/internal/services/build_service.go
@@ -5,9 +5,12 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
+	"fmt"
 	"io"
+	"net/url"
 	"os"
 	"regexp"
+	"strings"
 	"time"
 	"xprem/config"
 	"xprem/internal/bucket"
@@ -73,9 +76,8 @@ type FailBuildInput struct {
 	FinishedAt time.Time `json:"finishedAt"`
 }
 type BuildRegistration struct {
-	Build      *types.BuildRecord  `json:"build"`
-	Upload     *bucket.BuildUpload `json:"upload,omitempty"`
-	LocalToken string              `json:"-"`
+	Build  *types.BuildRecord  `json:"build"`
+	Upload *bucket.BuildUpload `json:"upload,omitempty"`
 }
 
 func validateBuildID(id string) error {
@@ -282,9 +284,30 @@ func (s *BuildService) RegisterArtifact(ctx context.Context, appID, identifierID
 		return nil, err
 	}
 	if result.Upload.URL == "" {
-		result.LocalToken, err = s.uploadToken(*existing)
+		result.Upload.URL, err = publicBuildURL(fmt.Sprintf("/%s/build/%s/artifacts/%s/upload", existing.AppID, existing.AppIdentifierID, existing.ID))
+		if err != nil {
+			return nil, err
+		}
+		token, tokenErr := s.uploadToken(*existing)
+		if tokenErr != nil {
+			return nil, tokenErr
+		}
+		result.Upload.Headers = map[string]string{bucket.LocalUploadTokenHeader: token}
 	}
-	return result, err
+	return result, nil
+}
+
+// publicBuildURL appends route to BASE_URL, keeping any sub-path it is served from.
+func publicBuildURL(route string) (string, error) {
+	base, err := url.Parse(strings.TrimRight(config.GetEnv("BASE_URL"), "/"))
+	if err != nil || base.Host == "" || (base.Scheme != "https" && base.Scheme != "http") || base.User != nil {
+		return "", fmt.Errorf("invalid BASE_URL")
+	}
+	base.Path = strings.TrimRight(base.Path, "/") + route
+	base.RawPath = ""
+	base.RawQuery = ""
+	base.Fragment = ""
+	return base.String(), nil
 }
 
 func (s *BuildService) Get(ctx context.Context, appID, id string) (*types.BuildRecord, error) {
@@ -445,13 +468,16 @@ func (r *countingReader) Read(p []byte) (int, error) {
 }
 
 // UploadLocal stores the body in staging; anything beyond the declared size is discarded.
-func (s *BuildService) UploadLocal(ctx context.Context, token string, body io.Reader) error {
+func (s *BuildService) UploadLocal(ctx context.Context, appID, identifierID, id, token string, body io.Reader) error {
+	if s.repo == nil {
+		return store.ErrNotSupportedInStatelessMode
+	}
 	claims := &buildUploadClaims{}
 	_, err := jwt.ParseWithClaims(token, claims, func(*jwt.Token) (any, error) { return []byte(config.GetEnv("JWT_SECRET")), nil }, jwt.WithValidMethods([]string{"HS256"}), jwt.WithExpirationRequired(), jwt.WithSubject("build-upload"), jwt.WithTimeFunc(s.now))
-	if err != nil {
+	if err != nil || claims.AppID != appID || claims.IdentifierID != identifierID || claims.BuildID != id {
 		return ErrUnauthorized
 	}
-	b, err := s.Get(ctx, claims.AppID, claims.BuildID)
+	b, err := s.Get(ctx, appID, id)
 	if err != nil {
 		return err
 	}

--- a/internal/services/build_service_test.go
+++ b/internal/services/build_service_test.go
@@ -299,6 +299,84 @@ func TestBuildRegisterValidation(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestBuildRegistrationPlatformRules(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		platform     types.Platform
+		artifactType types.BuildArtifactType
+		buildNumber  string
+		wantError    string
+	}{
+		{"android apk", types.PlatformAndroid, types.BuildArtifactAPK, "42", ""},
+		{"android aab", types.PlatformAndroid, types.BuildArtifactAAB, "2100000000", ""},
+		{"android dotted number", types.PlatformAndroid, types.BuildArtifactAPK, "1.2.3", "buildNumber"},
+		{"android zero", types.PlatformAndroid, types.BuildArtifactAPK, "0", "buildNumber"},
+		{"android overflow", types.PlatformAndroid, types.BuildArtifactAPK, "2100000001", "buildNumber"},
+		{"ios dotted number", types.PlatformIOS, types.BuildArtifactIPA, "1.2.3", ""},
+		{"ios beyond android limit", types.PlatformIOS, types.BuildArtifactIPA, "2100000001", ""},
+		{"ios invalid number", types.PlatformIOS, types.BuildArtifactIPA, "1.02.3", "buildNumber"},
+		{"ipa for android", types.PlatformAndroid, types.BuildArtifactIPA, "42", "does not match identifier platform"},
+		{"apk for ios", types.PlatformIOS, types.BuildArtifactAPK, "42", "does not match identifier platform"},
+		{"aab for ios", types.PlatformIOS, types.BuildArtifactAAB, "42", "does not match identifier platform"},
+		{"unknown artifact", types.PlatformAndroid, "zip", "42", "unsupported build artifact type"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			f := newBuildFixture(t)
+			input := f.registerInput([]byte("artifact"))
+			input.ArtifactType = tc.artifactType
+			input.Metadata.BuildNumber = tc.buildNumber
+			err := f.service.validateRegister(tc.platform, &input)
+			if tc.wantError == "" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, tc.wantError)
+				require.True(t, validation.IsValidationError(err))
+			}
+		})
+	}
+}
+
+func TestBuildRejectsUnsupportedPlatformBeforeMetadata(t *testing.T) {
+	for _, operation := range []string{"start", "register"} {
+		t.Run(operation, func(t *testing.T) {
+			f := newBuildFixture(t)
+			// No storage may be consulted and no build persisted on rejection.
+			f.service.storage = nil
+			var err error
+			if operation == "start" {
+				_, err = f.service.Start(context.Background(), testBuildApp, otherBuildID, testBuildID, BuildStartInput{ArtifactType: types.BuildArtifactIPA})
+			} else {
+				_, err = f.service.RegisterArtifact(context.Background(), testBuildApp, otherBuildID, testBuildID, RegisterBuildInput{ArtifactType: types.BuildArtifactIPA})
+			}
+			require.ErrorContains(t, err, "iOS build artifacts are not supported yet")
+			require.True(t, validation.IsValidationError(err))
+			require.Empty(t, f.repo.builds)
+		})
+	}
+}
+
+func TestBuildRejectsArtifactForAnotherPlatform(t *testing.T) {
+	for _, operation := range []string{"start", "register"} {
+		t.Run(operation, func(t *testing.T) {
+			f := newBuildFixture(t)
+			f.service.storage = nil
+			var err error
+			if operation == "start" {
+				input := f.startInput()
+				input.ArtifactType = types.BuildArtifactIPA
+				_, err = f.service.Start(context.Background(), testBuildApp, testBuildIdentifier, testBuildID, input)
+			} else {
+				input := f.registerInput([]byte("artifact"))
+				input.ArtifactType = types.BuildArtifactIPA
+				_, err = f.service.RegisterArtifact(context.Background(), testBuildApp, testBuildIdentifier, testBuildID, input)
+			}
+			require.ErrorContains(t, err, "does not match identifier platform")
+			require.True(t, validation.IsValidationError(err))
+			require.Empty(t, f.repo.builds)
+		})
+	}
+}
+
 func TestBuildLifecycleStartUploadComplete(t *testing.T) {
 	f := newBuildFixture(t)
 	ctx := WithCliAuth(context.Background(), CliCredential{AppID: testBuildApp, KeyID: 7, KeyName: "ci-key"})

--- a/internal/services/build_service_test.go
+++ b/internal/services/build_service_test.go
@@ -377,6 +377,36 @@ func TestBuildRejectsArtifactForAnotherPlatform(t *testing.T) {
 	}
 }
 
+func TestBuildRegistrationLocalUploadURL(t *testing.T) {
+	for _, tc := range []struct {
+		baseURL string
+		wantURL string
+	}{
+		{baseURL: "https://ota.example.com", wantURL: "https://ota.example.com/" + testBuildApp + "/build/" + testBuildIdentifier + "/artifacts/" + testBuildID + "/upload"},
+		{baseURL: "https://ota.example.com/sub/path/", wantURL: "https://ota.example.com/sub/path/" + testBuildApp + "/build/" + testBuildIdentifier + "/artifacts/" + testBuildID + "/upload"},
+		{baseURL: "not a url"},
+		{baseURL: "ftp://ota.example.com"},
+		{baseURL: "https://user:secret@ota.example.com"},
+		{baseURL: "/relative"},
+	} {
+		t.Run(tc.baseURL, func(t *testing.T) {
+			f := newBuildFixture(t)
+			t.Setenv("BASE_URL", tc.baseURL)
+			registration, err := f.service.RegisterArtifact(context.Background(), testBuildApp, testBuildIdentifier, testBuildID, f.registerInput([]byte("apk")))
+			if tc.wantURL == "" {
+				require.Error(t, err)
+				require.Nil(t, registration, "an invalid base URL must not return partial upload instructions")
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, registration.Upload)
+			require.Equal(t, tc.wantURL, registration.Upload.URL)
+			require.Equal(t, "PUT", registration.Upload.Method)
+			require.NotEmpty(t, registration.Upload.Headers[bucket.LocalUploadTokenHeader])
+		})
+	}
+}
+
 func TestBuildLifecycleStartUploadComplete(t *testing.T) {
 	f := newBuildFixture(t)
 	ctx := WithCliAuth(context.Background(), CliCredential{AppID: testBuildApp, KeyID: 7, KeyName: "ci-key"})
@@ -397,13 +427,13 @@ func TestBuildLifecycleStartUploadComplete(t *testing.T) {
 	require.Equal(t, int64(9*time.Minute/time.Millisecond), b.Metadata.DurationMs, "duration is computed by the server, not taken from the client")
 	require.NotNil(t, registration.Upload)
 	require.Equal(t, "PUT", registration.Upload.Method)
-	require.Empty(t, registration.Upload.URL, "local storage hands out a token instead of a presigned URL")
-	require.NotEmpty(t, registration.LocalToken)
+	require.NotEmpty(t, registration.Upload.URL, "registration returns complete upload instructions")
+	require.NotEmpty(t, registration.Upload.Headers[bucket.LocalUploadTokenHeader])
 
 	retry, err := f.service.RegisterArtifact(context.Background(), testBuildApp, testBuildIdentifier, testBuildID, f.registerInput(content))
 	require.NoError(t, err)
 	require.Equal(t, types.BuildStatusUploading, retry.Build.Status)
-	require.NotEmpty(t, retry.LocalToken, "an identical retry gets a fresh upload grant")
+	require.NotEmpty(t, retry.Upload.Headers[bucket.LocalUploadTokenHeader], "an identical retry gets a fresh upload grant")
 
 	_, err = f.service.Complete(ctx, testBuildApp, testBuildIdentifier, testBuildID)
 	require.ErrorIs(t, err, ErrBuildIntegrity, "nothing staged yet")
@@ -416,7 +446,7 @@ func TestBuildLifecycleStartUploadComplete(t *testing.T) {
 	retry, err = f.service.RegisterArtifact(context.Background(), testBuildApp, testBuildIdentifier, testBuildID, f.registerInput(content))
 	require.NoError(t, err)
 	require.Equal(t, types.BuildStatusUploading, retry.Build.Status, "a failed upload can be retried with the same artifact")
-	require.NoError(t, f.service.UploadLocal(ctx, retry.LocalToken, bytes.NewReader(content)))
+	require.NoError(t, f.service.UploadLocal(ctx, testBuildApp, testBuildIdentifier, testBuildID, retry.Upload.Headers[bucket.LocalUploadTokenHeader], bytes.NewReader(content)))
 	staged, err := os.ReadFile(f.stagedPath(t, *retry.Build))
 	require.NoError(t, err)
 	require.Equal(t, content, staged)
@@ -441,7 +471,6 @@ func TestBuildLifecycleStartUploadComplete(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, types.BuildStatusReady, registration.Build.Status)
 	require.Nil(t, registration.Upload, "a ready build gets no upload grant")
-	require.Empty(t, registration.LocalToken)
 
 	failed, err := f.service.Fail(ctx, testBuildApp, testBuildIdentifier, testBuildID, FailBuildInput{FinishedAt: f.now})
 	require.NoError(t, err)
@@ -545,7 +574,7 @@ func TestBuildFailFromUploadingDiscardsStaging(t *testing.T) {
 	content := []byte("partial")
 	registration, err := f.service.RegisterArtifact(ctx, testBuildApp, testBuildIdentifier, testBuildID, f.registerInput(content))
 	require.NoError(t, err)
-	require.NoError(t, f.service.UploadLocal(ctx, registration.LocalToken, bytes.NewReader(content)))
+	require.NoError(t, f.service.UploadLocal(ctx, testBuildApp, testBuildIdentifier, testBuildID, registration.Upload.Headers[bucket.LocalUploadTokenHeader], bytes.NewReader(content)))
 	_, err = os.Stat(f.stagedPath(t, *registration.Build))
 	require.NoError(t, err)
 
@@ -557,7 +586,7 @@ func TestBuildFailFromUploadingDiscardsStaging(t *testing.T) {
 	_, err = os.Stat(f.stagedPath(t, *registration.Build))
 	require.True(t, os.IsNotExist(err))
 
-	require.ErrorIs(t, f.service.UploadLocal(ctx, registration.LocalToken, bytes.NewReader(content)), ErrBuildState, "an old grant cannot upload into a failed build")
+	require.ErrorIs(t, f.service.UploadLocal(ctx, testBuildApp, testBuildIdentifier, testBuildID, registration.Upload.Headers[bucket.LocalUploadTokenHeader], bytes.NewReader(content)), ErrBuildState, "an old grant cannot upload into a failed build")
 	_, err = f.service.Complete(ctx, testBuildApp, testBuildIdentifier, testBuildID)
 	require.ErrorIs(t, err, ErrBuildState)
 }
@@ -596,7 +625,7 @@ func TestBuildCompleteRejectsTamperedUpload(t *testing.T) {
 	registration, err = f.service.RegisterArtifact(ctx, testBuildApp, testBuildIdentifier, testBuildID, f.registerInput([]byte("declared")))
 	require.NoError(t, err)
 	require.Equal(t, types.BuildStatusUploading, registration.Build.Status)
-	require.NoError(t, f.service.UploadLocal(ctx, registration.LocalToken, strings.NewReader("declared")))
+	require.NoError(t, f.service.UploadLocal(ctx, testBuildApp, testBuildIdentifier, testBuildID, registration.Upload.Headers[bucket.LocalUploadTokenHeader], strings.NewReader("declared")))
 	ready, err := f.service.Complete(ctx, testBuildApp, testBuildIdentifier, testBuildID)
 	require.NoError(t, err)
 	require.Equal(t, types.BuildStatusReady, ready.Status)
@@ -608,21 +637,20 @@ func TestBuildUploadLocalBounds(t *testing.T) {
 	registration, err := f.service.RegisterArtifact(ctx, testBuildApp, testBuildIdentifier, testBuildID, f.registerInput([]byte("12345")))
 	require.NoError(t, err)
 
-	err = f.service.UploadLocal(ctx, registration.LocalToken, strings.NewReader("123456"))
+	err = f.service.UploadLocal(ctx, testBuildApp, testBuildIdentifier, testBuildID, registration.Upload.Headers[bucket.LocalUploadTokenHeader], strings.NewReader("123456"))
 	require.ErrorIs(t, err, ErrBuildIntegrity)
 	_, err = os.Stat(f.stagedPath(t, *registration.Build))
 	require.True(t, os.IsNotExist(err), "an oversized body is not kept")
 
-	require.ErrorIs(t, f.service.UploadLocal(ctx, "not-a-token", strings.NewReader("12345")), ErrUnauthorized)
-	require.ErrorIs(t, f.service.UploadLocal(ctx, registration.LocalToken+"x", strings.NewReader("12345")), ErrUnauthorized)
+	require.ErrorIs(t, f.service.UploadLocal(ctx, testBuildApp, testBuildIdentifier, testBuildID, "not-a-token", strings.NewReader("12345")), ErrUnauthorized)
+	require.ErrorIs(t, f.service.UploadLocal(ctx, testBuildApp, testBuildIdentifier, testBuildID, registration.Upload.Headers[bucket.LocalUploadTokenHeader]+"x", strings.NewReader("12345")), ErrUnauthorized)
 
 	forged, err := f.service.uploadToken(types.BuildRecord{ID: testBuildID, AppID: testBuildApp, AppIdentifierID: otherBuildID})
 	require.NoError(t, err)
-	var missing *store.ErrResourceNotFound
-	require.ErrorAs(t, f.service.UploadLocal(ctx, forged, strings.NewReader("12345")), &missing)
+	require.ErrorIs(t, f.service.UploadLocal(ctx, testBuildApp, testBuildIdentifier, testBuildID, forged, strings.NewReader("12345")), ErrUnauthorized)
 
 	f.service.now = func() time.Time { return f.now.Add(11 * time.Minute) }
-	require.ErrorIs(t, f.service.UploadLocal(ctx, registration.LocalToken, strings.NewReader("12345")), ErrUnauthorized, "grants expire after ten minutes")
+	require.ErrorIs(t, f.service.UploadLocal(ctx, testBuildApp, testBuildIdentifier, testBuildID, registration.Upload.Headers[bucket.LocalUploadTokenHeader], strings.NewReader("12345")), ErrUnauthorized, "grants expire after ten minutes")
 }
 
 func TestBuildTokenRejectsOtherSecret(t *testing.T) {
@@ -631,7 +659,27 @@ func TestBuildTokenRejectsOtherSecret(t *testing.T) {
 	registration, err := f.service.RegisterArtifact(ctx, testBuildApp, testBuildIdentifier, testBuildID, f.registerInput([]byte("x")))
 	require.NoError(t, err)
 	t.Setenv("JWT_SECRET", "rotated")
-	require.ErrorIs(t, f.service.UploadLocal(ctx, registration.LocalToken, strings.NewReader("x")), ErrUnauthorized)
+	require.ErrorIs(t, f.service.UploadLocal(ctx, testBuildApp, testBuildIdentifier, testBuildID, registration.Upload.Headers[bucket.LocalUploadTokenHeader], strings.NewReader("x")), ErrUnauthorized)
+}
+
+func TestBuildLocalUploadTokenIsBoundToRequestedTarget(t *testing.T) {
+	f := newBuildFixture(t)
+	registration, err := f.service.RegisterArtifact(context.Background(), testBuildApp, testBuildIdentifier, testBuildID, f.registerInput([]byte("apk")))
+	require.NoError(t, err)
+	token := registration.Upload.Headers[bucket.LocalUploadTokenHeader]
+	require.NotEmpty(t, token)
+	for _, target := range []struct{ app, identifier, build string }{
+		{otherBuildID, testBuildIdentifier, testBuildID},
+		{testBuildApp, otherBuildID, testBuildID},
+		{testBuildApp, testBuildIdentifier, otherBuildID},
+	} {
+		body := strings.NewReader("apk")
+		err := f.service.UploadLocal(context.Background(), target.app, target.identifier, target.build, token, body)
+		require.ErrorIs(t, err, ErrUnauthorized)
+		require.Equal(t, 3, body.Len(), "rejected grants must not consume the body")
+	}
+	_, err = os.Stat(f.stagedPath(t, *registration.Build))
+	require.True(t, os.IsNotExist(err))
 }
 
 func TestBuildConcurrentRegistrationsAgree(t *testing.T) {

--- a/internal/services/build_service_test.go
+++ b/internal/services/build_service_test.go
@@ -1,0 +1,588 @@
+package services
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+	"xprem/internal/bucket"
+	"xprem/internal/store"
+	"xprem/internal/types"
+	"xprem/internal/validation"
+
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testBuildApp        = "11111111-1111-4111-8111-111111111111"
+	testBuildIdentifier = "22222222-2222-4222-8222-222222222222"
+	testBuildID         = "3a3a3a3a-3a3a-4a3a-8a3a-3a3a3a3a3a3a"
+	otherBuildID        = "4b4b4b4b-4b4b-4b4b-8b4b-4b4b4b4b4b4b"
+)
+
+type memoryBuildRepo struct {
+	mu     sync.Mutex
+	builds map[string]types.BuildRecord
+	err    error
+}
+
+func newMemoryBuildRepo() *memoryBuildRepo {
+	return &memoryBuildRepo{builds: map[string]types.BuildRecord{}}
+}
+
+func (r *memoryBuildRepo) Create(_ context.Context, record types.BuildRecord) (*types.BuildRecord, bool, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.err != nil {
+		return nil, false, r.err
+	}
+	if existing, ok := r.builds[record.ID]; ok {
+		if existing.AppID != record.AppID {
+			return nil, false, &store.ErrResourceNotFound{Resource: "build", Identifier: record.ID}
+		}
+		return &existing, false, nil
+	}
+	record.CreatedAt, record.UpdatedAt = time.Now(), time.Now()
+	r.builds[record.ID] = record
+	return &record, true, nil
+}
+
+func (r *memoryBuildRepo) Get(_ context.Context, appID, id string) (*types.BuildRecord, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.err != nil {
+		return nil, r.err
+	}
+	record, ok := r.builds[id]
+	if !ok || record.AppID != appID {
+		return nil, &store.ErrResourceNotFound{Resource: "build", Identifier: id}
+	}
+	return &record, nil
+}
+
+func (r *memoryBuildRepo) List(_ context.Context, appID string, _, _ int32) ([]types.BuildRecord, int64, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	var records []types.BuildRecord
+	for _, record := range r.builds {
+		if record.AppID == appID {
+			records = append(records, record)
+		}
+	}
+	return records, int64(len(records)), nil
+}
+
+func (r *memoryBuildRepo) Transition(ctx context.Context, appID, id string, decide func(types.BuildRecord) (*types.BuildRecord, error)) (*types.BuildRecord, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	current, ok := r.builds[id]
+	if !ok || current.AppID != appID {
+		return nil, &store.ErrResourceNotFound{Resource: "build", Identifier: id}
+	}
+	next, err := decide(current)
+	if err != nil {
+		return nil, err
+	}
+	if next == nil {
+		return &current, nil
+	}
+	if next.Status == types.BuildStatusReady {
+		if next.ReadyAt == nil {
+			now := time.Now()
+			next.ReadyAt = &now
+		}
+	} else {
+		next.ReadyAt = nil
+	}
+	next.UpdatedAt = time.Now()
+	r.builds[id] = *next
+	return next, nil
+}
+
+type buildFixture struct {
+	service *BuildService
+	repo    *memoryBuildRepo
+	storage *bucket.BuildArtifactStorage
+	root    string
+	now     time.Time
+}
+
+func newBuildFixture(t *testing.T) *buildFixture {
+	t.Helper()
+	t.Setenv("JWT_SECRET", "test-secret")
+	identifiers := newFakeIdentifierRepo(testBuildApp)
+	identifiers.add(testBuildIdentifier, types.PlatformAndroid, "com.example.app")
+	identifiers.add(otherBuildID, types.PlatformIOS, "com.example.ios")
+	root := t.TempDir()
+	storage := bucket.NewBuildArtifactStorage(&bucket.LocalBucket{BasePath: root})
+	repo := newMemoryBuildRepo()
+	service := NewBuildService(repo, identifiers, storage)
+	now := time.Date(2026, 9, 9, 12, 0, 0, 0, time.UTC)
+	service.now = func() time.Time { return now }
+	return &buildFixture{service: service, repo: repo, storage: storage, root: root, now: now}
+}
+
+func (f *buildFixture) startInput() BuildStartInput {
+	return BuildStartInput{ArtifactType: "apk", Metadata: BuildStartMetadata{Profile: "production", Mode: "release", Channel: "stable", CLIVersion: "1.2.3", GitCommit: "abc123", GitMessage: "release", GitDirty: true, StartedAt: f.now.Add(-10 * time.Minute)}}
+}
+
+func (f *buildFixture) registerInput(content []byte) RegisterBuildInput {
+	sum := sha256.Sum256(content)
+	start := f.startInput().Metadata
+	return RegisterBuildInput{ArtifactType: "apk", Size: int64(len(content)), SHA256: hex.EncodeToString(sum[:]), Metadata: types.BuildMetadata{
+		Profile: start.Profile, Mode: start.Mode, Channel: start.Channel, CLIVersion: start.CLIVersion, GitCommit: start.GitCommit, GitMessage: start.GitMessage, GitDirty: start.GitDirty, StartedAt: start.StartedAt,
+		Version: "1.0.0", BuildNumber: "42", Fingerprint: strings.Repeat("a", 40), RuntimeVersion: "1.0.0", ExpoSDK: "54.0.0", FinishedAt: f.now.Add(-time.Minute), DurationMs: 999999,
+	}}
+}
+
+func (f *buildFixture) stagedPath(t *testing.T, b types.BuildRecord) string {
+	key, err := artifactRef(b).Key(true)
+	require.NoError(t, err)
+	return filepath.Join(f.root, key)
+}
+
+func (f *buildFixture) finalPath(t *testing.T, b types.BuildRecord) string {
+	key, err := artifactRef(b).Key(false)
+	require.NoError(t, err)
+	return filepath.Join(f.root, key)
+}
+
+func TestBuildStartRecordsBuildingAndIsIdempotent(t *testing.T) {
+	f := newBuildFixture(t)
+	ctx := WithCliAuth(context.Background(), CliCredential{AppID: testBuildApp, KeyID: 7, KeyName: "ci-key"})
+	input := f.startInput()
+	input.Metadata.StartedAt = input.Metadata.StartedAt.Add(300 * time.Nanosecond)
+	first, err := f.service.Start(ctx, testBuildApp, testBuildIdentifier, testBuildID, input)
+	require.NoError(t, err)
+	require.Equal(t, types.BuildStatusBuilding, first.Status)
+	require.Equal(t, "com.example.app", first.ApplicationID)
+	require.Equal(t, "apk", first.ArtifactType)
+	require.Equal(t, "release", first.Metadata.Mode)
+	require.Zero(t, first.Size)
+	require.Empty(t, first.SHA256)
+	require.Empty(t, first.Metadata.Fingerprint)
+	require.True(t, first.Metadata.FinishedAt.IsZero())
+	require.Zero(t, first.Metadata.DurationMs)
+	require.Equal(t, "api_key", first.ActorType)
+	require.Equal(t, "7", first.ActorID)
+	require.Equal(t, "ci-key", first.ActorDisplay)
+	require.Equal(t, f.now.Add(-10*time.Minute), first.Metadata.StartedAt, "sub-microsecond precision is dropped before storage")
+
+	again, err := f.service.Start(WithCliAuth(context.Background(), CliCredential{AppID: testBuildApp, KeyID: 9, KeyName: "other"}), testBuildApp, testBuildIdentifier, testBuildID, input)
+	require.NoError(t, err)
+	require.Equal(t, first.ID, again.ID)
+	require.Equal(t, "7", again.ActorID, "the first actor is retained")
+	require.Len(t, f.repo.builds, 1)
+
+	changed := input
+	changed.Metadata.Profile = "preview"
+	_, err = f.service.Start(ctx, testBuildApp, testBuildIdentifier, testBuildID, changed)
+	require.ErrorIs(t, err, ErrBuildConflict)
+	changed = input
+	changed.ArtifactType = "aab"
+	_, err = f.service.Start(ctx, testBuildApp, testBuildIdentifier, testBuildID, changed)
+	require.ErrorIs(t, err, ErrBuildConflict)
+	changed = input
+	changed.Metadata.GitDirty = false
+	_, err = f.service.Start(ctx, testBuildApp, testBuildIdentifier, testBuildID, changed)
+	require.ErrorIs(t, err, ErrBuildConflict)
+	changed = input
+	changed.Metadata.Mode = "debug"
+	_, err = f.service.Start(ctx, testBuildApp, testBuildIdentifier, testBuildID, changed)
+	require.ErrorIs(t, err, ErrBuildConflict)
+	changedUpload := f.registerInput([]byte("apk"))
+	changedUpload.Metadata.Mode = "debug"
+	_, err = f.service.Begin(ctx, testBuildApp, testBuildIdentifier, testBuildID, changedUpload)
+	require.ErrorIs(t, err, ErrBuildConflict)
+}
+
+func TestBuildModePreservedAndOptionalForOlderClients(t *testing.T) {
+	for _, mode := range []string{"release", "debug", ""} {
+		t.Run("mode="+mode, func(t *testing.T) {
+			f := newBuildFixture(t)
+			input := f.startInput()
+			input.Metadata.Mode = mode
+			started, err := f.service.Start(context.Background(), testBuildApp, testBuildIdentifier, testBuildID, input)
+			require.NoError(t, err)
+			require.Equal(t, mode, started.Metadata.Mode)
+			upload := f.registerInput([]byte("apk"))
+			upload.Metadata.Mode = mode
+			registered, err := f.service.Begin(context.Background(), testBuildApp, testBuildIdentifier, testBuildID, upload)
+			require.NoError(t, err)
+			require.Equal(t, mode, registered.Build.Metadata.Mode)
+		})
+	}
+}
+
+func TestBuildStartValidation(t *testing.T) {
+	f := newBuildFixture(t)
+	ctx := context.Background()
+	for name, mutate := range map[string]func(*BuildStartInput){
+		"artifact type": func(i *BuildStartInput) { i.ArtifactType = "ipa" },
+		"profile":       func(i *BuildStartInput) { i.Metadata.Profile = "" },
+		"mode":          func(i *BuildStartInput) { i.Metadata.Mode = "production" },
+		"cli version":   func(i *BuildStartInput) { i.Metadata.CLIVersion = "" },
+		"zero start":    func(i *BuildStartInput) { i.Metadata.StartedAt = time.Time{} },
+		"future start":  func(i *BuildStartInput) { i.Metadata.StartedAt = f.now.Add(10 * time.Minute) },
+		"long channel":  func(i *BuildStartInput) { i.Metadata.Channel = strings.Repeat("c", 256) },
+		"long message":  func(i *BuildStartInput) { i.Metadata.GitMessage = strings.Repeat("m", 1001) },
+	} {
+		t.Run(name, func(t *testing.T) {
+			input := f.startInput()
+			mutate(&input)
+			_, err := f.service.Start(ctx, testBuildApp, testBuildIdentifier, testBuildID, input)
+			require.True(t, validation.IsValidationError(err), "%v", err)
+			require.Empty(t, f.repo.builds)
+		})
+	}
+	_, err := f.service.Start(ctx, testBuildApp, testBuildIdentifier, "not-a-uuid", f.startInput())
+	require.True(t, validation.IsValidationError(err))
+	_, err = f.service.Start(ctx, testBuildApp, testBuildIdentifier, strings.ToUpper(testBuildID), f.startInput())
+	require.True(t, validation.IsValidationError(err), "only canonical lowercase UUIDs")
+	_, err = f.service.Start(ctx, testBuildApp, otherBuildID, testBuildID, f.startInput())
+	require.True(t, validation.IsValidationError(err), "iOS identifiers are refused")
+	var missing *store.ErrResourceNotFound
+	_, err = f.service.Start(ctx, testBuildApp, "55555555-5555-4555-8555-555555555555", testBuildID, f.startInput())
+	require.ErrorAs(t, err, &missing)
+	_, err = f.service.Start(ctx, "other-app", testBuildIdentifier, testBuildID, f.startInput())
+	require.ErrorAs(t, err, &missing)
+	require.Empty(t, f.repo.builds)
+
+	stateless := NewBuildService(nil, nil, nil)
+	_, err = stateless.Start(ctx, testBuildApp, testBuildIdentifier, testBuildID, f.startInput())
+	require.ErrorIs(t, err, store.ErrNotSupportedInStatelessMode)
+	_, err = stateless.Fail(ctx, testBuildApp, testBuildIdentifier, testBuildID, FailBuildInput{FinishedAt: time.Now().Add(-time.Hour)})
+	require.ErrorIs(t, err, store.ErrNotSupportedInStatelessMode)
+}
+
+func TestBuildRegisterValidation(t *testing.T) {
+	f := newBuildFixture(t)
+	ctx := context.Background()
+	for name, mutate := range map[string]func(*RegisterBuildInput){
+		"size zero":          func(i *RegisterBuildInput) { i.Size = 0 },
+		"size too large":     func(i *RegisterBuildInput) { i.Size = MaxBuildSize + 1 },
+		"sha uppercase":      func(i *RegisterBuildInput) { i.SHA256 = strings.ToUpper(i.SHA256) },
+		"sha short":          func(i *RegisterBuildInput) { i.SHA256 = i.SHA256[:63] },
+		"version code zero":  func(i *RegisterBuildInput) { i.Metadata.BuildNumber = "0" },
+		"version code limit": func(i *RegisterBuildInput) { i.Metadata.BuildNumber = "2100000001" },
+		"version code text":  func(i *RegisterBuildInput) { i.Metadata.BuildNumber = "1.2" },
+		"fingerprint short":  func(i *RegisterBuildInput) { i.Metadata.Fingerprint = strings.Repeat("a", 39) },
+		"fingerprint upper":  func(i *RegisterBuildInput) { i.Metadata.Fingerprint = strings.Repeat("A", 64) },
+		"fingerprint empty":  func(i *RegisterBuildInput) { i.Metadata.Fingerprint = "" },
+		"finished before":    func(i *RegisterBuildInput) { i.Metadata.FinishedAt = i.Metadata.StartedAt.Add(-time.Second) },
+		"finished zero":      func(i *RegisterBuildInput) { i.Metadata.FinishedAt = time.Time{} },
+		"finished future":    func(i *RegisterBuildInput) { i.Metadata.FinishedAt = f.now.Add(time.Hour) },
+		"too long":           func(i *RegisterBuildInput) { i.Metadata.StartedAt = f.now.Add(-8 * 24 * time.Hour) },
+		"profile":            func(i *RegisterBuildInput) { i.Metadata.Profile = "" },
+		"mode":               func(i *RegisterBuildInput) { i.Metadata.Mode = "production" },
+		"long version":       func(i *RegisterBuildInput) { i.Metadata.Version = strings.Repeat("v", 256) },
+	} {
+		t.Run(name, func(t *testing.T) {
+			input := f.registerInput([]byte("apk"))
+			mutate(&input)
+			_, err := f.service.Begin(ctx, testBuildApp, testBuildIdentifier, testBuildID, input)
+			require.True(t, validation.IsValidationError(err), "%v", err)
+			require.Empty(t, f.repo.builds)
+		})
+	}
+	input := f.registerInput([]byte("apk"))
+	input.Metadata.BuildNumber = "2100000000"
+	input.Metadata.Fingerprint = strings.Repeat("f", 64)
+	_, err := f.service.Begin(ctx, testBuildApp, testBuildIdentifier, testBuildID, input)
+	require.NoError(t, err)
+}
+
+func TestBuildLifecycleStartUploadComplete(t *testing.T) {
+	f := newBuildFixture(t)
+	ctx := WithCliAuth(context.Background(), CliCredential{AppID: testBuildApp, KeyID: 7, KeyName: "ci-key"})
+	content := []byte("signed apk bytes")
+	started, err := f.service.Start(ctx, testBuildApp, testBuildIdentifier, testBuildID, f.startInput())
+	require.NoError(t, err)
+
+	registration, err := f.service.Begin(context.Background(), testBuildApp, testBuildIdentifier, testBuildID, f.registerInput(content))
+	require.NoError(t, err)
+	b := registration.Build
+	require.Equal(t, types.BuildStatusUploading, b.Status)
+	require.Equal(t, int64(len(content)), b.Size)
+	require.Equal(t, "42", b.Metadata.BuildNumber)
+	require.Equal(t, "stable", b.Metadata.Channel)
+	require.Equal(t, "release", b.Metadata.Mode)
+	require.Equal(t, started.CreatedAt, b.CreatedAt)
+	require.Equal(t, "7", b.ActorID, "the starting actor is retained through the upload")
+	require.Equal(t, int64(9*time.Minute/time.Millisecond), b.Metadata.DurationMs, "duration is computed by the server, not taken from the client")
+	require.NotNil(t, registration.Upload)
+	require.Equal(t, "PUT", registration.Upload.Method)
+	require.Empty(t, registration.Upload.URL, "local storage hands out a token instead of a presigned URL")
+	require.NotEmpty(t, registration.LocalToken)
+
+	retry, err := f.service.Begin(context.Background(), testBuildApp, testBuildIdentifier, testBuildID, f.registerInput(content))
+	require.NoError(t, err)
+	require.Equal(t, types.BuildStatusUploading, retry.Build.Status)
+	require.NotEmpty(t, retry.LocalToken, "an identical retry gets a fresh upload grant")
+
+	_, err = f.service.Complete(ctx, testBuildApp, testBuildIdentifier, testBuildID)
+	require.ErrorIs(t, err, ErrBuildIntegrity, "nothing staged yet")
+	afterMissing, err := f.service.Get(ctx, testBuildApp, testBuildID)
+	require.NoError(t, err)
+	require.Equal(t, types.BuildStatusFailed, afterMissing.Status)
+	require.Equal(t, f.now, afterMissing.Metadata.FinishedAt, "failure time is the server clock")
+	require.Equal(t, int64(len(content)), afterMissing.Size, "the declared artifact is kept on a failed upload")
+
+	retry, err = f.service.Begin(context.Background(), testBuildApp, testBuildIdentifier, testBuildID, f.registerInput(content))
+	require.NoError(t, err)
+	require.Equal(t, types.BuildStatusUploading, retry.Build.Status, "a failed upload can be retried with the same artifact")
+	require.NoError(t, f.service.UploadLocal(ctx, retry.LocalToken, bytes.NewReader(content)))
+	staged, err := os.ReadFile(f.stagedPath(t, *retry.Build))
+	require.NoError(t, err)
+	require.Equal(t, content, staged)
+
+	ready, err := f.service.Complete(ctx, testBuildApp, testBuildIdentifier, testBuildID)
+	require.NoError(t, err)
+	require.Equal(t, types.BuildStatusReady, ready.Status)
+	require.Equal(t, "release", ready.Metadata.Mode)
+	require.NotNil(t, ready.ReadyAt)
+	require.Equal(t, f.now.Add(-time.Minute), ready.Metadata.FinishedAt, "ready keeps the client's compile end time")
+	final, err := os.ReadFile(f.finalPath(t, *ready))
+	require.NoError(t, err)
+	require.Equal(t, content, final)
+	_, err = os.Stat(f.stagedPath(t, *ready))
+	require.True(t, os.IsNotExist(err), "staging is cleaned after publication")
+
+	again, err := f.service.Complete(ctx, testBuildApp, testBuildIdentifier, testBuildID)
+	require.NoError(t, err)
+	require.Equal(t, ready.ReadyAt, again.ReadyAt, "complete is idempotent")
+
+	registration, err = f.service.Begin(context.Background(), testBuildApp, testBuildIdentifier, testBuildID, f.registerInput(content))
+	require.NoError(t, err)
+	require.Equal(t, types.BuildStatusReady, registration.Build.Status)
+	require.Nil(t, registration.Upload, "a ready build gets no upload grant")
+	require.Empty(t, registration.LocalToken)
+
+	failed, err := f.service.Fail(ctx, testBuildApp, testBuildIdentifier, testBuildID, FailBuildInput{FinishedAt: f.now})
+	require.NoError(t, err)
+	require.Equal(t, types.BuildStatusReady, failed.Status, "ready never regresses")
+
+	file, err := f.service.Download(ctx, *ready)
+	require.NoError(t, err)
+	downloaded, err := io.ReadAll(file.Reader)
+	require.NoError(t, err)
+	require.NoError(t, file.Reader.Close())
+	require.Equal(t, content, downloaded)
+	_, err = f.service.Download(ctx, *afterMissing)
+	require.ErrorIs(t, err, ErrBuildNotReady)
+}
+
+func TestBuildRegisterWithoutStart(t *testing.T) {
+	f := newBuildFixture(t)
+	ctx := context.Background()
+	content := []byte("direct")
+	registration, err := f.service.Begin(ctx, testBuildApp, testBuildIdentifier, testBuildID, f.registerInput(content))
+	require.NoError(t, err)
+	require.Equal(t, types.BuildStatusUploading, registration.Build.Status)
+	require.Len(t, f.repo.builds, 1)
+
+	changed := f.registerInput([]byte("different"))
+	_, err = f.service.Begin(ctx, testBuildApp, testBuildIdentifier, testBuildID, changed)
+	require.ErrorIs(t, err, ErrBuildConflict, "checksum is immutable once declared")
+	changed = f.registerInput(content)
+	changed.Metadata.BuildNumber = "43"
+	_, err = f.service.Begin(ctx, testBuildApp, testBuildIdentifier, testBuildID, changed)
+	require.ErrorIs(t, err, ErrBuildConflict, "no second allocation on the same build")
+	changed = f.registerInput(content)
+	changed.Metadata.Profile = "preview"
+	_, err = f.service.Begin(ctx, testBuildApp, testBuildIdentifier, testBuildID, changed)
+	require.ErrorIs(t, err, ErrBuildConflict)
+	changed = f.registerInput(content)
+	changed.Metadata.FinishedAt = changed.Metadata.FinishedAt.Add(time.Second)
+	_, err = f.service.Begin(ctx, testBuildApp, testBuildIdentifier, testBuildID, changed)
+	require.ErrorIs(t, err, ErrBuildConflict)
+
+	_, err = f.service.Start(ctx, testBuildApp, testBuildIdentifier, testBuildID, f.startInput())
+	require.NoError(t, err, "a late start with the same inputs is a no-op")
+	current, err := f.service.Get(ctx, testBuildApp, testBuildID)
+	require.NoError(t, err)
+	require.Equal(t, types.BuildStatusUploading, current.Status)
+
+	_, err = f.service.Complete(ctx, "other-app", testBuildIdentifier, testBuildID)
+	var missing *store.ErrResourceNotFound
+	require.ErrorAs(t, err, &missing)
+	_, err = f.service.Complete(ctx, testBuildApp, otherBuildID, testBuildID)
+	require.ErrorAs(t, err, &missing, "the build belongs to another identifier")
+	_, err = f.service.Fail(ctx, testBuildApp, otherBuildID, testBuildID, FailBuildInput{FinishedAt: f.now})
+	require.ErrorAs(t, err, &missing)
+}
+
+func TestBuildFailFromBuilding(t *testing.T) {
+	f := newBuildFixture(t)
+	ctx := context.Background()
+	_, err := f.service.Start(ctx, testBuildApp, testBuildIdentifier, testBuildID, f.startInput())
+	require.NoError(t, err)
+
+	_, err = f.service.Fail(ctx, testBuildApp, testBuildIdentifier, testBuildID, FailBuildInput{})
+	require.True(t, validation.IsValidationError(err))
+	_, err = f.service.Fail(ctx, testBuildApp, testBuildIdentifier, testBuildID, FailBuildInput{FinishedAt: f.now.Add(time.Hour)})
+	require.True(t, validation.IsValidationError(err))
+	_, err = f.service.Fail(ctx, testBuildApp, testBuildIdentifier, testBuildID, FailBuildInput{FinishedAt: f.now.Add(-time.Hour)})
+	require.True(t, validation.IsValidationError(err), "finishedAt before startedAt")
+	current, err := f.service.Get(ctx, testBuildApp, testBuildID)
+	require.NoError(t, err)
+	require.Equal(t, types.BuildStatusBuilding, current.Status)
+
+	failed, err := f.service.Fail(ctx, testBuildApp, testBuildIdentifier, testBuildID, FailBuildInput{FinishedAt: f.now.Add(-2*time.Minute + 700*time.Nanosecond)})
+	require.NoError(t, err)
+	require.Equal(t, types.BuildStatusFailed, failed.Status)
+	require.Equal(t, f.now.Add(-2*time.Minute), failed.Metadata.FinishedAt)
+	require.Equal(t, int64(8*time.Minute/time.Millisecond), failed.Metadata.DurationMs)
+	require.Zero(t, failed.Size)
+	require.Empty(t, failed.Metadata.Fingerprint)
+	require.Nil(t, failed.ReadyAt)
+
+	again, err := f.service.Fail(ctx, testBuildApp, testBuildIdentifier, testBuildID, FailBuildInput{FinishedAt: f.now})
+	require.NoError(t, err)
+	require.Equal(t, failed.Metadata.FinishedAt, again.Metadata.FinishedAt, "the first failure report wins")
+
+	_, err = f.service.Complete(ctx, testBuildApp, testBuildIdentifier, testBuildID)
+	require.ErrorIs(t, err, ErrBuildState)
+	still, err := f.service.Get(ctx, testBuildApp, testBuildID)
+	require.NoError(t, err)
+	require.Equal(t, types.BuildStatusFailed, still.Status)
+
+	_, err = f.service.Start(ctx, testBuildApp, testBuildIdentifier, testBuildID, f.startInput())
+	require.NoError(t, err, "re-declaring the failed build with identical inputs is idempotent")
+	_, err = f.service.Fail(ctx, testBuildApp, testBuildIdentifier, otherBuildID, FailBuildInput{FinishedAt: f.now})
+	var missing *store.ErrResourceNotFound
+	require.ErrorAs(t, err, &missing)
+}
+
+func TestBuildFailFromUploadingDiscardsStaging(t *testing.T) {
+	f := newBuildFixture(t)
+	ctx := context.Background()
+	content := []byte("partial")
+	registration, err := f.service.Begin(ctx, testBuildApp, testBuildIdentifier, testBuildID, f.registerInput(content))
+	require.NoError(t, err)
+	require.NoError(t, f.service.UploadLocal(ctx, registration.LocalToken, bytes.NewReader(content)))
+	_, err = os.Stat(f.stagedPath(t, *registration.Build))
+	require.NoError(t, err)
+
+	failed, err := f.service.Fail(ctx, testBuildApp, testBuildIdentifier, testBuildID, FailBuildInput{FinishedAt: f.now})
+	require.NoError(t, err)
+	require.Equal(t, types.BuildStatusFailed, failed.Status)
+	require.Equal(t, f.now, failed.Metadata.FinishedAt)
+	require.Equal(t, int64(len(content)), failed.Size, "the failed row keeps what was declared")
+	_, err = os.Stat(f.stagedPath(t, *registration.Build))
+	require.True(t, os.IsNotExist(err))
+
+	require.ErrorIs(t, f.service.UploadLocal(ctx, registration.LocalToken, bytes.NewReader(content)), ErrBuildState, "an old grant cannot upload into a failed build")
+	_, err = f.service.Complete(ctx, testBuildApp, testBuildIdentifier, testBuildID)
+	require.ErrorIs(t, err, ErrBuildState)
+}
+
+func TestBuildCompleteRequiresUploadingState(t *testing.T) {
+	f := newBuildFixture(t)
+	ctx := context.Background()
+	_, err := f.service.Start(ctx, testBuildApp, testBuildIdentifier, testBuildID, f.startInput())
+	require.NoError(t, err)
+	_, err = f.service.Complete(ctx, testBuildApp, testBuildIdentifier, testBuildID)
+	require.ErrorIs(t, err, ErrBuildState)
+	current, err := f.service.Get(ctx, testBuildApp, testBuildID)
+	require.NoError(t, err)
+	require.Equal(t, types.BuildStatusBuilding, current.Status, "a premature complete does not fail the build")
+	_, err = f.service.Complete(ctx, testBuildApp, testBuildIdentifier, otherBuildID)
+	var missing *store.ErrResourceNotFound
+	require.ErrorAs(t, err, &missing)
+	_, err = f.service.Complete(ctx, testBuildApp, testBuildIdentifier, "bad")
+	require.True(t, validation.IsValidationError(err))
+}
+
+func TestBuildCompleteRejectsTamperedUpload(t *testing.T) {
+	f := newBuildFixture(t)
+	ctx := context.Background()
+	registration, err := f.service.Begin(ctx, testBuildApp, testBuildIdentifier, testBuildID, f.registerInput([]byte("declared")))
+	require.NoError(t, err)
+	require.NoError(t, f.storage.Put(ctx, artifactRef(*registration.Build), true, strings.NewReader("tampered")))
+	_, err = f.service.Complete(ctx, testBuildApp, testBuildIdentifier, testBuildID)
+	require.ErrorIs(t, err, ErrBuildIntegrity)
+	_, err = os.Stat(f.finalPath(t, *registration.Build))
+	require.True(t, os.IsNotExist(err), "nothing is published on a checksum mismatch")
+	failed, err := f.service.Get(ctx, testBuildApp, testBuildID)
+	require.NoError(t, err)
+	require.Equal(t, types.BuildStatusFailed, failed.Status)
+
+	registration, err = f.service.Begin(ctx, testBuildApp, testBuildIdentifier, testBuildID, f.registerInput([]byte("declared")))
+	require.NoError(t, err)
+	require.Equal(t, types.BuildStatusUploading, registration.Build.Status)
+	require.NoError(t, f.service.UploadLocal(ctx, registration.LocalToken, strings.NewReader("declared")))
+	ready, err := f.service.Complete(ctx, testBuildApp, testBuildIdentifier, testBuildID)
+	require.NoError(t, err)
+	require.Equal(t, types.BuildStatusReady, ready.Status)
+}
+
+func TestBuildUploadLocalBounds(t *testing.T) {
+	f := newBuildFixture(t)
+	ctx := context.Background()
+	registration, err := f.service.Begin(ctx, testBuildApp, testBuildIdentifier, testBuildID, f.registerInput([]byte("12345")))
+	require.NoError(t, err)
+
+	err = f.service.UploadLocal(ctx, registration.LocalToken, strings.NewReader("123456"))
+	require.ErrorIs(t, err, ErrBuildIntegrity)
+	_, err = os.Stat(f.stagedPath(t, *registration.Build))
+	require.True(t, os.IsNotExist(err), "an oversized body is not kept")
+
+	require.ErrorIs(t, f.service.UploadLocal(ctx, "not-a-token", strings.NewReader("12345")), ErrUnauthorized)
+	require.ErrorIs(t, f.service.UploadLocal(ctx, registration.LocalToken+"x", strings.NewReader("12345")), ErrUnauthorized)
+
+	forged, err := f.service.uploadToken(types.BuildRecord{ID: testBuildID, AppID: testBuildApp, AppIdentifierID: otherBuildID})
+	require.NoError(t, err)
+	var missing *store.ErrResourceNotFound
+	require.ErrorAs(t, f.service.UploadLocal(ctx, forged, strings.NewReader("12345")), &missing)
+
+	f.service.now = func() time.Time { return f.now.Add(11 * time.Minute) }
+	require.ErrorIs(t, f.service.UploadLocal(ctx, registration.LocalToken, strings.NewReader("12345")), ErrUnauthorized, "grants expire after ten minutes")
+}
+
+func TestBuildTokenRejectsOtherSecret(t *testing.T) {
+	f := newBuildFixture(t)
+	ctx := context.Background()
+	registration, err := f.service.Begin(ctx, testBuildApp, testBuildIdentifier, testBuildID, f.registerInput([]byte("x")))
+	require.NoError(t, err)
+	t.Setenv("JWT_SECRET", "rotated")
+	require.ErrorIs(t, f.service.UploadLocal(ctx, registration.LocalToken, strings.NewReader("x")), ErrUnauthorized)
+}
+
+func TestBuildConcurrentRegistrationsAgree(t *testing.T) {
+	f := newBuildFixture(t)
+	ctx := context.Background()
+	content := []byte("race")
+	const workers = 12
+	var wg sync.WaitGroup
+	results := make(chan error, workers)
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			var err error
+			if i%2 == 0 {
+				_, err = f.service.Start(ctx, testBuildApp, testBuildIdentifier, testBuildID, f.startInput())
+			} else {
+				_, err = f.service.Begin(ctx, testBuildApp, testBuildIdentifier, testBuildID, f.registerInput(content))
+			}
+			results <- err
+		}(i)
+	}
+	wg.Wait()
+	close(results)
+	for err := range results {
+		require.NoError(t, err)
+	}
+	require.Len(t, f.repo.builds, 1)
+	current, err := f.service.Get(ctx, testBuildApp, testBuildID)
+	require.NoError(t, err)
+	require.Equal(t, types.BuildStatusUploading, current.Status)
+}

--- a/internal/services/build_service_test.go
+++ b/internal/services/build_service_test.go
@@ -17,6 +17,7 @@ import (
 	"xprem/internal/types"
 	"xprem/internal/validation"
 
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/require"
 )
 
@@ -124,7 +125,7 @@ func newBuildFixture(t *testing.T) *buildFixture {
 	storage := &bucket.LocalBucket{BasePath: root}
 	repo := newMemoryBuildRepo()
 	service := NewBuildService(repo, identifiers, storage)
-	now := time.Date(2026, 9, 9, 12, 0, 0, 0, time.UTC)
+	now := time.Now().UTC().Truncate(time.Microsecond)
 	service.now = func() time.Time { return now }
 	return &buildFixture{service: service, repo: repo, storage: storage, root: root, now: now}
 }
@@ -645,12 +646,18 @@ func TestBuildUploadLocalBounds(t *testing.T) {
 	require.ErrorIs(t, f.service.UploadLocal(ctx, testBuildApp, testBuildIdentifier, testBuildID, "not-a-token", strings.NewReader("12345")), ErrUnauthorized)
 	require.ErrorIs(t, f.service.UploadLocal(ctx, testBuildApp, testBuildIdentifier, testBuildID, registration.Upload.Headers[bucket.LocalUploadTokenHeader]+"x", strings.NewReader("12345")), ErrUnauthorized)
 
-	forged, err := f.service.uploadToken(types.BuildRecord{ID: testBuildID, AppID: testBuildApp, AppIdentifierID: otherBuildID})
+	otherUpload, err := f.storage.RequestBuildArtifactUploadURL(ctx, testBuildApp, bucket.BuildArtifact{IdentifierID: otherBuildID, BuildID: testBuildID, Type: types.BuildArtifactAPK})
 	require.NoError(t, err)
-	require.ErrorIs(t, f.service.UploadLocal(ctx, testBuildApp, testBuildIdentifier, testBuildID, forged, strings.NewReader("12345")), ErrUnauthorized)
+	require.ErrorIs(t, f.service.UploadLocal(ctx, testBuildApp, testBuildIdentifier, testBuildID, otherUpload.Headers[bucket.LocalUploadTokenHeader], strings.NewReader("12345")), ErrUnauthorized)
 
-	f.service.now = func() time.Time { return f.now.Add(11 * time.Minute) }
-	require.ErrorIs(t, f.service.UploadLocal(ctx, testBuildApp, testBuildIdentifier, testBuildID, registration.Upload.Headers[bucket.LocalUploadTokenHeader], strings.NewReader("12345")), ErrUnauthorized, "grants expire after ten minutes")
+	expiredToken, err := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		"sub": "build-upload", "exp": time.Now().Add(-time.Minute).Unix(),
+		"appId": testBuildApp, "identifierId": testBuildIdentifier, "buildId": testBuildID,
+	}).SignedString([]byte("test-secret"))
+	require.NoError(t, err)
+	body := strings.NewReader("12345")
+	require.ErrorIs(t, f.service.UploadLocal(ctx, testBuildApp, testBuildIdentifier, testBuildID, expiredToken, body), ErrUnauthorized)
+	require.Equal(t, 5, body.Len(), "expired grants must not consume the body")
 }
 
 func TestBuildTokenRejectsOtherSecret(t *testing.T) {

--- a/internal/services/build_service_test.go
+++ b/internal/services/build_service_test.go
@@ -199,7 +199,7 @@ func TestBuildStartRecordsBuildingAndIsIdempotent(t *testing.T) {
 	require.ErrorIs(t, err, ErrBuildConflict)
 	changedUpload := f.registerInput([]byte("apk"))
 	changedUpload.Metadata.Mode = "debug"
-	_, err = f.service.Begin(ctx, testBuildApp, testBuildIdentifier, testBuildID, changedUpload)
+	_, err = f.service.RegisterArtifact(ctx, testBuildApp, testBuildIdentifier, testBuildID, changedUpload)
 	require.ErrorIs(t, err, ErrBuildConflict)
 }
 
@@ -214,7 +214,7 @@ func TestBuildModePreservedAndOptionalForOlderClients(t *testing.T) {
 			require.Equal(t, mode, started.Metadata.Mode)
 			upload := f.registerInput([]byte("apk"))
 			upload.Metadata.Mode = mode
-			registered, err := f.service.Begin(context.Background(), testBuildApp, testBuildIdentifier, testBuildID, upload)
+			registered, err := f.service.RegisterArtifact(context.Background(), testBuildApp, testBuildIdentifier, testBuildID, upload)
 			require.NoError(t, err)
 			require.Equal(t, mode, registered.Build.Metadata.Mode)
 		})
@@ -287,7 +287,7 @@ func TestBuildRegisterValidation(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			input := f.registerInput([]byte("apk"))
 			mutate(&input)
-			_, err := f.service.Begin(ctx, testBuildApp, testBuildIdentifier, testBuildID, input)
+			_, err := f.service.RegisterArtifact(ctx, testBuildApp, testBuildIdentifier, testBuildID, input)
 			require.True(t, validation.IsValidationError(err), "%v", err)
 			require.Empty(t, f.repo.builds)
 		})
@@ -295,7 +295,7 @@ func TestBuildRegisterValidation(t *testing.T) {
 	input := f.registerInput([]byte("apk"))
 	input.Metadata.BuildNumber = "2100000000"
 	input.Metadata.Fingerprint = strings.Repeat("f", 64)
-	_, err := f.service.Begin(ctx, testBuildApp, testBuildIdentifier, testBuildID, input)
+	_, err := f.service.RegisterArtifact(ctx, testBuildApp, testBuildIdentifier, testBuildID, input)
 	require.NoError(t, err)
 }
 
@@ -306,7 +306,7 @@ func TestBuildLifecycleStartUploadComplete(t *testing.T) {
 	started, err := f.service.Start(ctx, testBuildApp, testBuildIdentifier, testBuildID, f.startInput())
 	require.NoError(t, err)
 
-	registration, err := f.service.Begin(context.Background(), testBuildApp, testBuildIdentifier, testBuildID, f.registerInput(content))
+	registration, err := f.service.RegisterArtifact(context.Background(), testBuildApp, testBuildIdentifier, testBuildID, f.registerInput(content))
 	require.NoError(t, err)
 	b := registration.Build
 	require.Equal(t, types.BuildStatusUploading, b.Status)
@@ -322,7 +322,7 @@ func TestBuildLifecycleStartUploadComplete(t *testing.T) {
 	require.Empty(t, registration.Upload.URL, "local storage hands out a token instead of a presigned URL")
 	require.NotEmpty(t, registration.LocalToken)
 
-	retry, err := f.service.Begin(context.Background(), testBuildApp, testBuildIdentifier, testBuildID, f.registerInput(content))
+	retry, err := f.service.RegisterArtifact(context.Background(), testBuildApp, testBuildIdentifier, testBuildID, f.registerInput(content))
 	require.NoError(t, err)
 	require.Equal(t, types.BuildStatusUploading, retry.Build.Status)
 	require.NotEmpty(t, retry.LocalToken, "an identical retry gets a fresh upload grant")
@@ -335,7 +335,7 @@ func TestBuildLifecycleStartUploadComplete(t *testing.T) {
 	require.Equal(t, f.now, afterMissing.Metadata.FinishedAt, "failure time is the server clock")
 	require.Equal(t, int64(len(content)), afterMissing.Size, "the declared artifact is kept on a failed upload")
 
-	retry, err = f.service.Begin(context.Background(), testBuildApp, testBuildIdentifier, testBuildID, f.registerInput(content))
+	retry, err = f.service.RegisterArtifact(context.Background(), testBuildApp, testBuildIdentifier, testBuildID, f.registerInput(content))
 	require.NoError(t, err)
 	require.Equal(t, types.BuildStatusUploading, retry.Build.Status, "a failed upload can be retried with the same artifact")
 	require.NoError(t, f.service.UploadLocal(ctx, retry.LocalToken, bytes.NewReader(content)))
@@ -359,7 +359,7 @@ func TestBuildLifecycleStartUploadComplete(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, ready.ReadyAt, again.ReadyAt, "complete is idempotent")
 
-	registration, err = f.service.Begin(context.Background(), testBuildApp, testBuildIdentifier, testBuildID, f.registerInput(content))
+	registration, err = f.service.RegisterArtifact(context.Background(), testBuildApp, testBuildIdentifier, testBuildID, f.registerInput(content))
 	require.NoError(t, err)
 	require.Equal(t, types.BuildStatusReady, registration.Build.Status)
 	require.Nil(t, registration.Upload, "a ready build gets no upload grant")
@@ -383,25 +383,25 @@ func TestBuildRegisterWithoutStart(t *testing.T) {
 	f := newBuildFixture(t)
 	ctx := context.Background()
 	content := []byte("direct")
-	registration, err := f.service.Begin(ctx, testBuildApp, testBuildIdentifier, testBuildID, f.registerInput(content))
+	registration, err := f.service.RegisterArtifact(ctx, testBuildApp, testBuildIdentifier, testBuildID, f.registerInput(content))
 	require.NoError(t, err)
 	require.Equal(t, types.BuildStatusUploading, registration.Build.Status)
 	require.Len(t, f.repo.builds, 1)
 
 	changed := f.registerInput([]byte("different"))
-	_, err = f.service.Begin(ctx, testBuildApp, testBuildIdentifier, testBuildID, changed)
+	_, err = f.service.RegisterArtifact(ctx, testBuildApp, testBuildIdentifier, testBuildID, changed)
 	require.ErrorIs(t, err, ErrBuildConflict, "checksum is immutable once declared")
 	changed = f.registerInput(content)
 	changed.Metadata.BuildNumber = "43"
-	_, err = f.service.Begin(ctx, testBuildApp, testBuildIdentifier, testBuildID, changed)
+	_, err = f.service.RegisterArtifact(ctx, testBuildApp, testBuildIdentifier, testBuildID, changed)
 	require.ErrorIs(t, err, ErrBuildConflict, "no second allocation on the same build")
 	changed = f.registerInput(content)
 	changed.Metadata.Profile = "preview"
-	_, err = f.service.Begin(ctx, testBuildApp, testBuildIdentifier, testBuildID, changed)
+	_, err = f.service.RegisterArtifact(ctx, testBuildApp, testBuildIdentifier, testBuildID, changed)
 	require.ErrorIs(t, err, ErrBuildConflict)
 	changed = f.registerInput(content)
 	changed.Metadata.FinishedAt = changed.Metadata.FinishedAt.Add(time.Second)
-	_, err = f.service.Begin(ctx, testBuildApp, testBuildIdentifier, testBuildID, changed)
+	_, err = f.service.RegisterArtifact(ctx, testBuildApp, testBuildIdentifier, testBuildID, changed)
 	require.ErrorIs(t, err, ErrBuildConflict)
 
 	_, err = f.service.Start(ctx, testBuildApp, testBuildIdentifier, testBuildID, f.startInput())
@@ -465,7 +465,7 @@ func TestBuildFailFromUploadingDiscardsStaging(t *testing.T) {
 	f := newBuildFixture(t)
 	ctx := context.Background()
 	content := []byte("partial")
-	registration, err := f.service.Begin(ctx, testBuildApp, testBuildIdentifier, testBuildID, f.registerInput(content))
+	registration, err := f.service.RegisterArtifact(ctx, testBuildApp, testBuildIdentifier, testBuildID, f.registerInput(content))
 	require.NoError(t, err)
 	require.NoError(t, f.service.UploadLocal(ctx, registration.LocalToken, bytes.NewReader(content)))
 	_, err = os.Stat(f.stagedPath(t, *registration.Build))
@@ -504,7 +504,7 @@ func TestBuildCompleteRequiresUploadingState(t *testing.T) {
 func TestBuildCompleteRejectsTamperedUpload(t *testing.T) {
 	f := newBuildFixture(t)
 	ctx := context.Background()
-	registration, err := f.service.Begin(ctx, testBuildApp, testBuildIdentifier, testBuildID, f.registerInput([]byte("declared")))
+	registration, err := f.service.RegisterArtifact(ctx, testBuildApp, testBuildIdentifier, testBuildID, f.registerInput([]byte("declared")))
 	require.NoError(t, err)
 	require.NoError(t, f.storage.PutBuildArtifact(ctx, artifactRef(*registration.Build), true, strings.NewReader("tampered")))
 	_, err = f.service.Complete(ctx, testBuildApp, testBuildIdentifier, testBuildID)
@@ -515,7 +515,7 @@ func TestBuildCompleteRejectsTamperedUpload(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, types.BuildStatusFailed, failed.Status)
 
-	registration, err = f.service.Begin(ctx, testBuildApp, testBuildIdentifier, testBuildID, f.registerInput([]byte("declared")))
+	registration, err = f.service.RegisterArtifact(ctx, testBuildApp, testBuildIdentifier, testBuildID, f.registerInput([]byte("declared")))
 	require.NoError(t, err)
 	require.Equal(t, types.BuildStatusUploading, registration.Build.Status)
 	require.NoError(t, f.service.UploadLocal(ctx, registration.LocalToken, strings.NewReader("declared")))
@@ -527,7 +527,7 @@ func TestBuildCompleteRejectsTamperedUpload(t *testing.T) {
 func TestBuildUploadLocalBounds(t *testing.T) {
 	f := newBuildFixture(t)
 	ctx := context.Background()
-	registration, err := f.service.Begin(ctx, testBuildApp, testBuildIdentifier, testBuildID, f.registerInput([]byte("12345")))
+	registration, err := f.service.RegisterArtifact(ctx, testBuildApp, testBuildIdentifier, testBuildID, f.registerInput([]byte("12345")))
 	require.NoError(t, err)
 
 	err = f.service.UploadLocal(ctx, registration.LocalToken, strings.NewReader("123456"))
@@ -550,7 +550,7 @@ func TestBuildUploadLocalBounds(t *testing.T) {
 func TestBuildTokenRejectsOtherSecret(t *testing.T) {
 	f := newBuildFixture(t)
 	ctx := context.Background()
-	registration, err := f.service.Begin(ctx, testBuildApp, testBuildIdentifier, testBuildID, f.registerInput([]byte("x")))
+	registration, err := f.service.RegisterArtifact(ctx, testBuildApp, testBuildIdentifier, testBuildID, f.registerInput([]byte("x")))
 	require.NoError(t, err)
 	t.Setenv("JWT_SECRET", "rotated")
 	require.ErrorIs(t, f.service.UploadLocal(ctx, registration.LocalToken, strings.NewReader("x")), ErrUnauthorized)
@@ -571,7 +571,7 @@ func TestBuildConcurrentRegistrationsAgree(t *testing.T) {
 			if i%2 == 0 {
 				_, err = f.service.Start(ctx, testBuildApp, testBuildIdentifier, testBuildID, f.startInput())
 			} else {
-				_, err = f.service.Begin(ctx, testBuildApp, testBuildIdentifier, testBuildID, f.registerInput(content))
+				_, err = f.service.RegisterArtifact(ctx, testBuildApp, testBuildIdentifier, testBuildID, f.registerInput(content))
 			}
 			results <- err
 		}(i)

--- a/internal/services/build_service_test.go
+++ b/internal/services/build_service_test.go
@@ -109,7 +109,7 @@ func (r *memoryBuildRepo) Transition(ctx context.Context, appID, id string, deci
 type buildFixture struct {
 	service *BuildService
 	repo    *memoryBuildRepo
-	storage *bucket.BuildArtifactStorage
+	storage *bucket.LocalBucket
 	root    string
 	now     time.Time
 }
@@ -121,7 +121,7 @@ func newBuildFixture(t *testing.T) *buildFixture {
 	identifiers.add(testBuildIdentifier, types.PlatformAndroid, "com.example.app")
 	identifiers.add(otherBuildID, types.PlatformIOS, "com.example.ios")
 	root := t.TempDir()
-	storage := bucket.NewBuildArtifactStorage(&bucket.LocalBucket{BasePath: root})
+	storage := &bucket.LocalBucket{BasePath: root}
 	repo := newMemoryBuildRepo()
 	service := NewBuildService(repo, identifiers, storage)
 	now := time.Date(2026, 9, 9, 12, 0, 0, 0, time.UTC)
@@ -163,7 +163,7 @@ func TestBuildStartRecordsBuildingAndIsIdempotent(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, types.BuildStatusBuilding, first.Status)
 	require.Equal(t, "com.example.app", first.ApplicationID)
-	require.Equal(t, "apk", first.ArtifactType)
+	require.Equal(t, types.BuildArtifactAPK, first.ArtifactType)
 	require.Equal(t, "release", first.Metadata.Mode)
 	require.Zero(t, first.Size)
 	require.Empty(t, first.SHA256)
@@ -506,7 +506,7 @@ func TestBuildCompleteRejectsTamperedUpload(t *testing.T) {
 	ctx := context.Background()
 	registration, err := f.service.Begin(ctx, testBuildApp, testBuildIdentifier, testBuildID, f.registerInput([]byte("declared")))
 	require.NoError(t, err)
-	require.NoError(t, f.storage.Put(ctx, artifactRef(*registration.Build), true, strings.NewReader("tampered")))
+	require.NoError(t, f.storage.PutBuildArtifact(ctx, artifactRef(*registration.Build), true, strings.NewReader("tampered")))
 	_, err = f.service.Complete(ctx, testBuildApp, testBuildIdentifier, testBuildID)
 	require.ErrorIs(t, err, ErrBuildIntegrity)
 	_, err = os.Stat(f.finalPath(t, *registration.Build))

--- a/internal/services/rollout_resolution_test.go
+++ b/internal/services/rollout_resolution_test.go
@@ -1346,6 +1346,6 @@ func (fakeRolloutBucket) DeleteBuildArtifact(context.Context, bucket.BuildArtifa
 	return nil
 }
 
-func (fakeRolloutBucket) RequestBuildArtifactUploadURL(context.Context, bucket.BuildArtifact) (string, error) {
-	return "", nil
+func (fakeRolloutBucket) RequestBuildArtifactUploadURL(context.Context, string, bucket.BuildArtifact) (*bucket.UploadRequest, error) {
+	return &bucket.UploadRequest{Method: "PUT"}, nil
 }

--- a/test/migrations_test.go
+++ b/test/migrations_test.go
@@ -236,7 +236,7 @@ func (b *dummyMigrationsBucket) DeleteBuildArtifact(context.Context, bucket.Buil
 	return nil
 }
 
-func (b *dummyMigrationsBucket) RequestBuildArtifactUploadURL(context.Context, bucket.BuildArtifact) (string, error) {
+func (b *dummyMigrationsBucket) RequestBuildArtifactUploadURL(context.Context, string, bucket.BuildArtifact) (*bucket.UploadRequest, error) {
 	b.actionsRecorded = append(b.actionsRecorded, "RequestBuildArtifactUploadURL")
-	return "", nil
+	return &bucket.UploadRequest{Method: "PUT"}, nil
 }


### PR DESCRIPTION
Local builds can now be registered, uploaded and downloaded through authenticated build endpoints. Upload completion verifies the artifact before marking it ready; app-scoped authorization protects registry reads and downloads, and request logging redacts upload capabilities.

Validation: all Go packages compile; focused registry lifecycle, handler, router ACL, middleware and RBAC tests pass. PostgreSQL-backed build store and service tests pass against an isolated PostgreSQL 16 database. Cleanup, install links and log streaming are added by subsequent PRs in this stack.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added build registry support for starting, tracking, completing, and failing builds.
  * Added build listing, details, artifact downloads, signed uploads, and authenticated local uploads.
  * Added build permissions for viewing metadata and downloading artifacts.
  * Added platform-aware build handling for Android and iOS.
* **Security**
  * Added validation for build metadata, artifact integrity, upload authorization, and access permissions.
  * Sensitive credentials, session data, cookies, and upload tokens are now redacted from logs.
* **Bug Fixes**
  * Build lookups now use the requested platform instead of assuming Android.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->