### PR TITLE
remove eas build deps

### DIFF
--- a/apps/eoas/THIRD_PARTY_NOTICES
+++ b/apps/eoas/THIRD_PARTY_NOTICES
@@ -1,0 +1,31 @@
+The following files are copied, in whole or in part, from eas-cli v16.3.1
+(https://github.com/expo/eas-cli/tree/v16.3.1), licensed under the MIT License:
+
+  src/lib/assets.ts
+  src/lib/expoConfig.ts
+  src/lib/log.ts
+  src/lib/prompts.ts
+  src/lib/repo.ts
+  src/lib/vcs/
+
+The MIT License (MIT)
+
+Copyright (c) 2020-present 650 Industries, Inc. (aka Expo)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/apps/eoas/package-lock.json
+++ b/apps/eoas/package-lock.json
@@ -13,7 +13,6 @@
         "@expo/code-signing-certificates": "^0.0.5",
         "@expo/config": "10.0.11",
         "@expo/config-plugins": "9.0.12",
-        "@expo/eas-build-job": "1.0.165",
         "@expo/fingerprint": "^0.11.7",
         "@expo/package-manager": "1.7.0",
         "@expo/spawn-async": "1.7.2",
@@ -1405,43 +1404,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/@expo/eas-build-job": {
-      "version": "1.0.165",
-      "resolved": "https://registry.npmjs.org/@expo/eas-build-job/-/eas-build-job-1.0.165.tgz",
-      "integrity": "sha512-l4bPVRmc6SlrgiC7AOid6s+o3kyP47x17cGIPQ0d4FOaOxu6pP3bPZ3BuPjts1mfvrKg/c/Phe1fJ1nnNlo3Xw==",
-      "license": "MIT",
-      "dependencies": {
-        "@expo/logger": "1.0.117",
-        "joi": "^17.13.1",
-        "semver": "^7.6.2",
-        "zod": "^3.23.8"
-      }
-    },
-    "node_modules/@expo/eas-build-job/node_modules/joi": {
-      "version": "17.13.3",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.3.tgz",
-      "integrity": "sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@hapi/hoek": "^9.3.0",
-        "@hapi/topo": "^5.1.0",
-        "@sideway/address": "^4.1.5",
-        "@sideway/formula": "^3.0.1",
-        "@sideway/pinpoint": "^2.0.0"
-      }
-    },
-    "node_modules/@expo/eas-build-job/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@expo/fingerprint": {
       "version": "0.11.7",
       "resolved": "https://registry.npmjs.org/@expo/fingerprint/-/fingerprint-0.11.7.tgz",
@@ -1484,16 +1446,6 @@
         "@babel/code-frame": "~7.10.4",
         "json5": "^2.2.3",
         "write-file-atomic": "^2.3.0"
-      }
-    },
-    "node_modules/@expo/logger": {
-      "version": "1.0.117",
-      "resolved": "https://registry.npmjs.org/@expo/logger/-/logger-1.0.117.tgz",
-      "integrity": "sha512-tuCT5fmjRjED6HYAf4HgE+UbiHT3JYrkUzUv9FC769goxo4LuuewBNQiDUkeecQTha7aTS5aO2YHlfdipI8gzg==",
-      "license": "BUSL-1.1",
-      "dependencies": {
-        "@types/bunyan": "^1.8.11",
-        "bunyan": "^1.8.15"
       }
     },
     "node_modules/@expo/package-manager": {
@@ -2507,15 +2459,6 @@
       "integrity": "sha512-5xxU8vVs9/FNcvm3gE07fPbn9tl6tqGGWA9tSlwsUEkBxtRnTsNmwrV8gasZ9F/EobaSv9+nu8AxUKccw77JpQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/bunyan": {
-      "version": "1.8.11",
-      "resolved": "https://registry.npmjs.org/@types/bunyan/-/bunyan-1.8.11.tgz",
-      "integrity": "sha512-758fRH7umIMk5qt5ELmRMff4mLDlN+xyYzC+dkPTdKwbSkJFvz6xwyScrytPU0QIBbRRwbiE8/BIg8bpajerNQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
     },
     "node_modules/@types/estree": {
       "version": "1.0.9",
@@ -3544,24 +3487,6 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "license": "MIT"
     },
-    "node_modules/bunyan": {
-      "version": "1.8.15",
-      "resolved": "https://registry.npmjs.org/bunyan/-/bunyan-1.8.15.tgz",
-      "integrity": "sha512-0tECWShh6wUysgucJcBAoYegf3JJoZWibxdqhTm7OHPeT42qdjkZ29QCMcKwbgU1kiH+auSIasNRXMLWXafXig==",
-      "engines": [
-        "node >=0.10.0"
-      ],
-      "license": "MIT",
-      "bin": {
-        "bunyan": "bin/bunyan"
-      },
-      "optionalDependencies": {
-        "dtrace-provider": "~0.8",
-        "moment": "^2.19.3",
-        "mv": "~2",
-        "safe-json-stringify": "~1"
-      }
-    },
     "node_modules/cac": {
       "version": "6.7.14",
       "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
@@ -4037,20 +3962,6 @@
       },
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/dtrace-provider": {
-      "version": "0.8.8",
-      "resolved": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.8.8.tgz",
-      "integrity": "sha512-b7Z7cNtHPhH9EJhNNbbeqTcXB8LGFFZhq1PGgEvpeHlzd36bhbdTWoE/Ba/YguqpBSlAPKnARWhVlhunCMwfxg==",
-      "hasInstallScript": true,
-      "license": "BSD-2-Clause",
-      "optional": true,
-      "dependencies": {
-        "nan": "^2.14.0"
-      },
-      "engines": {
-        "node": ">=0.10"
       }
     },
     "node_modules/dunder-proto": {
@@ -6672,7 +6583,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -6713,81 +6624,11 @@
         "node": ">=8"
       }
     },
