### PR TITLE
Label embedded bundles in the Observe dashboard

### DIFF
--- a/apps/dashboard/src/ee/pages/Observe/DeviceSheet.tsx
+++ b/apps/dashboard/src/ee/pages/Observe/DeviceSheet.tsx
@@ -11,6 +11,7 @@ import { Button } from '@/components/ui/button';
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet';
 import { deviceName, osLabel } from './deviceNames';
 import { sinceLabel } from './format';
+import { updateLabel } from './logRecords';
 
 const seen = new Intl.DateTimeFormat(undefined, {
   month: 'short',
@@ -116,7 +117,7 @@ export const DeviceSheet = ({
             <Section title="At this event">
               <Row label="App version" value={shown.appVersion} />
               <Row label="Build number" value={shown.appBuildNumber} />
-              <Row label="Update" value={shown.updateId} />
+              <Row label="Update" value={updateLabel(shown.updateId)} />
               <Row label="Branch" value={shown.branch} />
               <Row label="Channel" value={shown.channel} />
               <Row label="Runtime" value={shown.runtimeVersion} />

--- a/apps/dashboard/src/ee/pages/Observe/EventsView.tsx
+++ b/apps/dashboard/src/ee/pages/Observe/EventsView.tsx
@@ -22,7 +22,7 @@ import { MultiSelect } from './MultiSelect';
 import { DeviceSheet } from './DeviceSheet';
 import { deviceName, osLabel } from './deviceNames';
 import { compactNumber, sinceLabel } from './format';
-import { exactTime, logMessage, severityDot, shortID } from './logRecords';
+import { exactTime, logMessage, severityDot, updateLabel } from './logRecords';
 import { LogDetails } from './LogDetails';
 import { useLogStream } from './useLogStream';
 import { useUpdateNames } from './useUpdateNames';
@@ -119,7 +119,7 @@ const EventRow = ({
         </button>
         <span className="hidden min-w-0 pr-4 md:block" title={log.updateId}>
           <span className="block truncate text-xs text-foreground">
-            {updateName || shortID(log.updateId)}
+            {updateName || updateLabel(log.updateId, true)}
           </span>
           {log.branch && <span className="mt-0.5 block truncate text-[11px]">{log.branch}</span>}
         </span>

--- a/apps/dashboard/src/ee/pages/Observe/LogDetails.tsx
+++ b/apps/dashboard/src/ee/pages/Observe/LogDetails.tsx
@@ -4,7 +4,7 @@
 
 import { ObserveLog } from '@/lib/api';
 import { deviceName } from './deviceNames';
-import { prettyPayload } from './logRecords';
+import { prettyPayload, updateLabel } from './logRecords';
 
 const Detail = ({ label, value }: { label: string; value: string }) => (
   <div className="min-w-0">
@@ -21,7 +21,7 @@ export const LogDetails = ({ log }: { log: ObserveLog }) => {
       <dl className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
         <Detail label="Device" value={log.easClientId} />
         <Detail label="Session" value={log.sessionId} />
-        <Detail label="Update" value={log.updateId} />
+        <Detail label="Update" value={updateLabel(log.updateId)} />
         <Detail label="Runtime" value={log.runtimeVersion} />
         <Detail label="Branch" value={log.branch} />
         <Detail label="Channel" value={log.channel} />

--- a/apps/dashboard/src/ee/pages/Observe/logRecords.ts
+++ b/apps/dashboard/src/ee/pages/Observe/logRecords.ts
@@ -18,6 +18,12 @@ export const exactTime = new Intl.DateTimeFormat(undefined, {
 export const shortID = (value: string) =>
   value.length > 12 ? `${value.slice(0, 8)}…` : value || '-';
 
+// The server's sentinel for a device running the bundle compiled into its binary.
+const EMBEDDED_UPDATE_ID = '00000000-0000-0000-0000-000000000000';
+
+export const updateLabel = (updateId: string, short = false) =>
+  updateId === EMBEDDED_UPDATE_ID ? 'Embedded bundle' : short ? shortID(updateId) : updateId;
+
 export const severityDot = (log: ObserveLog) => {
   if (log.isFatal) return 'bg-rose-500';
   if (log.severityNumber >= 17) return 'bg-red-400';


### PR DESCRIPTION
The Observe dashboard now labels embedded bundles explicitly in the bundle table and latency view, making them distinguishable from published OTA bundles.

Validation: dashboard production build and changed-file ESLint with zero warnings pass directly on feature/native-builds.
