### PR TITLE
Adjust the Android example layout and APK build profile

### DIFF
--- a/apps/example-app/app.json
+++ b/apps/example-app/app.json
@@ -6,7 +6,7 @@
     "orientation": "portrait",
     "icon": "./assets/images/icon.png",
     "scheme": "myapp",
-    "userInterfaceStyle": "automatic",
+    "userInterfaceStyle": "light",
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.expoota.exampleapp"

--- a/apps/example-app/screens/CatalogScreen.tsx
+++ b/apps/example-app/screens/CatalogScreen.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from 'react'
-import { FlatList, SafeAreaView, StyleSheet, TouchableOpacity } from 'react-native'
+import { FlatList, StyleSheet, TouchableOpacity } from 'react-native'
+import { SafeAreaView } from 'react-native-safe-area-context'
 import { useObserve } from 'expo-observe'
 
 import { ThemedText } from '@/components/ThemedText'

--- a/apps/example-app/screens/ItemScreen.tsx
+++ b/apps/example-app/screens/ItemScreen.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from 'react'
-import { SafeAreaView, ScrollView, StyleSheet } from 'react-native'
+import { ScrollView, StyleSheet } from 'react-native'
+import { SafeAreaView } from 'react-native-safe-area-context'
 import { useObserve } from 'expo-observe'
 
 import { ThemedText } from '@/components/ThemedText'

--- a/apps/example-app/screens/LabScreen.tsx
+++ b/apps/example-app/screens/LabScreen.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
-import { SafeAreaView, ScrollView, StyleSheet, TouchableOpacity } from 'react-native'
+import { ScrollView, StyleSheet, TouchableOpacity } from 'react-native'
+import { SafeAreaView } from 'react-native-safe-area-context'
 import { Observe, useObserve } from 'expo-observe'
 
 import { ThemedText } from '@/components/ThemedText'

--- a/apps/example-app/screens/ModalScreen.tsx
+++ b/apps/example-app/screens/ModalScreen.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from 'react'
-import { Button, SafeAreaView, StyleSheet } from 'react-native'
+import { Button, StyleSheet } from 'react-native'
+import { SafeAreaView } from 'react-native-safe-area-context'
 import { useObserve } from 'expo-observe'
 
 import { ThemedText } from '@/components/ThemedText'

--- a/apps/example-app/screens/SlowScreen.tsx
+++ b/apps/example-app/screens/SlowScreen.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
-import { ActivityIndicator, SafeAreaView, StyleSheet } from 'react-native'
+import { ActivityIndicator, StyleSheet } from 'react-native'
+import { SafeAreaView } from 'react-native-safe-area-context'
 import { useObserve } from 'expo-observe'
 
 import { ThemedText } from '@/components/ThemedText'

--- a/apps/example-app/screens/UpdatesScreen.tsx
+++ b/apps/example-app/screens/UpdatesScreen.tsx
@@ -2,12 +2,12 @@ import { useEffect, useState } from 'react'
 import {
   ActivityIndicator,
   Platform,
-  SafeAreaView,
-  ScrollView,
+ScrollView,
   StyleSheet,
   TouchableOpacity,
   View,
 } from 'react-native'
+import { SafeAreaView } from 'react-native-safe-area-context'
 import * as Updates from 'expo-updates'
 import Constants from 'expo-constants'
 import * as Clipboard from 'expo-clipboard'

--- a/apps/example-app/xprem.json
+++ b/apps/example-app/xprem.json
@@ -5,7 +5,7 @@
       "android": {
         "applicationId": "com.xprem.sample",
         "mode": "release",
-        "artifact": "aab"
+        "artifact": "apk"
       },
       "channel": "production"
     }


### PR DESCRIPTION
The example app uses a light theme and adjusts screen safe areas for the updated Android layout. Its test build profile produces an APK for installation on a device.

Validation: both JSON files parse. TypeScript diagnostics match the base branch exactly: six existing errors involving Jest globals, IconSymbol and useThemeColor. No Android build was run. This PR is independent of the build upload stack and preserves the original example changes.
