### PR TITLE
fix(db): backfill the asset mapping of updates imported from a bucket

### DIFF
--- a/internal/database/postgres/migrations/20260913120000_backfill_update_asset_mapping.go
+++ b/internal/database/postgres/migrations/20260913120000_backfill_update_asset_mapping.go
@@ -1,0 +1,59 @@
+package migrations
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log"
+	"strconv"
+	"xprem/internal/bucket"
+	"xprem/internal/database/postgres/pgdb"
+	"xprem/internal/store"
+	"xprem/internal/types"
+
+	"github.com/pressly/goose/v3"
+)
+
+func init() {
+	goose.AddMigrationContext(UpBackfillUpdateAssetMapping, DownBackfillUpdateAssetMapping)
+}
+
+// UpBackfillUpdateAssetMapping copies into updates.asset_mapping the mapping
+// of every update imported from a bucket before that column existed.
+func UpBackfillUpdateAssetMapping(ctx context.Context, tx *sql.Tx) error {
+	// Only wire.go injects the engine; tests run goose without it and have no imported rows.
+	if dbEngine == nil {
+		return nil
+	}
+	return dbEngine.WithTx(ctx, func(qtx *pgdb.Queries) error {
+		rows, err := qtx.ListUpdatesWithoutAssetMapping(ctx, int32(types.NormalUpdate))
+		if err != nil {
+			return err
+		}
+		if len(rows) == 0 {
+			return nil
+		}
+		updateStore := store.NewBucketUpdateStore(bucket.GetBucket())
+		copied := 0
+		for _, row := range rows {
+			update := types.Update{AppId: row.AppID.String(), Branch: row.Branch, RuntimeVersion: row.RuntimeVersion, UpdateId: strconv.FormatInt(row.ID, 10)}
+			mapping, err := updateStore.GetUpdateAssetMapping(ctx, update)
+			if err != nil {
+				return fmt.Errorf("reading the bucket asset mapping of update %s (app %s): %w", update.UpdateId, update.AppId, err)
+			}
+			if mapping == nil {
+				continue
+			}
+			if _, err := qtx.SetUpdateAssetMapping(ctx, pgdb.SetUpdateAssetMappingParams{ID: row.ID, AssetMapping: mapping, AppID: row.AppID, Name: row.Branch}); err != nil {
+				return fmt.Errorf("storing the asset mapping of update %s (app %s): %w", update.UpdateId, update.AppId, err)
+			}
+			copied++
+		}
+		log.Printf("📦 [DATABASE] Backfilled the asset mapping of %d update(s) from the bucket", copied)
+		return nil
+	})
+}
+
+func DownBackfillUpdateAssetMapping(ctx context.Context, tx *sql.Tx) error {
+	return nil
+}

--- a/internal/database/postgres/migrations/20260913120000_backfill_update_asset_mapping.go
+++ b/internal/database/postgres/migrations/20260913120000_backfill_update_asset_mapping.go
@@ -15,12 +15,12 @@ import (
 )
 
 func init() {
-	goose.AddMigrationContext(UpBackfillUpdateAssetMapping, DownBackfillUpdateAssetMapping)
+	goose.AddMigrationNoTxContext(UpBackfillUpdateAssetMapping, DownBackfillUpdateAssetMapping)
 }
 
 // UpBackfillUpdateAssetMapping copies into updates.asset_mapping the mapping
 // of every update imported from a bucket before that column existed.
