### PR TITLE
fix(bucket): write local uploads atomically and verify blob hashes

### DIFF
--- a/internal/bucket/localBucket.go
+++ b/internal/bucket/localBucket.go
@@ -3,11 +3,12 @@ package bucket
 import (
 	"bufio"
 	"context"
+	"crypto/sha256"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"io"
 	"io/fs"
-	"mime/multipart"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -374,7 +375,10 @@ func (b *LocalBucket) GetBlob(_ context.Context, appId, hash string) (*types.Buc
 }
 
 func (b *LocalBucket) PutBlob(_ context.Context, appId, hash string, body io.Reader) error {
-	return b.writeFile(b.blobPath(appId, hash), body)
+	if b.BasePath == "" {
+		return errors.New("BasePath not set")
+	}
+	return writeFileAtomically(b.blobPath(appId, hash), body, hash)
 }
 
 func (b *LocalBucket) BSDiffExists(_ context.Context, appId, branch, targetUpdateUUID, sourceUpdateUUID string) (bool, error) {
@@ -437,16 +441,36 @@ func (b *LocalBucket) writeFile(filePath string, body io.Reader) error {
 	if b.BasePath == "" {
 		return errors.New("BasePath not set")
 	}
-	if err := os.MkdirAll(filepath.Dir(filePath), os.ModePerm); err != nil {
+	return writeFileAtomically(filePath, body, "")
+}
+
+// ErrBlobHashMismatch reports a blob whose bytes do not hash to its name.
+var ErrBlobHashMismatch = errors.New("uploaded blob does not match its hash")
+
+// writeFileAtomically streams body into a temporary file next to target and
+// renames it into place, so an interrupted write leaves nothing at target. A
+// non-empty expectedHash must equal the base64url SHA-256 of the body.
+func writeFileAtomically(target string, body io.Reader, expectedHash string) error {
+	dir := filepath.Dir(target)
+	if err := os.MkdirAll(dir, os.ModePerm); err != nil {
 		return err
 	}
-	out, err := os.Create(filePath)
+	tmp, err := os.CreateTemp(dir, ".upload-")
 	if err != nil {
 		return err
 	}
-	defer out.Close()
-	_, err = io.Copy(out, body)
-	return err
+	defer os.Remove(tmp.Name())
+	digest := sha256.New()
+	_, copyErr := io.Copy(io.MultiWriter(tmp, digest), body)
+	syncErr := tmp.Sync()
+	closeErr := tmp.Close()
+	if err := errors.Join(copyErr, syncErr, closeErr); err != nil {
+		return err
+	}
+	if expectedHash != "" && base64.RawURLEncoding.EncodeToString(digest.Sum(nil)) != expectedHash {
+		return ErrBlobHashMismatch
+	}
+	return os.Rename(tmp.Name(), target)
 }
 
 func (b *LocalBucket) RequestBlobUploadURL(appId, hash, branch string) (*UploadRequest, error) {
@@ -498,21 +522,13 @@ func ResolveUploadTokenBranch(token string) (string, error) {
 	return branch, err
 }
 
-func HandleUploadFile(filePath string, body multipart.File) (bool, error) {
-	err := os.MkdirAll(filepath.Dir(filePath), os.ModePerm)
-	if err != nil {
-		return false, err
+// HandleUploadFile stores a local upload; a file under cas/ must hash to its own name.
+func HandleUploadFile(appId, filePath string, body io.Reader) error {
+	expectedHash := ""
+	if uploadPathIsBlob(filePath, appId) {
+		expectedHash = filepath.Base(filePath)
 	}
-	file, err := os.Create(filePath)
-	if err != nil {
-		return false, err
-	}
-	defer file.Close()
-	_, err = io.Copy(file, body)
-	if err != nil {
-		return false, err
-	}
-	return true, nil
+	return writeFileAtomically(filePath, body, expectedHash)
 }
 
 func (b *LocalBucket) CreateUpdateFrom(previousUpdate *types.Update, newUpdateId string) (*types.Update, error) {

--- a/internal/bucket/local_upload_test.go
+++ b/internal/bucket/local_upload_test.go
@@ -1,0 +1,82 @@
+package bucket
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"errors"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"testing/iotest"
+
+	"github.com/stretchr/testify/require"
+)
+
+func blobHash(content []byte) string {
+	sum := sha256.Sum256(content)
+	return base64.RawURLEncoding.EncodeToString(sum[:])
+}
+
+func requireNoLeftovers(t *testing.T, root string) {
+	t.Helper()
+	require.NoError(t, filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		require.NoError(t, err)
+		require.False(t, strings.HasPrefix(d.Name(), ".upload-"), "temporary file left behind: %s", path)
+		return nil
+	}))
+}
+
+func TestHandleUploadFileVerifiesBlobsAndWritesAtomically(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("LOCAL_BUCKET_BASE_PATH", root)
+	t.Setenv("BUCKET_KEY_PREFIX", "")
+	t.Setenv("S3_KEY_PREFIX", "")
+	content := []byte("bundle bytes")
+	blob := filepath.Join(root, "app-1", casDir, blobHash(content))
+
+	require.NoError(t, HandleUploadFile("app-1", blob, bytes.NewReader(content)))
+	written, err := os.ReadFile(blob)
+	require.NoError(t, err)
+	require.Equal(t, content, written)
+
+	tampered := filepath.Join(root, "app-1", casDir, blobHash([]byte("what the CLI hashed")))
+	require.ErrorIs(t, HandleUploadFile("app-1", tampered, bytes.NewReader([]byte("what it sent"))), ErrBlobHashMismatch)
+	_, err = os.Stat(tampered)
+	require.True(t, os.IsNotExist(err), "a blob that does not match its hash is not written")
+
+	interrupted := filepath.Join(root, "app-1", casDir, blobHash([]byte("full payload")))
+	body := io.MultiReader(strings.NewReader("full pay"), iotest.ErrReader(errors.New("connection reset")))
+	require.Error(t, HandleUploadFile("app-1", interrupted, body))
+	_, err = os.Stat(interrupted)
+	require.True(t, os.IsNotExist(err), "an interrupted upload leaves no partial blob")
+
+	configFile := filepath.Join(root, "app-1", "production", "1", "1737455526", "metadata.json")
+	require.NoError(t, HandleUploadFile("app-1", configFile, strings.NewReader(`{"version":0}`)))
+	written, err = os.ReadFile(configFile)
+	require.NoError(t, err)
+	require.Equal(t, `{"version":0}`, string(written), "update folder files are stored without a hash check")
+
+	requireNoLeftovers(t, root)
+}
+
+func TestPutBlobRejectsMismatchedHash(t *testing.T) {
+	root := t.TempDir()
+	b := &LocalBucket{BasePath: root}
+	content := []byte("blob")
+	require.NoError(t, b.PutBlob(context.Background(), "app-1", blobHash(content), bytes.NewReader(content)))
+	exists, err := b.BlobExists(context.Background(), "app-1", blobHash(content))
+	require.NoError(t, err)
+	require.True(t, exists)
+
+	other := blobHash([]byte("other"))
+	require.ErrorIs(t, b.PutBlob(context.Background(), "app-1", other, bytes.NewReader(content)), ErrBlobHashMismatch)
+	exists, err = b.BlobExists(context.Background(), "app-1", other)
+	require.NoError(t, err)
+	require.False(t, exists)
+	requireNoLeftovers(t, root)
+}

--- a/internal/handlers/upload_handler.go
+++ b/internal/handlers/upload_handler.go
@@ -215,6 +215,10 @@ func (h *UploadHandler) RequestUploadLocalFileHandler(w http.ResponseWriter, r *
 			http.Error(w, "Upload token does not match this app", http.StatusForbidden)
 			return
 		}
+		if errors.Is(err, services.ErrUploadHashMismatch) {
+			http.Error(w, "Uploaded file does not match its hash", http.StatusBadRequest)
+			return
+		}
 		if errors.Is(err, services.ErrUploadFailed) {
 			http.Error(w, "Error handling upload file", http.StatusInternalServerError)
 			return

--- a/internal/services/deployment_service.go
+++ b/internal/services/deployment_service.go
@@ -27,12 +27,13 @@ import (
 )
 
 var (
-	ErrInvalidUpdate     = errors.New("invalid update")
-	ErrNoChangesDetected = errors.New("no changes detected in the update from the previous one")
-	ErrInvalidBucketType = errors.New("the configured storage engine does not support local uploads")
-	ErrInvalidToken      = errors.New("the provided upload token is invalid or expired")
-	ErrTokenAppMismatch  = errors.New("upload token does not match the requested application context")
-	ErrUploadFailed      = errors.New("failed to write upload file stream to destination storage")
+	ErrInvalidUpdate      = errors.New("invalid update")
+	ErrNoChangesDetected  = errors.New("no changes detected in the update from the previous one")
+	ErrInvalidBucketType  = errors.New("the configured storage engine does not support local uploads")
+	ErrInvalidToken       = errors.New("the provided upload token is invalid or expired")
+	ErrTokenAppMismatch   = errors.New("upload token does not match the requested application context")
+	ErrUploadFailed       = errors.New("failed to write upload file stream to destination storage")
+	ErrUploadHashMismatch = errors.New("uploaded file does not match its hash")
 	// ErrActiveRolloutBlocksPublish refuses any publish, republish or rollback on a
 	// (branch, runtime version) that has an active per-update rollout.
 	ErrActiveRolloutBlocksPublish = errors.New("a progressive rollout is active on this branch and runtime version; finish or revert it from the dashboard first")
@@ -317,16 +318,13 @@ func (s *DeploymentService) RequestUploadLocalFile(ctx context.Context, params R
 		return ErrTokenAppMismatch
 	}
 
-	success, err := bucket.HandleUploadFile(params.FilePath, params.Body)
-	if err != nil {
+	if err := bucket.HandleUploadFile(params.AppID, params.FilePath, params.Body); err != nil {
 		log.Printf("[RequestID: %s] Error handling upload file: %v", params.RequestID, err)
-		return err
-	}
-	if !success {
-		log.Printf("[RequestID: %s] Error handling upload file", params.RequestID)
+		if errors.Is(err, bucket.ErrBlobHashMismatch) {
+			return ErrUploadHashMismatch
+		}
 		return ErrUploadFailed
 	}
-
 	return nil
 }
 


### PR DESCRIPTION
Local uploads were written straight to their final path, so an interrupted upload left a partial file under cas/ that BlobExists reported as present and dedup then reused. Files now go through a temporary file renamed into place, and a blob must hash to its own name or the upload is refused with a 400.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Local file uploads now verify that content matches the expected SHA-256 hash.
  - Uploads are written atomically, preventing incomplete files from being saved.
  - Hash-mismatched uploads are rejected with a clear error message.
  - Failed or interrupted uploads no longer leave temporary files behind.
  - Configuration files continue to support storage without hash validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->