### PR TITLE
Clean up deleted build artifacts and abandoned uploads

### DIFF
--- a/internal/database/postgres/migrations/20260909130000_build_cleanup.sql
+++ b/internal/database/postgres/migrations/20260909130000_build_cleanup.sql
@@ -1,0 +1,42 @@
+-- +goose Up
+
+-- Outbox of build artifacts whose row is gone. No foreign keys: the row is
+-- written by the DELETE trigger and must outlive the cascade that fired it.
+CREATE TABLE build_artifact_cleanup (
+    id BIGSERIAL PRIMARY KEY,
+    build_id UUID NOT NULL,
+    platform TEXT NOT NULL,
+    app_identifier_id UUID NOT NULL,
+    artifact_type TEXT NOT NULL,
+    due_at TIMESTAMPTZ NOT NULL DEFAULT now() + interval '15 minutes',
+    attempts INTEGER NOT NULL DEFAULT 0,
+    last_error TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX build_artifact_cleanup_due ON build_artifact_cleanup (due_at);
+
+-- +goose StatementBegin
+CREATE FUNCTION enqueue_build_artifact_cleanup() RETURNS trigger AS $$
+BEGIN
+    INSERT INTO build_artifact_cleanup (build_id, platform, app_identifier_id, artifact_type)
+    VALUES (OLD.id, OLD.platform, OLD.app_identifier_id, OLD.artifact_type);
+    RETURN OLD;
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+CREATE TRIGGER trg_build_artifact_cleanup
+AFTER DELETE ON builds
+FOR EACH ROW EXECUTE FUNCTION enqueue_build_artifact_cleanup();
+
+-- Ledger of stale staging sweeps, so a ready build is swept once.
+CREATE TABLE build_staging_sweeps (
+    build_id UUID PRIMARY KEY REFERENCES builds (id) ON DELETE CASCADE,
+    swept_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- +goose Down
+DROP TABLE IF EXISTS build_staging_sweeps;
+DROP TRIGGER IF EXISTS trg_build_artifact_cleanup ON builds;
+DROP FUNCTION IF EXISTS enqueue_build_artifact_cleanup;
+DROP TABLE IF EXISTS build_artifact_cleanup;

--- a/internal/database/postgres/pgdb/builds.sql.go
+++ b/internal/database/postgres/pgdb/builds.sql.go
@@ -23,6 +23,31 @@ func (q *Queries) CountBuilds(ctx context.Context, appID pgtype.UUID) (int64, er
 	return count, err
 }
 
+const deferBuildArtifactCleanup = `-- name: DeferBuildArtifactCleanup :exec
+UPDATE build_artifact_cleanup SET attempts = attempts + 1, last_error = $1, due_at = now() + $2::interval
+WHERE id = $3
+`
+
+type DeferBuildArtifactCleanupParams struct {
+	LastError *string         `json:"last_error"`
+	Backoff   pgtype.Interval `json:"backoff"`
+	ID        int64           `json:"id"`
+}
+
+func (q *Queries) DeferBuildArtifactCleanup(ctx context.Context, arg DeferBuildArtifactCleanupParams) error {
+	_, err := q.db.Exec(ctx, deferBuildArtifactCleanup, arg.LastError, arg.Backoff, arg.ID)
+	return err
+}
+
+const deleteBuildArtifactCleanup = `-- name: DeleteBuildArtifactCleanup :exec
+DELETE FROM build_artifact_cleanup WHERE id = $1
+`
+
+func (q *Queries) DeleteBuildArtifactCleanup(ctx context.Context, id int64) error {
+	_, err := q.db.Exec(ctx, deleteBuildArtifactCleanup, id)
+	return err
+}
+
 const getBuild = `-- name: GetBuild :one
 SELECT id, app_id, app_identifier_id, platform, application_id, status, artifact_type, size, sha256, artifact_key, metadata, actor_type, actor_id, actor_display, started_at, finished_at, duration_ms, created_at, updated_at, ready_at FROM builds WHERE app_id=$1 AND id=$2
 `
@@ -183,6 +208,86 @@ func (q *Queries) ListBuilds(ctx context.Context, arg ListBuildsParams) ([]Build
 	return items, nil
 }
 
+const listDueBuildArtifactCleanup = `-- name: ListDueBuildArtifactCleanup :many
+SELECT id, app_identifier_id, build_id, artifact_type, attempts
+FROM build_artifact_cleanup WHERE due_at <= now()
+ORDER BY due_at, id LIMIT $1 FOR UPDATE SKIP LOCKED
+`
+
+type ListDueBuildArtifactCleanupRow struct {
+	ID              int64                   `json:"id"`
+	AppIdentifierID pgtype.UUID             `json:"app_identifier_id"`
+	BuildID         pgtype.UUID             `json:"build_id"`
+	ArtifactType    types.BuildArtifactType `json:"artifact_type"`
+	Attempts        int32                   `json:"attempts"`
+}
+
+func (q *Queries) ListDueBuildArtifactCleanup(ctx context.Context, batchSize int32) ([]ListDueBuildArtifactCleanupRow, error) {
+	rows, err := q.db.Query(ctx, listDueBuildArtifactCleanup, batchSize)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListDueBuildArtifactCleanupRow
+	for rows.Next() {
+		var i ListDueBuildArtifactCleanupRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.AppIdentifierID,
+			&i.BuildID,
+			&i.ArtifactType,
+			&i.Attempts,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listStaleBuildStaging = `-- name: ListStaleBuildStaging :many
+SELECT b.id, b.app_identifier_id, b.artifact_type
+FROM builds b LEFT JOIN build_staging_sweeps s ON s.build_id = b.id
+WHERE b.updated_at < now() - $1::interval
+  AND b.status IN ('ready', 'failed', 'uploading')
+  AND (s.build_id IS NULL OR (b.status <> 'ready' AND s.swept_at < now() - $1::interval))
+ORDER BY b.created_at, b.id LIMIT $2 FOR UPDATE OF b SKIP LOCKED
+`
+
+type ListStaleBuildStagingParams struct {
+	StaleAfter pgtype.Interval `json:"stale_after"`
+	BatchSize  int32           `json:"batch_size"`
+}
+
+type ListStaleBuildStagingRow struct {
+	ID              pgtype.UUID             `json:"id"`
+	AppIdentifierID pgtype.UUID             `json:"app_identifier_id"`
+	ArtifactType    types.BuildArtifactType `json:"artifact_type"`
+}
+
+func (q *Queries) ListStaleBuildStaging(ctx context.Context, arg ListStaleBuildStagingParams) ([]ListStaleBuildStagingRow, error) {
+	rows, err := q.db.Query(ctx, listStaleBuildStaging, arg.StaleAfter, arg.BatchSize)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListStaleBuildStagingRow
+	for rows.Next() {
+		var i ListStaleBuildStagingRow
+		if err := rows.Scan(&i.ID, &i.AppIdentifierID, &i.ArtifactType); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const lockBuild = `-- name: LockBuild :one
 SELECT id, app_id, app_identifier_id, platform, application_id, status, artifact_type, size, sha256, artifact_key, metadata, actor_type, actor_id, actor_display, started_at, finished_at, duration_ms, created_at, updated_at, ready_at FROM builds WHERE app_id=$1 AND id=$2 FOR UPDATE
 `
@@ -218,6 +323,16 @@ func (q *Queries) LockBuild(ctx context.Context, arg LockBuildParams) (Build, er
 		&i.ReadyAt,
 	)
 	return i, err
+}
+
+const markBuildStagingSwept = `-- name: MarkBuildStagingSwept :exec
+INSERT INTO build_staging_sweeps (build_id, swept_at) VALUES ($1, now())
+ON CONFLICT (build_id) DO UPDATE SET swept_at = now()
+`
+
+func (q *Queries) MarkBuildStagingSwept(ctx context.Context, buildID pgtype.UUID) error {
+	_, err := q.db.Exec(ctx, markBuildStagingSwept, buildID)
+	return err
 }
 
 const updateBuild = `-- name: UpdateBuild :one

--- a/internal/database/postgres/pgdb/models.go
+++ b/internal/database/postgres/pgdb/models.go
@@ -145,6 +145,23 @@ type Build struct {
 	ReadyAt         pgtype.Timestamptz      `json:"ready_at"`
 }
 
+type BuildArtifactCleanup struct {
+	ID              int64              `json:"id"`
+	BuildID         pgtype.UUID        `json:"build_id"`
+	Platform        string             `json:"platform"`
+	AppIdentifierID pgtype.UUID        `json:"app_identifier_id"`
+	ArtifactType    string             `json:"artifact_type"`
+	DueAt           pgtype.Timestamptz `json:"due_at"`
+	Attempts        int32              `json:"attempts"`
+	LastError       *string            `json:"last_error"`
+	CreatedAt       pgtype.Timestamptz `json:"created_at"`
+}
+
+type BuildStagingSweep struct {
+	BuildID pgtype.UUID        `json:"build_id"`
+	SweptAt pgtype.Timestamptz `json:"swept_at"`
+}
+
 type BundlePatch struct {
 	BranchID         int64                   `json:"branch_id"`
 	TargetUpdateID   int64                   `json:"target_update_id"`

--- a/internal/database/postgres/pgdb/models.go
+++ b/internal/database/postgres/pgdb/models.go
@@ -146,15 +146,15 @@ type Build struct {
 }
 
 type BuildArtifactCleanup struct {
-	ID              int64              `json:"id"`
-	BuildID         pgtype.UUID        `json:"build_id"`
-	Platform        string             `json:"platform"`
-	AppIdentifierID pgtype.UUID        `json:"app_identifier_id"`
-	ArtifactType    string             `json:"artifact_type"`
-	DueAt           pgtype.Timestamptz `json:"due_at"`
-	Attempts        int32              `json:"attempts"`
-	LastError       *string            `json:"last_error"`
-	CreatedAt       pgtype.Timestamptz `json:"created_at"`
+	ID              int64                   `json:"id"`
+	BuildID         pgtype.UUID             `json:"build_id"`
+	Platform        types.Platform          `json:"platform"`
+	AppIdentifierID pgtype.UUID             `json:"app_identifier_id"`
+	ArtifactType    types.BuildArtifactType `json:"artifact_type"`
+	DueAt           pgtype.Timestamptz      `json:"due_at"`
+	Attempts        int32                   `json:"attempts"`
+	LastError       *string                 `json:"last_error"`
+	CreatedAt       pgtype.Timestamptz      `json:"created_at"`
 }
 
 type BuildStagingSweep struct {

--- a/internal/database/postgres/queries/builds.sql
+++ b/internal/database/postgres/queries/builds.sql
@@ -19,3 +19,27 @@ SELECT * FROM builds WHERE app_id=$1 ORDER BY created_at DESC,id DESC LIMIT $2 O
 
 -- name: CountBuilds :one
 SELECT count(*) FROM builds WHERE app_id=$1;
+
+-- name: ListDueBuildArtifactCleanup :many
+SELECT id, app_identifier_id, build_id, artifact_type, attempts
+FROM build_artifact_cleanup WHERE due_at <= now()
+ORDER BY due_at, id LIMIT sqlc.arg('batch_size') FOR UPDATE SKIP LOCKED;
+
+-- name: DeferBuildArtifactCleanup :exec
+UPDATE build_artifact_cleanup SET attempts = attempts + 1, last_error = sqlc.arg('last_error'), due_at = now() + sqlc.arg('backoff')::interval
+WHERE id = sqlc.arg('id');
+
+-- name: DeleteBuildArtifactCleanup :exec
+DELETE FROM build_artifact_cleanup WHERE id = $1;
+
+-- name: ListStaleBuildStaging :many
+SELECT b.id, b.app_identifier_id, b.artifact_type
+FROM builds b LEFT JOIN build_staging_sweeps s ON s.build_id = b.id
+WHERE b.updated_at < now() - sqlc.arg('stale_after')::interval
+  AND b.status IN ('ready', 'failed', 'uploading')
+  AND (s.build_id IS NULL OR (b.status <> 'ready' AND s.swept_at < now() - sqlc.arg('stale_after')::interval))
+ORDER BY b.created_at, b.id LIMIT sqlc.arg('batch_size') FOR UPDATE OF b SKIP LOCKED;
+
+-- name: MarkBuildStagingSwept :exec
+INSERT INTO build_staging_sweeps (build_id, swept_at) VALUES ($1, now())
+ON CONFLICT (build_id) DO UPDATE SET swept_at = now();

--- a/internal/router/wire.go
+++ b/internal/router/wire.go
@@ -112,6 +112,7 @@ func InitDependencies(ctx context.Context) (*AppContainer, func()) {
 	// nil in stateless mode: store identities and signing credentials only
 	// exist on the control plane.
 	var buildRepo services.BuildRepository
+	var buildCleanup *services.BuildCleanup
 	var appIdentifierRepo services.AppIdentifierRepository
 	var credentialsRepo services.CredentialsRepository
 	var environmentRepo services.EnvironmentRepository
@@ -190,6 +191,7 @@ func InitDependencies(ctx context.Context) (*AppContainer, func()) {
 		bundlePatchRepo = store.NewPostgresBundlePatchStore(dbEngine)
 		appIdentifierRepo = store.NewPostgresAppIdentifierStore(dbEngine)
 		buildRepo = store.NewPostgresBuildStore(dbEngine)
+		buildCleanup = services.NewBuildCleanup(dbEngine.DB, resolvedBucket)
 		credentialsRepo = store.NewPostgresCredentialsStore(dbEngine)
 		environmentRepo = store.NewPostgresEnvironmentStore(dbEngine)
 
@@ -321,6 +323,9 @@ func InitDependencies(ctx context.Context) (*AppContainer, func()) {
 	rolloutService := services.NewRolloutService(rolloutRepo, channelRepo, updateRepo, deploymentService)
 	rolloutService.SetOnAuditEvent(auditService.Record)
 	buildService := services.NewBuildService(buildRepo, appIdentifierRepo, resolvedBucket)
+	if buildCleanup != nil {
+		addCleanup(buildCleanup.Start(ctx))
+	}
 	appIdentifierService := services.NewAppIdentifierService(appIdentifierRepo)
 	appIdentifierService.SetOnAuditEvent(auditService.Record)
 	credentialsService := services.NewCredentialsService(credentialsRepo, appIdentifierRepo)

--- a/internal/services/build_cleanup.go
+++ b/internal/services/build_cleanup.go
@@ -20,8 +20,8 @@ const (
 	buildStagingSweepInterval  = 15 * time.Minute
 	buildCleanupBatchTimeout   = 5 * time.Minute
 	buildCleanupItemTimeout    = 30 * time.Second
-	buildOutboxBatchSize       = 25
-	buildStagingSweepBatchSize = 100
+	buildOutboxBatchSize       = 4 // Two deletes per row leave 1 minute for SQL and commit.
+	buildStagingSweepBatchSize = 9 // One delete per row leaves 30 seconds for SQL and commit.
 	buildOutboxMaxBackoff      = 6 * time.Hour
 	buildStagingStaleAfter     = 24 * time.Hour
 )

--- a/internal/services/build_cleanup.go
+++ b/internal/services/build_cleanup.go
@@ -9,8 +9,8 @@ import (
 	"time"
 	"xprem/internal/bucket"
 	"xprem/internal/database"
+	"xprem/internal/database/postgres/pgdb"
 
-	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
@@ -86,12 +86,6 @@ func (c *BuildCleanup) loop(ctx context.Context, interval time.Duration, name st
 	}
 }
 
-type buildCleanupItem struct {
-	id       int64
-	ref      bucket.BuildArtifact
-	attempts int32
-}
-
 // DrainOutbox deletes the final and staging objects of one batch of due
 // outbox rows and removes each row once both deletes succeeded.
 func (c *BuildCleanup) DrainOutbox(ctx context.Context) (int, error) {
@@ -100,47 +94,29 @@ func (c *BuildCleanup) DrainOutbox(ctx context.Context) (int, error) {
 		return 0, err
 	}
 	defer tx.Rollback(ctx)
-	rows, err := tx.Query(ctx, `SELECT id, app_identifier_id, build_id, artifact_type, attempts
-FROM build_artifact_cleanup WHERE due_at <= now() ORDER BY due_at, id LIMIT $1 FOR UPDATE SKIP LOCKED`, buildOutboxBatchSize)
-	if err != nil {
-		return 0, err
-	}
-	items, err := scanCleanupItems(rows)
+	q := pgdb.New(tx)
+	rows, err := q.ListDueBuildArtifactCleanup(ctx, buildOutboxBatchSize)
 	if err != nil {
 		return 0, err
 	}
 	done := 0
-	for _, item := range items {
-		if err := c.deleteArtifact(ctx, item.ref, true, true); err != nil {
-			backoff := buildOutboxBackoff(item.attempts)
-			log.Printf("🧹 [BUILD-CLEANUP] build %s artifact delete failed (attempt %d, retry in %s): %v", item.ref.BuildID, item.attempts+1, backoff, err)
-			if _, err := tx.Exec(ctx, `UPDATE build_artifact_cleanup SET attempts = attempts + 1, last_error = $2, due_at = now() + $3::interval WHERE id = $1`, item.id, truncateError(err), pgtype.Interval{Microseconds: backoff.Microseconds(), Valid: true}); err != nil {
+	for _, row := range rows {
+		ref := bucket.BuildArtifact{IdentifierID: row.AppIdentifierID.String(), BuildID: row.BuildID.String(), Type: row.ArtifactType}
+		if err := c.deleteArtifact(ctx, ref, true, true); err != nil {
+			backoff := buildOutboxBackoff(row.Attempts)
+			log.Printf("🧹 [BUILD-CLEANUP] build %s artifact delete failed (attempt %d, retry in %s): %v", ref.BuildID, row.Attempts+1, backoff, err)
+			lastError := truncateError(err)
+			if err := q.DeferBuildArtifactCleanup(ctx, pgdb.DeferBuildArtifactCleanupParams{ID: row.ID, LastError: &lastError, Backoff: pgtype.Interval{Microseconds: backoff.Microseconds(), Valid: true}}); err != nil {
 				return done, err
 			}
 			continue
 		}
-		if _, err := tx.Exec(ctx, `DELETE FROM build_artifact_cleanup WHERE id = $1`, item.id); err != nil {
+		if err := q.DeleteBuildArtifactCleanup(ctx, row.ID); err != nil {
 			return done, err
 		}
 		done++
 	}
 	return done, tx.Commit(ctx)
-}
-
-func scanCleanupItems(rows pgx.Rows) ([]buildCleanupItem, error) {
-	defer rows.Close()
-	var items []buildCleanupItem
-	for rows.Next() {
-		var item buildCleanupItem
-		var identifier, build pgtype.UUID
-		if err := rows.Scan(&item.id, &identifier, &build, &item.ref.Type, &item.attempts); err != nil {
-			return nil, err
-		}
-		item.ref.IdentifierID = identifier.String()
-		item.ref.BuildID = build.String()
-		items = append(items, item)
-	}
-	return items, rows.Err()
 }
 
 // SweepStaging deletes the staging upload of builds untouched for a day whose
@@ -152,48 +128,24 @@ func (c *BuildCleanup) SweepStaging(ctx context.Context) (int, error) {
 		return 0, err
 	}
 	defer tx.Rollback(ctx)
-	rows, err := tx.Query(ctx, `SELECT b.id, b.app_identifier_id, b.artifact_type
-FROM builds b LEFT JOIN build_staging_sweeps s ON s.build_id = b.id
-WHERE b.updated_at < now() - $1::interval
-  AND b.status IN ('ready', 'failed', 'uploading')
-  AND (s.build_id IS NULL OR (b.status <> 'ready' AND s.swept_at < now() - $1::interval))
-ORDER BY b.created_at, b.id LIMIT $2 FOR UPDATE OF b SKIP LOCKED`, pgtype.Interval{Microseconds: buildStagingStaleAfter.Microseconds(), Valid: true}, buildStagingSweepBatchSize)
-	if err != nil {
-		return 0, err
-	}
-	refs, err := scanStagingRefs(rows)
+	q := pgdb.New(tx)
+	rows, err := q.ListStaleBuildStaging(ctx, pgdb.ListStaleBuildStagingParams{StaleAfter: pgtype.Interval{Microseconds: buildStagingStaleAfter.Microseconds(), Valid: true}, BatchSize: buildStagingSweepBatchSize})
 	if err != nil {
 		return 0, err
 	}
 	swept := 0
-	for _, ref := range refs {
+	for _, row := range rows {
+		ref := bucket.BuildArtifact{IdentifierID: row.AppIdentifierID.String(), BuildID: row.ID.String(), Type: row.ArtifactType}
 		if err := c.deleteArtifact(ctx, ref, true, false); err != nil {
 			log.Printf("🧹 [BUILD-CLEANUP] build %s staging delete failed: %v", ref.BuildID, err)
 			continue
 		}
-		if _, err := tx.Exec(ctx, `INSERT INTO build_staging_sweeps (build_id, swept_at) VALUES ($1, now())
-ON CONFLICT (build_id) DO UPDATE SET swept_at = now()`, ref.BuildID); err != nil {
+		if err := q.MarkBuildStagingSwept(ctx, row.ID); err != nil {
 			return swept, err
 		}
 		swept++
 	}
 	return swept, tx.Commit(ctx)
-}
-
-func scanStagingRefs(rows pgx.Rows) ([]bucket.BuildArtifact, error) {
-	defer rows.Close()
-	var refs []bucket.BuildArtifact
-	for rows.Next() {
-		var ref bucket.BuildArtifact
-		var identifier, build pgtype.UUID
-		if err := rows.Scan(&build, &identifier, &ref.Type); err != nil {
-			return nil, err
-		}
-		ref.IdentifierID = identifier.String()
-		ref.BuildID = build.String()
-		refs = append(refs, ref)
-	}
-	return refs, rows.Err()
 }
 
 func (c *BuildCleanup) deleteArtifact(ctx context.Context, ref bucket.BuildArtifact, staging, final bool) error {

--- a/internal/services/build_cleanup.go
+++ b/internal/services/build_cleanup.go
@@ -1,0 +1,243 @@
+package services
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"sync"
+	"time"
+	"xprem/internal/bucket"
+	"xprem/internal/database"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+const (
+	buildCleanupStartDelay     = 30 * time.Second
+	buildOutboxInterval        = time.Minute
+	buildStagingSweepInterval  = 15 * time.Minute
+	buildCleanupBatchTimeout   = 5 * time.Minute
+	buildCleanupItemTimeout    = 30 * time.Second
+	buildOutboxBatchSize       = 25
+	buildStagingSweepBatchSize = 100
+	buildOutboxMaxBackoff      = 6 * time.Hour
+	buildStagingStaleAfter     = 24 * time.Hour
+)
+
+// BuildArtifactDeleter removes one artifact object; absent objects are not an error.
+type BuildArtifactDeleter interface {
+	DeleteBuildArtifact(context.Context, bucket.BuildArtifact, bool) error
+}
+
+// BuildCleanup drains the build_artifact_cleanup outbox and sweeps stale
+// staging uploads. Final artifacts of ready builds are never touched.
+type BuildCleanup struct {
+	db      database.DBTX
+	storage BuildArtifactDeleter
+}
+
+func NewBuildCleanup(db database.DBTX, storage BuildArtifactDeleter) *BuildCleanup {
+	return &BuildCleanup{db: db, storage: storage}
+}
+
+// Start runs both loops until the returned stop function is called.
+func (c *BuildCleanup) Start(parent context.Context) func() {
+	ctx, cancel := context.WithCancel(parent)
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		c.loop(ctx, buildOutboxInterval, "outbox", c.DrainOutbox)
+	}()
+	go func() {
+		defer wg.Done()
+		c.loop(ctx, buildStagingSweepInterval, "staging sweep", c.SweepStaging)
+	}()
+	return func() {
+		cancel()
+		wg.Wait()
+	}
+}
+
+func (c *BuildCleanup) loop(ctx context.Context, interval time.Duration, name string, run func(context.Context) (int, error)) {
+	select {
+	case <-ctx.Done():
+		return
+	case <-time.After(buildCleanupStartDelay):
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		batchCtx, cancel := context.WithTimeout(ctx, buildCleanupBatchTimeout)
+		count, err := run(batchCtx)
+		cancel()
+		if err != nil && ctx.Err() == nil {
+			log.Printf("🧹 [BUILD-CLEANUP] %s failed: %v", name, err)
+		} else if count > 0 {
+			log.Printf("🧹 [BUILD-CLEANUP] %s handled %d builds", name, count)
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
+	}
+}
+
+type buildCleanupItem struct {
+	id       int64
+	ref      bucket.BuildArtifact
+	attempts int32
+}
+
+// DrainOutbox deletes the final and staging objects of one batch of due
+// outbox rows and removes each row once both deletes succeeded.
+func (c *BuildCleanup) DrainOutbox(ctx context.Context) (int, error) {
+	tx, err := c.db.Begin(ctx)
+	if err != nil {
+		return 0, err
+	}
+	defer tx.Rollback(ctx)
+	rows, err := tx.Query(ctx, `SELECT id, app_identifier_id, build_id, artifact_type, attempts
+FROM build_artifact_cleanup WHERE due_at <= now() ORDER BY due_at, id LIMIT $1 FOR UPDATE SKIP LOCKED`, buildOutboxBatchSize)
+	if err != nil {
+		return 0, err
+	}
+	items, err := scanCleanupItems(rows)
+	if err != nil {
+		return 0, err
+	}
+	done := 0
+	for _, item := range items {
+		if err := c.deleteArtifact(ctx, item.ref, true, true); err != nil {
+			backoff := buildOutboxBackoff(item.attempts)
+			log.Printf("🧹 [BUILD-CLEANUP] build %s artifact delete failed (attempt %d, retry in %s): %v", item.ref.BuildID, item.attempts+1, backoff, err)
+			if _, err := tx.Exec(ctx, `UPDATE build_artifact_cleanup SET attempts = attempts + 1, last_error = $2, due_at = now() + $3::interval WHERE id = $1`, item.id, truncateError(err), pgtype.Interval{Microseconds: backoff.Microseconds(), Valid: true}); err != nil {
+				return done, err
+			}
+			continue
+		}
+		if _, err := tx.Exec(ctx, `DELETE FROM build_artifact_cleanup WHERE id = $1`, item.id); err != nil {
+			return done, err
+		}
+		done++
+	}
+	return done, tx.Commit(ctx)
+}
+
+func scanCleanupItems(rows pgx.Rows) ([]buildCleanupItem, error) {
+	defer rows.Close()
+	var items []buildCleanupItem
+	for rows.Next() {
+		var item buildCleanupItem
+		var identifier, build pgtype.UUID
+		if err := rows.Scan(&item.id, &identifier, &build, &item.ref.Type, &item.attempts); err != nil {
+			return nil, err
+		}
+		item.ref.IdentifierID = identifier.String()
+		item.ref.BuildID = build.String()
+		items = append(items, item)
+	}
+	return items, rows.Err()
+}
+
+// SweepStaging deletes the staging upload of builds untouched for a day whose
+// upload is finished or abandoned. Ready builds are swept once, the others
+// again after a day, so a retried upload is not left behind either.
+func (c *BuildCleanup) SweepStaging(ctx context.Context) (int, error) {
+	tx, err := c.db.Begin(ctx)
+	if err != nil {
+		return 0, err
+	}
+	defer tx.Rollback(ctx)
+	rows, err := tx.Query(ctx, `SELECT b.id, b.app_identifier_id, b.artifact_type
+FROM builds b LEFT JOIN build_staging_sweeps s ON s.build_id = b.id
+WHERE b.updated_at < now() - $1::interval
+  AND b.status IN ('ready', 'failed', 'uploading')
+  AND (s.build_id IS NULL OR (b.status <> 'ready' AND s.swept_at < now() - $1::interval))
+ORDER BY b.created_at, b.id LIMIT $2 FOR UPDATE OF b SKIP LOCKED`, pgtype.Interval{Microseconds: buildStagingStaleAfter.Microseconds(), Valid: true}, buildStagingSweepBatchSize)
+	if err != nil {
+		return 0, err
+	}
+	refs, err := scanStagingRefs(rows)
+	if err != nil {
+		return 0, err
+	}
+	swept := 0
+	for _, ref := range refs {
+		if err := c.deleteArtifact(ctx, ref, true, false); err != nil {
+			log.Printf("🧹 [BUILD-CLEANUP] build %s staging delete failed: %v", ref.BuildID, err)
+			continue
+		}
+		if _, err := tx.Exec(ctx, `INSERT INTO build_staging_sweeps (build_id, swept_at) VALUES ($1, now())
+ON CONFLICT (build_id) DO UPDATE SET swept_at = now()`, ref.BuildID); err != nil {
+			return swept, err
+		}
+		swept++
+	}
+	return swept, tx.Commit(ctx)
+}
+
+func scanStagingRefs(rows pgx.Rows) ([]bucket.BuildArtifact, error) {
+	defer rows.Close()
+	var refs []bucket.BuildArtifact
+	for rows.Next() {
+		var ref bucket.BuildArtifact
+		var identifier, build pgtype.UUID
+		if err := rows.Scan(&build, &identifier, &ref.Type); err != nil {
+			return nil, err
+		}
+		ref.IdentifierID = identifier.String()
+		ref.BuildID = build.String()
+		refs = append(refs, ref)
+	}
+	return refs, rows.Err()
+}
+
+func (c *BuildCleanup) deleteArtifact(ctx context.Context, ref bucket.BuildArtifact, staging, final bool) error {
+	if _, err := ref.Key(false); err != nil {
+		return fmt.Errorf("unusable artifact reference: %w", err)
+	}
+	var errs []error
+	if staging {
+		if err := c.deleteOne(ctx, ref, true); err != nil {
+			errs = append(errs, fmt.Errorf("staging: %w", err))
+		}
+	}
+	if final {
+		if err := c.deleteOne(ctx, ref, false); err != nil {
+			errs = append(errs, fmt.Errorf("final: %w", err))
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func (c *BuildCleanup) deleteOne(ctx context.Context, ref bucket.BuildArtifact, staging bool) error {
+	itemCtx, cancel := context.WithTimeout(ctx, buildCleanupItemTimeout)
+	defer cancel()
+	return c.storage.DeleteBuildArtifact(itemCtx, ref, staging)
+}
+
+func buildOutboxBackoff(attempts int32) time.Duration {
+	if attempts < 0 {
+		attempts = 0
+	}
+	if attempts > 20 {
+		return buildOutboxMaxBackoff
+	}
+	backoff := time.Minute << uint(attempts)
+	if backoff > buildOutboxMaxBackoff {
+		return buildOutboxMaxBackoff
+	}
+	return backoff
+}
+
+func truncateError(err error) string {
+	message := err.Error()
+	if len(message) > 1000 {
+		return message[:1000]
+	}
+	return message
+}

--- a/internal/services/build_cleanup_test.go
+++ b/internal/services/build_cleanup_test.go
@@ -1,0 +1,343 @@
+package services
+
+import (
+	"context"
+	"errors"
+	"os"
+	"sync"
+	"testing"
+	"time"
+	"xprem/internal/bucket"
+	"xprem/internal/database/postgres"
+	"xprem/internal/database/postgres/pgtest"
+	"xprem/internal/types"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+)
+
+// The Postgres-backed tests share TEST_DATABASE_URL with the store packages;
+// pgtest serializes them so wholesale cleanups cannot wipe each other's rows.
+func TestMain(m *testing.M) {
+	os.Exit(pgtest.RunSerialized(m))
+}
+
+type recordingDeleter struct {
+	mu      sync.Mutex
+	deleted []string
+	failOn  map[string]error
+}
+
+func (r *recordingDeleter) DeleteBuildArtifact(_ context.Context, ref bucket.BuildArtifact, staging bool) error {
+	key, err := ref.Key(staging)
+	if err != nil {
+		return err
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if err := r.failOn[key]; err != nil {
+		return err
+	}
+	r.deleted = append(r.deleted, key)
+	return nil
+}
+
+func (r *recordingDeleter) keys() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]string(nil), r.deleted...)
+}
+
+func setupBuildCleanup(t *testing.T) (*pgxpool.Pool, *recordingDeleter, *BuildCleanup) {
+	t.Helper()
+	dbURL := os.Getenv("TEST_DATABASE_URL")
+	if dbURL == "" {
+		if os.Getenv("CI") != "" {
+			t.Fatal("TEST_DATABASE_URL must be set in CI: these tests cover a trigger and locking SQL that no fake can reach")
+		}
+		t.Skip("TEST_DATABASE_URL not set, start a Postgres and set it to run the build cleanup tests")
+	}
+	t.Setenv("ADMIN_EMAIL", "seed-admin@example.com")
+	t.Setenv("ADMIN_PASSWORD", "Sup3rSecret!")
+	postgres.RunDBMigrations(dbURL)
+	pool, err := pgxpool.New(context.Background(), dbURL)
+	require.NoError(t, err)
+	t.Cleanup(pool.Close)
+	_, err = pool.Exec(context.Background(), "DELETE FROM build_artifact_cleanup")
+	require.NoError(t, err)
+	deleter := &recordingDeleter{failOn: map[string]error{}}
+	return pool, deleter, NewBuildCleanup(pool, deleter)
+}
+
+type cleanupFixture struct {
+	appID        string
+	identifierID string
+}
+
+func insertCleanupFixture(t *testing.T, pool *pgxpool.Pool) cleanupFixture {
+	t.Helper()
+	ctx := context.Background()
+	appID := uuid.NewString()
+	_, err := pool.Exec(ctx, "INSERT INTO apps (id, name) VALUES ($1, $2)", appID, "cleanup-"+appID[:8])
+	require.NoError(t, err)
+	t.Cleanup(func() { _, _ = pool.Exec(context.Background(), "DELETE FROM apps WHERE id = $1", appID) })
+	identifierID := uuid.NewString()
+	_, err = pool.Exec(ctx, "INSERT INTO app_identifiers (id, app_id, platform, identifier) VALUES ($1, $2, 'android', $3)", identifierID, appID, "com.example."+identifierID[:8])
+	require.NoError(t, err)
+	return cleanupFixture{appID: appID, identifierID: identifierID}
+}
+
+func (f cleanupFixture) insertBuild(t *testing.T, pool *pgxpool.Pool, status string, age time.Duration) bucket.BuildArtifact {
+	t.Helper()
+	ref := bucket.BuildArtifact{IdentifierID: f.identifierID, BuildID: uuid.NewString(), Type: types.BuildArtifactAPK}
+	key, err := ref.Key(false)
+	require.NoError(t, err)
+	_, err = pool.Exec(context.Background(), `INSERT INTO builds (id, app_id, app_identifier_id, platform, application_id, status, artifact_type, size, sha256, artifact_key, metadata, actor_type, actor_id, actor_display, started_at, finished_at, duration_ms, ready_at, created_at, updated_at)
+VALUES ($1, $2, $3, 'android', 'com.example.app', $4, 'apk',
+        CASE WHEN $4 = 'building' THEN 0 ELSE 1 END,
+        CASE WHEN $4 = 'building' THEN '' ELSE repeat('a', 64) END,
+        $5, '{}', 'user', 'tester', 'Tester',
+        now() - $6::interval,
+        CASE WHEN $4 = 'building' THEN NULL ELSE now() - $6::interval END,
+        CASE WHEN $4 = 'building' THEN NULL ELSE 1000 END,
+        CASE WHEN $4 = 'ready' THEN now() - $6::interval ELSE NULL END,
+        now() - $6::interval, now() - $6::interval)`,
+		ref.BuildID, f.appID, f.identifierID, status, key, pgInterval(age))
+	require.NoError(t, err)
+	return ref
+}
+
+func pgInterval(d time.Duration) pgtype.Interval {
+	return pgtype.Interval{Microseconds: d.Microseconds(), Valid: true}
+}
+
+func duration(i pgtype.Interval) time.Duration {
+	return time.Duration(i.Microseconds)*time.Microsecond + time.Duration(i.Days)*24*time.Hour + time.Duration(i.Months)*30*24*time.Hour
+}
+
+func keysOf(t *testing.T, ref bucket.BuildArtifact) (final, staging string) {
+	t.Helper()
+	final, err := ref.Key(false)
+	require.NoError(t, err)
+	staging, err = ref.Key(true)
+	require.NoError(t, err)
+	return final, staging
+}
+
+func outboxRows(t *testing.T, pool *pgxpool.Pool, buildID string) int {
+	t.Helper()
+	var count int
+	require.NoError(t, pool.QueryRow(context.Background(), "SELECT count(*) FROM build_artifact_cleanup WHERE build_id = $1", buildID).Scan(&count))
+	return count
+}
+
+func makeDue(t *testing.T, pool *pgxpool.Pool, buildID string) {
+	t.Helper()
+	_, err := pool.Exec(context.Background(), "UPDATE build_artifact_cleanup SET due_at = now() - interval '1 second' WHERE build_id = $1", buildID)
+	require.NoError(t, err)
+}
+
+func TestBuildCleanupTriggerOutlivesTheCascade(t *testing.T) {
+	pool, _, _ := setupBuildCleanup(t)
+	ctx := context.Background()
+	fixture := insertCleanupFixture(t, pool)
+	first := fixture.insertBuild(t, pool, "ready", 0)
+	second := fixture.insertBuild(t, pool, "uploading", 0)
+
+	_, err := pool.Exec(ctx, "DELETE FROM app_identifiers WHERE id = $1", fixture.identifierID)
+	require.NoError(t, err)
+	for _, ref := range []bucket.BuildArtifact{first, second} {
+		var platform, artifactType string
+		var identifier string
+		var dueIn pgtype.Interval
+		require.NoError(t, pool.QueryRow(ctx, "SELECT platform, app_identifier_id::text, artifact_type, due_at - now() FROM build_artifact_cleanup WHERE build_id = $1", ref.BuildID).Scan(&platform, &identifier, &artifactType, &dueIn))
+		require.Equal(t, "android", platform)
+		require.Equal(t, fixture.identifierID, identifier)
+		require.Equal(t, "apk", artifactType)
+		require.Greater(t, duration(dueIn), 14*time.Minute, "the row waits out the signed upload expiry")
+	}
+
+	other := insertCleanupFixture(t, pool)
+	third := other.insertBuild(t, pool, "failed", 0)
+	_, err = pool.Exec(ctx, "DELETE FROM apps WHERE id = $1", other.appID)
+	require.NoError(t, err)
+	require.Equal(t, 1, outboxRows(t, pool, third.BuildID), "an app delete cascades through identifiers into the outbox")
+}
+
+func TestBuildCleanupDrainsDueRowsWithExactKeys(t *testing.T) {
+	pool, deleter, cleanup := setupBuildCleanup(t)
+	ctx := context.Background()
+	fixture := insertCleanupFixture(t, pool)
+	due := fixture.insertBuild(t, pool, "ready", 0)
+	pending := fixture.insertBuild(t, pool, "ready", 0)
+	_, err := pool.Exec(ctx, "DELETE FROM builds WHERE id = ANY($1)", []string{due.BuildID, pending.BuildID})
+	require.NoError(t, err)
+	makeDue(t, pool, due.BuildID)
+
+	count, err := cleanup.DrainOutbox(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 1, count)
+	final, staging := keysOf(t, due)
+	require.ElementsMatch(t, []string{final, staging}, deleter.keys())
+	require.Equal(t, 0, outboxRows(t, pool, due.BuildID))
+	require.Equal(t, 1, outboxRows(t, pool, pending.BuildID), "a row inside the upload expiry window waits")
+}
+
+func TestBuildCleanupRetriesFailedDeletesWithBackoff(t *testing.T) {
+	pool, deleter, cleanup := setupBuildCleanup(t)
+	ctx := context.Background()
+	fixture := insertCleanupFixture(t, pool)
+	ref := fixture.insertBuild(t, pool, "ready", 0)
+	final, staging := keysOf(t, ref)
+	deleter.failOn[staging] = errors.New("storage unavailable")
+	_, err := pool.Exec(ctx, "DELETE FROM builds WHERE id = $1", ref.BuildID)
+	require.NoError(t, err)
+	makeDue(t, pool, ref.BuildID)
+
+	count, err := cleanup.DrainOutbox(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 0, count)
+	var attempts int
+	var lastError string
+	var dueIn pgtype.Interval
+	require.NoError(t, pool.QueryRow(ctx, "SELECT attempts, last_error, due_at - now() FROM build_artifact_cleanup WHERE build_id = $1", ref.BuildID).Scan(&attempts, &lastError, &dueIn))
+	require.Equal(t, 1, attempts)
+	require.Contains(t, lastError, "storage unavailable")
+	require.Greater(t, duration(dueIn), 30*time.Second)
+	require.Equal(t, []string{final}, deleter.keys(), "the final object was still removed on the failed attempt")
+
+	count, err = cleanup.DrainOutbox(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 0, count, "a backed-off row is not retried early")
+
+	delete(deleter.failOn, staging)
+	makeDue(t, pool, ref.BuildID)
+	count, err = cleanup.DrainOutbox(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 1, count)
+	require.Equal(t, 0, outboxRows(t, pool, ref.BuildID))
+	require.ElementsMatch(t, []string{final, staging, final}, deleter.keys(), "retries re-issue exact idempotent deletes")
+}
+
+func TestBuildCleanupSkipsRowsHeldByAnotherWorker(t *testing.T) {
+	pool, deleter, cleanup := setupBuildCleanup(t)
+	ctx := context.Background()
+	fixture := insertCleanupFixture(t, pool)
+	ref := fixture.insertBuild(t, pool, "ready", 0)
+	_, err := pool.Exec(ctx, "DELETE FROM builds WHERE id = $1", ref.BuildID)
+	require.NoError(t, err)
+	makeDue(t, pool, ref.BuildID)
+
+	holder, err := pool.BeginTx(ctx, pgx.TxOptions{})
+	require.NoError(t, err)
+	_, err = holder.Exec(ctx, "SELECT id FROM build_artifact_cleanup WHERE build_id = $1 FOR UPDATE", ref.BuildID)
+	require.NoError(t, err)
+	count, err := cleanup.DrainOutbox(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 0, count)
+	require.Empty(t, deleter.keys())
+	require.NoError(t, holder.Rollback(ctx))
+
+	count, err = cleanup.DrainOutbox(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 1, count)
+}
+
+func TestBuildStagingSweepOnlyTouchesStaleStaging(t *testing.T) {
+	pool, deleter, cleanup := setupBuildCleanup(t)
+	ctx := context.Background()
+	fixture := insertCleanupFixture(t, pool)
+	oldReady := fixture.insertBuild(t, pool, "ready", 25*time.Hour)
+	oldFailed := fixture.insertBuild(t, pool, "failed", 25*time.Hour)
+	oldUploading := fixture.insertBuild(t, pool, "uploading", 25*time.Hour)
+	youngReady := fixture.insertBuild(t, pool, "ready", time.Hour)
+	youngUploading := fixture.insertBuild(t, pool, "uploading", 23*time.Hour)
+	oldBuilding := fixture.insertBuild(t, pool, "building", 25*time.Hour)
+	retried := fixture.insertBuild(t, pool, "uploading", 25*time.Hour)
+	_, err := pool.Exec(ctx, "UPDATE builds SET updated_at = now() WHERE id = $1", retried.BuildID)
+	require.NoError(t, err)
+
+	count, err := cleanup.SweepStaging(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 3, count)
+	var expected []string
+	for _, ref := range []bucket.BuildArtifact{oldReady, oldFailed, oldUploading} {
+		_, staging := keysOf(t, ref)
+		expected = append(expected, staging)
+	}
+	require.ElementsMatch(t, expected, deleter.keys(), "only staging keys of stale builds are removed")
+	for _, ref := range []bucket.BuildArtifact{youngReady, youngUploading, oldBuilding, retried} {
+		_, staging := keysOf(t, ref)
+		require.NotContains(t, deleter.keys(), staging)
+	}
+
+	count, err = cleanup.SweepStaging(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 0, count, "swept builds are not visited again")
+
+	_, err = pool.Exec(ctx, "UPDATE build_staging_sweeps SET swept_at = now() - interval '2 days' WHERE build_id = ANY($1)", []string{oldReady.BuildID, oldUploading.BuildID})
+	require.NoError(t, err)
+	count, err = cleanup.SweepStaging(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 1, count, "only a build that can still receive uploads is swept again")
+	_, uploadingStaging := keysOf(t, oldUploading)
+	require.Equal(t, uploadingStaging, deleter.keys()[len(deleter.keys())-1])
+}
+
+func TestBuildStagingSweepKeepsLedgerOnDeleteFailureAndSkipsLockedBuilds(t *testing.T) {
+	pool, deleter, cleanup := setupBuildCleanup(t)
+	ctx := context.Background()
+	fixture := insertCleanupFixture(t, pool)
+	failing := fixture.insertBuild(t, pool, "ready", 25*time.Hour)
+	locked := fixture.insertBuild(t, pool, "uploading", 25*time.Hour)
+	_, failingStaging := keysOf(t, failing)
+	deleter.failOn[failingStaging] = errors.New("storage unavailable")
+
+	holder, err := pool.BeginTx(ctx, pgx.TxOptions{})
+	require.NoError(t, err)
+	_, err = holder.Exec(ctx, "SELECT id FROM builds WHERE id = $1 FOR UPDATE", locked.BuildID)
+	require.NoError(t, err)
+	count, err := cleanup.SweepStaging(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 0, count)
+	require.NoError(t, holder.Rollback(ctx))
+
+	var ledger int
+	require.NoError(t, pool.QueryRow(ctx, "SELECT count(*) FROM build_staging_sweeps WHERE build_id = ANY($1)", []string{failing.BuildID, locked.BuildID}).Scan(&ledger))
+	require.Equal(t, 0, ledger)
+
+	delete(deleter.failOn, failingStaging)
+	count, err = cleanup.SweepStaging(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 2, count)
+	_, lockedStaging := keysOf(t, locked)
+	require.ElementsMatch(t, []string{failingStaging, lockedStaging}, deleter.keys())
+}
+
+func TestBuildCleanupStartStopsCleanly(t *testing.T) {
+	pool, _, cleanup := setupBuildCleanup(t)
+	_ = pool
+	stop := cleanup.Start(context.Background())
+	done := make(chan struct{})
+	go func() {
+		stop()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("stop did not return")
+	}
+}
+
+func TestBuildOutboxBackoffIsBoundedAndGrows(t *testing.T) {
+	require.Equal(t, time.Minute, buildOutboxBackoff(0))
+	require.Equal(t, 2*time.Minute, buildOutboxBackoff(1))
+	require.Equal(t, 8*time.Minute, buildOutboxBackoff(3))
+	require.Equal(t, buildOutboxMaxBackoff, buildOutboxBackoff(9))
+	require.Equal(t, buildOutboxMaxBackoff, buildOutboxBackoff(60))
+	require.Equal(t, time.Minute, buildOutboxBackoff(-3))
+}

--- a/sqlc.yaml
+++ b/sqlc.yaml
@@ -37,6 +37,14 @@ sql:
             go_type:
               import: "xprem/internal/types"
               type: "BuildArtifactType"
+          - column: "build_artifact_cleanup.platform"
+            go_type:
+              import: "xprem/internal/types"
+              type: "Platform"
+          - column: "build_artifact_cleanup.artifact_type"
+            go_type:
+              import: "xprem/internal/types"
+              type: "BuildArtifactType"
           - column: "updates.platform"
             go_type:
               import: "xprem/internal/types"


### PR DESCRIPTION
Deleting builds or their parent records now queues artifact deletion, and abandoned staging uploads are collected automatically. The worker uses database locks, retries and backoff so concurrent workers and temporary bucket failures do not lose cleanup work.

Validation: all Go packages compile. PostgreSQL-backed cleanup, staging and outbox tests pass, including cascaded deletion, concurrent workers, cancellation and retries.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic cleanup of deleted build artifacts.
  * Added periodic cleanup of stale build staging data.
  * Cleanup runs in batches with safe concurrent processing.
* **Reliability**
  * Added retry handling with backoff for temporary deletion failures.
  * Cleanup continues processing other items and shuts down gracefully.
* **Tests**
  * Added coverage for retries, locking, staging detection, deletion failures, batching, and shutdown behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->