-    "node_modules/mkdirp": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "minimist": "^1.2.6"
-      },
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      }
-    },
-    "node_modules/moment": {
-      "version": "2.30.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
-      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
-    },
-    "node_modules/mv": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/mv/-/mv-2.1.1.tgz",
-      "integrity": "sha512-at/ZndSy3xEGJ8i0ygALh8ru9qy7gWW1cmkaqBN29JmMlIvM//MEO9y1sk/avxuwnPcfhkejkLsuPxH81BrkSg==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "mkdirp": "~0.5.1",
-        "ncp": "~2.0.0",
-        "rimraf": "~2.4.0"
-      },
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/mv/node_modules/glob": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
-      "integrity": "sha512-MKZeRNyYZAVVVG1oZeLaWie1uweH40m9AZwIwxyPbTSX4hHrVYSzLg0Ro5Z5R7XKkIX+Cc6oD1rqeDJnwsB8/A==",
-      "deprecated": "Glob versions prior to v9 are no longer supported",
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "2 || 3",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/mv/node_modules/rimraf": {
-      "version": "2.4.5",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
-      "integrity": "sha512-J5xnxTyqaiw06JjMftq7L9ouA448dw/E7dKghkP9WpKNuwmARNNg+Gk8/u5ryb9N/Yo2+z3MCwuqFK/+qPOPfQ==",
-      "deprecated": "Rimraf versions prior to v4 are no longer supported",
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "glob": "^6.0.1"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      }
     },
     "node_modules/mz": {
       "version": "2.7.0",
@@ -6799,13 +6640,6 @@
         "object-assign": "^4.0.1",
         "thenify-all": "^1.0.0"
       }
