### PR TITLE
pin-license-server-url

### DIFF
--- a/ee/licensing/client.go
+++ b/ee/licensing/client.go
@@ -16,8 +16,8 @@ import (
 	"time"
 )
 
-// DefaultAPIBaseURL is the production license server.
-const DefaultAPIBaseURL = "https://api.xprem.dev"
+// APIBaseURL is the license server.
+const APIBaseURL = "https://api.xprem.dev"
 
 // Error codes answered by the license server on check, attach and validate.
 const (
@@ -58,11 +58,12 @@ type Client struct {
 	httpClient *http.Client
 }
 
-// NewClient falls back to DefaultAPIBaseURL when baseURL is empty.
-func NewClient(baseURL string) *Client {
-	if baseURL == "" {
-		baseURL = DefaultAPIBaseURL
-	}
+// NewClient talks to the license server at APIBaseURL.
+func NewClient() *Client {
+	return newClient(APIBaseURL)
+}
+
+func newClient(baseURL string) *Client {
 	baseURL = strings.TrimRight(baseURL, "/")
 	return &Client{baseURL: baseURL, httpClient: &http.Client{Timeout: 15 * time.Second}}
 }

--- a/ee/licensing/client_test.go
+++ b/ee/licensing/client_test.go
@@ -48,7 +48,7 @@ func (f *fakeLicenseServer) client(t *testing.T) *Client {
 	}
 	server := httptest.NewServer(router)
 	t.Cleanup(server.Close)
-	return NewClient(server.URL)
+	return newClient(server.URL)
 }
 
 func writeJSONBody(w http.ResponseWriter, status int, body string) {
@@ -145,7 +145,7 @@ func TestClientTrimsTrailingSlashFromBaseURL(t *testing.T) {
 	server := httptest.NewServer(router)
 	t.Cleanup(server.Close)
 
-	result, err := NewClient(server.URL+"/").Check(context.Background(), testKeyParams("XPREM-KEY"))
+	result, err := newClient(server.URL+"/").Check(context.Background(), testKeyParams("XPREM-KEY"))
 	require.NoError(t, err)
 	assert.True(t, result.Valid)
 }
@@ -194,6 +194,6 @@ func TestClientUnexpectedStatusIsUnreachable(t *testing.T) {
 func TestClientConnectionFailureIsUnreachable(t *testing.T) {
 	server := httptest.NewServer(http.NotFoundHandler())
 	server.Close()
-	_, err := NewClient(server.URL).Check(context.Background(), testKeyParams("XPREM-KEY"))
+	_, err := newClient(server.URL).Check(context.Background(), testKeyParams("XPREM-KEY"))
 	require.ErrorIs(t, err, ErrServerUnreachable)
 }

--- a/ee/licensing/service_audit_test.go
+++ b/ee/licensing/service_audit_test.go
@@ -90,7 +90,7 @@ func TestSyncEmitsSuspensionEventBeforeDroppingTheLicense(t *testing.T) {
 	anchor := time.Now().Add(-GracePeriod - time.Hour).UTC()
 	repo.stored.ValidationFailedAt = &anchor
 	repo.stored.ValidationErrorCode = CodeSubscriptionInactive
-	service := newTestService(t, repo, NewClient("http://127.0.0.1:1"))
+	service := newTestService(t, repo, newClient("http://127.0.0.1:1"))
 	var recorded []auditlog.Event
 	service.SetOnAuditEvent(gatedRecorder(&recorded))
 	Activate(repo.stored.License)

--- a/ee/licensing/service_test.go
+++ b/ee/licensing/service_test.go
@@ -128,7 +128,7 @@ func repoWithAcme() *fakeLicenseRepo {
 }
 
 func TestServiceStatelessModeAnswersControlPlaneError(t *testing.T) {
-	service := newTestService(t, nil, NewClient(""))
+	service := newTestService(t, nil, NewClient())
 	if _, err := service.Status(context.Background()); !errors.Is(err, ErrLicenseRequiresControlPlane) {
 		t.Fatalf("expected ErrLicenseRequiresControlPlane, got %v", err)
 	}
@@ -387,7 +387,7 @@ func TestValidateNowSkipsWithoutInstanceIdInsteadOfBurningGrace(t *testing.T) {
 	repo := repoWithAcme()
 	Deactivate()
 	t.Cleanup(Deactivate)
-	service := NewLicenseService(repo, NewClient("http://127.0.0.1:1"), "", "https://updates.example.com")
+	service := NewLicenseService(repo, newClient("http://127.0.0.1:1"), "", "https://updates.example.com")
 	Activate(repo.stored.License)
 
 	service.ValidateNow(context.Background())
@@ -399,7 +399,7 @@ func TestValidateNowSkipsWithoutInstanceIdInsteadOfBurningGrace(t *testing.T) {
 func TestValidateNowSkipsWhenSecretUnreadableInsteadOfBurningGrace(t *testing.T) {
 	repo := repoWithAcme()
 	repo.secretErr = errors.New("failed to unseal the license activation secret")
-	service := newTestService(t, repo, NewClient("http://127.0.0.1:1"))
+	service := newTestService(t, repo, newClient("http://127.0.0.1:1"))
 	Activate(repo.stored.License)
 
 	service.ValidateNow(context.Background())
@@ -410,7 +410,7 @@ func TestValidateNowSkipsWhenSecretUnreadableInsteadOfBurningGrace(t *testing.T)
 
 func TestValidateNowIgnoresShutdownCancellation(t *testing.T) {
 	repo := repoWithAcme()
-	service := newTestService(t, repo, NewClient("http://127.0.0.1:1"))
+	service := newTestService(t, repo, newClient("http://127.0.0.1:1"))
 	Activate(repo.stored.License)
 	cancelled, cancel := context.WithCancel(context.Background())
 	cancel()
@@ -425,7 +425,7 @@ func TestActivateFromStoreWithinGrace(t *testing.T) {
 	repo := repoWithAcme()
 	failedAt := time.Now().Add(-time.Hour).UTC()
 	repo.stored.ValidationFailedAt = &failedAt
-	service := newTestService(t, repo, NewClient(""))
+	service := newTestService(t, repo, NewClient())
 
 	require.NoError(t, service.ActivateFromStore(context.Background()))
 	assert.True(t, IsEnterprise())
@@ -435,7 +435,7 @@ func TestActivateFromStoreSuspendedRunsCommunity(t *testing.T) {
 	repo := repoWithAcme()
 	failedAt := time.Now().Add(-GracePeriod - time.Hour).UTC()
 	repo.stored.ValidationFailedAt = &failedAt
-	service := newTestService(t, repo, NewClient(""))
+	service := newTestService(t, repo, NewClient())
 
 	require.NoError(t, service.ActivateFromStore(context.Background()))
 	assert.False(t, IsEnterprise())
@@ -449,7 +449,7 @@ func TestActivateFromStoreSuspendedRunsCommunity(t *testing.T) {
 
 func TestRemoveDropsToCommunity(t *testing.T) {
 	repo := repoWithAcme()
-	service := newTestService(t, repo, NewClient(""))
+	service := newTestService(t, repo, NewClient())
 	Activate(repo.stored.License)
 
 	require.NoError(t, service.Remove(context.Background()))

--- a/internal/router/wire.go
+++ b/internal/router/wire.go
@@ -247,7 +247,7 @@ func InitDependencies(ctx context.Context) (*AppContainer, func()) {
 	}
 	auditService.StartRetentionPurgeFromEnv(ctx)
 
-	licenseClient := licensing.NewClient(config.GetEnv("LICENSE_API_URL"))
+	licenseClient := licensing.NewClient()
 	licenseService := licensing.NewLicenseService(licenseRepo, licenseClient, instanceId, config.BaseURL())
 	// Wired before the loops start: they emit audit events from goroutines.
 	licenseService.SetOnAuditEvent(auditService.Record)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Changes**
  - Standardized licensing client initialization around the configured default licensing API endpoint.
  - Removed support for selecting a custom licensing endpoint through the application’s environment configuration.
  - Updated the licensing API naming and client construction interface.
- **Tests**
  - Updated licensing client and service tests to reflect the revised initialization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->