-func UpBackfillUpdateAssetMapping(ctx context.Context, tx *sql.Tx) error {
+func UpBackfillUpdateAssetMapping(ctx context.Context, _ *sql.DB) error {
 	// Only wire.go injects the engine; tests run goose without it and have no imported rows.
 	if dbEngine == nil {
 		return nil
@@ -54,6 +54,6 @@ func UpBackfillUpdateAssetMapping(ctx context.Context, tx *sql.Tx) error {
 	})
 }
 
-func DownBackfillUpdateAssetMapping(ctx context.Context, tx *sql.Tx) error {
+func DownBackfillUpdateAssetMapping(context.Context, *sql.DB) error {
 	return nil
 }

--- a/internal/database/postgres/migrations/backfill_update_asset_mapping_test.go
+++ b/internal/database/postgres/migrations/backfill_update_asset_mapping_test.go
@@ -1,0 +1,101 @@
+package migrations_test
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"xprem/internal/bucket"
+	"xprem/internal/database"
+	"xprem/internal/database/postgres"
+	"xprem/internal/database/postgres/migrations"
+	"xprem/internal/database/postgres/pgdb"
+	"xprem/internal/types"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUpBackfillUpdateAssetMappingCopiesBucketMappings(t *testing.T) {
+	dbURL := os.Getenv("TEST_DATABASE_URL")
+	if dbURL == "" {
+		if os.Getenv("CI") != "" {
+			t.Fatal("TEST_DATABASE_URL must be set in CI")
+		}
+		t.Skip("TEST_DATABASE_URL not set")
+	}
+	t.Setenv("ADMIN_EMAIL", "seed-admin@example.com")
+	t.Setenv("ADMIN_PASSWORD", "Sup3rSecret!")
+	postgres.RunDBMigrations(dbURL)
+	ctx := context.Background()
+	pool, err := pgxpool.New(ctx, dbURL)
+	require.NoError(t, err)
+	t.Cleanup(pool.Close)
+	migrations.SetEngine(&database.Engine{Queries: pgdb.New(pool), DB: pool})
+	t.Cleanup(func() { migrations.SetEngine(nil) })
+
+	root := t.TempDir()
+	t.Setenv("STORAGE_MODE", "local")
+	t.Setenv("LOCAL_BUCKET_BASE_PATH", root)
+	bucket.ResetBucketInstance()
+	t.Cleanup(bucket.ResetBucketInstance)
+
+	appID := uuid.NewString()
+	_, err = pool.Exec(ctx, "INSERT INTO apps (id, name) VALUES ($1, $2)", appID, "backfill-"+appID[:8])
+	require.NoError(t, err)
+	t.Cleanup(func() { _, _ = pool.Exec(context.Background(), "DELETE FROM apps WHERE id = $1", appID) })
+	var branchID, runtimeVersionID int64
+	require.NoError(t, pool.QueryRow(ctx, "INSERT INTO branches (app_id, name) VALUES ($1, 'production') RETURNING id", appID).Scan(&branchID))
+	require.NoError(t, pool.QueryRow(ctx, "INSERT INTO runtime_versions (app_id, version) VALUES ($1, '1') RETURNING id", appID).Scan(&runtimeVersionID))
+
+	mapping := types.UpdateAssetMapping{
+		LaunchAsset: types.ShapedAsset{Hash: "vH93RoNbdzk_2emr38L0ZVYJVBTPcspX5-5DXLUkiQ8", Key: "e44a25e2b1df198470a04adc1dd82e4e", FileExtension: ".bundle", ContentType: "application/javascript"},
+		Assets:      []types.ShapedAsset{{Hash: "JCcs2u_4LMX6zazNmCpvBbYMRQRwS7-UwZpjiGWYgLs", Key: "4f1cb2cac2370cd5050681232e8575a8", FileExtension: ".png", ContentType: "image/png"}},
+	}
+	withMapping, err := json.Marshal(map[string]any{"platform": "ios", "assetMapping": mapping})
+	require.NoError(t, err)
+	withoutMapping := []byte(`{"platform":"ios"}`)
+	const (
+		casUpdate      = 1001
+		legacyUpdate   = 1002
+		rollbackUpdate = 1003
+		orphanUpdate   = 1004
+	)
+	for _, row := range []struct {
+		id         int64
+		updateType types.UpdateType
+		metadata   []byte
+	}{
+		{casUpdate, types.NormalUpdate, withMapping},
+		{legacyUpdate, types.NormalUpdate, withoutMapping},
+		{rollbackUpdate, types.Rollback, withMapping},
+		{orphanUpdate, types.NormalUpdate, nil},
+	} {
+		_, err = pool.Exec(ctx, "INSERT INTO updates (id, branch_id, runtime_version_id, update_type, commit_hash, platform, checked_at) VALUES ($1, $2, $3, $4, 'abc', 'ios', now())", row.id, branchID, runtimeVersionID, int32(row.updateType))
+		require.NoError(t, err)
+		if row.metadata != nil {
+			dir := filepath.Join(root, appID, "production", "1", strconv.FormatInt(row.id, 10))
+			require.NoError(t, os.MkdirAll(dir, 0o755))
+			require.NoError(t, os.WriteFile(filepath.Join(dir, "update-metadata.json"), row.metadata, 0o644))
+		}
+	}
+
+	storedMapping := func(id int64) []byte {
+		var raw []byte
+		require.NoError(t, pool.QueryRow(ctx, "SELECT asset_mapping FROM updates WHERE branch_id = $1 AND id = $2", branchID, id).Scan(&raw))
+		return raw
+	}
+
+	for run := 0; run < 2; run++ {
+		require.NoError(t, migrations.UpBackfillUpdateAssetMapping(ctx, nil), "run %d", run)
+		var got types.UpdateAssetMapping
+		require.NoError(t, json.Unmarshal(storedMapping(casUpdate), &got))
+		require.Equal(t, mapping, got)
+		require.Nil(t, storedMapping(legacyUpdate), "a bucket file without a mapping leaves the column NULL")
+		require.Nil(t, storedMapping(rollbackUpdate), "rollbacks carry no assets")
+		require.Nil(t, storedMapping(orphanUpdate), "an update with no bucket metadata is left alone")
+	}
+}

--- a/internal/database/postgres/pgdb/queries.sql.go
+++ b/internal/database/postgres/pgdb/queries.sql.go
@@ -4690,6 +4690,47 @@ func (q *Queries) ListUpdateHealthStateDeltas(ctx context.Context, arg ListUpdat
 	return items, nil
 }
 
+const listUpdatesWithoutAssetMapping = `-- name: ListUpdatesWithoutAssetMapping :many
+SELECT u.id, b.app_id, b.name AS branch, rv.version AS runtime_version
+FROM updates u
+JOIN branches b ON u.branch_id = b.id
+JOIN runtime_versions rv ON u.runtime_version_id = rv.id
+WHERE u.asset_mapping IS NULL AND u.update_type = $1
+ORDER BY b.app_id, u.id
+`
+
+type ListUpdatesWithoutAssetMappingRow struct {
+	ID             int64       `json:"id"`
+	AppID          pgtype.UUID `json:"app_id"`
+	Branch         string      `json:"branch"`
+	RuntimeVersion string      `json:"runtime_version"`
+}
+
+func (q *Queries) ListUpdatesWithoutAssetMapping(ctx context.Context, updateType int32) ([]ListUpdatesWithoutAssetMappingRow, error) {
+	rows, err := q.db.Query(ctx, listUpdatesWithoutAssetMapping, updateType)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListUpdatesWithoutAssetMappingRow
+	for rows.Next() {
+		var i ListUpdatesWithoutAssetMappingRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.AppID,
+			&i.Branch,
+			&i.RuntimeVersion,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listUserAppGrants = `-- name: ListUserAppGrants :many
 SELECT g.user_id, g.app_id, g.role_id, g.extra_permissions,
        r.name AS role_name, r.permissions AS role_permissions

--- a/internal/database/postgres/queries/queries.sql
+++ b/internal/database/postgres/queries/queries.sql
@@ -389,6 +389,14 @@ FROM updates u
 JOIN branches b ON u.branch_id = b.id
 WHERE u.id = $1 AND b.app_id = $2 AND b.name = $3;
 
+-- name: ListUpdatesWithoutAssetMapping :many
+SELECT u.id, b.app_id, b.name AS branch, rv.version AS runtime_version
+FROM updates u
+JOIN branches b ON u.branch_id = b.id
+JOIN runtime_versions rv ON u.runtime_version_id = rv.id
+WHERE u.asset_mapping IS NULL AND u.update_type = $1
+ORDER BY b.app_id, u.id;
+
 -- name: GetLatestUpdate :one
 SELECT 
     u.id,


### PR DESCRIPTION
The stateless-to-PostgreSQL import predates the asset_mapping column, so CAS updates imported that way lost their mapping and their manifest failed with "asset file not found". A new migration copies the mapping from each update's bucket metadata into the column when it is still NULL.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Data Integrity**
  - Added a backfill for missing update asset mappings using available bucket metadata.
  - Existing mappings remain unchanged, while updates without matching metadata are left untouched.
  - Backfilled mappings are stored transactionally for consistency.

- **Reliability**
  - Added safeguards and contextual error reporting for incomplete or unavailable mapping data.
  - Re-running the backfill avoids duplicating or altering existing mappings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->