-    },
-    "node_modules/nan": {
-      "version": "2.22.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.22.0.tgz",
-      "integrity": "sha512-nbajikzWTMwsW+eSsNm3QwlOs7het9gGJU5dDZzRTQGk03vyBOauxgI4VakDzE0PtsGTmXPsXTbbjVhRwR5mpw==",
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/nanoid": {
       "version": "3.3.16",
@@ -6831,16 +6665,6 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "license": "MIT"
-    },
-    "node_modules/ncp": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
-      "integrity": "sha512-zIdGUrPRFTUELUvr3Gmc7KZ2Sw/h1PiVM0Af/oHB6zgnV1ikqSfRk+TOufi79aHYCW3NiOXmr1BP5nWbzojLaA==",
-      "license": "MIT",
-      "optional": true,
-      "bin": {
-        "ncp": "bin/ncp"
-      }
     },
     "node_modules/neo-async": {
       "version": "2.6.2",
@@ -7780,13 +7604,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/safe-json-stringify": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/safe-json-stringify/-/safe-json-stringify-1.2.0.tgz",
-      "integrity": "sha512-gH8eh2nZudPQO6TytOvbxnuhYBOvDBBLW52tz5q6X58lJcd/tkmqFR+5Z9adS8aJtURSXWThWy/xJtJwixErvg==",
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/safe-push-apply": {
       "version": "1.0.0",
@@ -9405,15 +9222,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/zod": {
-      "version": "3.24.1",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.1.tgz",
-      "integrity": "sha512-muH7gBL9sI1nciMZV67X5fTKKBLtwpZ5VBp1vsOQzj1MhrBZ4wlVCm3gedKZWLp0Oyel8sIGfeiz54Su+OVT+A==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/apps/eoas/package.json
+++ b/apps/eoas/package.json
@@ -30,7 +30,6 @@
     "@expo/code-signing-certificates": "^0.0.5",
     "@expo/config": "10.0.11",
     "@expo/config-plugins": "9.0.12",
-    "@expo/eas-build-job": "1.0.165",
     "@expo/fingerprint": "^0.11.7",
     "@expo/package-manager": "1.7.0",
     "@expo/spawn-async": "1.7.2",

--- a/apps/eoas/package.json
+++ b/apps/eoas/package.json
@@ -98,6 +98,7 @@
   },
   "files": [
     "/bin",
-    "/dist"
+    "/dist",
+    "/THIRD_PARTY_NOTICES"
   ]
 }

--- a/apps/eoas/src/commands/__tests__/publish.test.ts
+++ b/apps/eoas/src/commands/__tests__/publish.test.ts
@@ -43,7 +43,10 @@ vi.mock('../../lib/package', () => ({ isExpoInstalled: () => true }));
 vi.mock('../../lib/runtimeVersion', () => ({
   resolveRuntimeVersionAsync: async () => ({ runtimeVersion: '1.0.0' }),
 }));
