### PR TITLE
fix(publish): send local upload tokens in headers

### DIFF
--- a/apps/eoas/src/commands/__tests__/publish.test.ts
+++ b/apps/eoas/src/commands/__tests__/publish.test.ts
@@ -245,6 +245,25 @@ describe('publish forwards the storage backend requirements', () => {
 });
 
 describe('publish credential handling', () => {
+  it('sends the local upload grant in a header alongside the CLI credential', async () => {
+    const uploadUrl = `${SERVER}/app-1/uploadLocalFile`;
+    respondWith([
+      uploadRequest({
+        requestUploadUrl: uploadUrl,
+        headers: { 'local-upload-token': 'file-grant' },
+      }),
+    ]);
+
+    await runPublish();
+
+    const [call] = putCalls();
+    expect(call.url).toBe(uploadUrl);
+    expect(call.options.headers['local-upload-token']).toBe('file-grant');
+    expect(call.options.headers.Authorization).toBe('Bearer test-token');
+    expect(call.options.headers['content-type']).toMatch(/^multipart\/form-data; boundary=/);
+    expect(call.options.redirect).toBe('error');
+  });
+
   it('attaches the token only to the configured server, never to storage', async () => {
     respondWith([
       uploadRequest({ requestUploadUrl: `${SERVER}/app-1/uploadLocalFile?file=metadata.json` }),

--- a/apps/eoas/src/commands/publish.ts
+++ b/apps/eoas/src/commands/publish.ts
@@ -421,6 +421,7 @@ export default class Publish extends Command {
               return {
                 method: 'PUT',
                 headers: {
+                  ...(itm.headers ?? {}),
                   ...formData.getHeaders(),
                   ...getAuthHeaders(credentials),
                 },

--- a/internal/bucket/azureBucket.go
+++ b/internal/bucket/azureBucket.go
@@ -176,6 +176,11 @@ func (b *AzureBucket) GetFile(update types.Update, assetPath string) (*types.Buc
 	return &types.BucketFile{Reader: resp.Body, CreatedAt: created}, nil
 }
 
+// uploadHeaders are the headers the uploader must send verbatim on its PUT.
+func (b *AzureBucket) uploadHeaders() map[string]string {
+	return map[string]string{"x-ms-blob-type": "BlockBlob"}
+}
+
 func (b *AzureBucket) RequestUploadUrlForFileUpdate(appId string, branch string, runtimeVersion string, updateId string, fileName string) (*UploadRequest, error) {
 	if b.ContainerName == "" {
 		return nil, errors.New("ContainerName not set")
@@ -185,7 +190,7 @@ func (b *AzureBucket) RequestUploadUrlForFileUpdate(appId string, branch string,
 	if err != nil {
 		return nil, fmt.Errorf("error generating SAS URL: %w", err)
 	}
-	return &UploadRequest{URL: url, Method: "PUT", Headers: uploadHeaders(b)}, nil
+	return &UploadRequest{URL: url, Method: "PUT", Headers: b.uploadHeaders()}, nil
 }
 
 func (b *AzureBucket) blobKey(appId, hash string) string {
@@ -274,7 +279,7 @@ func (b *AzureBucket) RequestBlobUploadURL(appId, hash, _ string) (*UploadReques
 	if err != nil {
 		return nil, fmt.Errorf("error generating SAS URL: %w", err)
 	}
-	return &UploadRequest{URL: url, Method: "PUT", Headers: uploadHeaders(b)}, nil
+	return &UploadRequest{URL: url, Method: "PUT", Headers: b.uploadHeaders()}, nil
 }
 
 func (b *AzureBucket) UploadFileIntoUpdate(update types.Update, fileName string, file io.Reader) error {

--- a/internal/bucket/azureBucket.go
+++ b/internal/bucket/azureBucket.go
@@ -176,16 +176,16 @@ func (b *AzureBucket) GetFile(update types.Update, assetPath string) (*types.Buc
 	return &types.BucketFile{Reader: resp.Body, CreatedAt: created}, nil
 }
 
-func (b *AzureBucket) RequestUploadUrlForFileUpdate(appId string, branch string, runtimeVersion string, updateId string, fileName string) (string, error) {
+func (b *AzureBucket) RequestUploadUrlForFileUpdate(appId string, branch string, runtimeVersion string, updateId string, fileName string) (*UploadRequest, error) {
 	if b.ContainerName == "" {
-		return "", errors.New("ContainerName not set")
+		return nil, errors.New("ContainerName not set")
 	}
 	key := b.prefixedKey(fmt.Sprintf("%s/%s/%s/%s/%s", appId, branch, runtimeVersion, updateId, fileName))
 	url, err := azure.SignBlobSAS(b.ContainerName, key, sas.BlobPermissions{Create: true, Write: true}, 15*time.Minute)
 	if err != nil {
-		return "", fmt.Errorf("error generating SAS URL: %w", err)
+		return nil, fmt.Errorf("error generating SAS URL: %w", err)
 	}
-	return url, nil
+	return &UploadRequest{URL: url, Method: "PUT", Headers: uploadHeaders(b)}, nil
 }
 
 func (b *AzureBucket) blobKey(appId, hash string) string {
@@ -266,15 +266,15 @@ func (b *AzureBucket) putObject(ctx context.Context, key string, body io.Reader)
 	return nil
 }
 
-func (b *AzureBucket) RequestBlobUploadURL(appId, hash, _ string) (string, error) {
+func (b *AzureBucket) RequestBlobUploadURL(appId, hash, _ string) (*UploadRequest, error) {
 	if b.ContainerName == "" {
-		return "", errors.New("ContainerName not set")
+		return nil, errors.New("ContainerName not set")
 	}
 	url, err := azure.SignBlobSAS(b.ContainerName, b.blobKey(appId, hash), sas.BlobPermissions{Create: true, Write: true}, 15*time.Minute)
 	if err != nil {
-		return "", fmt.Errorf("error generating SAS URL: %w", err)
+		return nil, fmt.Errorf("error generating SAS URL: %w", err)
 	}
-	return url, nil
+	return &UploadRequest{URL: url, Method: "PUT", Headers: uploadHeaders(b)}, nil
 }
 
 func (b *AzureBucket) UploadFileIntoUpdate(update types.Update, fileName string, file io.Reader) error {

--- a/internal/bucket/azureBucket_integration_test.go
+++ b/internal/bucket/azureBucket_integration_test.go
@@ -93,19 +93,19 @@ func TestAzuriteUploadListGet(t *testing2.T) {
 
 func TestAzuriteSASUploadRequiresBlockBlobHeader(t *testing2.T) {
 	b := setupAzuriteBucket(t)
-	uploadURL, err := b.RequestUploadUrlForFileUpdate("app-1", "production", "1", "1674170951", "bundles/android.js")
+	upload, err := b.RequestUploadUrlForFileUpdate("app-1", "production", "1", "1674170951", "bundles/android.js")
 	require.NoError(t, err)
 
 	// Without the header Azure refuses the PUT: the exact failure eoas hit
 	// before the server started returning upload headers.
-	reqWithoutHeader, err := http.NewRequest(http.MethodPut, uploadURL, strings.NewReader("payload"))
+	reqWithoutHeader, err := http.NewRequest(http.MethodPut, upload.URL, strings.NewReader("payload"))
 	require.NoError(t, err)
 	respWithoutHeader, err := http.DefaultClient.Do(reqWithoutHeader)
 	require.NoError(t, err)
 	respWithoutHeader.Body.Close()
 	assert.Equal(t, http.StatusBadRequest, respWithoutHeader.StatusCode)
 
-	req, err := http.NewRequest(http.MethodPut, uploadURL, strings.NewReader("payload"))
+	req, err := http.NewRequest(http.MethodPut, upload.URL, strings.NewReader("payload"))
 	require.NoError(t, err)
 	req.Header.Set("x-ms-blob-type", "BlockBlob")
 	req.Header.Set("Content-Type", "application/javascript")

--- a/internal/bucket/bucket.go
+++ b/internal/bucket/bucket.go
@@ -202,7 +202,7 @@ type Bucket interface {
 	GetRuntimeVersions(appId string, branch string) ([]types.RuntimeVersionWithStats, error)
 	GetUpdates(appId string, branch string, runtimeVersion string) ([]types.Update, error)
 	GetFile(update types.Update, assetPath string) (*types.BucketFile, error)
-	RequestUploadUrlForFileUpdate(appId string, branch string, runtimeVersion string, updateId string, fileName string) (string, error)
+	RequestUploadUrlForFileUpdate(appId string, branch string, runtimeVersion string, updateId string, fileName string) (*UploadRequest, error)
 	UploadFileIntoUpdate(update types.Update, fileName string, file io.Reader) error
 	CopyFileIntoUpdate(source types.Update, target types.Update, fileName string) error
 	DeleteUpdateFolder(appId string, branch string, runtimeVersion string, updateId string) error
@@ -215,7 +215,7 @@ type Bucket interface {
 	BlobExists(ctx context.Context, appId, hash string) (bool, error)
 	GetBlob(ctx context.Context, appId, hash string) (*types.BucketFile, error)
 	PutBlob(ctx context.Context, appId, hash string, body io.Reader) error
-	RequestBlobUploadURL(appId, hash, branch string) (string, error)
+	RequestBlobUploadURL(appId, hash, branch string) (*UploadRequest, error)
 	BSDiffExists(ctx context.Context, appId, branch, targetUpdateUUID, sourceUpdateUUID string) (bool, error)
 	GetBSDiff(ctx context.Context, appId, branch, targetUpdateUUID, sourceUpdateUUID string) (*types.BucketFile, error)
 	PutBSDiff(ctx context.Context, appId, branch, targetUpdateUUID, sourceUpdateUUID string, body io.Reader) error
@@ -302,6 +302,15 @@ func ResetBucketInstance() {
 	once = sync.Once{}
 }
 
+const LocalUploadTokenHeader = "local-upload-token"
+
+// UploadRequest describes a PUT, including any per-file authorization headers.
+type UploadRequest struct {
+	URL     string            `json:"url"`
+	Method  string            `json:"method"`
+	Headers map[string]string `json:"headers,omitempty"`
+}
+
 type FileUploadRequest struct {
 	RequestUploadUrl string `json:"requestUploadUrl"`
 	FileName         string `json:"fileName"`
@@ -311,7 +320,7 @@ type FileUploadRequest struct {
 	// Headers must be sent verbatim by the uploader on its PUT to
 	// RequestUploadUrl. Azure Put Blob rejects requests missing
 	// x-ms-blob-type, and carrying the requirement in the response keeps
-	// the CLI provider-agnostic. Absent for the other backends.
+	// the CLI provider-agnostic. Local uploads carry their per-file token here.
 	Headers map[string]string `json:"headers,omitempty"`
 }
 
@@ -338,7 +347,6 @@ func uploadHeaders(bucket Bucket) map[string]string {
 // folder for the rest.
 func RequestUploadUrlsForFileUpdates(appId, branch, runtimeVersion, updateId string, files []UploadFile) ([]FileUploadRequest, error) {
 	resolvedBucket := GetBucket()
-	headers := uploadHeaders(resolvedBucket)
 
 	// Several files may name the same blob; presign it once.
 	toSign := make([]UploadFile, 0, len(files))
@@ -360,24 +368,24 @@ func RequestUploadUrlsForFileUpdates(appId, branch, runtimeVersion, updateId str
 	for i, file := range toSign {
 		go func(index int, file UploadFile) {
 			defer wg.Done()
-			var requestUploadUrl string
+			var upload *UploadRequest
 			var err error
 			if file.InUpdateFolder {
-				requestUploadUrl, err = resolvedBucket.RequestUploadUrlForFileUpdate(appId, branch, runtimeVersion, updateId, file.Name)
+				upload, err = resolvedBucket.RequestUploadUrlForFileUpdate(appId, branch, runtimeVersion, updateId, file.Name)
 			} else {
-				requestUploadUrl, err = resolvedBucket.RequestBlobUploadURL(appId, file.Hash, branch)
+				upload, err = resolvedBucket.RequestBlobUploadURL(appId, file.Hash, branch)
 			}
 			if err != nil {
 				errChan <- err
 				return
 			}
 			requests[index] = FileUploadRequest{
-				RequestUploadUrl: requestUploadUrl,
+				RequestUploadUrl: upload.URL,
 				FileName:         filepath.Base(file.Name),
 				FilePath:         file.Name,
 				OriginalFileName: file.Name,
 				Hash:             file.Hash,
-				Headers:          headers,
+				Headers:          upload.Headers,
 			}
 		}(i, file)
 	}

--- a/internal/bucket/bucket.go
+++ b/internal/bucket/bucket.go
@@ -334,14 +334,6 @@ type UploadFile struct {
 	InUpdateFolder bool
 }
 
-// uploadHeaders are the headers the uploader must send verbatim on its PUT.
-func uploadHeaders(bucket Bucket) map[string]string {
-	if _, ok := UnwrapBucket(bucket).(*AzureBucket); ok {
-		return map[string]string{"x-ms-blob-type": "BlockBlob"}
-	}
-	return nil
-}
-
 // RequestUploadUrlsForFileUpdates presigns one publish's uploads, routing each
 // file by where it lives: cas/{hash} for content-addressed files, the update
 // folder for the rest.

--- a/internal/bucket/bucket_test.go
+++ b/internal/bucket/bucket_test.go
@@ -107,19 +107,26 @@ func TestRequestUploadUrlsCarryAzureBlobTypeHeader(t *testing2.T) {
 	assert.Contains(t, requests[0].RequestUploadUrl, "sig=")
 }
 
-func TestRequestUploadUrlsCarryNoHeadersOnLocal(t *testing2.T) {
+func TestRequestUploadUrlsCarryLocalUploadTokenInHeaders(t *testing2.T) {
 	teardown := setup(t)
 	defer teardown()
 	os.Setenv("STORAGE_MODE", "local")
 	os.Setenv("LOCAL_BUCKET_BASE_PATH", t.TempDir())
 	os.Setenv("BASE_URL", "http://localhost:3000")
 	os.Setenv("JWT_SECRET", "test_jwt_secret")
-	requests, err := RequestUploadUrlsForFileUpdates("app", "branch", "1", "100", []UploadFile{{Name: "bundles/android.js", Hash: testBlobHash}})
+	requests, err := RequestUploadUrlsForFileUpdates("app", "branch", "1", "100", []UploadFile{
+		{Name: "bundles/android.js", Hash: testBlobHash},
+		{Name: "metadata.json", InUpdateFolder: true},
+	})
 	assert.Nil(t, err)
-	assert.Len(t, requests, 1)
+	assert.Len(t, requests, 2)
 	assert.Equal(t, "android.js", requests[0].FileName)
 	assert.Equal(t, "bundles/android.js", requests[0].OriginalFileName)
-	assert.Nil(t, requests[0].Headers)
+	for _, request := range requests {
+		assert.Equal(t, "http://localhost:3000/app/uploadLocalFile", request.RequestUploadUrl)
+		assert.NotEmpty(t, request.Headers["local-upload-token"])
+	}
+	assert.NotEqual(t, requests[0].Headers["local-upload-token"], requests[1].Headers["local-upload-token"], "each file has its own grant")
 }
 
 func TestConvertReadCloserToBytes(t *testing2.T) {

--- a/internal/bucket/cas_test.go
+++ b/internal/bucket/cas_test.go
@@ -102,12 +102,13 @@ func TestLocalBucket_RequestBlobUploadURL_TokenAcceptsCASPath(t *testing.T) {
 	t.Setenv("DB_URL", "postgres://localhost/xprem")
 
 	b := &LocalBucket{BasePath: root}
-	uploadURL, err := b.RequestBlobUploadURL("app-1", testBlobHash, "production")
+	upload, err := b.RequestBlobUploadURL("app-1", testBlobHash, "production")
 	require.NoError(t, err)
 
-	parsed, err := url.Parse(uploadURL)
+	parsed, err := url.Parse(upload.URL)
 	require.NoError(t, err)
-	filePath, appId, branch, err := ValidateUploadTokenAndResolveFilePath(parsed.Query().Get("token"))
+	require.Empty(t, parsed.RawQuery)
+	filePath, appId, branch, err := ValidateUploadTokenAndResolveFilePath(upload.Headers[LocalUploadTokenHeader])
 	require.NoError(t, err)
 	assert.Equal(t, "app-1", appId)
 	assert.Equal(t, "production", branch)

--- a/internal/bucket/gcsBucket.go
+++ b/internal/bucket/gcsBucket.go
@@ -233,16 +233,16 @@ func (b *GCSBucket) GetFile(update types.Update, assetPath string) (*types.Bucke
 	return &types.BucketFile{Reader: r, CreatedAt: created}, nil
 }
 
-func (b *GCSBucket) RequestUploadUrlForFileUpdate(appId string, branch string, runtimeVersion string, updateId string, fileName string) (string, error) {
+func (b *GCSBucket) RequestUploadUrlForFileUpdate(appId string, branch string, runtimeVersion string, updateId string, fileName string) (*UploadRequest, error) {
 	if b.BucketName == "" {
-		return "", errors.New("BucketName not set")
+		return nil, errors.New("BucketName not set")
 	}
 	key := b.prefixedKey(fmt.Sprintf("%s/%s/%s/%s/%s", appId, branch, runtimeVersion, updateId, fileName))
 	url, err := gcp.SignedURL(b.BucketName, key, "PUT", "", 15*time.Minute)
 	if err != nil {
-		return "", fmt.Errorf("error generating signed URL: %w", err)
+		return nil, fmt.Errorf("error generating signed URL: %w", err)
 	}
-	return url, nil
+	return &UploadRequest{URL: url, Method: "PUT"}, nil
 }
 
 func (b *GCSBucket) blobKey(appId, hash string) string {
@@ -327,15 +327,15 @@ func (b *GCSBucket) putObject(ctx context.Context, key string, body io.Reader) e
 	return w.Close()
 }
 
-func (b *GCSBucket) RequestBlobUploadURL(appId, hash, _ string) (string, error) {
+func (b *GCSBucket) RequestBlobUploadURL(appId, hash, _ string) (*UploadRequest, error) {
 	if b.BucketName == "" {
-		return "", errors.New("BucketName not set")
+		return nil, errors.New("BucketName not set")
 	}
 	url, err := gcp.SignedURL(b.BucketName, b.blobKey(appId, hash), "PUT", "", 15*time.Minute)
 	if err != nil {
-		return "", fmt.Errorf("error generating signed URL: %w", err)
+		return nil, fmt.Errorf("error generating signed URL: %w", err)
 	}
-	return url, nil
+	return &UploadRequest{URL: url, Method: "PUT"}, nil
 }
 
 func (b *GCSBucket) UploadFileIntoUpdate(update types.Update, fileName string, file io.Reader) error {

--- a/internal/bucket/localBucket.go
+++ b/internal/bucket/localBucket.go
@@ -46,42 +46,16 @@ func (b *LocalBucket) DeleteUpdateFolder(appId string, branch string, runtimeVer
 	return os.RemoveAll(dirPath)
 }
 
-func (b *LocalBucket) RequestUploadUrlForFileUpdate(appId string, branch string, runtimeVersion string, updateId string, fileName string) (string, error) {
+func (b *LocalBucket) RequestUploadUrlForFileUpdate(appId string, branch string, runtimeVersion string, updateId string, fileName string) (*UploadRequest, error) {
 	if b.BasePath == "" {
-		return "", errors.New("BasePath not set")
+		return nil, errors.New("BasePath not set")
 	}
 	dirPath := filepath.Join(b.rootPath(), appId, branch, runtimeVersion, updateId)
 	err := os.MkdirAll(dirPath, os.ModePerm)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
-	token, err := crypto.GenerateJWTToken(config.GetEnv("JWT_SECRET"), uploadClaims{
-		RegisteredClaims: jwt.RegisteredClaims{
-			Subject:   GetSubjectForApp(appId),
-			ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Minute * 10)),
-		},
-		FilePath: filepath.Join(dirPath, fileName),
-		Action:   "uploadLocalFile",
-		AppID:    appId,
-		Branch:   branch,
-	})
-	if err != nil {
-		return "", err
-	}
-	parsedURL, err := url.Parse(config.GetEnv("BASE_URL"))
-	if err != nil {
-		return "", fmt.Errorf("invalid base URL: %w", err)
-	}
-	// The route is registered under the /{APP_ID} subrouter in router.go,
-	// so the URL must include the appId segment or the client PUT 404s.
-	parsedURL.Path, err = url.JoinPath(parsedURL.Path, appId, "uploadLocalFile")
-	if err != nil {
-		return "", fmt.Errorf("error joining path: %w", err)
-	}
-	query := url.Values{}
-	query.Set("token", token)
-	parsedURL.RawQuery = query.Encode()
-	return parsedURL.String(), nil
+	return b.localUploadRequest(appId, branch, filepath.Join(dirPath, fileName))
 }
 
 func (b *LocalBucket) GetUpdates(appId string, branch string, runtimeVersion string) ([]types.Update, error) {
@@ -275,7 +249,7 @@ func GetSubjectForApp(appId string) string {
 	return fmt.Sprintf("app:%s", appId)
 }
 
-// uploadClaims is the claim set of a local upload URL token. Branch is what
+// uploadClaims is the claim set of a local upload token. Branch is what
 // lets the router judge the upload route, which names no branch of its own,
 // against the API key's access rules.
 type uploadClaims struct {
@@ -291,7 +265,7 @@ type uploadClaims struct {
 // plus the appId claim so the caller can confirm the token is scoped to the
 // same app as the URL, without that check, an attacker who obtained a leaked
 // token for AppA could PUT into AppB's bucket by hitting
-// /{AppB}/uploadLocalFile?token=<appA_token>.
+// /{AppB}/uploadLocalFile with AppA's local-upload-token header.
 func ValidateUploadTokenAndResolveFilePath(token string) (filePath string, appId string, branch string, err error) {
 	claims := uploadClaims{}
 	if _, err := crypto.DecodeAndExtractJWTToken(config.GetEnv("JWT_SECRET"), token, &claims); err != nil {
@@ -475,39 +449,39 @@ func (b *LocalBucket) writeFile(filePath string, body io.Reader) error {
 	return err
 }
 
-func (b *LocalBucket) RequestBlobUploadURL(appId, hash, branch string) (string, error) {
+func (b *LocalBucket) RequestBlobUploadURL(appId, hash, branch string) (*UploadRequest, error) {
 	if b.BasePath == "" {
-		return "", errors.New("BasePath not set")
+		return nil, errors.New("BasePath not set")
 	}
 	dirPath := filepath.Join(b.rootPath(), appId, casDir)
 	if err := os.MkdirAll(dirPath, os.ModePerm); err != nil {
-		return "", err
+		return nil, err
 	}
+	return b.localUploadRequest(appId, branch, filepath.Join(dirPath, hash))
+}
+
+// localUploadRequest keeps the per-file grant out of URLs and request logs.
+func (b *LocalBucket) localUploadRequest(appId, branch, filePath string) (*UploadRequest, error) {
 	token, err := crypto.GenerateJWTToken(config.GetEnv("JWT_SECRET"), uploadClaims{
 		RegisteredClaims: jwt.RegisteredClaims{
 			Subject:   GetSubjectForApp(appId),
-			ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Minute * 10)),
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(10 * time.Minute)),
 		},
-		FilePath: filepath.Join(dirPath, hash),
-		Action:   "uploadLocalFile",
-		AppID:    appId,
-		Branch:   branch,
+		FilePath: filePath, Action: "uploadLocalFile", AppID: appId, Branch: branch,
 	})
 	if err != nil {
-		return "", err
+		return nil, err
 	}
-	parsedURL, err := url.Parse(config.GetEnv("BASE_URL"))
+	uploadURL, err := url.Parse(config.GetEnv("BASE_URL"))
 	if err != nil {
-		return "", fmt.Errorf("invalid base URL: %w", err)
+		return nil, fmt.Errorf("invalid base URL: %w", err)
 	}
-	parsedURL.Path, err = url.JoinPath(parsedURL.Path, appId, "uploadLocalFile")
+	uploadURL.Path, err = url.JoinPath(uploadURL.Path, appId, "uploadLocalFile")
 	if err != nil {
-		return "", fmt.Errorf("error joining path: %w", err)
+		return nil, fmt.Errorf("error joining path: %w", err)
 	}
-	query := url.Values{}
-	query.Set("token", token)
-	parsedURL.RawQuery = query.Encode()
-	return parsedURL.String(), nil
+	uploadURL.RawQuery, uploadURL.Fragment = "", ""
+	return &UploadRequest{URL: uploadURL.String(), Method: "PUT", Headers: map[string]string{LocalUploadTokenHeader: token}}, nil
 }
 
 // ResolveUploadTokenBranch returns the branch an upload token was minted for.

--- a/internal/bucket/s3Bucket.go
+++ b/internal/bucket/s3Bucket.go
@@ -260,14 +260,14 @@ func (b *S3Bucket) GetFile(update types.Update, assetPath string) (*types.Bucket
 	}, nil
 }
 
-func (b *S3Bucket) RequestUploadUrlForFileUpdate(appId string, branch string, runtimeVersion string, updateId string, fileName string) (string, error) {
+func (b *S3Bucket) RequestUploadUrlForFileUpdate(appId string, branch string, runtimeVersion string, updateId string, fileName string) (*UploadRequest, error) {
 	if b.BucketName == "" {
-		return "", errors.New("BucketName not set")
+		return nil, errors.New("BucketName not set")
 	}
 
 	s3Client, err := aws.GetS3Client()
 	if err != nil {
-		return "", fmt.Errorf("error getting S3 client: %w", err)
+		return nil, fmt.Errorf("error getting S3 client: %w", err)
 	}
 
 	presignClient := s3.NewPresignClient(s3Client)
@@ -283,10 +283,10 @@ func (b *S3Bucket) RequestUploadUrlForFileUpdate(appId string, branch string, ru
 		opt.Expires = 15 * time.Minute
 	})
 	if err != nil {
-		return "", fmt.Errorf("error presigning URL: %w", err)
+		return nil, fmt.Errorf("error presigning URL: %w", err)
 	}
 
-	return presignResult.URL, nil
+	return &UploadRequest{URL: presignResult.URL, Method: "PUT"}, nil
 }
 
 func (b *S3Bucket) blobKey(appId, hash string) string {
@@ -389,13 +389,13 @@ func (b *S3Bucket) putObject(ctx context.Context, key string, body io.Reader) er
 	return nil
 }
 
-func (b *S3Bucket) RequestBlobUploadURL(appId, hash, _ string) (string, error) {
+func (b *S3Bucket) RequestBlobUploadURL(appId, hash, _ string) (*UploadRequest, error) {
 	if b.BucketName == "" {
-		return "", errors.New("BucketName not set")
+		return nil, errors.New("BucketName not set")
 	}
 	s3Client, err := aws.GetS3Client()
 	if err != nil {
-		return "", fmt.Errorf("error getting S3 client: %w", err)
+		return nil, fmt.Errorf("error getting S3 client: %w", err)
 	}
 	presignClient := s3.NewPresignClient(s3Client)
 	presignResult, err := presignClient.PresignPutObject(context.TODO(), &s3.PutObjectInput{
@@ -405,9 +405,9 @@ func (b *S3Bucket) RequestBlobUploadURL(appId, hash, _ string) (string, error) {
 		opt.Expires = 15 * time.Minute
 	})
 	if err != nil {
-		return "", fmt.Errorf("error presigning URL: %w", err)
+		return nil, fmt.Errorf("error presigning URL: %w", err)
 	}
-	return presignResult.URL, nil
+	return &UploadRequest{URL: presignResult.URL, Method: "PUT"}, nil
 }
 
 func (b *S3Bucket) UploadFileIntoUpdate(update types.Update, fileName string, file io.Reader) error {

--- a/internal/bucket/validatingBucket.go
+++ b/internal/bucket/validatingBucket.go
@@ -75,21 +75,21 @@ func (v *validatingBucket) GetFile(update types.Update, assetPath string) (*type
 	return v.Inner.GetFile(update, assetPath)
 }
 
-func (v *validatingBucket) RequestUploadUrlForFileUpdate(appId, branch, runtimeVersion, updateId, fileName string) (string, error) {
+func (v *validatingBucket) RequestUploadUrlForFileUpdate(appId, branch, runtimeVersion, updateId, fileName string) (*UploadRequest, error) {
 	if err := validateSegment("appId", appId); err != nil {
-		return "", err
+		return nil, err
 	}
 	if err := validateBranch(branch); err != nil {
-		return "", err
+		return nil, err
 	}
 	if err := validateSegment("runtimeVersion", runtimeVersion); err != nil {
-		return "", err
+		return nil, err
 	}
 	if err := validateSegment("updateId", updateId); err != nil {
-		return "", err
+		return nil, err
 	}
 	if err := validateRelativePath("fileName", fileName); err != nil {
-		return "", err
+		return nil, err
 	}
 	return v.Inner.RequestUploadUrlForFileUpdate(appId, branch, runtimeVersion, updateId, fileName)
 }
@@ -253,15 +253,15 @@ func (v *validatingBucket) DeleteBSDiffs(ctx context.Context, appId, branch stri
 	return v.Inner.DeleteBSDiffs(ctx, appId, branch)
 }
 
-func (v *validatingBucket) RequestBlobUploadURL(appId, hash, branch string) (string, error) {
+func (v *validatingBucket) RequestBlobUploadURL(appId, hash, branch string) (*UploadRequest, error) {
 	if err := validateSegment("appId", appId); err != nil {
-		return "", err
+		return nil, err
 	}
 	if err := ValidateBlobHash(hash); err != nil {
-		return "", err
+		return nil, err
 	}
 	if err := validateBranch(branch); err != nil {
-		return "", err
+		return nil, err
 	}
 	return v.Inner.RequestBlobUploadURL(appId, hash, branch)
 }

--- a/internal/bucket/validatingBucket_test.go
+++ b/internal/bucket/validatingBucket_test.go
@@ -34,9 +34,9 @@ func (s *stubBucket) GetFile(update types.Update, assetPath string) (*types.Buck
 	s.mark()
 	return nil, nil
 }
-func (s *stubBucket) RequestUploadUrlForFileUpdate(appId, branch, runtimeVersion, updateId, fileName string) (string, error) {
+func (s *stubBucket) RequestUploadUrlForFileUpdate(appId, branch, runtimeVersion, updateId, fileName string) (*UploadRequest, error) {
 	s.mark()
-	return "", nil
+	return &UploadRequest{Method: "PUT"}, nil
 }
 func (s *stubBucket) UploadFileIntoUpdate(update types.Update, fileName string, file io.Reader) error {
 	s.mark()
@@ -87,9 +87,9 @@ func (s *stubBucket) DeleteBSDiffs(context.Context, string, string) error {
 	s.mark()
 	return nil
 }
-func (s *stubBucket) RequestBlobUploadURL(_, _, _ string) (string, error) {
+func (s *stubBucket) RequestBlobUploadURL(_, _, _ string) (*UploadRequest, error) {
 	s.mark()
-	return "", nil
+	return &UploadRequest{Method: "PUT"}, nil
 }
 
 func validUpdate() types.Update {

--- a/internal/bucketmigrations/20260422_v2_scope_data_under_appid/20260422_v2_scope_data_under_appid_test.go
+++ b/internal/bucketmigrations/20260422_v2_scope_data_under_appid/20260422_v2_scope_data_under_appid_test.go
@@ -36,9 +36,9 @@ func (u unreachableBucket) GetFile(types.Update, string) (*types.BucketFile, err
 	u.t.Fatal("migration should have skipped")
 	return nil, nil
 }
-func (u unreachableBucket) RequestUploadUrlForFileUpdate(string, string, string, string, string) (string, error) {
+func (u unreachableBucket) RequestUploadUrlForFileUpdate(string, string, string, string, string) (*bucket.UploadRequest, error) {
 	u.t.Fatal("migration should have skipped")
-	return "", nil
+	return &bucket.UploadRequest{Method: "PUT"}, nil
 }
 func (u unreachableBucket) UploadFileIntoUpdate(types.Update, string, io.Reader) error {
 	u.t.Fatal("migration should have skipped")
@@ -104,9 +104,9 @@ func (u unreachableBucket) DeleteBSDiffs(context.Context, string, string) error 
 	u.t.Fatal("migration should have skipped")
 	return nil
 }
-func (u unreachableBucket) RequestBlobUploadURL(string, string, string) (string, error) {
+func (u unreachableBucket) RequestBlobUploadURL(string, string, string) (*bucket.UploadRequest, error) {
 	u.t.Fatal("migration should have skipped")
-	return "", nil
+	return &bucket.UploadRequest{Method: "PUT"}, nil
 }
 
 // resetEnv unsets every env var up() reads, then restores the previous

--- a/internal/handlers/upload_handler.go
+++ b/internal/handlers/upload_handler.go
@@ -169,7 +169,7 @@ func (h *UploadHandler) RequestUploadLocalFileHandler(w http.ResponseWriter, r *
 	requestID := uuid.New().String()
 	appId := mux.Vars(r)["APP_ID"]
 
-	token := r.URL.Query().Get("token")
+	token := r.Header.Get(bucket.LocalUploadTokenHeader)
 	if token == "" {
 		log.Printf("[RequestID: %s] No token provided", requestID)
 		http.Error(w, "No token provided", http.StatusBadRequest)

--- a/internal/middleware/logging_middleware.go
+++ b/internal/middleware/logging_middleware.go
@@ -11,7 +11,7 @@ import (
 func redactHeaders(headers http.Header) http.Header {
 	redactedHeaders := make(http.Header)
 	for key, values := range headers {
-		if strings.EqualFold(key, "Authorization") || strings.EqualFold(key, "X-Expo-Access-Token") {
+		if strings.EqualFold(key, "Authorization") || strings.EqualFold(key, "X-Expo-Access-Token") || strings.EqualFold(key, "local-upload-token") {
 			redactedHeaders[key] = []string{"REDACTED"}
 		} else {
 			redactedHeaders[key] = values

--- a/internal/middleware/logging_middleware_test.go
+++ b/internal/middleware/logging_middleware_test.go
@@ -1,7 +1,9 @@
 package middleware
 
 import (
+	"bytes"
 	"context"
+	"log"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -44,4 +46,37 @@ func TestLoggingMiddlewarePreservesFlush(t *testing.T) {
 	handler.ServeHTTP(recorder, request)
 
 	require.True(t, recorder.Flushed, "the flush must reach the underlying writer")
+}
+
+func captureLogs(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var buffer bytes.Buffer
+	previous := log.Writer()
+	log.SetOutput(&buffer)
+	t.Cleanup(func() { log.SetOutput(previous) })
+	return &buffer
+}
+
+const uploadGrant = "eyJhbGciOiJIUzI1NiJ9.UPLOADGRANT.sig"
+
+func TestLoggingMiddlewareRedactsLocalUploadHeader(t *testing.T) {
+	for _, header := range []string{"local-upload-token", "Local-Upload-Token", "LOCAL-UPLOAD-TOKEN"} {
+		for _, panics := range []bool{false, true} {
+			logs := captureLogs(t)
+			handler := LoggingMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				require.Equal(t, []string{uploadGrant}, r.Header[header], "logging must not alter the request")
+				if panics {
+					panic("upload failed")
+				}
+				w.WriteHeader(http.StatusNoContent)
+			}))
+			request := httptest.NewRequest(http.MethodPut, "/app-1/uploadLocalFile", nil)
+			request.Header[header] = []string{uploadGrant}
+			request.Header.Set("Authorization", "Bearer eoo-secret")
+			handler.ServeHTTP(httptest.NewRecorder(), request)
+			require.Contains(t, logs.String(), "REDACTED")
+			require.NotContains(t, logs.String(), uploadGrant)
+			require.NotContains(t, logs.String(), "eoo-secret")
+		}
+	}
 }

--- a/internal/router/access_publish.go
+++ b/internal/router/access_publish.go
@@ -51,7 +51,7 @@ func routeBranch(r *http.Request) string {
 // same validation the handler runs. Anything unreadable, expired,
 // foreign-signed or claimless yields "".
 func uploadTokenBranch(r *http.Request) string {
-	branchName, err := bucket.ResolveUploadTokenBranch(r.URL.Query().Get("token"))
+	branchName, err := bucket.ResolveUploadTokenBranch(r.Header.Get(bucket.LocalUploadTokenHeader))
 	if err != nil {
 		return ""
 	}

--- a/internal/router/routes_publish_test.go
+++ b/internal/router/routes_publish_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
-	"net/url"
 	"os"
 	"testing"
 
@@ -134,15 +133,16 @@ func TestUploadTokenBranchResolution(t *testing.T) {
 
 	valid := mintUploadToken(t, "app-1", "production")
 	for name, tc := range map[string]struct {
-		query string
+		query, token string
 		// branch empty means the request must be refused without asking the policy.
 		branch string
 		status int
 	}{
-		"valid token":   {"?token=" + valid, "production", http.StatusOK},
-		"no token":      {"", "", http.StatusForbidden},
-		"garbage token": {"?token=not-a-jwt", "", http.StatusForbidden},
-		"foreign token": {"?token=" + mintForeignUploadToken(t, "app-1", "production"), "", http.StatusForbidden},
+		"valid token":         {"", valid, "production", http.StatusOK},
+		"query token refused": {"?token=" + valid, "", "", http.StatusForbidden},
+		"no token":            {"", "", "", http.StatusForbidden},
+		"garbage token":       {"", "not-a-jwt", "", http.StatusForbidden},
+		"foreign token":       {"", mintForeignUploadToken(t, "app-1", "production"), "", http.StatusForbidden},
 	} {
 		t.Run(name, func(t *testing.T) {
 			policy := &recordingPolicy{}
@@ -158,6 +158,7 @@ func TestUploadTokenBranchResolution(t *testing.T) {
 
 			r := httptest.NewRequest(http.MethodPut, "/app-1/uploadLocalFile"+tc.query, nil)
 			r.Header.Set("Authorization", "Bearer eoo_key")
+			r.Header.Set(bucket.LocalUploadTokenHeader, tc.token)
 			w := httptest.NewRecorder()
 			router.ServeHTTP(w, r)
 
@@ -222,13 +223,9 @@ func mintUploadToken(t *testing.T, appId, branch string) string {
 	// local bucket from this env, so minting anywhere else is not "the way the
 	// local bucket does".
 	local := &bucket.LocalBucket{BasePath: os.Getenv("LOCAL_BUCKET_BASE_PATH")}
-	uploadURL, err := local.RequestUploadUrlForFileUpdate(appId, branch, "1.0.0", "1", "bundle.js")
+	upload, err := local.RequestUploadUrlForFileUpdate(appId, branch, "1.0.0", "1", "bundle.js")
 	if err != nil {
 		t.Fatalf("could not mint an upload token: %v", err)
 	}
-	parsed, err := url.Parse(uploadURL)
-	if err != nil {
-		t.Fatalf("could not parse the upload url: %v", err)
-	}
-	return parsed.Query().Get("token")
+	return upload.Headers[bucket.LocalUploadTokenHeader]
 }

--- a/internal/services/rollout_resolution_test.go
+++ b/internal/services/rollout_resolution_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"xprem/config"
+	"xprem/internal/bucket"
 	"xprem/internal/crypto"
 	"xprem/internal/rollout"
 	"xprem/internal/store"
@@ -642,8 +643,8 @@ func (fakeRolloutBucket) GetFile(_ types.Update, _ string) (*types.BucketFile, e
 	return nil, fmt.Errorf("fake bucket stores no files")
 }
 
-func (fakeRolloutBucket) RequestUploadUrlForFileUpdate(_, _, _, _, _ string) (string, error) {
-	return "", nil
+func (fakeRolloutBucket) RequestUploadUrlForFileUpdate(_, _, _, _, _ string) (*bucket.UploadRequest, error) {
+	return &bucket.UploadRequest{Method: "PUT"}, nil
 }
 
 func (fakeRolloutBucket) UploadFileIntoUpdate(_ types.Update, _ string, _ io.Reader) error {
@@ -703,8 +704,8 @@ func (fakeRolloutBucket) DeleteBSDiffs(context.Context, string, string) error {
 	return nil
 }
 
-func (fakeRolloutBucket) RequestBlobUploadURL(_, _, _ string) (string, error) {
-	return "", nil
+func (fakeRolloutBucket) RequestBlobUploadURL(_, _, _ string) (*bucket.UploadRequest, error) {
+	return &bucket.UploadRequest{Method: "PUT"}, nil
 }
 
 type rolloutTestHarness struct {

--- a/test/migrations_test.go
+++ b/test/migrations_test.go
@@ -19,9 +19,9 @@ func (b *dummyMigrationsBucket) DeleteUpdateFolder(_, _, _, _ string) error {
 	b.actionsRecorded = append(b.actionsRecorded, "DeleteUpdateFolder")
 	return nil
 }
-func (b *dummyMigrationsBucket) RequestUploadUrlForFileUpdate(_, _, _, _, _ string) (string, error) {
+func (b *dummyMigrationsBucket) RequestUploadUrlForFileUpdate(_, _, _, _, _ string) (*bucket.UploadRequest, error) {
 	b.actionsRecorded = append(b.actionsRecorded, "RequestUploadUrlForFileUpdate")
-	return "", nil
+	return &bucket.UploadRequest{Method: "PUT"}, nil
 }
 func (b *dummyMigrationsBucket) GetUpdates(_, _, _ string) ([]types.Update, error) {
 	b.actionsRecorded = append(b.actionsRecorded, "GetUpdates")
@@ -99,9 +99,9 @@ func (b *dummyMigrationsBucket) DeleteBSDiffs(context.Context, string, string) e
 	b.actionsRecorded = append(b.actionsRecorded, "DeleteBSDiffs")
 	return nil
 }
-func (b *dummyMigrationsBucket) RequestBlobUploadURL(_, _, _ string) (string, error) {
+func (b *dummyMigrationsBucket) RequestBlobUploadURL(_, _, _ string) (*bucket.UploadRequest, error) {
 	b.actionsRecorded = append(b.actionsRecorded, "RequestBlobUploadURL")
-	return "", nil
+	return &bucket.UploadRequest{Method: "PUT"}, nil
 }
 
 func TestShouldNotRunAppliedMigrations(t *testing.T) {

--- a/test/requestUpload_test.go
+++ b/test/requestUpload_test.go
@@ -263,7 +263,8 @@ func TestRequestUploadUrlWithSampleUpdate(t *testing.T) {
 		assert.Equal(t, "http", parsedUrl.Scheme, "Expected HTTP scheme")
 		assert.Equal(t, "localhost:3000", parsedUrl.Host, "Expected localhost:3000 host")
 		assert.Equal(t, "/test-app-id/uploadLocalFile", parsedUrl.Path, "Expected /{appId}/uploadLocalFile path")
-		token := parsedUrl.Query().Get("token")
+		assert.Empty(t, parsedUrl.RawQuery)
+		token := req.Headers[bucket.LocalUploadTokenHeader]
 		assert.NotEmpty(t, token, "Expected non-empty token")
 		claims := jwt.MapClaims{}
 		decoded, err := crypto.DecodeAndExtractJWTToken("test_jwt_secret", token, claims)
@@ -312,8 +313,8 @@ func TestRequestUploadUrlWithSampleUpdate(t *testing.T) {
 				errs <- err
 				return
 			}
-			token := parsedUrl.Query().Get("token")
-			uploadFileReq := httptest.NewRequest("PUT", "/test-app-id/uploadLocalFile?token="+token, body)
+			uploadFileReq := httptest.NewRequest("PUT", parsedUrl.RequestURI(), body)
+			uploadFileReq.Header.Set(bucket.LocalUploadTokenHeader, uploadReq.Headers[bucket.LocalUploadTokenHeader])
 			uploadFileReq.Header.Set("Content-Type", writer.FormDataContentType())
 			uploadFileReq.Header.Set("Authorization", "Bearer expo_test_token")
 			serveThroughRouter(ws[index], uploadFileReq)


### PR DESCRIPTION
Return per-file upload instructions from the bucket and send local upload grants through local-upload-token for update assets, bundles and metadata.
Read the header during update authorization and upload handling, and redact it from request logs.
Adapt the CLI and tests to the new contract.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Upload requests now support per-file authorization and upload headers across supported storage providers.
  - Local uploads send upload tokens securely through request headers rather than URL query parameters.
  - Upload requests consistently specify the appropriate HTTP method and preserve provider-specific upload details.

- **Bug Fixes**
  - Local multipart uploads now correctly forward server-provided upload authorization.
  - Sensitive upload tokens are redacted from application logs, including during request failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->