### PR TITLE
fix(example-app): apply a rollback before offering to restart

### DIFF
--- a/apps/example-app/screens/UpdatesScreen.tsx
+++ b/apps/example-app/screens/UpdatesScreen.tsx
@@ -265,7 +265,10 @@ export function UpdatesScreen() {
     try {
       const result = await Updates.checkForUpdateAsync()
       if (result.isRollBackToEmbedded) {
-        setFlowMessage('The server asks to roll back to the embedded bundle.')
+        // A rollback is applied by fetchUpdateAsync, which re-stamps the
+        // embedded update so the launcher picks it on the next restart.
+        await Updates.fetchUpdateAsync()
+        setFlowMessage('Rolled back to the embedded bundle. Restart to apply.')
       } else if (!result.isAvailable) {
         setFlowMessage('Up to date.')
       }


### PR DESCRIPTION
The updates hook reports a rollback as already downloaded as soon as the check returns it, so the screen offered Restart without ever calling fetchUpdateAsync, which is what re-stamps the embedded update. The app relaunched the same update and asked the server to roll back forever.