### PR TITLE
fix: prevent corrupt metadata from blocking asset mapping backfill

### DIFF
--- a/internal/database/postgres/migrations/20260913120000_backfill_update_asset_mapping.go
+++ b/internal/database/postgres/migrations/20260913120000_backfill_update_asset_mapping.go
@@ -3,6 +3,8 @@ package migrations
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"strconv"
@@ -19,7 +21,7 @@ func init() {
 }
 
 // UpBackfillUpdateAssetMapping copies into updates.asset_mapping the mapping
-// of every update imported from a bucket before that column existed.
+// of completed updates imported from a bucket before that column existed.
 func UpBackfillUpdateAssetMapping(ctx context.Context, _ *sql.DB) error {
 	// Only wire.go injects the engine; tests run goose without it and have no imported rows.
 	if dbEngine == nil {
@@ -39,6 +41,14 @@ func UpBackfillUpdateAssetMapping(ctx context.Context, _ *sql.DB) error {
 			update := types.Update{AppId: row.AppID.String(), Branch: row.Branch, RuntimeVersion: row.RuntimeVersion, UpdateId: strconv.FormatInt(row.ID, 10)}
 			mapping, err := updateStore.GetUpdateAssetMapping(ctx, update)
 			if err != nil {
+				// Corrupt historical metadata must not block startup. Storage errors
+				// still abort the migration so it can be retried.
+				var syntaxErr *json.SyntaxError
+				var typeErr *json.UnmarshalTypeError
+				if errors.As(err, &syntaxErr) || errors.As(err, &typeErr) {
+					log.Printf("⚠️ [DATABASE] Skipping invalid bucket asset mapping of update %s (app %s): %v", update.UpdateId, update.AppId, err)
+					continue
+				}
 				return fmt.Errorf("reading the bucket asset mapping of update %s (app %s): %w", update.UpdateId, update.AppId, err)
 			}
 			if mapping == nil {

--- a/internal/database/postgres/migrations/backfill_update_asset_mapping_test.go
+++ b/internal/database/postgres/migrations/backfill_update_asset_mapping_test.go
@@ -59,10 +59,17 @@ func TestUpBackfillUpdateAssetMappingCopiesBucketMappings(t *testing.T) {
 	require.NoError(t, err)
 	withoutMapping := []byte(`{"platform":"ios"}`)
 	const (
-		casUpdate      = 1001
-		legacyUpdate   = 1002
-		rollbackUpdate = 1003
-		orphanUpdate   = 1004
+		casUpdate          = 1001
+		legacyUpdate       = 1002
+		rollbackUpdate     = 1003
+		orphanUpdate       = 1004
+		truncatedUpdate    = 1005
+		emptyUpdate        = 1006
+		invalidJSONUpdate  = 1007
+		invalidTypeUpdate  = 1008
+		uncheckedUpdate    = 1009
+		existingUpdate     = 1010
+		healthyLaterUpdate = 1011
 	)
 	for _, row := range []struct {
 		id         int64
@@ -73,6 +80,13 @@ func TestUpBackfillUpdateAssetMappingCopiesBucketMappings(t *testing.T) {
 		{legacyUpdate, types.NormalUpdate, withoutMapping},
 		{rollbackUpdate, types.Rollback, withMapping},
 		{orphanUpdate, types.NormalUpdate, nil},
+		{truncatedUpdate, types.NormalUpdate, []byte(`{"assetMapping":`)},
+		{emptyUpdate, types.NormalUpdate, []byte{}},
+		{invalidJSONUpdate, types.NormalUpdate, []byte(`{"assetMapping":!}`)},
+		{invalidTypeUpdate, types.NormalUpdate, []byte(`{"assetMapping":"invalid"}`)},
+		{uncheckedUpdate, types.NormalUpdate, withMapping},
+		{existingUpdate, types.NormalUpdate, withoutMapping},
+		{healthyLaterUpdate, types.NormalUpdate, withMapping},
 	} {
 		_, err = pool.Exec(ctx, "INSERT INTO updates (id, branch_id, runtime_version_id, update_type, commit_hash, platform, checked_at) VALUES ($1, $2, $3, $4, 'abc', 'ios', now())", row.id, branchID, runtimeVersionID, int32(row.updateType))
 		require.NoError(t, err)
@@ -82,6 +96,12 @@ func TestUpBackfillUpdateAssetMappingCopiesBucketMappings(t *testing.T) {
 			require.NoError(t, os.WriteFile(filepath.Join(dir, "update-metadata.json"), row.metadata, 0o644))
 		}
 	}
+	_, err = pool.Exec(ctx, "UPDATE updates SET checked_at = NULL WHERE branch_id = $1 AND id = $2", branchID, uncheckedUpdate)
+	require.NoError(t, err)
+	existingMapping, err := json.Marshal(mapping)
+	require.NoError(t, err)
+	_, err = pool.Exec(ctx, "UPDATE updates SET asset_mapping = $1 WHERE branch_id = $2 AND id = $3", existingMapping, branchID, existingUpdate)
+	require.NoError(t, err)
 
 	storedMapping := func(id int64) []byte {
 		var raw []byte
@@ -89,13 +109,43 @@ func TestUpBackfillUpdateAssetMappingCopiesBucketMappings(t *testing.T) {
 		return raw
 	}
 
-	for run := 0; run < 2; run++ {
-		require.NoError(t, migrations.UpBackfillUpdateAssetMapping(ctx, nil), "run %d", run)
-		var got types.UpdateAssetMapping
-		require.NoError(t, json.Unmarshal(storedMapping(casUpdate), &got))
-		require.Equal(t, mapping, got)
-		require.Nil(t, storedMapping(legacyUpdate), "a bucket file without a mapping leaves the column NULL")
-		require.Nil(t, storedMapping(rollbackUpdate), "rollbacks carry no assets")
-		require.Nil(t, storedMapping(orphanUpdate), "an update with no bucket metadata is left alone")
-	}
+	t.Run("only completed normal updates without a mapping are selected", func(t *testing.T) {
+		rows, err := pgdb.New(pool).ListUpdatesWithoutAssetMapping(ctx, int32(types.NormalUpdate))
+		require.NoError(t, err)
+		for _, row := range rows {
+			if row.AppID.String() == appID {
+				require.NotContains(t, []int64{rollbackUpdate, uncheckedUpdate, existingUpdate}, row.ID)
+			}
+		}
+	})
+
+	t.Run("storage errors roll back copied mappings", func(t *testing.T) {
+		// A directory in place of the metadata file causes a real read failure.
+		metadataPath := filepath.Join(root, appID, "production", "1", strconv.Itoa(healthyLaterUpdate), "update-metadata.json")
+		require.NoError(t, os.Remove(metadataPath))
+		require.NoError(t, os.Mkdir(metadataPath, 0o755))
+		t.Cleanup(func() {
+			require.NoError(t, os.Remove(metadataPath))
+			require.NoError(t, os.WriteFile(metadataPath, withMapping, 0o644))
+		})
+		err := migrations.UpBackfillUpdateAssetMapping(ctx, nil)
+		require.ErrorContains(t, err, "reading the bucket asset mapping of update "+strconv.Itoa(healthyLaterUpdate))
+		var pathErr *os.PathError
+		require.ErrorAs(t, err, &pathErr)
+		require.Nil(t, storedMapping(casUpdate), "earlier writes must roll back after a storage failure")
+	})
+
+	t.Run("corrupt metadata is skipped and valid mappings are copied idempotently", func(t *testing.T) {
+		for run := 0; run < 2; run++ {
+			require.NoError(t, migrations.UpBackfillUpdateAssetMapping(ctx, nil), "run %d", run)
+			for _, id := range []int64{casUpdate, existingUpdate, healthyLaterUpdate} {
+				var got types.UpdateAssetMapping
+				require.NoError(t, json.Unmarshal(storedMapping(id), &got))
+				require.Equal(t, mapping, got)
+			}
+			for _, id := range []int64{legacyUpdate, rollbackUpdate, orphanUpdate, truncatedUpdate, emptyUpdate, invalidJSONUpdate, invalidTypeUpdate, uncheckedUpdate} {
+				require.Nil(t, storedMapping(id), "update %d must be left alone", id)
+			}
+		}
+	})
 }

--- a/internal/database/postgres/pgdb/queries.sql.go
+++ b/internal/database/postgres/pgdb/queries.sql.go
@@ -4695,7 +4695,7 @@ SELECT u.id, b.app_id, b.name AS branch, rv.version AS runtime_version
 FROM updates u
 JOIN branches b ON u.branch_id = b.id
 JOIN runtime_versions rv ON u.runtime_version_id = rv.id
-WHERE u.asset_mapping IS NULL AND u.update_type = $1
+WHERE u.asset_mapping IS NULL AND u.update_type = $1 AND u.checked_at IS NOT NULL
 ORDER BY b.app_id, u.id
 `
 

--- a/internal/database/postgres/queries/queries.sql
+++ b/internal/database/postgres/queries/queries.sql
@@ -394,7 +394,7 @@ SELECT u.id, b.app_id, b.name AS branch, rv.version AS runtime_version
 FROM updates u
 JOIN branches b ON u.branch_id = b.id
 JOIN runtime_versions rv ON u.runtime_version_id = rv.id
-WHERE u.asset_mapping IS NULL AND u.update_type = $1
+WHERE u.asset_mapping IS NULL AND u.update_type = $1 AND u.checked_at IS NOT NULL
 ORDER BY b.app_id, u.id;
 
 -- name: GetLatestUpdate :one

--- a/internal/store/update_bucket.go
+++ b/internal/store/update_bucket.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	bucket2 "xprem/internal/bucket"
 	"xprem/internal/crypto"
 	"xprem/internal/helpers"
@@ -308,8 +309,14 @@ func (s *BucketUpdateStore) readUpdateMetadataFile(update types.Update) (*update
 		return nil, nil
 	}
 	defer file.Reader.Close()
+	// Read fully before decoding to distinguish an interrupted bucket read
+	// from malformed JSON in a complete file during the asset mapping backfill.
+	metadata, err := io.ReadAll(file.Reader)
+	if err != nil {
+		return nil, err
+	}
 	var stored updateMetadataFile
-	if err := json.NewDecoder(file.Reader).Decode(&stored); err != nil {
+	if err := json.Unmarshal(metadata, &stored); err != nil {
 		return nil, err
 	}
 	return &stored, nil

--- a/internal/store/update_bucket_test.go
+++ b/internal/store/update_bucket_test.go
@@ -1,0 +1,35 @@
+package store_test
+
+import (
+	"context"
+	"io"
+	"strings"
+	"testing"
+	"testing/iotest"
+	"xprem/internal/bucket"
+	"xprem/internal/store"
+	"xprem/internal/types"
+
+	"github.com/stretchr/testify/require"
+)
+
+type metadataReaderBucket struct {
+	bucket.Bucket
+	reader io.Reader
+}
+
+func (b metadataReaderBucket) GetFile(types.Update, string) (*types.BucketFile, error) {
+	return &types.BucketFile{Reader: io.NopCloser(b.reader)}, nil
+}
+
+func TestGetUpdateAssetMappingPreservesReadErrors(t *testing.T) {
+	for _, metadata := range []string{`{"assetMapping":`, `{"assetMapping":{}}`} {
+		t.Run(metadata, func(t *testing.T) {
+			reader := io.MultiReader(strings.NewReader(metadata), iotest.ErrReader(io.ErrUnexpectedEOF))
+			updateStore := store.NewBucketUpdateStore(metadataReaderBucket{reader: reader})
+			mapping, err := updateStore.GetUpdateAssetMapping(context.Background(), types.Update{})
+			require.ErrorIs(t, err, io.ErrUnexpectedEOF)
+			require.Nil(t, mapping)
+		})
+	}
+}


### PR DESCRIPTION
Historical updates with malformed metadata could fail the asset mapping backfill and prevent the server from starting.

Skip incomplete updates and log malformed metadata without aborting the migration. Storage and database errors still fail the migration and roll back its writes.

Validated migrations, store, and services tests against isolated PostgreSQL, including regression coverage for corrupt metadata, rollback, and idempotency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Asset-mapping backfills now skip malformed or incomplete historical metadata while continuing to process valid records.
  * Genuine storage read errors remain visible and can still trigger migration retry behavior.
  * Unchecked uploads are excluded from asset-mapping backfills, preventing premature processing.
  * Update metadata reading now distinguishes incomplete reads from invalid JSON, improving reliability and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->