### PR TITLE
Align token access summaries with Build and Submit permissions

### DIFF
--- a/apps/dashboard/src/lib/api.ts
+++ b/apps/dashboard/src/lib/api.ts
@@ -746,8 +746,9 @@ export type CreateApiKeyResponse = {
   apiKey: string;
 };
 
-// Enterprise token permissions. Empty action/rule lists grant no access;
-// an empty IP allowlist permits any source address. MIT ignores these restrictions.
+// Enterprise token permissions. Empty Updates rules grant no access; empty Build
+// and Submit rules are unrestricted within the app. An empty IP allowlist permits
+// any source address. MIT ignores these restrictions.
 export type ApiKeyAccessRecord = {
   apiKeyId: string;
   updates: { rules: UpdateRuleRecord[] };

--- a/apps/dashboard/src/pages/ApiTokens/index.tsx
+++ b/apps/dashboard/src/pages/ApiTokens/index.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { Copy, Pencil, Plus, ShieldCheck, Trash2 } from 'lucide-react';
+import { Copy, Pencil, Plus, Trash2 } from 'lucide-react';
 import { api, ApiKeyRecord, ApiProblemError } from '@/lib/api';
 import { useSelectedApp } from '@/lib/SelectedAppContext';
 import { useSettings } from '@/lib/SettingsContext';
@@ -36,7 +36,7 @@ export const ApiTokens = () => {
     enabled: !!selectedAppId && CONTROL_PLANE_ENABLED,
   });
 