-vi.mock('../../lib/workflow', () => ({ resolveWorkflowAsync: async () => 'generic' }));
+vi.mock('../../lib/workflow', async importOriginal => ({
+  ...(await importOriginal<typeof import('../../lib/workflow')>()),
+  resolveWorkflowAsync: async () => 'generic',
+}));
 vi.mock('../../lib/expoConfig', async importOriginal => {
   const original = await importOriginal<typeof import('../../lib/expoConfig')>();
   return {

--- a/apps/eoas/src/commands/doctor.ts
+++ b/apps/eoas/src/commands/doctor.ts
@@ -1,7 +1,6 @@
-import { Env } from '@expo/eas-build-job';
 import { Command, Flags } from '@oclif/core';
 
-import { getExpoAppId, getPrivateExpoConfigAsync, resolveServerUrl } from '../lib/expoConfig';
+import { Env, getExpoAppId, getPrivateExpoConfigAsync, resolveServerUrl } from '../lib/expoConfig';
 import { fetchWithRetries } from '../lib/fetch';
 import Log from '../lib/log';
 import { ora } from '../lib/ora';

--- a/apps/eoas/src/commands/publish.ts
+++ b/apps/eoas/src/commands/publish.ts
@@ -1,4 +1,3 @@
-import { Env, Platform } from '@expo/eas-build-job';
 import spawnAsync from '@expo/spawn-async';
 import { Command, Flags } from '@oclif/core';
 import { randomUUID } from 'crypto';
@@ -18,6 +17,7 @@ import {
 } from '../lib/assets';
 import { getAuthHeaders, retrieveCredentials, validateCredentials } from '../lib/auth';
 import {
+  Env,
   RequestedPlatform,
   getPrivateExpoConfigAsync,
   getPublicExpoConfigAsync,
@@ -34,7 +34,7 @@ import { RateLimiter } from '../lib/rateLimiter';
 import { ensureRepoIsCleanAsync } from '../lib/repo';
 import { resolveRuntimeVersionAsync } from '../lib/runtimeVersion';
 import { resolveVcsClient } from '../lib/vcs';
-import { resolveWorkflowAsync } from '../lib/workflow';
+import { Platform, resolveWorkflowAsync } from '../lib/workflow';
 
 export default class Publish extends Command {
   static override args = {};

--- a/apps/eoas/src/commands/republish.ts
+++ b/apps/eoas/src/commands/republish.ts
@@ -1,8 +1,12 @@
-import { Env } from '@expo/eas-build-job';
 import { Command, Flags } from '@oclif/core';
 
 import { getAuthHeaders, retrieveCredentials, validateCredentials } from '../lib/auth';
-import { getPrivateExpoConfigAsync, requireExpoAppId, resolveServerUrl } from '../lib/expoConfig';
+import {
+  Env,
+  getPrivateExpoConfigAsync,
+  requireExpoAppId,
+  resolveServerUrl,
+} from '../lib/expoConfig';
 import { fetchWithRetries } from '../lib/fetch';
 import Log from '../lib/log';
 import { ora } from '../lib/ora';

--- a/apps/eoas/src/commands/rollback.ts
+++ b/apps/eoas/src/commands/rollback.ts
@@ -1,8 +1,8 @@
-import { Env, Platform } from '@expo/eas-build-job';
 import { Command, Flags } from '@oclif/core';
 
 import { getAuthHeaders, retrieveCredentials, validateCredentials } from '../lib/auth';
 import {
+  Env,
   RequestedPlatform,
   getPrivateExpoConfigAsync,
   requireExpoAppId,
@@ -15,7 +15,7 @@ import { isExpoInstalled } from '../lib/package';
 import { confirmAsync } from '../lib/prompts';
 import { resolveRuntimeVersionAsync } from '../lib/runtimeVersion';
 import { resolveVcsClient } from '../lib/vcs';
-import { resolveWorkflowAsync } from '../lib/workflow';
+import { Platform, resolveWorkflowAsync } from '../lib/workflow';
 
 export default class Publish extends Command {
   static override args = {};

--- a/apps/eoas/src/lib/assets.ts
+++ b/apps/eoas/src/lib/assets.ts
@@ -1,4 +1,4 @@
-// This file is partially copied from eas-cli[https://github.com/expo/eas-cli] to ensure consistent user experience across the CLI.
+// This file is partially copied from eas-cli v16.3.1 (MIT, https://github.com/expo/eas-cli/tree/v16.3.1) to ensure consistent user experience across the CLI.
 import { Platform } from '@expo/config';
 import fs from 'fs-extra';
 import Joi from 'joi';

--- a/apps/eoas/src/lib/expoConfig.ts
+++ b/apps/eoas/src/lib/expoConfig.ts
@@ -1,6 +1,5 @@
 // This file is copied from eas-cli[https://github.com/expo/eas-cli] to ensure consistent user experience across the CLI.
 import { ExpoConfig, getConfig, getConfigFilePaths } from '@expo/config';
-import { Env } from '@expo/eas-build-job';
 import spawnAsync from '@expo/spawn-async';
 import fs from 'fs-extra';
 import Joi from 'joi';
@@ -10,6 +9,8 @@ import path from 'path';
 import Log from './log';
 import { isExpoInstalled } from './package';
 import { resolvePackageRunner, splitPackageRunner } from './packageRunner';
+
+export type Env = Record<string, string>;
 
 export enum RequestedPlatform {
   Android = 'android',

--- a/apps/eoas/src/lib/expoConfig.ts
+++ b/apps/eoas/src/lib/expoConfig.ts
@@ -1,4 +1,4 @@
-// This file is copied from eas-cli[https://github.com/expo/eas-cli] to ensure consistent user experience across the CLI.
+// This file is copied from eas-cli v16.3.1 (MIT, https://github.com/expo/eas-cli/tree/v16.3.1) to ensure consistent user experience across the CLI.
 import { ExpoConfig, getConfig, getConfigFilePaths } from '@expo/config';
 import spawnAsync from '@expo/spawn-async';
 import fs from 'fs-extra';

--- a/apps/eoas/src/lib/log.ts
+++ b/apps/eoas/src/lib/log.ts
@@ -1,6 +1,6 @@
 // Rendering for every command's output, drawn with the @clack/prompts
 // primitives so the whole CLI shares one visual identity (gutter, symbols,
-// notes). The static API is kept from the original eas-cli logger so call
+// notes). The static API is kept from the eas-cli v16.3.1 logger (MIT) so call
 // sites did not have to change.
 import * as clack from '@clack/prompts';
 import chalk from 'chalk';

--- a/apps/eoas/src/lib/prompts.ts
+++ b/apps/eoas/src/lib/prompts.ts
@@ -1,4 +1,4 @@
-// This file is copied from eas-cli[https://github.com/expo/eas-cli] to ensure consistent user experience across the CLI.
+// This file is copied from eas-cli v16.3.1 (MIT, https://github.com/expo/eas-cli/tree/v16.3.1) to ensure consistent user experience across the CLI.
 import * as clack from '@clack/prompts';
 import chalk from 'chalk';
 import { constants } from 'os';

--- a/apps/eoas/src/lib/repo.ts
+++ b/apps/eoas/src/lib/repo.ts
@@ -1,4 +1,4 @@
-// This file is copied from eas-cli[https://github.com/expo/eas-cli] to ensure consistent user experience across the CLI.
+// This file is copied from eas-cli v16.3.1 (MIT, https://github.com/expo/eas-cli/tree/v16.3.1) to ensure consistent user experience across the CLI.
 import chalk from 'chalk';
 
 import Log from './log';

--- a/apps/eoas/src/lib/runtimeVersion.ts
+++ b/apps/eoas/src/lib/runtimeVersion.ts
@@ -1,12 +1,13 @@
 import { ExpoConfig } from '@expo/config';
 import { Updates } from '@expo/config-plugins';
-import { Env, Workflow } from '@expo/eas-build-job';
 import spawnAsync from '@expo/spawn-async';
 import fs from 'fs-extra';
 import resolveFrom, { silent as silentResolveFrom } from 'resolve-from';
 import semver from 'semver';
 
+import { Env } from './expoConfig';
 import Log, { link } from './log';
+import { Workflow } from './workflow';
 
 export class ExpoUpdatesCLIModuleNotFoundError extends Error {}
 export class ExpoUpdatesCLIInvalidCommandError extends Error {}

--- a/apps/eoas/src/lib/vcs/README.md
+++ b/apps/eoas/src/lib/vcs/README.md
@@ -1,1 +1,1 @@
-This library is copied from eas-cli[https://github.com/expo/eas-cli] to ensure consistent user experience.
+This library is copied from eas-cli v16.3.1 (MIT, https://github.com/expo/eas-cli/tree/v16.3.1) to ensure consistent user experience.

--- a/apps/eoas/src/lib/workflow.ts
+++ b/apps/eoas/src/lib/workflow.ts
@@ -1,9 +1,18 @@
 import { AndroidConfig, IOSConfig } from '@expo/config-plugins';
-import { Platform, Workflow } from '@expo/eas-build-job';
 import fs from 'fs-extra';
 import path from 'path';
 
 import { Client } from './vcs/vcs';
+
+export enum Platform {
+  ANDROID = 'android',
+  IOS = 'ios',
+}
+
+export enum Workflow {
+  GENERIC = 'generic',
+  MANAGED = 'managed',
+}
 
 export async function resolveWorkflowAsync(
   projectDir: string,


### PR DESCRIPTION
@expo/eas-build-job is licensed under BSL 1.1 (not MIT as its package.json says), and the license excludes commercial build services. We only used three type definitions from it, so they now live in the CLI and the package is gone.

The eas-cli copy notices now name the version (v16.3.1, MIT), and THIRD_PARTY_NOTICES ships Expo's MIT notice with the package.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added third-party licensing and attribution information for components derived from eas-cli.
  - Updated source references to identify the applicable eas-cli version and MIT license.

- **Maintenance**
  - The package no longer relies on the removed build-job dependency.
  - Internal configuration and workflow types are now maintained locally, with no intended changes to end-user command behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->