### PR TITLE
Preserve CAS asset mappings when republishing updates

### DIFF
--- a/internal/services/deployment_service.go
+++ b/internal/services/deployment_service.go
@@ -661,6 +661,10 @@ func (s *DeploymentService) republishUpdateInternal(ctx context.Context, previou
 	if metadata.Platform != platform {
 		return nil, &RepublishError{Status: http.StatusBadRequest, Message: "Update platform mismatch"}
 	}
+	mapping, err := s.updateRepo.GetUpdateAssetMapping(ctx, *existing)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read the source update asset mapping: %w", err)
+	}
 
 	updateId := update2.GenerateUpdateTimestamp(platform)
 	_, err = s.bucket.CreateUpdateFrom(previousUpdate, update2.ConvertUpdateTimestampToString(updateId))
@@ -670,6 +674,13 @@ func (s *DeploymentService) republishUpdateInternal(ctx context.Context, previou
 	newUpdate, err := s.updateRepo.CreateUpdate(ctx, previousUpdate.AppId, updateId, previousUpdate.Branch, previousUpdate.RuntimeVersion, platform, commitHash, "", publishGroup)
 	if err != nil {
 		return nil, err
+	}
+	// Shared blobs are not copied with the update folder. Preserve their mapping
+	// before publishing the new update; legacy updates have no mapping to copy.
+	if mapping != nil {
+		if err := s.updateRepo.StoreUpdateAssetMapping(ctx, *newUpdate, mapping); err != nil {
+			return nil, fmt.Errorf("failed to store the republished update asset mapping: %w", err)
+		}
 	}
 	err = s.MarkUpdateAsChecked(ctx, *newUpdate, types.NormalUpdate)
 	if err != nil {

--- a/test/republish_cas_test.go
+++ b/test/republish_cas_test.go
@@ -1,0 +1,90 @@
+package test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+	"xprem/internal/bucket"
+	"xprem/internal/crypto"
+	"xprem/internal/store"
+	"xprem/internal/types"
+	"xprem/internal/update"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRepublishCASUpdateRemainsDownloadable(t *testing.T) {
+	teardown := setup(t)
+	defer teardown()
+	mockExpoForRequestUploadUrlTest("staging")
+	projectRoot, err := findProjectRoot()
+	require.NoError(t, err)
+	root := t.TempDir()
+	require.NoError(t, copyDir(filepath.Join(projectRoot, "test/test-updates"), root))
+	t.Setenv("LOCAL_BUCKET_BASE_PATH", root)
+	t.Setenv("STORAGE_MODE", "local")
+	t.Setenv("DB_URL", "")
+	bucket.ResetBucketInstance()
+	repo := store.NewBucketUpdateStore(bucket.GetBucket())
+	ctx := context.Background()
+	original, err := repo.GetUpdate(ctx, "test-app-id", "branch-2", "1", "1737455526")
+	require.NoError(t, err)
+	require.NotNil(t, original)
+	originalMapping, err := repo.GetUpdateAssetMapping(ctx, *original)
+	require.NoError(t, err)
+	require.NotNil(t, originalMapping)
+	originalManifest := composeStoredManifest(t, *original)
+
+	w, _, _, r := createRepublishRequest("branch-2", "1", "Authorization", "Bearer expo_test_token", "ios", "republished-commit", original.UpdateId)
+	serveThroughRouter(w, r)
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	var republished types.Update
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &republished))
+	republishedMapping, err := repo.GetUpdateAssetMapping(ctx, republished)
+	require.NoError(t, err)
+	require.Equal(t, originalMapping, republishedMapping, "republish must retain the shared blob references")
+	republishedManifest := composeStoredManifest(t, republished)
+	assert.NotEmpty(t, republishedManifest.Id)
+	assert.NotEqual(t, originalManifest.Id, republishedManifest.Id)
+	assert.NotEqual(t, original.UpdateId, republished.UpdateId)
+	assert.Equal(t, originalManifest.LaunchAsset, republishedManifest.LaunchAsset)
+	assert.Equal(t, originalManifest.Assets, republishedManifest.Assets)
+
+	for _, manifest := range []types.UpdateManifest{originalManifest, republishedManifest} {
+		for _, asset := range append([]types.ManifestAsset{manifest.LaunchAsset}, manifest.Assets...) {
+			assetResponse := httptest.NewRecorder()
+			assetRequest := httptest.NewRequest(http.MethodGet, asset.Url, nil)
+			assetRequest.Header.Set("expo-app-id", "test-app-id")
+			testContainer().ExpoProtocolHandler.HandleAssets(assetResponse, assetRequest)
+			require.Equal(t, http.StatusOK, assetResponse.Code)
+			hash, err := crypto.CreateHash(assetResponse.Body.Bytes(), "sha256", "base64")
+			require.NoError(t, err)
+			assert.Equal(t, asset.Hash, crypto.GetBase64URLEncoding(hash))
+		}
+	}
+	assert.Equal(t, originalManifest, composeStoredManifest(t, *original), "republishing must not change the source manifest")
+	stored, err := repo.RetrieveUpdateStoredMetadata(ctx, republished)
+	require.NoError(t, err)
+	assert.Equal(t, "republished-commit", stored.CommitHash)
+	assert.Equal(t, republishedManifest.Id, stored.UpdateUUID)
+}
+
+// composeStoredManifest follows the stateless manifest path using the actual local bucket.
+func composeStoredManifest(t *testing.T, published types.Update) types.UpdateManifest {
+	t.Helper()
+	ctx := context.Background()
+	repo := store.NewBucketUpdateStore(bucket.GetBucket())
+	metadata, err := update.GetMetadata(published)
+	require.NoError(t, err)
+	stored, err := repo.RetrieveUpdateStoredMetadata(ctx, published)
+	require.NoError(t, err)
+	mapping, err := repo.GetUpdateAssetMapping(ctx, published)
+	require.NoError(t, err)
+	manifest, err := update.ComposeUpdateManifest(&metadata, published, stored, mapping, types.PlatformIOS)
+	require.NoError(t, err)
+	return manifest
+}


### PR DESCRIPTION
Republishing a CAS update currently returns success but discards its asset mapping. The resulting update is treated as a legacy directory update, so `/manifest` fails with `Error composing manifest: asset file not found`.

Copy the source mapping through `UpdateRepository` before marking the new update complete. This keeps shared blob references intact across storage providers while preserving legacy updates with no mapping and assigning the republished update its own identity.

A regression test uses the real local bucket and stateless store, composes both manifests, verifies the new update ID/UUID and unchanged source, then downloads and hash-checks their assets. It fails before the fix and passes afterward.

Validation:
- `go test ./test -run 'Test.*(Republish|Rollback)' -count=1`
- `go test ./internal/services ./internal/store -run 'Test.*(Republish|Rollback|PublishGroup|RequestUpload|AssetMapping)' -count=1`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Republished updates now preserve references to shared assets, keeping both the original and republished versions downloadable.
  * Asset mappings remain intact when assets are shared rather than copied.
  * Republished update metadata and manifests remain consistent without modifying the source update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->