-  // What each token is allowed to do, summarized in the Access column. The
+  // What each token is allowed to do, summarized by domain. The
   // editing itself lives in ApiKeyAccessSheet.
   const apiKeyAccessQuery = useQuery({
     queryKey: ['apiKeyAccess', selectedAppId],
@@ -53,25 +53,31 @@ export const ApiTokens = () => {
     enabled: CONTROL_PLANE_ENABLED,
   });
 
-  const describeAccess = (apiKeyId: string) => {
-    if (!licenseQuery.data) return licenseQuery.isError ? 'Access unavailable' : 'Loading access…';
-    if (!licenseQuery.data.valid) return 'Unrestricted';
-    const access = accessByKeyId.get(apiKeyId);
-    if (!access) return apiKeyAccessQuery.isError ? 'Access unavailable' : 'Loading access…';
-    const ruleCount = access.updates.rules.length;
-    const parts = [
-      ruleCount > 0
-        ? `Updates: ${ruleCount} branch rule${ruleCount > 1 ? 's' : ''}`
-        : 'Updates: no access',
-    ];
-    parts.push(
-      access.build.rules.length ? `Build: ${access.build.rules.length} identifier(s)` : 'Build: no access'
-    );
-    parts.push(access.submit.rules.length ? `Submit: ${access.submit.rules.length} destination rule(s)` : 'Submit: no access');
-    if (access.allowedIps.length) {
-      parts.push(`${access.allowedIps.length} IP${access.allowedIps.length > 1 ? 's' : ''}`);
+  const renderAccess = (apiKeyId: string, domain: 'updates' | 'build' | 'submit' | 'allowedIps') => {
+    if (!licenseQuery.data) {
+      return <span className="text-xs text-muted-foreground">{licenseQuery.isError ? 'Access unavailable' : 'Loading access…'}</span>;
     }
-    return parts.join(' · ');
+    if (!licenseQuery.data.valid) {
+      return <span className="rounded-md bg-muted px-2 py-1 text-xs font-medium">Unrestricted</span>;
+    }
+    const access = accessByKeyId.get(apiKeyId);
+    if (!access) {
+      return <span className="text-xs text-muted-foreground">{apiKeyAccessQuery.isError ? 'Access unavailable' : 'Loading access…'}</span>;
+    }
+    const count = domain === 'allowedIps' ? access.allowedIps.length : access[domain].rules.length;
+    const unit = { updates: 'branch rule', build: 'identifier', submit: 'destination', allowedIps: 'IP rule' }[domain];
+    const empty = domain === 'updates' ? 'No access' : domain === 'allowedIps' ? 'Any IP' : 'Full access';
+    return (
+      <span className={`inline-flex h-6 items-center whitespace-nowrap rounded-md px-2 text-xs font-medium ${
+        count > 0
+          ? 'bg-primary/10 text-primary'
+          : domain === 'updates' || domain === 'allowedIps'
+            ? 'bg-muted text-muted-foreground'
+            : 'bg-emerald-500/10 text-emerald-700 dark:text-emerald-300'
+      }`}>
+        {count > 0 ? `${count} ${unit}${count > 1 ? 's' : ''}` : empty}
+      </span>
+    );
   };
 
   const handleCreateApiKey = async () => {
@@ -182,7 +188,7 @@ export const ApiTokens = () => {
             <p className="mt-0.5 text-xs text-muted-foreground">
               Copy it now, it will not be shown again.
               {licenseQuery.data?.valid &&
-                ' New tokens have no access. Use Edit in the Access column to grant permissions.'}
+                ' New tokens have full Build and Submit access for this app, and no Updates access. Use Edit in the Access column to configure permissions.'}
             </p>
             <div className="mt-3 flex items-center gap-2">
               <code className="flex-1 select-all break-all rounded-lg border bg-background p-2.5 font-mono text-xs">
@@ -235,50 +241,41 @@ export const ApiTokens = () => {
                 return <TimestampCell dateString={lastUsed} />;
               },
             },
-            {
-              header: 'Access',
-              id: 'access',
-              cell: ({ row }: { row: { original: ApiKeyRecord } }) => {
-                const summary = describeAccess(row.original.id);
-                const state = summary ? (
-                  <span className="inline-flex items-center gap-1.5 text-sm font-medium text-emerald-700 dark:text-emerald-300">
-                    <ShieldCheck className="h-3.5 w-3.5" />
-                    {summary}
-                  </span>
-                ) : (
-                  <span className="text-sm text-muted-foreground/60">Access unavailable</span>
-                );
-                if (!canManageApiKeys) {
-                  return state;
-                }
-                return (
-                  <button
-                    type="button"
-                    onClick={() => setKeyToRestrict(row.original)}
-                    className="group inline-flex items-center gap-2.5"
-                    title="Edit what this token is allowed to do">
-                    {state}
-                    <span className="inline-flex items-center gap-1 text-sm font-medium text-link group-hover:underline">
-                      <Pencil className="h-3 w-3" />
-                      Edit
-                    </span>
-                  </button>
-                );
-              },
-            },
+            ...(['updates', 'build', 'submit'] as const).map(domain => ({
+              header: { updates: 'Updates', build: 'Build', submit: 'Submit' }[domain],
+              id: domain,
+              cell: ({ row }: { row: { original: ApiKeyRecord } }) => renderAccess(row.original.id, domain),
+            })),
+            ...(licenseQuery.data?.valid && apiKeyAccessQuery.data?.some(access => access.allowedIps.length > 0)
+              ? [{
+                  header: 'IP allowlist',
+                  id: 'allowedIps',
+                  cell: ({ row }: { row: { original: ApiKeyRecord } }) => renderAccess(row.original.id, 'allowedIps'),
+                }]
+              : []),
             ...(canManageApiKeys
               ? [
                   {
                     header: '',
                     id: 'actions',
                     cell: ({ row }: { row: { original: ApiKeyRecord } }) => (
-                      <div className="text-right">
+                      <div className="flex justify-end gap-1">
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          onClick={() => setKeyToRestrict(row.original)}
+                          className="h-8 w-8 text-muted-foreground"
+                          title="Edit access"
+                          aria-label={`Edit access for ${row.original.name}`}>
+                          <Pencil />
+                        </Button>
                         <Button
                           variant="ghost"
                           size="sm"
                           onClick={() => setKeyToRevoke(row.original)}
                           className="h-8 w-8 p-0 text-muted-foreground hover:bg-destructive/10 hover:text-destructive"
-                          title="Revoke token">
+                          title="Revoke token"
+                          aria-label={`Revoke token ${row.original.name}`}>
                           <Trash2 />
                         </Button>
                       </div>

--- a/apps/dashboard/src/pages/ApiTokens/index.tsx
+++ b/apps/dashboard/src/pages/ApiTokens/index.tsx
@@ -188,7 +188,7 @@ export const ApiTokens = () => {
             <p className="mt-0.5 text-xs text-muted-foreground">
               Copy it now, it will not be shown again.
               {licenseQuery.data?.valid &&
-                ' New tokens have full Build and Submit access for this app, and no Updates access. Use Edit in the Access column to configure permissions.'}
+                ' New tokens have full Build and Submit access for this app, and no Updates access. Use the Edit access action to configure permissions.'}
             </p>
             <div className="mt-3 flex items-center gap-2">
               <code className="flex-1 select-all break-all rounded-lg border bg-background p-2.5 font-mono text-xs">


### PR DESCRIPTION
The token table now shows Updates, Build and Submit access separately with aligned columns and compact badges. Empty Build and Submit restrictions are displayed as full access, matching the authorization behavior, while empty Updates restrictions remain no access.

Validation: dashboard production build and targeted lint pass. This PR is independent of the build upload stack and changes only the token summary presentation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * API token access is now shown separately for Updates, Build, and Submit permissions.
  * IP allowlist status is displayed in its own column when applicable.
  * Permission states now clearly indicate unrestricted, unavailable, no-access, and full-access conditions.
  * New-token messaging clarifies default access for valid-license tokens.

* **Documentation**
  * Updated permission guidance to explain how empty rules affect each permission area and IP allowlists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->